### PR TITLE
Fix column-add-btn metadata fetching to use column.orig/type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,3 +57,14 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T10:50:20.957Z
+
+---
+
+Issue to solve: https://github.com/ideav/crm/issues/248
+Your prepared branch: issue-248-bf0915e64194
+Your prepared working directory: /tmp/gh-issue-solver-1770390186928
+
+Proceed.
+
+
+Run timestamp: 2026-02-06T15:03:08.369Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,14 +57,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T10:50:20.957Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/248
-Your prepared branch: issue-248-bf0915e64194
-Your prepared working directory: /tmp/gh-issue-solver-1770390186928
-
-Proceed.
-
-
-Run timestamp: 2026-02-06T15:03:08.369Z

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -2650,12 +2650,10 @@ class IntegramTable {
                 return false;
             }
 
-            // Check if there's a corresponding column with "ID" suffix
-            const idColumnName = column.name + 'ID';
-            const idColumn = this.columns.find(col => col.name === idColumnName);
+            // Check if column has orig or type (metadata type identifier)
+            const hasMetadataType = (column.orig && column.orig > 0) || (column.type && column.type > 0);
 
-            // Check if ID column exists and has a ref (reference type)
-            return idColumn && idColumn.ref && idColumn.ref > 0;
+            return hasMetadataType;
         }
 
         async openColumnCreateForm(columnId) {
@@ -2666,16 +2664,14 @@ class IntegramTable {
                     return;
                 }
 
-                // Find the corresponding ID column
-                const idColumnName = column.name + 'ID';
-                const idColumn = this.columns.find(col => col.name === idColumnName);
+                // Determine typeId from column metadata
+                // Priority: 1) column.orig, 2) column.type
+                const typeId = column.orig || column.type;
 
-                if (!idColumn || !idColumn.ref) {
+                if (!typeId) {
                     this.showToast('Ошибка: не найден тип записи', 'error');
                     return;
                 }
-
-                const typeId = idColumn.ref;
 
                 // Fetch metadata and open create form
                 if (!this.metadataCache[typeId]) {


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request fixes the metadata fetching logic for the column add button (`column-add-btn`) in `integram-table.js`.

### 📋 Issue Reference
Fixes #248

### 🐛 Problem
The column add button was incorrectly fetching metadata by looking for a corresponding ID column (e.g., `columnName + 'ID'`) and using its `ref` field. This approach didn't align with the expected behavior described in the issue.

### ✅ Solution
Changed the metadata fetching logic to:
1. **First priority**: Use `column.orig` field from the columns section
2. **Fallback**: Use `column.type` field if `orig` is not present

### 📝 Changes Made

#### Modified Methods in `assets/js/integram-table.js`:

1. **`openColumnCreateForm(columnId)`** (lines 2659-2690):
   - Removed logic that searched for ID column with `name + 'ID'` pattern
   - Now directly uses `column.orig || column.type` to determine the metadata type ID
   - Simplified the code by eliminating unnecessary ID column lookup

2. **`shouldShowAddButton(column)`** (lines 2647-2657):
   - Updated condition to check for `column.orig` or `column.type` instead of searching for ID column
   - Verifies that the metadata type identifier exists and is greater than 0
   - Maintains the existing `granted === 1` permission check

### 🔍 Code Comparison

**Before:**
```javascript
// Find the corresponding ID column
const idColumnName = column.name + 'ID';
const idColumn = this.columns.find(col => col.name === idColumnName);

if (!idColumn || !idColumn.ref) {
    this.showToast('Ошибка: не найден тип записи', 'error');
    return;
}

const typeId = idColumn.ref;
```

**After:**
```javascript
// Determine typeId from column metadata
// Priority: 1) column.orig, 2) column.type
const typeId = column.orig || column.type;

if (!typeId) {
    this.showToast('Ошибка: не найден тип записи', 'error');
    return;
}
```

### 🎯 Benefits
- ✅ Correctly follows the metadata fetching specification from issue #248
- ✅ Simplified code with fewer lookups and less complexity
- ✅ More reliable by using direct column properties instead of searching for related columns
- ✅ Consistent with other parts of the codebase that already use `column.orig` pattern

---
*This PR was created automatically by the AI issue solver*