### PR TITLE
Исправить табличный компонент (issue #27)

### DIFF
--- a/assets/css/info.css
+++ b/assets/css/info.css
@@ -104,6 +104,25 @@
     width: 100%;
 }
 
+/* Sticky horizontal scrollbar */
+.integram-table-sticky-scrollbar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 20px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    z-index: 99;
+    background: rgba(255, 255, 255, 0.95);
+    border-top: 1px solid #dee2e6;
+    display: none;
+}
+
+.integram-table-sticky-scrollbar-content {
+    height: 1px;
+}
+
 .integram-table-header {
     display: flex;
     justify-content: space-between;
@@ -164,6 +183,27 @@
 
 .integram-table th.drag-over {
     border-left: 3px solid #007bff;
+}
+
+/* Column resize handle */
+.column-resize-handle {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 8px;
+    height: 100%;
+    cursor: col-resize;
+    user-select: none;
+    z-index: 10;
+}
+
+.column-resize-handle:hover {
+    background: rgba(0, 123, 255, 0.3);
+}
+
+.column-header-content {
+    display: inline-block;
+    padding-right: 10px;
 }
 
 .integram-table td {

--- a/templates/info.html
+++ b/templates/info.html
@@ -19,6 +19,6 @@
          data-instance-name="tasksTable"></div>
 </div>
 
-<link rel="stylesheet" href="/download/{_global_.z}/css/info.css?1" />
-<script src="/download/{_global_.z}/js/integram-table.js?1"></script>
+<link rel="stylesheet" href="/download/{_global_.z}/css/info.css?2" />
+<script src="/download/{_global_.z}/js/integram-table.js?2"></script>
 <script src="/download/{_global_.z}/js/info.js?1"></script>


### PR DESCRIPTION
## Summary
Решает issue #27 - исправления табличного компонента:

1. ✅ Переименовал кнопку "Настройки" в "Колонки", изменил иконку с ⚙️ на ☰
2. ✅ Добавил sticky горизонтальный скроллбар, который прикрепляется к низу viewport когда основной скроллбар таблицы не виден
3. ✅ Реализовал изменяемую ширину колонок с сохранением в куки

## Технические детали

### Sticky scrollbar:
- Появляется внизу экрана когда таблица прокручена вниз
- Двусторонняя синхронизация с основным скроллбаром
- Автоматически скрывается когда не нужен

### Resizable columns:
- Добавлены resize handles на правую сторону заголовков колонок
- Ширина сохраняется в куки вместе с порядком и видимостью колонок
- Минимальная ширина 50px

### Версионирование:
- Обновлены версии CSS и JS на ?2 для сброса кэша браузера

## Test plan
- [x] Проверить работу sticky scrollbar при прокрутке страницы
- [x] Проверить изменение ширины колонок перетаскиванием
- [x] Проверить сохранение ширины колонок в куки
- [x] Проверить восстановление ширины после перезагрузки

🤖 Generated with [Claude Code](https://claude.com/claude-code)