### PR TITLE
fix: prevent undefined in dropdown options on client edit form

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1833,8 +1833,10 @@ function renderClientEditForm(data){
         html += '<option value="">Выберите статус</option>';
         var statusValue = getReqValue(reqs, '4874');
         statusesData.forEach(function(status){
-            var selected = statusValue == status['СтатусID'] ? 'selected' : '';
-            html += '<option value="' + escapeHtml(status['СтатусID'] || '') + '" ' + selected + '>' + escapeHtml(status['Статус'] || '') + '</option>';
+            var statusId = safeValue(status['СтатусID']);
+            var statusName = safeValue(status['Статус']);
+            var selected = statusValue && statusId && statusValue == statusId ? 'selected' : '';
+            html += '<option value="' + escapeHtml(statusId) + '" ' + selected + '>' + escapeHtml(statusName) + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -1856,8 +1858,10 @@ function renderClientEditForm(data){
         html += '<option value="">Выберите партнера</option>';
         var partnerValue = getReqValue(reqs, '443');
         partnersData.forEach(function(partner){
-            var selected = partnerValue == partner['ПартнерID'] ? 'selected' : '';
-            html += '<option value="' + escapeHtml(partner['ПартнерID'] || '') + '" ' + selected + '>' + escapeHtml(partner['Партнер'] || '') + '</option>';
+            var partnerId = safeValue(partner['ПартнерID']);
+            var partnerName = safeValue(partner['Партнер']);
+            var selected = partnerValue && partnerId && partnerValue == partnerId ? 'selected' : '';
+            html += '<option value="' + escapeHtml(partnerId) + '" ' + selected + '>' + escapeHtml(partnerName) + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -1871,8 +1875,10 @@ function renderClientEditForm(data){
         html += '<option value="">Выберите дистрибьютора</option>';
         var distributorValue = getReqValue(reqs, '4862');
         distributorsData.forEach(function(distributor){
-            var selected = distributorValue == distributor['ДистрибьюторID'] ? 'selected' : '';
-            html += '<option value="' + escapeHtml(distributor['ДистрибьюторID'] || '') + '" ' + selected + '>' + escapeHtml(distributor['Дистрибьютор'] || '') + '</option>';
+            var distributorId = safeValue(distributor['ДистрибьюторID']);
+            var distributorName = safeValue(distributor['Дистрибьютор']);
+            var selected = distributorValue && distributorId && distributorValue == distributorId ? 'selected' : '';
+            html += '<option value="' + escapeHtml(distributorId) + '" ' + selected + '>' + escapeHtml(distributorName) + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -1910,8 +1916,10 @@ function renderClientEditForm(data){
         html += '<option value="">Выберите источник</option>';
         var sourceValue = getReqValue(reqs, '4861');
         sourcesData.forEach(function(source){
-            var selected = sourceValue == source['ИсточникID'] ? 'selected' : '';
-            html += '<option value="' + escapeHtml(source['ИсточникID'] || '') + '" ' + selected + '>' + escapeHtml(source['Источник'] || '') + '</option>';
+            var sourceId = safeValue(source['ИсточникID']);
+            var sourceName = safeValue(source['Источник']);
+            var selected = sourceValue && sourceId && sourceValue == sourceId ? 'selected' : '';
+            html += '<option value="' + escapeHtml(sourceId) + '" ' + selected + '>' + escapeHtml(sourceName) + '</option>';
         });
         html += '</select>';
         html += '</div>';
@@ -2015,8 +2023,10 @@ function renderTaskCreateForm(){
     html += '<select class="kanban-edit-form-select" id="taskExecutor" name="t3942">';
     html += '<option value="">Выберите исполнителя</option>';
     managersData.forEach(function(manager){
-        var selected = (typeof window.uid !== 'undefined' && manager['ПользовательID'] == window.uid) ? 'selected' : '';
-        html += '<option value="' + manager['ПользовательID'] + '" ' + selected + '>' + manager['Пользователь'] + '</option>';
+        var managerId = safeValue(manager['ПользовательID']);
+        var managerName = safeValue(manager['Пользователь']);
+        var selected = (typeof window.uid !== 'undefined' && managerId && managerId == window.uid) ? 'selected' : '';
+        html += '<option value="' + escapeHtml(managerId) + '" ' + selected + '>' + escapeHtml(managerName) + '</option>';
     });
     html += '</select>';
     html += '</div>';
@@ -2027,7 +2037,9 @@ function renderTaskCreateForm(){
     html += '<select class="kanban-edit-form-select" id="taskType" name="t4299">';
     html += '<option value="">Выберите тип задачи</option>';
     taskTypesData.forEach(function(taskType){
-        html += '<option value="' + taskType['Тип задачиID'] + '">' + taskType['Тип задачи'] + '</option>';
+        var taskTypeId = safeValue(taskType['Тип задачиID']);
+        var taskTypeName = safeValue(taskType['Тип задачи']);
+        html += '<option value="' + escapeHtml(taskTypeId) + '">' + escapeHtml(taskTypeName) + '</option>';
     });
     html += '</select>';
     html += '</div>';


### PR DESCRIPTION
## Summary
- Updated all dropdown renderers to use `safeValue()` helper function
- Applied to: Status, Partner, Distributor, Source, Manager, and Task Type dropdowns
- Ensures undefined/null values from data arrays are converted to empty strings

## Changes
All dropdown iterations now:
1. Extract values using `safeValue()` before use
2. Properly escape values with `escapeHtml()`
3. Check for empty values before comparison for selection

## Test plan
- [ ] Open client edit form
- [ ] Verify no "undefined" text appears in any dropdown options
- [ ] Verify dropdown selections work correctly
- [ ] Open task creation form and verify dropdowns work correctly

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)