### PR TITLE
Fix issue #230: Use proper IntegramTable prototype for form rendering

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1913,24 +1913,9 @@ function openAddRecordModal(statusId, statusName){
                     instanceName: 'tempAddClientTable'
                 };
 
-                // Create a simple object with the renderEditFormModal method
-                var tempTable = {
-                    options: tempOptions,
-                    parseAttrs: function(attrs){
-                        var result = {required: false, alias: '', multi: false};
-                        if(!attrs) return result;
-                        var parts = attrs.split(':');
-                        if(parts[0]) result.alias = parts[0];
-                        if(attrs.includes('!NULL:')) result.required = true;
-                        if(attrs.includes('MULTI:')) result.multi = true;
-                        return result;
-                    },
-                    escapeHtml: function(str){
-                        if(!str) return '';
-                        return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
-                    },
-                    renderEditFormModal: IntegramTable.prototype.renderEditFormModal
-                };
+                // Create a wrapper object that delegates to IntegramTable prototype
+                var tempTable = Object.create(IntegramTable.prototype);
+                tempTable.options = tempOptions;
 
                 // Create a mock record data with the status pre-set
                 var recordData = {


### PR DESCRIPTION
## Summary
Fix 'renderAttributesForm is not a function' error by using IntegramTable prototype properly.

## Changes
- Changed from creating a minimal mock object to using Object.create(IntegramTable.prototype)
- This ensures all IntegramTable methods are available through the prototype chain
- Simplified code by removing manual method definitions

## Why This Fixes the Issue
The renderEditFormModal method internally calls renderAttributesForm, but the temporary object was missing this method. By using Object.create(IntegramTable.prototype), all prototype methods are now accessible.