### PR TITLE
Автоматически устанавливать общее количество записей

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -155,6 +155,11 @@ class IntegramTable {
 
                 this.loadedRecords += newRows.length;
 
+                // Auto-set total count if we've reached the end
+                if (!this.hasMore && this.totalRows === null) {
+                    this.totalRows = this.loadedRecords;
+                }
+
                 // Process columns to hide ID and Style suffixes
                 this.processColumnVisibility();
 


### PR DESCRIPTION
Closes #21

## Проблема

При использовании бесконечного скролла:
- Когда загружается последняя страница данных (записей меньше чем LIMIT)
- Счетчик показывает "Показано 15 из ?"
- Пользователь должен кликнуть на "?" чтобы узнать общее количество

Но на самом деле, мы уже знаем общее количество - это `loadedRecords`, потому что больше записей нет.

## Решение

Автоматически устанавливать `totalRows = loadedRecords` когда:
- `hasMore = false` (достигнут конец данных)
- `totalRows === null` (общее количество ещё не известно)

### Код изменения

**assets/js/integram-table.js:156-161**

```javascript
this.loadedRecords += newRows.length;

// Auto-set total count if we've reached the end
if (!this.hasMore && this.totalRows === null) {
    this.totalRows = this.loadedRecords;
}
```

## Логика работы

### Сценарий 1: Таблица с 15 записями (pageSize = 20)

1. Первый запрос: `LIMIT=0,21`
2. API возвращает 15 записей (меньше 21)
3. `hasMore = false` (15 < 21)
4. `loadedRecords = 15`
5. **Автоматически:** `totalRows = 15`
6. Счетчик показывает: **"Показано 15 из 15"** ✅

**Без клика на "?"!**

### Сценарий 2: Таблица с 45 записями (pageSize = 20)

1. Первый запрос: `LIMIT=0,21` → получено 21 записей
   - `hasMore = true`, `totalRows = null`
   - Показано: "Показано 20 из ?"

2. Скролл вниз, второй запрос: `LIMIT=20,21` → получено 21 записей
   - `hasMore = true`, `totalRows = null`
   - Показано: "Показано 40 из ?"

3. Скролл вниз, третий запрос: `LIMIT=40,21` → получено 5 записей
   - `hasMore = false`, `loadedRecords = 45`
   - **Автоматически:** `totalRows = 45`
   - Показано: **"Показано 45 из 45"** ✅

### Сценарий 3: С фильтрацией

1. Пользователь вводит фильтр
2. `totalRows = null` (сброс)
3. Загрузка данных: 8 записей
4. `hasMore = false`
5. **Автоматически:** `totalRows = 8`
6. Показано: **"Показано 8 из 8"** ✅

## Преимущества

### ✅ Улучшенный UX
Пользователь сразу видит точное количество записей без дополнительных действий

### ✅ Меньше API запросов
Не нужен отдельный запрос `RECORD_COUNT=1` когда данных мало

### ✅ Умное поведение
Автоматически определяет когда возможно узнать total count

### ✅ "?" остаётся полезным
Если данных много (больше одной страницы), "?" всё ещё нужен для точного подсчёта

## Тестирование

### Тест 1: Малая таблица
1. Открыть таблицу с 10 записями
2. ✅ Должно показать "Показано 10 из 10" сразу
3. ✅ Без клика на "?"

### Тест 2: Большая таблица
1. Открыть таблицу с 100 записями
2. После первой загрузки: "Показано 20 из ?"
3. Прокрутить до конца
4. ✅ На последней странице: "Показано 100 из 100"
5. ✅ Автоматически, без клика

### Тест 3: Фильтрация
1. Применить фильтр, результат 3 записи
2. ✅ Должно показать "Показано 3 из 3"
3. Изменить фильтр, результат 50 записей
4. Показано "Показано 20 из ?"
5. Прокрутить до конца
6. ✅ "Показано 50 из 50"

### Тест 4: Клик на "?" всё ещё работает
1. Открыть таблицу с 1000 записями
2. Показано "Показано 20 из ?"
3. Кликнуть на "?"
4. ✅ Запрос RECORD_COUNT=1
5. ✅ Показано "Показано 20 из 1000"

## Совместимость

✅ Обратная совместимость полная
✅ "?" работает как раньше
✅ RECORD_COUNT API используется только при клике
✅ Фильтры сбрасывают totalRows правильно