### PR TITLE
Add FR_partners parameter to kanban report requests

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -613,9 +613,14 @@ function loadKanbanData(){
     var tasksReportId = '3769';
     var statusesReportId = '3796';
 
+    // Check for 'partners' URL parameter
+    var urlParams = new URLSearchParams(window.location.search);
+    var hasPartnersParam = urlParams.has('partners');
+    var frPartnersValue = hasPartnersParam ? '%' : '!%';
+
     // Load tasks
     var xhr1 = new XMLHttpRequest();
-    xhr1.open('GET', 'https://' + window.location.hostname + '/' + db + '/report/' + tasksReportId + '?JSON_KV', true);
+    xhr1.open('GET', 'https://' + window.location.hostname + '/' + db + '/report/' + tasksReportId + '?JSON_KV&FR_partners=' + encodeURIComponent(frPartnersValue), true);
     xhr1.onload = function(){
         if(xhr1.status === 200){
             try{
@@ -635,7 +640,7 @@ function loadKanbanData(){
 
     // Load statuses
     var xhr2 = new XMLHttpRequest();
-    xhr2.open('GET', 'https://' + window.location.hostname + '/' + db + '/report/' + statusesReportId + '?JSON_KV', true);
+    xhr2.open('GET', 'https://' + window.location.hostname + '/' + db + '/report/' + statusesReportId + '?JSON_KV&FR_partners=' + encodeURIComponent(frPartnersValue), true);
     xhr2.onload = function(){
         if(xhr2.status === 200){
             try{


### PR DESCRIPTION
## Summary
Pass FR_partners parameter to report/3796 and report/3769 based on the presence of 'partners' URL parameter.

## Changes
- ✅ Check for 'partners' URL parameter using URLSearchParams
- ✅ Set FR_partners value:
  - `%` if 'partners' parameter exists in URL
  - `!%` otherwise
- ✅ Add FR_partners to report/3769 (tasks) request
- ✅ Add FR_partners to report/3796 (statuses) request
- ✅ Properly encode parameter value using encodeURIComponent

## Implementation
```javascript
// Check for 'partners' URL parameter
var urlParams = new URLSearchParams(window.location.search);
var hasPartnersParam = urlParams.has('partners');
var frPartnersValue = hasPartnersParam ? '%' : '!%';

// Add to report URLs
xhr1.open('GET', '.../' + db + '/report/' + tasksReportId + '?JSON_KV&FR_partners=' + encodeURIComponent(frPartnersValue), true);
xhr2.open('GET', '.../' + db + '/report/' + statusesReportId + '?JSON_KV&FR_partners=' + encodeURIComponent(frPartnersValue), true);
```

## Test plan
- [x] Verify FR_partners=!% is sent when URL has no 'partners' parameter
- [x] Verify FR_partners=% is sent when URL has 'partners' parameter
- [x] Verify both report requests include the parameter

Resolves #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)