### PR TITLE
Fix #117: Ensure style columns remain hidden when loaded from cookie state

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -180,6 +180,9 @@ class IntegramTable {
                 }
                 if (this.visibleColumns.length === 0) {
                     this.visibleColumns = this.columns.filter(c => !this.idColumns.has(c.id)).map(c => c.id);
+                } else {
+                    // Filter out style columns from visibleColumns if loaded from cookie
+                    this.visibleColumns = this.visibleColumns.filter(id => !this.idColumns.has(id));
                 }
 
                 if (this.options.onDataLoad) {


### PR DESCRIPTION
## Problem
Columns with **"Style"** or **"Стиль"** suffix are meant to contain CSS styles that get applied to their corresponding base columns. These style columns should be automatically hidden.

The feature was already implemented but had a **cookie persistence bug**:
- ✅ Style columns were detected and hidden on first page load
- ❌ After saving column state and reloading, style columns could reappear
- ❌ Style columns loaded from cookies weren't being filtered out

### Root Cause

**Execution order issue:**
1. `constructor()` runs
2. `loadColumnState()` runs (line 98) → loads `visibleColumns` from cookie
3. Later: `loadData()` runs
4. `processColumnVisibility()` runs (line 176) → populates `idColumns` with style columns
5. Line 181-182 checks: `if (this.visibleColumns.length === 0)`
   - **Condition is false** because visibleColumns was loaded from cookie
   - **Filtering is skipped** ❌
6. Result: Style columns remain in `visibleColumns` and appear on screen

## Solution

Added `else` clause to filter style columns even when `visibleColumns` is loaded from cookie:

```javascript
if (this.visibleColumns.length === 0) {
    this.visibleColumns = this.columns.filter(c => !this.idColumns.has(c.id)).map(c => c.id);
} else {
    // Filter out style columns from visibleColumns if loaded from cookie
    this.visibleColumns = this.visibleColumns.filter(id => !this.idColumns.has(id));
}
```

### Why this works:
- ✅ First load: Empty `visibleColumns` gets filtered list
- ✅ Reload with cookie: Existing `visibleColumns` gets filtered to remove style columns
- ✅ Style columns can never appear visible
- ✅ Preserves user's column customizations (order, widths, visibility of other columns)

## How the Style Column Feature Works

### 1. Column Detection (lines 279-298)

Detects columns ending with "Style" or "Стиль" (case-insensitive):

```javascript
// Example columns:
// "Amount" + "AmountStyle"
// "Название" + "НазваниеСтиль"

if (lowerName.endsWith('стиль') || lowerName.endsWith('style')) {
    let baseName = name.slice(0, -5);  // Remove suffix
    const baseCol = this.columns.find(c =>
        c.name.toLowerCase() === baseName.toLowerCase()
    );
    
    if (baseCol) {
        this.styleColumns[baseCol.id] = col.id;  // Map base → style
        this.idColumns.add(col.id);              // Mark for hiding
    }
}
```

### 2. Style Application (lines 471-480)

When rendering cells, applies styles from style column:

```javascript
if (this.styleColumns[column.id]) {
    const styleColId = this.styleColumns[column.id];
    const styleColIndex = this.columns.findIndex(c => c.id === styleColId);
    if (styleColIndex !== -1 && this.data[rowIndex]) {
        const styleValue = this.data[rowIndex][styleColIndex];
        if (styleValue) {
            customStyle = ` style="${styleValue}"`;
        }
    }
}
```

### 3. Column Hiding

- Style columns added to `idColumns` (line 296)
- Now properly filtered from `visibleColumns` **in all cases** (new fix)

## Example Usage

**Database columns:**
```
Amount      | AmountStyle
------------|----------------------
10000       | color: green
-5000       | color: red; font-weight: bold
0           | color: gray
```

**Result:**
- ✅ "AmountStyle" column is hidden
- ✅ "Amount" cells display: 10000 with green color
- ✅ "Amount" cells display: -5000 with red color and bold
- ✅ "Amount" cells display: 0 with gray color
- ✅ Works correctly even after page reload with saved state

## Technical Details

### Suffix Handling
- **"Style"**: 5 characters (s-t-y-l-e)
- **"Стиль"**: 5 characters (с-т-и-л-ь)
- Both use `slice(0, -5)` correctly

### Case Insensitivity
- Detection: `lowerName.endsWith('style')` or `lowerName.endsWith('стиль')`
- Matching: `c.name.toLowerCase() === baseName.toLowerCase()`
- Works with: "Style", "STYLE", "style", "Стиль", "СТИЛЬ", "стиль"

### Integration
- ✅ Compatible with ID column hiding (same mechanism)
- ✅ Compatible with column state persistence (cookies)
- ✅ Compatible with column reordering
- ✅ Compatible with manual column visibility toggling
- ✅ Doesn't break existing functionality

## Testing

**Before fix:**
1. Load page → Style columns hidden ✅
2. Manually show style column in settings
3. Save state (cookie)
4. Reload page → Style column visible ❌

**After fix:**
1. Load page → Style columns hidden ✅
2. Manually show style column in settings
3. Save state (cookie)
4. Reload page → Style column hidden again ✅

## Changes
- Modified `assets/js/integram-table.js` at lines 183-185
- Added else clause to filter style columns from loaded cookie state

Fixes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)