### PR TITLE
Add sticky table header and vertical column separators (Issue #95)

### DIFF
--- a/templates/integram-table.html
+++ b/templates/integram-table.html
@@ -43,7 +43,10 @@
             text-align: left;
             font-weight: 600;
             border-bottom: 2px solid #dee2e6;
-            position: relative;
+            border-right: 1px solid #e9ecef;
+            position: sticky;
+            top: 0;
+            z-index: 10;
             cursor: move;
             user-select: none;
         }
@@ -60,6 +63,7 @@
         .integram-table td {
             padding: 10px 12px;
             border-bottom: 1px solid #dee2e6;
+            border-right: 1px solid #e9ecef;
         }
 
         .integram-table tr:hover {
@@ -91,6 +95,10 @@
         .filter-row td {
             padding: 5px;
             background: #f8f9fa;
+            border-right: 1px solid #e9ecef;
+            position: sticky;
+            top: 41px;
+            z-index: 9;
         }
 
         .filter-cell {


### PR DESCRIPTION
## Summary
Implemented sticky table header and light vertical column separators for improved table usability and readability.

## Changes
✅ **Sticky Header:** Table header now stays visible when scrolling vertically
✅ **Sticky Filter Row:** Filter row also stays visible below the header when scrolling
✅ **Vertical Separators:** Added light vertical borders between columns for better visual separation

## Technical Details
- Added `position: sticky; top: 0; z-index: 10` to table headers
- Added `position: sticky; top: 41px; z-index: 9` to filter row cells  
- Added `border-right: 1px solid #e9ecef` to all table cells (th and td)

## Benefits
- Better UX when scrolling through large tables - headers remain visible
- Improved readability with clear column separation
- Filter controls stay accessible while scrolling

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)