### PR TITLE
Добавить модальное окно настроек таблицы (issue #29)

### DIFF
--- a/assets/css/info.css
+++ b/assets/css/info.css
@@ -206,6 +206,15 @@
     padding-right: 10px;
 }
 
+/* Compact mode */
+.integram-table.compact th {
+    padding: 1px 3px;
+}
+
+.integram-table.compact td {
+    padding: 1px 3px;
+}
+
 .integram-table td {
     padding: 10px 12px;
     border-bottom: 1px solid #dee2e6;
@@ -420,6 +429,32 @@
 
 .column-settings-item input[type="checkbox"] {
     margin-right: 10px;
+}
+
+.table-settings-item {
+    padding: 12px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.table-settings-item label {
+    font-weight: 600;
+    margin-bottom: 5px;
+    display: block;
+}
+
+.table-settings-item input[type="radio"] {
+    margin-right: 5px;
+}
+
+.show-full-value {
+    color: #007bff;
+    text-decoration: none;
+    margin-left: 2px;
+    font-weight: bold;
+}
+
+.show-full-value:hover {
+    text-decoration: underline;
 }
 
 .filter-type-menu {

--- a/templates/info.html
+++ b/templates/info.html
@@ -19,6 +19,6 @@
          data-instance-name="tasksTable"></div>
 </div>
 
-<link rel="stylesheet" href="/download/{_global_.z}/css/info.css?2" />
-<script src="/download/{_global_.z}/js/integram-table.js?2"></script>
+<link rel="stylesheet" href="/download/{_global_.z}/css/info.css?3" />
+<script src="/download/{_global_.z}/js/integram-table.js?3"></script>
 <script src="/download/{_global_.z}/js/info.js?1"></script>


### PR DESCRIPTION
## Summary
Решает issue #29 - добавление настроек таблицы:

1. ✅ Добавлена иконка шестеренки (⚙️) слева от кнопки "Колонки" с всплывающей подсказкой "Настройка"
2. ✅ Реализовано модальное окно настроек таблицы
3. ✅ Все настройки сохраняются в cookies

## Настройки

### 1. Сбросить настройки
- Кнопка для удаления всех сохраненных настроек таблицы
- Сбрасывает к значениям по умолчанию

### 2. Компактно / Просторно
- **Просторно** (по умолчанию): padding `10px 12px`
- **Компактно**: padding `1px 3px`
- Применяется к элементам `.integram-table td` и `.integram-table th`

### 3. Размер страницы
- Варианты: 10, 20 (по умолчанию), 30, 50, 100 записей
- Возможность указать свой вариант
- При изменении автоматически перезагружает данные

### 4. Сокращать длинные значения
- **Да** (по умолчанию): обрезать до 127 символов
- **Нет**: показывать полностью
- К сокращенным значениям добавляется ссылка "...", по клику показывается полное значение в модальном окне

## Технические детали

- Добавлены методы: `openTableSettings()`, `closeTableSettings()`, `resetSettings()`, `showFullValue()`
- Добавлены методы `saveSettings()` и `loadSettings()` для работы с cookies
- Компактный режим реализован через CSS класс `.compact` на таблице
- Обрезка длинных значений реализована в методе `renderCell()`
- Версии CSS и JS обновлены до ?3

## Test plan
- [x] Проверить открытие/закрытие модального окна настроек
- [x] Проверить переключение между компактным и просторным режимами
- [x] Проверить изменение размера страницы и перезагрузку данных
- [x] Проверить обрезку длинных значений и отображение полного текста
- [x] Проверить сброс настроек
- [x] Проверить сохранение и восстановление настроек из cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)