### PR TITLE
Fix #109: Properly escape JavaScript special characters in showFullValue onclick

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -540,7 +540,12 @@ class IntegramTable {
             // Truncate long values if setting is enabled
             if (this.settings.truncateLongValues && escapedValue.length > 127) {
                 const truncated = escapedValue.substring(0, 127);
-                const fullValueEscaped = escapedValue.replace(/'/g, '\\\'');
+                // Properly escape all JavaScript special characters for use in onclick string literal
+                const fullValueEscaped = escapedValue
+                    .replace(/\\/g, '\\\\')   // Escape backslashes first
+                    .replace(/\n/g, '\\n')    // Escape newlines
+                    .replace(/\r/g, '\\r')    // Escape carriage returns
+                    .replace(/'/g, '\\\'');   // Escape single quotes
                 const instanceName = this.options.instanceName;
                 escapedValue = `${ truncated }<a href="#" class="show-full-value" onclick="window.${ instanceName }.showFullValue(event, '${ fullValueEscaped }'); return false;">...</a>`;
             }


### PR DESCRIPTION
## Problem
The `showFullValue` onclick handler was causing JavaScript syntax errors when cell values contained newlines or other special characters:
```
Uncaught SyntaxError: Invalid or unexpected token (at crm:1:40)
```

This happened because the previous escaping (line 543) only handled single quotes, but didn't escape newlines, backslashes, or carriage returns.

### Example that caused the error:
```javascript
onclick="window.tasksTable.showFullValue(event, 'Менеджер
0. Основное РМ - Задачи
1. Выставленные и неоплаченные счета
...');"
```
The literal newline in the string caused a syntax error.

## Solution
Enhanced the JavaScript string escaping to properly handle all special characters:

```javascript
const fullValueEscaped = escapedValue
    .replace(/\\/g, '\\\\')   // Escape backslashes first
    .replace(/\n/g, '\\n')    // Escape newlines
    .replace(/\r/g, '\\r')    // Escape carriage returns
    .replace(/'/g, '\\\'');   // Escape single quotes
```

### Why this works:
1. **Backslashes** are escaped first to avoid double-escaping
2. **Newlines** (`\n`) are converted to the literal string `\\n` in the onclick attribute
3. When JavaScript parses the onclick, it interprets `\\n` as a newline character
4. The function receives the properly decoded value with actual newlines

### Example after fix:
```javascript
onclick="window.tasksTable.showFullValue(event, 'Менеджер\\n0. Основное РМ - Задачи\\n1. Выставленные и неоплаченные счета\\n...');"
```
✅ Valid JavaScript syntax!

## Security
No security issues introduced:
- Values are still HTML-escaped first (lines 534-538) for XSS protection
- JavaScript escaping is only for syntax correctness
- The modal displays values in a `<pre>` tag with HTML entities intact

## Testing
Verified that values with:
- ✅ Newlines
- ✅ Single quotes
- ✅ Backslashes
- ✅ Mixed special characters

All work correctly without syntax errors.

Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)