### PR TITLE
Исправлено парсинг дат в формате DD.MM.YYYY из API

### DIFF
--- a/templates/integram-table.html
+++ b/templates/integram-table.html
@@ -447,6 +447,44 @@ class IntegramTable {
         `;
     }
 
+    // Helper method to parse DD.MM.YYYY date format from API
+    parseDDMMYYYY(dateStr) {
+        if (!dateStr || typeof dateStr !== 'string') return null;
+        const parts = dateStr.trim().split('.');
+        if (parts.length !== 3) return null;
+        const day = parseInt(parts[0], 10);
+        const month = parseInt(parts[1], 10);
+        const year = parseInt(parts[2], 10);
+        if (isNaN(day) || isNaN(month) || isNaN(year)) return null;
+        // Month is 0-indexed in JavaScript Date
+        return new Date(year, month - 1, day);
+    }
+
+    // Helper method to parse DD.MM.YYYY HH:MM:SS datetime format from API
+    parseDDMMYYYYHHMMSS(datetimeStr) {
+        if (!datetimeStr || typeof datetimeStr !== 'string') return null;
+        const parts = datetimeStr.trim().split(' ');
+        if (parts.length !== 2) return this.parseDDMMYYYY(datetimeStr); // Fallback to date-only
+
+        const dateParts = parts[0].split('.');
+        const timeParts = parts[1].split(':');
+
+        if (dateParts.length !== 3 || timeParts.length !== 3) return null;
+
+        const day = parseInt(dateParts[0], 10);
+        const month = parseInt(dateParts[1], 10);
+        const year = parseInt(dateParts[2], 10);
+        const hour = parseInt(timeParts[0], 10);
+        const minute = parseInt(timeParts[1], 10);
+        const second = parseInt(timeParts[2], 10);
+
+        if (isNaN(day) || isNaN(month) || isNaN(year) ||
+            isNaN(hour) || isNaN(minute) || isNaN(second)) return null;
+
+        // Month is 0-indexed in JavaScript Date
+        return new Date(year, month - 1, day, hour, minute, second);
+    }
+
     renderCell(column, value, rowIndex, colIndex) {
         const format = column.format || 'SHORT';
         let cellClass = '';
@@ -464,13 +502,25 @@ class IntegramTable {
             case 'DATE':
                 cellClass = 'date-cell';
                 if (value) {
-                    displayValue = new Date(value).toLocaleDateString('ru-RU');
+                    const dateObj = this.parseDDMMYYYY(value);
+                    if (dateObj && !isNaN(dateObj.getTime())) {
+                        displayValue = dateObj.toLocaleDateString('ru-RU');
+                    } else {
+                        // Fallback: show original value if parsing fails
+                        displayValue = value;
+                    }
                 }
                 break;
             case 'DATETIME':
                 cellClass = 'datetime-cell';
                 if (value) {
-                    displayValue = new Date(value).toLocaleString('ru-RU');
+                    const datetimeObj = this.parseDDMMYYYYHHMMSS(value);
+                    if (datetimeObj && !isNaN(datetimeObj.getTime())) {
+                        displayValue = datetimeObj.toLocaleString('ru-RU');
+                    } else {
+                        // Fallback: show original value if parsing fails
+                        displayValue = value;
+                    }
                 }
                 break;
             case 'MEMO':

--- a/templates/table-example.html
+++ b/templates/table-example.html
@@ -604,6 +604,44 @@ class IntegramTable {
         `;
     }
 
+    // Helper method to parse DD.MM.YYYY date format from API
+    parseDDMMYYYY(dateStr) {
+        if (!dateStr || typeof dateStr !== 'string') return null;
+        const parts = dateStr.trim().split('.');
+        if (parts.length !== 3) return null;
+        const day = parseInt(parts[0], 10);
+        const month = parseInt(parts[1], 10);
+        const year = parseInt(parts[2], 10);
+        if (isNaN(day) || isNaN(month) || isNaN(year)) return null;
+        // Month is 0-indexed in JavaScript Date
+        return new Date(year, month - 1, day);
+    }
+
+    // Helper method to parse DD.MM.YYYY HH:MM:SS datetime format from API
+    parseDDMMYYYYHHMMSS(datetimeStr) {
+        if (!datetimeStr || typeof datetimeStr !== 'string') return null;
+        const parts = datetimeStr.trim().split(' ');
+        if (parts.length !== 2) return this.parseDDMMYYYY(datetimeStr); // Fallback to date-only
+
+        const dateParts = parts[0].split('.');
+        const timeParts = parts[1].split(':');
+
+        if (dateParts.length !== 3 || timeParts.length !== 3) return null;
+
+        const day = parseInt(dateParts[0], 10);
+        const month = parseInt(dateParts[1], 10);
+        const year = parseInt(dateParts[2], 10);
+        const hour = parseInt(timeParts[0], 10);
+        const minute = parseInt(timeParts[1], 10);
+        const second = parseInt(timeParts[2], 10);
+
+        if (isNaN(day) || isNaN(month) || isNaN(year) ||
+            isNaN(hour) || isNaN(minute) || isNaN(second)) return null;
+
+        // Month is 0-indexed in JavaScript Date
+        return new Date(year, month - 1, day, hour, minute, second);
+    }
+
     renderCell(column, value, rowIndex, colIndex) {
         const format = column.format || 'SHORT';
         let cellClass = '';
@@ -621,13 +659,25 @@ class IntegramTable {
             case 'DATE':
                 cellClass = 'date-cell';
                 if (value) {
-                    displayValue = new Date(value).toLocaleDateString('ru-RU');
+                    const dateObj = this.parseDDMMYYYY(value);
+                    if (dateObj && !isNaN(dateObj.getTime())) {
+                        displayValue = dateObj.toLocaleDateString('ru-RU');
+                    } else {
+                        // Fallback: show original value if parsing fails
+                        displayValue = value;
+                    }
                 }
                 break;
             case 'DATETIME':
                 cellClass = 'datetime-cell';
                 if (value) {
-                    displayValue = new Date(value).toLocaleString('ru-RU');
+                    const datetimeObj = this.parseDDMMYYYYHHMMSS(value);
+                    if (datetimeObj && !isNaN(datetimeObj.getTime())) {
+                        displayValue = datetimeObj.toLocaleString('ru-RU');
+                    } else {
+                        // Fallback: show original value if parsing fails
+                        displayValue = value;
+                    }
                 }
                 break;
             case 'MEMO':


### PR DESCRIPTION
## Описание

Исправлена обработка дат, приходящих из API в формате DD.MM.YYYY.

## Что сделано

Добавлены вспомогательные методы для корректного парсинга дат:
- `parseDDMMYYYY()` - парсинг дат в формате DD.MM.YYYY
- `parseDDMMYYYYHHMMSS()` - парсинг дат со временем в формате DD.MM.YYYY HH:MM:SS

Эти методы добавлены во все файлы с логикой отображения таблиц:
- assets/js/integram-table.js
- templates/integram-table.html
- templates/table-example.html

## Решаемая проблема

Fixes #47

Ранее код пытался парсить даты используя конструктор `new Date(value)`, который ожидает формат ISO 8601 (YYYY-MM-DD). Это приводило к ошибкам или неправильному отображению дат, когда API возвращает даты в формате DD.MM.YYYY.

## Тестирование

✅ Проверена синтаксическая корректность JavaScript
✅ Добавлен fallback для отображения оригинального значения в случае ошибки парсинга

🤖 Generated with [Claude Code](https://claude.com/claude-code)