### PR TITLE
Удалить неработающее правило .filter-row padding (issue #37)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -161,10 +161,6 @@
     font-family: monospace;
 }
 
-.filter-row {
-    padding: 0;
-}
-
 .filter-row td {
     padding: 0;
     background: #f8f9fa;

--- a/templates/info.html
+++ b/templates/info.html
@@ -20,6 +20,6 @@
 </div>
 
 <link rel="stylesheet" href="/download/{_global_.z}/css/info.css?5" />
-<link rel="stylesheet" href="/download/{_global_.z}/css/integram-table.css?2" />
+<link rel="stylesheet" href="/download/{_global_.z}/css/integram-table.css?3" />
 <script src="/download/{_global_.z}/js/integram-table.js?3"></script>
 <script src="/download/{_global_.z}/js/info.js?1"></script>


### PR DESCRIPTION
## Summary
Решает issue #37 - удаление неработающего CSS правила `.filter-row { padding: 0; }`.

## Problem
CSS правило `.filter-row { padding: 0; }` не работает, потому что элементы `<tr>` (table row) имеют `display: table-row`, который игнорирует свойство padding. Только ячейки таблицы (`<td>` и `<th>`) могут иметь padding.

## Solution
Удалено неработающее правило `.filter-row { padding: 0; }` (строки 164-166).

## What Still Works
- ✅ `.filter-row td { padding: 0; }` - работает корректно (padding применяется к ячейкам)
- ✅ `.filter-cell-wrapper { padding: 0; }` - работает корректно (применяется к div элементу)

## Changes
- Удалено: `.filter-row { padding: 0; }` (не работает для table row)
- Сохранено: `.filter-row td { padding: 0; }` (работает для table cells)
- Обновлена версия `integram-table.css` до ?3

## Technical Note
Table rows (`<tr>`) с `display: table-row` не могут иметь padding по спецификации CSS. Это ожидаемое поведение браузеров, а не баг.

🤖 Generated with [Claude Code](https://claude.com/claude-code)