### PR TITLE
feat: expand modal to 93% when viewing subordinate tables (#143)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -621,6 +621,13 @@
     display: flex;
     flex-direction: column;
     font-family: 'Roboto', sans-serif;
+    transition: max-width 0.3s ease, max-height 0.3s ease;
+}
+
+/* Expanded modal for subordinate tables */
+.edit-form-modal.expanded {
+    max-width: 93%;
+    max-height: 93vh;
 }
 
 .edit-form-header {

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1709,8 +1709,12 @@ class IntegramTable {
                     const footer = modal.querySelector('.edit-form-footer');
                     if (tabId === 'attributes') {
                         footer.style.display = 'flex';
+                        // Collapse modal back to normal size
+                        modal.classList.remove('expanded');
                     } else {
                         footer.style.display = 'none';
+                        // Expand modal to fit subordinate table
+                        modal.classList.add('expanded');
                     }
                 });
             });


### PR DESCRIPTION
## Summary
- Modal automatically expands to 93% of screen when viewing subordinate table tabs
- Returns to normal size (600px max-width) when switching back to Атрибуты tab
- Smooth CSS transition animation for size change

Fixes #143

## CSS changes
- Added `.edit-form-modal.expanded` class with `max-width: 93%` and `max-height: 93vh`
- Added transition for smooth resizing

## JavaScript changes
- Add `expanded` class when switching to subordinate table tab
- Remove `expanded` class when returning to attributes tab

## Test plan
- [ ] Open record with subordinate tables
- [ ] Click on subordinate table tab - modal should expand
- [ ] Click on Атрибуты tab - modal should shrink back
- [ ] Verify transition is smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)