### PR TITLE
Исправлено использование XSRF токена для POST запросов

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1758,9 +1758,9 @@ class IntegramTable {
             const formData = new FormData(form);
             const params = new URLSearchParams();
 
-            // Add XSRF token if available
-            if (typeof _xsrf !== 'undefined') {
-                params.append('_xsrf', _xsrf);
+            // Add XSRF token (global variable xsrf is initialized on the page)
+            if (typeof xsrf !== 'undefined') {
+                params.append('_xsrf', xsrf);
             }
 
             // Add all form fields


### PR DESCRIPTION
Fixes #72

Исправлено использование XSRF токена для всех POST запросов на сохранение и создание записей.

**Проблема:**
В коде использовалась переменная `_xsrf`, но на странице инициализирована глобальная переменная `xsrf` (без подчеркивания в начале).

**Решение:**
- Заменена проверка `typeof _xsrf !== 'undefined'` на `typeof xsrf !== 'undefined'`
- Используется глобальная переменная `xsrf` вместо `_xsrf`
- XSRF токен передаётся как POST-параметр `_xsrf` (с подчеркиванием в имени параметра)

**Изменения:**
```javascript
// Было:
if (typeof _xsrf !== 'undefined') {
    params.append('_xsrf', _xsrf);
}

// Стало:
if (typeof xsrf !== 'undefined') {
    params.append('_xsrf', xsrf);
}
```

**Применено в методах:**
- `saveRecord()` - сохранение и создание записей

**Тестирование:**
- ✅ JavaScript синтаксис проверен (node --check)
- ✅ Глобальная переменная `xsrf` используется корректно
- ✅ POST-параметр `_xsrf` передаётся во всех запросах на сохранение/создание