### PR TITLE
Apply Empty/Not Empty filters immediately and clear input text (Issue #105)

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -834,7 +834,24 @@ class IntegramTable {
                     target.textContent = symbol;
                     menu.remove();
 
-                    if (this.filters[columnId].value) {
+                    // For Empty (%) and Not Empty (!%) filters, clear input and apply immediately
+                    if (symbol === '%' || symbol === '!%') {
+                        this.filters[columnId].value = '';
+
+                        // Clear the input field
+                        const filterInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${columnId}"]`);
+                        if (filterInput) {
+                            filterInput.value = '';
+                        }
+
+                        // Reset data and load from beginning
+                        this.data = [];
+                        this.loadedRecords = 0;
+                        this.hasMore = true;
+                        this.totalRows = null;
+                        this.loadData(false);
+                    } else if (this.filters[columnId].value) {
+                        // For other filter types, only reload if there's a value
                         // Reset data and load from beginning
                         this.data = [];
                         this.loadedRecords = 0;


### PR DESCRIPTION
## Summary
Improved the filter UX by automatically applying "Empty" and "Not Empty" filters immediately when selected, and clearing any entered text.

## Problem
When users selected "Empty" (%) or "Not Empty" (!%) filter types:
- They had to manually clear any text in the filter input
- The filter wouldn't apply until they manually triggered it
- This created extra steps and confusion

## Solution
Modified the filter type selection handler in `assets/js/integram-table.js` to:
- Detect when "Empty" (%) or "Not Empty" (!%) is selected
- Automatically clear the filter input text
- Immediately apply the filter and reload data

## Changes

**File:** `assets/js/integram-table.js` (lines 827-845)

**Logic:**
```javascript
// For Empty (%) and Not Empty (!%) filters, clear input and apply immediately
if (symbol === '%' || symbol === '!%') {
    this.filters[columnId].value = '';
    
    // Clear the input field
    const filterInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${columnId}"]`);
    if (filterInput) {
        filterInput.value = '';
    }
    
    // Reset data and load from beginning
    this.data = [];
    this.loadedRecords = 0;
    this.hasMore = true;
    this.totalRows = null;
    this.loadData(false);
}
```

## Benefits
✅ **Automatic Text Clearing**: No need to manually clear text when selecting Empty/Not Empty  
✅ **Immediate Application**: Filter applies instantly without additional action  
✅ **Better UX**: More intuitive and faster workflow  
✅ **Consistent Behavior**: Empty/Not Empty filters work like toggle switches  

## Testing
- Select "Empty" or "Not Empty" filter type → Input clears and filter applies
- Enter text, then select "Empty" → Text clears and filter applies
- Other filter types maintain existing behavior (require value to apply)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)