### PR TITLE
Fix #111: Reset settings button now deletes state cookie and resets column state

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1083,6 +1083,9 @@ class IntegramTable {
             // Delete settings cookie
             document.cookie = `${ this.options.cookiePrefix }-settings=; path=/; max-age=0`;
 
+            // Delete state cookie (column order, visibility, widths)
+            document.cookie = `${ this.options.cookiePrefix }-state=; path=/; max-age=0`;
+
             // Reset to defaults
             this.settings = {
                 compact: false,
@@ -1090,6 +1093,11 @@ class IntegramTable {
                 truncateLongValues: true
             };
             this.options.pageSize = 20;
+
+            // Reset column state
+            this.columnOrder = [];
+            this.visibleColumns = [];
+            this.columnWidths = {};
 
             // Close modal and reload
             this.closeTableSettings();


### PR DESCRIPTION
## Problem
The **"Сбросить настройки"** (Reset settings) button wasn't fully working:
- ✅ It deleted the settings cookie (compact mode, page size, truncate)
- ❌ It **did NOT** delete the state cookie (`tasks-table-state`)
- ❌ Column customizations (order, visibility, widths) persisted after reset

### What the state cookie stores:
```javascript
{
  order: this.columnOrder,      // Column ordering
  visible: this.visibleColumns, // Which columns are visible
  widths: this.columnWidths     // Custom column widths
}
```

### User experience before fix:
1. User customizes columns (reorder, hide, resize)
2. User clicks "Сбросить настройки"
3. Page reloads but columns stay customized ❌
4. User confused why reset didn't work

## Solution
Enhanced the `resetSettings()` function to:

### 1. Delete BOTH cookies:
```javascript
// Settings cookie (was already deleted)
document.cookie = `${this.options.cookiePrefix}-settings=; path=/; max-age=0`;

// State cookie (NOW ALSO DELETED) ✨
document.cookie = `${this.options.cookiePrefix}-state=; path=/; max-age=0`;
```

### 2. Reset column state properties:
```javascript
this.columnOrder = [];
this.visibleColumns = [];
this.columnWidths = {};
```

## Technical Details
- State cookie saved by `saveColumnState()` at line 1151
- State cookie loaded by `loadColumnState()` at line 1154
- Without deleting state cookie, old state was restored on reload
- Modified `resetSettings()` at line 1082

## Testing
After fix, clicking "Сбросить настройки":
- ✅ Resets page size, compact mode, truncate setting
- ✅ Resets column order to default
- ✅ Resets column visibility to default
- ✅ Resets column widths to default
- ✅ **Complete table reset to factory defaults!**

## Changes
- Modified `assets/js/integram-table.js` at line 1082 (resetSettings function)
- Added state cookie deletion
- Added column state property reset

Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)