### PR TITLE
fix(kanban): show empty text instead of undefined in client edit form

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1777,8 +1777,9 @@ function renderClientEditForm(data){
         html += '<label class="kanban-edit-form-label">Статус</label>';
         html += '<select class="kanban-edit-form-select" id="editClientStatus" name="t4874">';
         html += '<option value="">Выберите статус</option>';
+        var statusValue = getReqValue(reqs, '4874');
         statusesData.forEach(function(status){
-            var selected = reqs['4874'].value == status['СтатусID'] ? 'selected' : '';
+            var selected = statusValue == status['СтатусID'] ? 'selected' : '';
             html += '<option value="' + status['СтатусID'] + '" ' + selected + '>' + status['Статус'] + '</option>';
         });
         html += '</select>';
@@ -1789,7 +1790,7 @@ function renderClientEditForm(data){
     if(reqs['637'] !== undefined){
         html += '<div class="kanban-edit-form-group">';
         html += '<label class="kanban-edit-form-label">ИНН</label>';
-        html += '<input type="text" class="kanban-edit-form-input" id="editClientInn" name="t637" value="' + escapeHtml(reqs['637'] ? reqs['637'].value || '' : '') + '">';
+        html += '<input type="text" class="kanban-edit-form-input" id="editClientInn" name="t637" value="' + escapeHtml(getReqValue(reqs, '637')) + '">';
         html += '</div>';
     }
 
@@ -1799,8 +1800,9 @@ function renderClientEditForm(data){
         html += '<label class="kanban-edit-form-label">Партнер</label>';
         html += '<select class="kanban-edit-form-select" id="editClientPartner" name="t443">';
         html += '<option value="">Выберите партнера</option>';
+        var partnerValue = getReqValue(reqs, '443');
         partnersData.forEach(function(partner){
-            var selected = reqs['443'] && reqs['443'].value == partner['ПартнерID'] ? 'selected' : '';
+            var selected = partnerValue == partner['ПартнерID'] ? 'selected' : '';
             html += '<option value="' + partner['ПартнерID'] + '" ' + selected + '>' + partner['Партнер'] + '</option>';
         });
         html += '</select>';
@@ -1813,8 +1815,9 @@ function renderClientEditForm(data){
         html += '<label class="kanban-edit-form-label">Дистрибьютор</label>';
         html += '<select class="kanban-edit-form-select" id="editClientDistributor" name="t4862">';
         html += '<option value="">Выберите дистрибьютора</option>';
+        var distributorValue = getReqValue(reqs, '4862');
         distributorsData.forEach(function(distributor){
-            var selected = reqs['4862'] && reqs['4862'].value == distributor['ДистрибьюторID'] ? 'selected' : '';
+            var selected = distributorValue == distributor['ДистрибьюторID'] ? 'selected' : '';
             html += '<option value="' + distributor['ДистрибьюторID'] + '" ' + selected + '>' + distributor['Дистрибьютор'] + '</option>';
         });
         html += '</select>';
@@ -1825,7 +1828,7 @@ function renderClientEditForm(data){
     if(reqs['4536'] !== undefined){
         html += '<div class="kanban-edit-form-group">';
         html += '<label class="kanban-edit-form-label">Телефон</label>';
-        html += '<input type="text" class="kanban-edit-form-input" id="editClientPhone" name="t4536" value="' + escapeHtml(reqs['4536'] ? reqs['4536'].value || '' : '') + '">';
+        html += '<input type="text" class="kanban-edit-form-input" id="editClientPhone" name="t4536" value="' + escapeHtml(getReqValue(reqs, '4536')) + '">';
         html += '</div>';
     }
 
@@ -1833,7 +1836,7 @@ function renderClientEditForm(data){
     if(reqs['4537'] !== undefined){
         html += '<div class="kanban-edit-form-group">';
         html += '<label class="kanban-edit-form-label">Email</label>';
-        html += '<input type="email" class="kanban-edit-form-input" id="editClientEmail" name="t4537" value="' + escapeHtml(reqs['4537'] ? reqs['4537'].value || '' : '') + '">';
+        html += '<input type="email" class="kanban-edit-form-input" id="editClientEmail" name="t4537" value="' + escapeHtml(getReqValue(reqs, '4537')) + '">';
         html += '</div>';
     }
 
@@ -1841,7 +1844,7 @@ function renderClientEditForm(data){
     if(reqs['4538'] !== undefined){
         html += '<div class="kanban-edit-form-group">';
         html += '<label class="kanban-edit-form-label">Контактное лицо</label>';
-        html += '<input type="text" class="kanban-edit-form-input" id="editClientContact" name="t4538" value="' + escapeHtml(reqs['4538'] ? reqs['4538'].value || '' : '') + '">';
+        html += '<input type="text" class="kanban-edit-form-input" id="editClientContact" name="t4538" value="' + escapeHtml(getReqValue(reqs, '4538')) + '">';
         html += '</div>';
     }
 
@@ -1851,8 +1854,9 @@ function renderClientEditForm(data){
         html += '<label class="kanban-edit-form-label">Источник</label>';
         html += '<select class="kanban-edit-form-select" id="editClientSource" name="t4861">';
         html += '<option value="">Выберите источник</option>';
+        var sourceValue = getReqValue(reqs, '4861');
         sourcesData.forEach(function(source){
-            var selected = reqs['4861'] && reqs['4861'].value == source['ИсточникID'] ? 'selected' : '';
+            var selected = sourceValue == source['ИсточникID'] ? 'selected' : '';
             html += '<option value="' + source['ИсточникID'] + '" ' + selected + '>' + source['Источник'] + '</option>';
         });
         html += '</select>';
@@ -1863,7 +1867,7 @@ function renderClientEditForm(data){
     if(reqs['4864'] !== undefined){
         html += '<div class="kanban-edit-form-group">';
         html += '<label class="kanban-edit-form-label">Сумма</label>';
-        html += '<input type="number" class="kanban-edit-form-input" id="editClientAmount" name="t4864" value="' + escapeHtml(reqs['4864'] ? reqs['4864'].value || '' : '') + '">';
+        html += '<input type="number" class="kanban-edit-form-input" id="editClientAmount" name="t4864" value="' + escapeHtml(getReqValue(reqs, '4864')) + '">';
         html += '</div>';
     }
 
@@ -1871,7 +1875,7 @@ function renderClientEditForm(data){
     if(reqs['4539'] !== undefined){
         html += '<div class="kanban-edit-form-group">';
         html += '<label class="kanban-edit-form-label">Примечание</label>';
-        html += '<textarea class="kanban-edit-form-textarea" id="editClientNote" name="t4539">' + escapeHtml(reqs['4539'] ? reqs['4539'].value || '' : '') + '</textarea>';
+        html += '<textarea class="kanban-edit-form-textarea" id="editClientNote" name="t4539">' + escapeHtml(getReqValue(reqs, '4539')) + '</textarea>';
         html += '</div>';
     }
 
@@ -2074,12 +2078,20 @@ function updateTaskCount(leadId){
 
 // Helper function to escape HTML
 function escapeHtml(text){
-    if(text === null || text === undefined) return '';
+    if(text === null || text === undefined || text === 'undefined' || text === 'null') return '';
     return String(text).replace(/&/g, '&amp;')
                        .replace(/</g, '&lt;')
                        .replace(/>/g, '&gt;')
                        .replace(/"/g, '&quot;')
                        .replace(/'/g, '&#039;');
+}
+
+// Helper function to safely get requisite value
+function getReqValue(reqs, key){
+    if(!reqs || !reqs[key]) return '';
+    var value = reqs[key].value;
+    if(value === null || value === undefined || value === 'undefined' || value === 'null') return '';
+    return value;
 }
 
 // Close modals when clicking outside


### PR DESCRIPTION
## Summary
- Fix empty fields showing "undefined" text in client edit form
- Add `getReqValue()` helper function to safely extract requisite values
- Update `escapeHtml()` to also treat literal strings 'undefined' and 'null' as empty

## Changes
1. **New helper function** `getReqValue(reqs, key)`:
   - Safely extracts value from requisites object
   - Returns empty string for null, undefined, 'undefined', or 'null' values

2. **Updated escapeHtml()**: 
   - Now also checks for literal strings 'undefined' and 'null'

3. **Updated all field value access**:
   - Status, Partner, Distributor, Source (select fields)
   - INN, Phone, Email, Contact person, Amount, Note (input/textarea fields)

## Test plan
- [ ] Open client edit form for a client with some empty fields
- [ ] Verify empty fields show blank instead of "undefined"
- [ ] Edit and save a client - verify data saves correctly
- [ ] Verify populated fields still display correctly

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)