### PR TITLE
Add sticky header and vertical separators to assets table component (Issue #97)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -120,7 +120,10 @@
     color: var(--md-text-secondary);
     border-bottom: 1px solid var(--md-divider);
     border-left: none;
-    position: relative;
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+    position: sticky;
+    top: 0;
+    z-index: 10;
     cursor: move;
     user-select: none;
 }
@@ -178,6 +181,7 @@
     padding: 16px;
     border-bottom: 1px solid var(--md-divider);
     border-left: none;
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
     color: var(--md-text-primary);
     font-size: 14px;
     letter-spacing: 0.25px;
@@ -230,6 +234,10 @@
     padding: 8px 16px !important;
     background: var(--md-background);
     border-bottom: 1px solid var(--md-divider);
+    border-right: 1px solid rgba(0, 0, 0, 0.06);
+    position: sticky;
+    top: 44px;
+    z-index: 9;
 }
 
 .filter-row td:first-child {

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -326,8 +326,8 @@ class IntegramTable {
                             ${ this.hasActiveFilters() ? `
                             <button class="btn btn-sm btn-outline-secondary mr-2" onclick="window.${ instanceName }.clearAllFilters()" title="Очистить фильтры">
                                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" style="vertical-align: middle;">
-                                    <path d="M3 3L7 7M7 7L3 11M7 7L11 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-                                    <path d="M14 7C14 7 14 7 14 7L14 13M14 13L12 11M14 13L16 11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                                    <polygon fill="var(--ci-primary-color, currentColor)" points="2,1 6,1 10,6 10,12 6,10 6,6"/>
+                                    <polygon fill="var(--ci-primary-color, currentColor)" points="10,10 11,9 13,11 15,9 16,10 14,12 16,14 15,15 13,13 11,15 10,14 12,12"/>
                                 </svg>
                             </button>
                             ` : '' }


### PR DESCRIPTION
## Summary
Implemented sticky table header and light vertical column separators for the `assets/js/integram-table.js` component.

## Changes

### CSS (assets/css/integram-table.css)
✅ **Sticky Header:** Table header now stays visible when scrolling vertically
- Added `position: sticky; top: 0; z-index: 10` to `.integram-table th`

✅ **Sticky Filter Row:** Filter row stays visible below the header when scrolling
- Added `position: sticky; top: 44px; z-index: 9` to `.filter-row td`

✅ **Vertical Separators:** Added light vertical borders between columns
- Added `border-right: 1px solid rgba(0, 0, 0, 0.06)` to both `th` and `td` elements

### JavaScript (assets/js/integram-table.js)
✅ **Clear Filters Icon:** Updated to funnel + X mark design
- Matches the consistent design from issue #87

## Benefits
- Better UX when scrolling through large tables - headers remain visible
- Filter controls stay accessible while scrolling
- Improved readability with clear column separation
- Consistent clear filters button across all table components

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)