### PR TITLE
Исправить парсинг RECORD_COUNT API ответа

### DIFF
--- a/TABLE_COMPONENT_README.md
+++ b/TABLE_COMPONENT_README.md
@@ -146,7 +146,13 @@ new IntegramTable('container-id', {
 /api/tasks?RECORD_COUNT=1&FR_4284=test%
 ```
 
-API должен вернуть **простое число** (не JSON): `142`
+API возвращает JSON объект с полем `count`:
+
+```json
+{
+    "count": "142"
+}
+```
 
 ## Фильтрация
 

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -198,8 +198,8 @@ class IntegramTable {
             try {
                 const separator = this.options.apiUrl.includes('?') ? '&' : '?';
                 const response = await fetch(`${ this.options.apiUrl }${ separator }${ params }`);
-                const text = await response.text();
-                this.totalRows = parseInt(text, 10);
+                const result = await response.json();
+                this.totalRows = parseInt(result.count, 10);
                 this.render();  // Re-render to update the counter
             } catch (error) {
                 console.error('Error fetching total count:', error);


### PR DESCRIPTION
Closes #15

## Проблема

RECORD_COUNT API возвращает JSON объект:
```json
{
    "count": "9"
}
```

Но код пытался парсить как простое число через `response.text()`.

## Исправления

### assets/js/integram-table.js
- Изменен метод `fetchTotalCount()`
- Было: `const text = await response.text(); this.totalRows = parseInt(text, 10);`
- Стало: `const result = await response.json(); this.totalRows = parseInt(result.count, 10);`

### TABLE_COMPONENT_README.md
- Обновлена документация раздела "Запрос общего количества"
- Указан правильный формат ответа API: `{"count": "142"}`
- Убрано неверное утверждение о "простом числе"

## Тестирование

1. Открыть таблицу с данными
2. Кликнуть на "?" в счетчике записей
3. Проверить, что общее количество корректно отображается
4. Проверить в DevTools Network, что API возвращает `{"count": "N"}`