### PR TITLE
Исправить скролл таблицы и улучшить UX

### DIFF
--- a/assets/css/info.css
+++ b/assets/css/info.css
@@ -99,6 +99,11 @@
     margin: 20px 0;
 }
 
+.integram-table-container {
+    overflow-x: auto;
+    width: 100%;
+}
+
 .integram-table-header {
     display: flex;
     justify-content: space-between;
@@ -276,11 +281,18 @@
 
 /* Scroll counter (replaces pagination) */
 .scroll-counter {
-    text-align: center;
-    margin-top: 15px;
-    padding: 10px 0;
-    color: #6c757d;
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    padding: 10px 15px;
+    background: white;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    color: #495057;
     font-size: 14px;
+    font-weight: 500;
+    z-index: 100;
 }
 
 .total-count-unknown {

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -177,6 +177,8 @@ class IntegramTable {
                 }
             } finally {
                 this.isLoading = false;
+                // Check if table fits on screen and needs more data
+                this.checkAndLoadMore();
             }
         }
 
@@ -297,7 +299,8 @@ class IntegramTable {
                             </div>
                         </div>
                     </div>
-                    <table class="integram-table">
+                    <div class="integram-table-container">
+                        <table class="integram-table">
                         <thead>
                             <tr>
                                 ${ orderedColumns.map(col => `
@@ -322,7 +325,8 @@ class IntegramTable {
                                 </tr>
                             `).join('') }
                         </tbody>
-                    </table>
+                        </table>
+                    </div>
                     ${ this.renderScrollCounter() }
                 </div>
             `;
@@ -527,6 +531,20 @@ class IntegramTable {
             };
 
             window.addEventListener('scroll', this.scrollListener);
+        }
+
+        checkAndLoadMore() {
+            // Check if table fits entirely on screen and there are more records
+            setTimeout(() => {
+                const tableWrapper = this.container.querySelector('.integram-table-wrapper');
+                if (!tableWrapper || this.isLoading || !this.hasMore) return;
+
+                const rect = tableWrapper.getBoundingClientRect();
+                // If table bottom is above viewport bottom (table fits on screen), load more
+                if (rect.bottom < window.innerHeight - 50) {
+                    this.loadData(true);  // Append mode
+                }
+            }, 100);  // Small delay to ensure DOM is updated
         }
 
         showFilterTypeMenu(target, columnId) {


### PR DESCRIPTION
Closes #17

## Проблемы

1. **Таблица не скроллится, когда помещается на экран** - Если таблица целиком видна (не требует прокрутки), бесконечный скролл не срабатывает для загрузки дополнительных записей
2. **Счетчик записей теряется при скролле** - Пользователь не видит количество загруженных записей при прокрутке вниз
3. **Нет горизонтальной прокрутки** - Широкие таблицы обрезаются

## Исправления

### 1. Автоподгрузка данных при малой таблице

**assets/js/integram-table.js**

Добавлен метод `checkAndLoadMore()`:
```javascript
checkAndLoadMore() {
    setTimeout(() => {
        const tableWrapper = this.container.querySelector('.integram-table-wrapper');
        if (!tableWrapper || this.isLoading || !this.hasMore) return;

        const rect = tableWrapper.getBoundingClientRect();
        // If table bottom is above viewport bottom, load more
        if (rect.bottom < window.innerHeight - 50) {
            this.loadData(true);
        }
    }, 100);
}
```

Вызывается автоматически после каждой загрузки данных в блоке `finally`.

**Как работает:**
- После загрузки данных проверяется, помещается ли таблица на экран
- Если нижний край таблицы выше нижнего края экрана → автоматически загружаются ещё данные
- Продолжается пока либо данные закончатся, либо таблица заполнит экран

### 2. Счетчик всегда видим внизу слева

**assets/css/info.css**

Было:
```css
.scroll-counter {
    text-align: center;
    margin-top: 15px;
    padding: 10px 0;
}
```

Стало:
```css
.scroll-counter {
    position: fixed;
    bottom: 20px;
    left: 20px;
    padding: 10px 15px;
    background: white;
    border: 1px solid #dee2e6;
    border-radius: 4px;
    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
    z-index: 100;
}
```

Теперь счетчик закреплен в нижнем левом углу экрана и всегда виден.

### 3. Горизонтальная прокрутка таблицы

**assets/css/info.css**
```css
.integram-table-container {
    overflow-x: auto;
    width: 100%;
}
```

**assets/js/integram-table.js**

Обернул таблицу в контейнер:
```html
<div class="integram-table-container">
    <table class="integram-table">
        ...
    </table>
</div>
```

Теперь если таблица шире экрана, появляется горизонтальный скроллбар.

## Тестирование

1. Открыть таблицу с небольшим количеством записей (< 20)
   - ✅ Должна автоматически подгрузиться вторая порция
   - ✅ Продолжать пока не заполнит экран или не закончатся данные

2. Прокрутить страницу вниз
   - ✅ Счетчик "Показано X из Y" остается видимым в нижнем левом углу

3. Открыть таблицу с большим количеством колонок
   - ✅ Появляется горизонтальный скроллбар
   - ✅ Можно прокручивать таблицу влево-вправо

4. Кликнуть на "?" в счетчике
   - ✅ Запрашивается общее количество и отображается