### PR TITLE
Fix issue #228: Add missing IntegramTable includes to kanban

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1032,6 +1032,10 @@
     </div>
 </div>
 
+<!-- Include IntegramTable component -->
+<link rel="stylesheet" href="/assets/css/integram-table.css">
+<script src="/assets/js/integram-table.js"></script>
+
 <script>
 // Kanban functionality
 var kanbanData = [];


### PR DESCRIPTION
## Summary
Fix 'IntegramTable is not defined' error by adding missing script and CSS includes.

## Changes
- Added link to integram-table.css stylesheet
- Added script include for integram-table.js
- Includes are placed before the inline script to ensure IntegramTable class is available when needed

## Why This Fixes the Issue
The kanban.html file was using IntegramTable.prototype.renderEditFormModal in openAddRecordModal() and openClientEditForm() functions, but the IntegramTable class was never included, causing a 'not defined' error. Now the necessary resources are loaded before the code that uses them.