### PR TITLE
Fix undefined values in client edit form dropdowns

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1834,7 +1834,7 @@ function renderClientEditForm(data){
         var statusValue = getReqValue(reqs, '4874');
         statusesData.forEach(function(status){
             var selected = statusValue == status['СтатусID'] ? 'selected' : '';
-            html += '<option value="' + status['СтатусID'] + '" ' + selected + '>' + status['Статус'] + '</option>';
+            html += '<option value="' + escapeHtml(status['СтатусID'] || '') + '" ' + selected + '>' + escapeHtml(status['Статус'] || '') + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -1857,7 +1857,7 @@ function renderClientEditForm(data){
         var partnerValue = getReqValue(reqs, '443');
         partnersData.forEach(function(partner){
             var selected = partnerValue == partner['ПартнерID'] ? 'selected' : '';
-            html += '<option value="' + partner['ПартнерID'] + '" ' + selected + '>' + partner['Партнер'] + '</option>';
+            html += '<option value="' + escapeHtml(partner['ПартнерID'] || '') + '" ' + selected + '>' + escapeHtml(partner['Партнер'] || '') + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -1872,7 +1872,7 @@ function renderClientEditForm(data){
         var distributorValue = getReqValue(reqs, '4862');
         distributorsData.forEach(function(distributor){
             var selected = distributorValue == distributor['ДистрибьюторID'] ? 'selected' : '';
-            html += '<option value="' + distributor['ДистрибьюторID'] + '" ' + selected + '>' + distributor['Дистрибьютор'] + '</option>';
+            html += '<option value="' + escapeHtml(distributor['ДистрибьюторID'] || '') + '" ' + selected + '>' + escapeHtml(distributor['Дистрибьютор'] || '') + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -1911,7 +1911,7 @@ function renderClientEditForm(data){
         var sourceValue = getReqValue(reqs, '4861');
         sourcesData.forEach(function(source){
             var selected = sourceValue == source['ИсточникID'] ? 'selected' : '';
-            html += '<option value="' + source['ИсточникID'] + '" ' + selected + '>' + source['Источник'] + '</option>';
+            html += '<option value="' + escapeHtml(source['ИсточникID'] || '') + '" ' + selected + '>' + escapeHtml(source['Источник'] || '') + '</option>';
         });
         html += '</select>';
         html += '</div>';


### PR DESCRIPTION
## Summary
- Apply escapeHtml() with fallback to empty string for all dropdown options in client edit form
- Fixed dropdowns: status, partner, distributor, source
- Prevents 'undefined' from appearing when data fields are missing

## Test plan
- [ ] Open client edit form in kanban view
- [ ] Verify all dropdowns show proper values without 'undefined'
- [ ] Test with clients that may have missing reference data

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)