### PR TITLE
Fix #107: Empty/Not Empty filter parameters now transmitted correctly

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -117,7 +117,7 @@ class IntegramTable {
 
             Object.keys(this.filters).forEach(colId => {
                 const filter = this.filters[colId];
-                if (filter.value) {
+                if (filter.value || filter.type === '%' || filter.type === '!%') {
                     const column = this.columns.find(c => c.id === colId);
                     if (column) {
                         this.applyFilter(params, column, filter);
@@ -206,7 +206,7 @@ class IntegramTable {
 
             Object.keys(this.filters).forEach(colId => {
                 const filter = this.filters[colId];
-                if (filter.value) {
+                if (filter.value || filter.type === '%' || filter.type === '!%') {
                     const column = this.columns.find(c => c.id === colId);
                     if (column) {
                         this.applyFilter(params, column, filter);


### PR DESCRIPTION
## Problem
Empty (%) and Not Empty (!%) filters were not sending parameters to the API because the condition `if (filter.value)` prevented filters with empty values from being applied.

## Solution
Changed the condition in both `loadData()` and `fetchTotalCount()` functions from:
```javascript
if (filter.value) {
```

to:
```javascript
if (filter.value || filter.type === '%' || filter.type === '!%') {
```

## Technical Details
- The `applyFilter()` function already handles these filter types correctly (lines 245-246)
- The issue was that `applyFilter()` wasn't being called due to the `filter.value` check
- Now Empty (%) filters properly transmit `FR_{T}=%` parameters
- Now Not Empty (!%) filters properly transmit `FR_{T}=!%` parameters

## Changes
- Modified `assets/js/integram-table.js` at lines 120 and 209

## Testing
- Empty filter (%) now sends `FR_{columnId}=%` parameter
- Not Empty filter (!%) now sends `FR_{columnId}=!%` parameter
- Other filter types continue to work as before

Fixes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)