### PR TITLE
fix(kanban): show warning and stay in edit mode when creating client

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1726,6 +1726,14 @@ function submitAddRecord(){
             try{
                 var response = JSON.parse(xhr.responseText);
                 console.log('Record created:', response);
+
+                // Check for warning in response - show it and stay in edit mode
+                if(response.warning && response.warning !== ''){
+                    alert('Предупреждение: ' + response.warning);
+                    // Don't close modal, stay in edit mode
+                    return;
+                }
+
                 closeAddRecordModal();
                 // Reload kanban to show new record
                 loadKanbanData();


### PR DESCRIPTION
## Summary
When creating a client, if the API response contains a non-empty `warning` key, display the warning and keep the form open instead of closing it.

## Changes
- Check for `response.warning` in the success handler
- If warning exists and is not empty, show alert and return early
- Form stays open in edit mode for user to make corrections

## Test plan
- [ ] Create a client that triggers a warning response
- [ ] Verify warning is displayed
- [ ] Verify form stays open after warning
- [ ] Verify normal creation (without warning) still closes form

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)