### PR TITLE
Fix datetime picker step: strip seconds from display format (issue #175)

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -2683,10 +2683,12 @@ class IntegramTable {
             if (!html5Value) return '';
 
             if (includeTime) {
-                // YYYY-MM-DDTHH:MM -> DD.MM.YYYY HH:MM
+                // YYYY-MM-DDTHH:MM(:SS) -> DD.MM.YYYY HH:MM
                 const [datePart, timePart] = html5Value.split('T');
                 const [year, month, day] = datePart.split('-');
-                return `${ day }.${ month }.${ year } ${ timePart }`;
+                // Strip seconds if present (keep only HH:MM)
+                const timeWithoutSeconds = timePart.split(':').slice(0, 2).join(':');
+                return `${ day }.${ month }.${ year } ${ timeWithoutSeconds }`;
             } else {
                 // YYYY-MM-DD -> DD.MM.YYYY
                 const [year, month, day] = html5Value.split('-');


### PR DESCRIPTION
## Summary
Fixes #175 - datetime picker now properly displays time in 5-minute increments without showing seconds.

## Changes
Modified `convertHtml5DateToDisplay()` function in `assets/js/integram-table.js` to strip seconds from the time portion when converting HTML5 datetime-local values to display format.

## Details
- datetime-local inputs already have `step="300"` (5-minute increments) 
- However, browsers allow manual entry of times with seconds
- The conversion function now strips seconds, ensuring display shows only `HH:MM` format
- Users can still manually enter times with 1-second precision if needed - the input will accept it but display will round to minutes

## Testing
- Create/edit records with datetime fields
- Verify time picker shows 5-minute steps
- Verify displayed time shows only hours and minutes (no seconds)
- Manually entering time with seconds should still work, but display without them

🤖 Generated with [Claude Code](https://claude.com/claude-code)