### PR TITLE
Добавлен фильтр ^ (начинается с...) для числовых полей

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -61,6 +61,7 @@ class IntegramTable {
                     { symbol: '$', name: 'заканчивается', format: 'FR_{ T }=%{ X }' }
                 ],
                 'NUMBER': [
+                    { symbol: '^', name: 'начинается с...', format: 'FR_{ T }={ X }%' },
                     { symbol: '=', name: 'равно', format: 'FR_{ T }={ X }' },
                     { symbol: '≠', name: 'не равно', format: 'FR_{ T }=!{ X }' },
                     { symbol: '≥', name: 'не меньше', format: 'FR_{ T }=>={ X }' },

--- a/templates/integram-table.html
+++ b/templates/integram-table.html
@@ -266,6 +266,7 @@ class IntegramTable {
                 { symbol: '$', name: 'заканчивается', format: 'FR_{T}=%{X}' }
             ],
             'NUMBER': [
+                { symbol: '^', name: 'начинается с...', format: 'FR_{T}={X}%' },
                 { symbol: '=', name: 'равно', format: 'FR_{T}={X}' },
                 { symbol: '≠', name: 'не равно', format: 'FR_{T}=!{X}' },
                 { symbol: '≥', name: 'не меньше', format: 'FR_{T}=>={X}' },

--- a/templates/table-example.html
+++ b/templates/table-example.html
@@ -411,6 +411,7 @@ class IntegramTable {
                 { symbol: '$', name: 'заканчивается', format: 'FR_{T}=%{X}' }
             ],
             'NUMBER': [
+                { symbol: '^', name: 'начинается с...', format: 'FR_{T}={X}%' },
                 { symbol: '=', name: 'равно', format: 'FR_{T}={X}' },
                 { symbol: '≠', name: 'не равно', format: 'FR_{T}=!{X}' },
                 { symbol: '≥', name: 'не меньше', format: 'FR_{T}=>={X}' },


### PR DESCRIPTION
## Описание

Добавлен новый тип фильтра "^" (начинается с...) для полей типа NUMBER и SIGNED в табличном компоненте.

## Что сделано

Добавлена новая опция фильтра в массив `filterTypes['NUMBER']`:
```javascript
{ symbol: '^', name: 'начинается с...', format: 'FR_{T}={X}%' }
```

Этот фильтр позволяет искать числовые значения, которые начинаются с определённой последовательности цифр. При применении генерируется параметр API в формате `FR_{T}={X}%`, где:
- `T` - ID колонки
- `X` - введённое значение

## Изменённые файлы

- assets/js/integram-table.js
- templates/integram-table.html
- templates/table-example.html

## Решаемая проблема

Fixes #48

## Тестирование

✅ Проверена синтаксическая корректность JavaScript
✅ Фильтр добавлен во все файлы с табличным компонентом
✅ Формат API соответствует требованиям: `FR_{T}={X}%`

🤖 Generated with [Claude Code](https://claude.com/claude-code)