### PR TITLE
Оставлен placeholder только в первой колонке фильтра

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -334,7 +334,7 @@ class IntegramTable {
                             </tr>
                             ${ this.filtersEnabled ? `
                             <tr class="filter-row">
-                                ${ orderedColumns.map(col => this.renderFilterCell(col)).join('') }
+                                ${ orderedColumns.map((col, idx) => this.renderFilterCell(col, idx)).join('') }
                             </tr>
                             ` : '' }
                         </thead>
@@ -364,9 +364,10 @@ class IntegramTable {
             this.attachColumnResizeHandlers();
         }
 
-        renderFilterCell(column) {
+        renderFilterCell(column, columnIndex = 0) {
             const format = column.format || 'SHORT';
             const currentFilter = this.filters[column.id] || { type: '^', value: '' };
+            const placeholder = columnIndex === 0 ? 'Фильтр...' : '';
 
             return `
                 <td>
@@ -378,7 +379,7 @@ class IntegramTable {
                                class="filter-input-with-icon"
                                data-column-id="${ column.id }"
                                value="${ currentFilter.value }"
-                               placeholder="Фильтр...">
+                               placeholder="${ placeholder }">
                     </div>
                 </td>
             `;

--- a/templates/integram-table.html
+++ b/templates/integram-table.html
@@ -404,7 +404,7 @@ class IntegramTable {
                         </tr>
                         ${this.filtersEnabled ? `
                         <tr class="filter-row">
-                            ${orderedColumns.map(col => this.renderFilterCell(col)).join('')}
+                            ${orderedColumns.map((col, idx) => this.renderFilterCell(col, idx)).join('')}
                         </tr>
                         ` : ''}
                     </thead>
@@ -427,10 +427,11 @@ class IntegramTable {
         this.attachEventListeners();
     }
 
-    renderFilterCell(column) {
+    renderFilterCell(column, columnIndex = 0) {
         const format = column.format || 'SHORT';
         const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
         const currentFilter = this.filters[column.id] || { type: '^', value: '' };
+        const placeholder = columnIndex === 0 ? 'Фильтр...' : '';
 
         return `
             <td>
@@ -442,7 +443,7 @@ class IntegramTable {
                            class="filter-input"
                            data-column-id="${column.id}"
                            value="${currentFilter.value}"
-                           placeholder="Фильтр...">
+                           placeholder="${placeholder}">
                 </div>
             </td>
         `;

--- a/templates/table-example.html
+++ b/templates/table-example.html
@@ -561,7 +561,7 @@ class IntegramTable {
                         </tr>
                         ${this.filtersEnabled ? `
                         <tr class="filter-row">
-                            ${orderedColumns.map(col => this.renderFilterCell(col)).join('')}
+                            ${orderedColumns.map((col, idx) => this.renderFilterCell(col, idx)).join('')}
                         </tr>
                         ` : ''}
                     </thead>
@@ -584,10 +584,11 @@ class IntegramTable {
         this.attachEventListeners();
     }
 
-    renderFilterCell(column) {
+    renderFilterCell(column, columnIndex = 0) {
         const format = column.format || 'SHORT';
         const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
         const currentFilter = this.filters[column.id] || { type: '^', value: '' };
+        const placeholder = columnIndex === 0 ? 'Фильтр...' : '';
 
         return `
             <td>
@@ -599,7 +600,7 @@ class IntegramTable {
                            class="filter-input"
                            data-column-id="${column.id}"
                            value="${currentFilter.value}"
-                           placeholder="Фильтр...">
+                           placeholder="${placeholder}">
                 </div>
             </td>
         `;


### PR DESCRIPTION
## Описание

Обновлён табличный компонент для отображения placeholder="Фильтр..." только в первой колонке фильтров. В остальных колонках placeholder теперь пустой.

## Что сделано

1. **Добавлен параметр `columnIndex`** в метод `renderFilterCell(column, columnIndex = 0)`
2. **Условный placeholder**: 
   ```javascript
   const placeholder = columnIndex === 0 ? 'Фильтр...' : '';
   ```
3. **Обновлён вызов метода** для передачи индекса колонки:
   ```javascript
   orderedColumns.map((col, idx) => this.renderFilterCell(col, idx))
   ```

## Изменённые файлы

- `assets/js/integram-table.js` - основной JS файл компонента
- `templates/integram-table.html` - HTML шаблон
- `templates/table-example.html` - пример использования

## До и после

**До**: Все фильтры имели placeholder="Фильтр..."
**После**: Только первая колонка имеет placeholder="Фильтр...", остальные - пустые

## Решаемая проблема

Fixes #51

## Тестирование

✅ Проверена синтаксическая корректность JavaScript
✅ Изменения применены во всех трёх файлах компонента
✅ Логика работает корректно с default параметром columnIndex = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)