### PR TITLE
Show column-add-btn only if column type/orig is found in metadata ids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,14 +68,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T15:08:55.260Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/251
-Your prepared branch: issue-251-ad6306ffe80a
-Your prepared working directory: /tmp/gh-issue-solver-1770391068756
-
-Proceed.
-
-
-Run timestamp: 2026-02-06T15:17:50.001Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,3 +68,14 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T15:08:55.260Z
+
+---
+
+Issue to solve: https://github.com/ideav/crm/issues/251
+Your prepared branch: issue-251-ad6306ffe80a
+Your prepared working directory: /tmp/gh-issue-solver-1770391068756
+
+Proceed.
+
+
+Run timestamp: 2026-02-06T15:17:50.001Z


### PR DESCRIPTION
## Summary
- Modified `shouldShowAddButton()` in `assets/js/integram-table.js` to validate the column's `type` or `orig` against the global metadata `id` values before showing the `+` button
- Checks both top-level metadata ids and requisite ids within metadata items
- Added re-render trigger after `loadGlobalMetadata()` completes to handle the case where metadata loads after data (both are async)

## Changes
1. **`shouldShowAddButton(column)`** (line 2653): Now resolves `typeId` from `column.orig || column.type` (consistent with `openColumnCreateForm`), then verifies it exists in `this.globalMetadata` — either as a top-level item `id` or as a `reqs[].id` within any metadata item
2. **`loadGlobalMetadata()`** (line 106): After successfully loading metadata, triggers `this.render()` if data is already loaded, ensuring column-add-btn visibility is recalculated

## Test plan
- [ ] Load a table with columns that have `type`/`orig` matching metadata ids — verify `+` buttons appear
- [ ] Load a table with columns that have `type`/`orig` NOT in metadata — verify `+` buttons are hidden
- [ ] Verify buttons appear correctly even when metadata loads slower than table data

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)