### PR TITLE
fix: set filter cell padding to 0 for maximum space efficiency (Issue #173)

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -348,14 +348,14 @@
     position: relative;
     display: flex;
     align-items: center;
-    padding: 4px;
+    padding: 0;
     height: 100%;
     min-height: 40px;
 }
 
 .filter-icon-inside {
     position: absolute;
-    left: 6px;
+    left: 2px;
     top: 50%;
     transform: translateY(-50%);
     cursor: pointer;


### PR DESCRIPTION
This PR resolves Issue #173 by setting filter cell padding to 0 for maximum space efficiency.

Changes:
- Changed .filter-cell-wrapper padding from 4px to 0
- Adjusted .filter-icon-inside left position from 6px to 2px to compensate

This ensures filter cells use the minimum space necessary while maintaining proper icon positioning.

Closes #173