### PR TITLE
Установить padding 0 в строке фильтров (issue #35)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -161,6 +161,10 @@
     font-family: monospace;
 }
 
+.filter-row {
+    padding: 0;
+}
+
 .filter-row td {
     padding: 0;
     background: #f8f9fa;
@@ -201,6 +205,7 @@
     position: relative;
     display: flex;
     align-items: center;
+    padding: 0;
 }
 
 .filter-icon-inside {

--- a/templates/info.html
+++ b/templates/info.html
@@ -20,6 +20,6 @@
 </div>
 
 <link rel="stylesheet" href="/download/{_global_.z}/css/info.css?5" />
-<link rel="stylesheet" href="/download/{_global_.z}/css/integram-table.css?1" />
+<link rel="stylesheet" href="/download/{_global_.z}/css/integram-table.css?2" />
 <script src="/download/{_global_.z}/js/integram-table.js?3"></script>
 <script src="/download/{_global_.z}/js/info.js?1"></script>


### PR DESCRIPTION
## Summary
Решает issue #35 - установка padding 0 в строке с фильтрами табличного компонента.

## Changes
- Добавлен явный `padding: 0` для селектора `.filter-row`
- Добавлен `padding: 0` для `.filter-cell-wrapper` для консистентности
- Обновлена версия `integram-table.css` до ?2

## Details
Ранее padding: 0 был установлен только для `.filter-row td`, теперь он явно установлен также для:
1. Самой строки `.filter-row` (tr element)
2. Обертки фильтра `.filter-cell-wrapper`

Это обеспечивает, что вся строка фильтров не имеет padding, как и было запрошено.

🤖 Generated with [Claude Code](https://claude.com/claude-code)