### PR TITLE
fix: ensure modal windows stack properly on top of each other (#135)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -596,6 +596,7 @@
 }
 
 /* Edit Form Modal */
+/* z-index is set dynamically in JavaScript for proper stacking of nested modals */
 .edit-form-overlay {
     position: fixed;
     top: 0;
@@ -603,7 +604,6 @@
     right: 0;
     bottom: 0;
     background: rgba(0, 0, 0, 0.32);
-    z-index: 1999;
     backdrop-filter: blur(2px);
 }
 
@@ -615,7 +615,6 @@
     background: var(--md-surface);
     border-radius: 4px;
     box-shadow: var(--md-elevation-4);
-    z-index: 2000;
     width: 90%;
     max-width: 600px;
     max-height: 85vh;
@@ -1276,11 +1275,7 @@
 }
 
 /* Subordinate form modal (stacked on top of main modal) */
-.subordinate-form-overlay {
-    z-index: 1100;
-}
-
+/* z-index is set dynamically in JavaScript for proper stacking */
 .subordinate-form-modal {
-    z-index: 1101;
     max-width: 500px;
 }


### PR DESCRIPTION
## Summary
- Added dynamic z-index management using `window._integramModalDepth` counter
- Each new modal gets z-index = 1000 + (depth * 10)
- Overlays and modals properly increment/decrement depth counter on open/close
- Removed hardcoded z-index from CSS (now fully controlled by JavaScript)
- Fixed close button handlers to use proper element references instead of querySelector
- Supports unlimited nesting depth for cyclic references and recursion

Fixes #135

## Technical details
- Base z-index: 1000
- Each modal level adds 10 to the z-index
- Modal uses z-index + 1 relative to its overlay
- Depth counter decrements when modal is closed
- Works with both main edit form and subordinate create form

## Test plan
- [ ] Open edit form for a record with subordinate tables
- [ ] Click on a row in subordinate table to open another edit form
- [ ] Verify new modal appears on top of the previous one
- [ ] Close inner modal - verify outer modal is still accessible
- [ ] Test multiple levels of nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)