### PR TITLE
Replace 'slider' with db variable in report requests

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -923,7 +923,7 @@ function copyContact(value, type, event){
 function loadSourcesAndDistributors(){
     // Load sources
     var xhr1 = new XMLHttpRequest();
-    xhr1.open('GET', 'https://' + window.location.hostname + '/slider/report/4500?JSON_KV', true);
+    xhr1.open('GET', 'https://' + window.location.hostname + '/' + db + '/report/4500?JSON_KV', true);
     xhr1.onload = function(){
         if(xhr1.status === 200){
             try{
@@ -943,7 +943,7 @@ function loadSourcesAndDistributors(){
 
     // Load distributors
     var xhr2 = new XMLHttpRequest();
-    xhr2.open('GET', 'https://' + window.location.hostname + '/slider/report/4506?JSON_KV', true);
+    xhr2.open('GET', 'https://' + window.location.hostname + '/' + db + '/report/4506?JSON_KV', true);
     xhr2.onload = function(){
         if(xhr2.status === 200){
             try{


### PR DESCRIPTION
## Summary
Replace all mentions of 'slider' in report/ requests with the current database name from the `db` variable.

## Changes
- Replace `/slider/report/4500` with `'/' + db + '/report/4500'` (sources)
- Replace `/slider/report/4506` with `'/' + db + '/report/4506'` (distributors)

## Why
- Makes code consistent with other API calls that use `db` variable
- Allows the kanban board to work correctly with different database names
- Removes hardcoded 'slider' database reference

## Test plan
- [x] Verify sources dropdown loads correctly
- [x] Verify distributors dropdown loads correctly
- [x] Confirm no remaining 'slider' references in codebase

Resolves #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)