### PR TITLE
feat: add quick create button (+) to column headers for reference fields (Issue #169)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -172,6 +172,50 @@
     padding-right: 10px;
 }
 
+/* Column header add button */
+.integram-table th {
+    position: relative;
+}
+
+.column-add-btn {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: var(--md-primary);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    width: 24px;
+    height: 24px;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 1;
+    padding: 0;
+    box-shadow: var(--md-elevation-1);
+    transition: var(--md-transition);
+    z-index: 1;
+}
+
+.integram-table th:hover .column-add-btn {
+    display: flex;
+}
+
+.column-add-btn:hover {
+    background: var(--md-primary-dark);
+    box-shadow: var(--md-elevation-2);
+}
+
+.column-add-btn:active {
+    background: var(--md-primary-dark);
+    box-shadow: var(--md-elevation-1);
+    transform: translateY(-50%) scale(0.95);
+}
+
 /* Compact mode */
 .integram-table.compact th {
     padding: 8px 5px;


### PR DESCRIPTION
Implemented a blue + button in table column headers that allows users to quickly create new records for reference fields directly from the table view.

Features:
- Button appears on hover for columns with granted=1 and corresponding ID column with ref
- Blue Material Design button (24x24px) aligned to the right
- Opens create form modal when clicked
- New record is fetched with filter and added to top of table
- Efficient refresh (only fetches new record, not full reload)
- Clean UI with smooth hover effects
- Permission-aware and error-safe

Implementation:
- shouldShowAddButton() - validates column criteria
- openColumnCreateForm() - opens create form with reference type
- refreshWithNewRecord() - fetches and adds new record to top
- Modified saveRecord() to handle special column header create flow

Benefits:
- Quick access to create related records
- No navigation needed
- Immediate feedback with new record at top
- Works with any reference field

Resolves #169