### PR TITLE
Always pass FR_manager parameter to report/3769 (issue #186)

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1255,11 +1255,8 @@ function loadKanbanData(){
         productParam = '&FR_product=' + encodeURIComponent(currentProductId);
     }
 
-    // Build FR_manager parameter if a manager is selected
-    var managerParam = '';
-    if (currentManagerId) {
-        managerParam = '&FR_manager=' + encodeURIComponent(currentManagerId);
-    }
+    // Build FR_manager parameter - always pass it
+    var managerParam = '&FR_manager=' + encodeURIComponent(currentManagerId || '');
 
     // Load tasks
     var xhr1 = new XMLHttpRequest();


### PR DESCRIPTION
## Summary
Fixes #186 - Ensures the `FR_manager` parameter is always passed to report/3769 requests.

## Problem
Previously, the `FR_manager` parameter was only included in report requests when `currentManagerId` was truthy (not null/undefined). This meant:
- On initial page load, before managers are loaded, the parameter wasn't sent
- If `currentManagerId` was somehow unset, the parameter would be missing

## Solution
Changed the `managerParam` construction to always include `FR_manager`:
```javascript
// Before:
var managerParam = '';
if (currentManagerId) {
    managerParam = '&FR_manager=' + encodeURIComponent(currentManagerId);
}

// After:
var managerParam = '&FR_manager=' + encodeURIComponent(currentManagerId || '');
```

## Changes
- Modified `loadKanbanData()` function to always construct `managerParam`
- Uses `currentManagerId || ''` to provide empty string fallback
- Both report/3769 (tasks) and report/3796 (statuses) now always receive FR_manager

## Testing
1. Load kanban board
2. Verify report/3769 request includes `FR_manager` parameter in URL
3. Change manager selection
4. Verify parameter value updates correctly
5. Check browser network tab to confirm parameter is always present

🤖 Generated with [Claude Code](https://claude.com/claude-code)