### PR TITLE
fix: prevent undefined from appearing in client edit form fields

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -2166,20 +2166,37 @@ function updateTaskCount(leadId){
 
 // Helper function to escape HTML
 function escapeHtml(text){
-    if(text === null || text === undefined || text === 'undefined' || text === 'null') return '';
-    return String(text).replace(/&/g, '&amp;')
-                       .replace(/</g, '&lt;')
-                       .replace(/>/g, '&gt;')
-                       .replace(/"/g, '&quot;')
-                       .replace(/'/g, '&#039;');
+    // Handle null, undefined, and their string representations
+    if(text === null || text === undefined) return '';
+    var str = String(text);
+    if(str === 'undefined' || str === 'null' || str === '') return '';
+    return str.replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+              .replace(/"/g, '&quot;')
+              .replace(/'/g, '&#039;');
+}
+
+// Helper function to safely get value (handles undefined/null strings)
+function safeValue(value){
+    if(value === null || value === undefined) return '';
+    var str = String(value);
+    if(str === 'undefined' || str === 'null') return '';
+    return str;
 }
 
 // Helper function to safely get requisite value
 function getReqValue(reqs, key){
     if(!reqs || !reqs[key]) return '';
-    var value = reqs[key].value;
-    if(value === null || value === undefined || value === 'undefined' || value === 'null') return '';
-    return value;
+    var req = reqs[key];
+    // Handle case where req itself might be a primitive value instead of an object
+    if(typeof req !== 'object' || req === null) return '';
+    var value = req.value;
+    // Handle null, undefined, and their string representations
+    if(value === null || value === undefined) return '';
+    var str = String(value);
+    if(str === 'undefined' || str === 'null') return '';
+    return str;
 }
 
 // Close modals when clicking outside


### PR DESCRIPTION
## Summary
- Improved `escapeHtml()` function to convert values to string before checking for 'undefined'/'null' strings
- Updated `getReqValue()` to properly check requisite structure and always return string values
- Added `safeValue()` helper function for general value sanitization

## Changes
The fix ensures that when the server returns values that might be undefined, null, or their string representations ('undefined', 'null'), they are properly converted to empty strings instead of being displayed in form fields.

## Test plan
- [ ] Open client edit form in kanban view
- [ ] Verify no "undefined" text appears in regular text fields
- [ ] Verify dropdown fields still work correctly
- [ ] Verify existing data is displayed properly

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)