### PR TITLE
fix: don't send t4874 (status) parameter when empty

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1969,6 +1969,8 @@ function submitEditClient(){
     $('#editClientSubmitButton').prop('disabled', true).text('Сохранение...');
 
     var formData = $('#editClientForm').serialize();
+    // Remove t4874 (status) if empty - don't send parameter when status is not selected
+    formData = formData.replace(/&t4874=(?=&|$)/, '').replace(/^t4874=&/, '');
     formData += '&_xsrf=' + xsrf;
 
     var xhr = new XMLHttpRequest();


### PR DESCRIPTION
When status is not selected on the client edit form, the t4874 parameter should not be included in the form submission.

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)