### PR TITLE
feat: add subordinate tables as tabs in edit form (#133)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -1152,3 +1152,135 @@
 .form-field-settings-footer .btn-secondary:active {
     background-color: var(--md-selected);
 }
+
+/* ========================================
+   Edit Form Tabs (Subordinate Tables)
+   ======================================== */
+
+.edit-form-tabs {
+    display: flex;
+    border-bottom: 1px solid var(--md-divider);
+    background-color: var(--md-surface);
+    padding: 0 16px;
+    overflow-x: auto;
+    flex-shrink: 0;
+}
+
+.edit-form-tab {
+    padding: 12px 24px;
+    cursor: pointer;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--md-text-secondary);
+    border-bottom: 2px solid transparent;
+    transition: var(--md-transition);
+    white-space: nowrap;
+    user-select: none;
+}
+
+.edit-form-tab:hover {
+    color: var(--md-primary);
+    background-color: var(--md-hover);
+}
+
+.edit-form-tab.active {
+    color: var(--md-primary);
+    border-bottom-color: var(--md-primary);
+}
+
+.edit-form-tab-content {
+    display: none;
+}
+
+.edit-form-tab-content.active {
+    display: block;
+}
+
+/* ========================================
+   Subordinate Table Styles
+   ======================================== */
+
+.subordinate-table-loading,
+.subordinate-table-error,
+.subordinate-table-empty {
+    padding: 40px 20px;
+    text-align: center;
+    color: var(--md-text-secondary);
+    font-size: 14px;
+}
+
+.subordinate-table-error {
+    color: #d32f2f;
+    background-color: #ffebee;
+    border-radius: 4px;
+    margin: 16px;
+}
+
+.subordinate-table-toolbar {
+    padding: 12px 0;
+    display: flex;
+    justify-content: flex-start;
+    gap: 8px;
+}
+
+.subordinate-add-btn {
+    font-size: 13px;
+    padding: 6px 16px;
+}
+
+.subordinate-table-wrapper {
+    overflow-x: auto;
+    margin-top: 8px;
+}
+
+.subordinate-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.subordinate-table th {
+    padding: 10px 12px;
+    text-align: left;
+    font-weight: 500;
+    color: var(--md-text-secondary);
+    background-color: var(--md-background);
+    border-bottom: 2px solid var(--md-divider);
+    white-space: nowrap;
+}
+
+.subordinate-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--md-divider);
+    color: var(--md-text-primary);
+    vertical-align: top;
+}
+
+.subordinate-table tbody tr:hover {
+    background-color: var(--md-hover);
+}
+
+.subordinate-cell-clickable {
+    cursor: pointer;
+    color: var(--md-primary);
+    font-weight: 500;
+}
+
+.subordinate-cell-clickable:hover {
+    text-decoration: underline;
+}
+
+.subordinate-nested-count {
+    color: var(--md-text-hint);
+    font-style: italic;
+}
+
+/* Subordinate form modal (stacked on top of main modal) */
+.subordinate-form-overlay {
+    z-index: 1100;
+}
+
+.subordinate-form-modal {
+    z-index: 1101;
+    max-width: 500px;
+}


### PR DESCRIPTION
## Summary
- Added tab system to edit form modal
- First tab "Атрибуты" shows regular fields (existing behavior)
- Subordinate tables (fields with `arr_id`) displayed as separate tabs with record count
- Lazy loading of subordinate table data when tab is clicked
- Subordinate table renders with proper field type formatting
- Reference values (format "id:label") display only the label
- Nested subordinate tables show only "(N)" count
- Click on first column opens edit form for that record
- "Добавить" button creates new records with parent ID

Fixes #133

## API endpoints used
- `GET /metadata/{typeId}` - fetch subordinate table structure
- `GET object/{typeId}/?JSON_DATA&F_U={parentId}` - fetch subordinate data
- `POST /_m_new/{typeId}?JSON&up={parentId}` - create new record

## Test plan
- [ ] Open edit form for a record that has subordinate tables
- [ ] Verify tabs appear with correct names and counts
- [ ] Click on subordinate table tab - verify data loads
- [ ] Click on first column of a row - verify edit form opens
- [ ] Click "Добавить" button - verify create form opens
- [ ] Create new record - verify it appears in the table
- [ ] Verify nested subordinate tables show "(N)" format

🤖 Generated with [Claude Code](https://claude.com/claude-code)