### PR TITLE
Fix broken reference field lists on record edit forms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T15:21:44.003Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/255
-Your prepared branch: issue-255-28c54c3ff42e
-Your prepared working directory: /tmp/gh-issue-solver-1770391865480
-
-Proceed.
-
-
-Run timestamp: 2026-02-06T15:31:06.694Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,14 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T15:21:44.003Z
+
+---
+
+Issue to solve: https://github.com/ideav/crm/issues/255
+Your prepared branch: issue-255-28c54c3ff42e
+Your prepared working directory: /tmp/gh-issue-solver-1770391865480
+
+Proceed.
+
+
+Run timestamp: 2026-02-06T15:31:06.694Z

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1542,31 +1542,6 @@ class IntegramTable {
             }
         }
 
-        async fetchReferenceOptions(colType, parentRecordId, searchText = '') {
-            const apiBase = this.getApiBase();
-            const params = new URLSearchParams({
-                JSON: '',
-                id: parentRecordId,
-                LIMIT: '50'
-            });
-
-            if (searchText) {
-                params.append('q', searchText);
-            }
-
-            const url = `${apiBase}/_ref_reqs/${colType}?${params}`;
-            console.log('[TRACE] fetchReferenceOptions - URL:', url);
-
-            const response = await fetch(url);
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-
-            const data = await response.json();
-            console.log('[TRACE] fetchReferenceOptions - received data:', data);
-            return data;
-        }
-
         renderReferenceOptions(options, currentValue) {
             // Filter out current value from options
             const filteredOptions = Object.entries(options).filter(([id, text]) => text !== currentValue);
@@ -1695,7 +1670,8 @@ class IntegramTable {
             // Store reference to overlay on modal for proper cleanup
             modal._overlayElement = overlay;
 
-            const title = `Создание: ${metadata.val}`;
+            const typeName = this.getMetadataName(metadata);
+            const title = `Создание: ${typeName}`;
 
             // Build attributes form HTML (similar to renderAttributesForm but simplified for create mode)
             const reqs = metadata.reqs || [];
@@ -1703,7 +1679,7 @@ class IntegramTable {
 
             let attributesHtml = `
                 <div class="form-group">
-                    <label for="field-main-ref-create">${metadata.val} <span class="required">*</span></label>
+                    <label for="field-main-ref-create">${typeName} <span class="required">*</span></label>
                     <input type="text" class="form-control" id="field-main-ref-create" name="main" value="${this.escapeHtml(initialValue)}" required>
                 </div>
             `;
@@ -2726,7 +2702,12 @@ class IntegramTable {
             const text = await response.text();
 
             try {
-                const data = JSON.parse(text);
+                let data = JSON.parse(text);
+
+                // Handle case where API returns an array instead of an object
+                if (Array.isArray(data)) {
+                    data = data[0] || {};
+                }
 
                 // Check for error in response
                 if (data.error) {
@@ -2771,16 +2752,19 @@ class IntegramTable {
 
         async fetchReferenceOptions(requisiteId, recordId = 0, searchQuery = '') {
             const apiBase = this.getApiBase();
-            const params = new URLSearchParams();
+            const params = new URLSearchParams({
+                JSON: '',
+                LIMIT: '50'
+            });
 
-            if (searchQuery) {
-                params.append('q', searchQuery);
-            }
             if (recordId && recordId !== 0) {
                 params.append('id', recordId);
             }
+            if (searchQuery) {
+                params.append('q', searchQuery);
+            }
 
-            const url = `${ apiBase }/_ref_reqs/${ requisiteId }${ params.toString() ? '?' + params.toString() : '' }`;
+            const url = `${ apiBase }/_ref_reqs/${ requisiteId }?${ params }`;
             const response = await fetch(url);
 
             if (!response.ok) {
@@ -2804,6 +2788,10 @@ class IntegramTable {
                 }
                 throw new Error(`Invalid JSON response: ${ text }`);
             }
+        }
+
+        getMetadataName(metadata) {
+            return metadata.val || metadata.name || metadata.title || `Тип #${ metadata.id || '?' }`;
         }
 
         getApiBase() {
@@ -2908,7 +2896,8 @@ class IntegramTable {
             // Store reference to overlay on modal for proper cleanup
             modal._overlayElement = overlay;
 
-            const title = isCreate ? `Создание: ${ metadata.val }` : `Редактирование: ${ metadata.val }`;
+            const typeName = this.getMetadataName(metadata);
+            const title = isCreate ? `Создание: ${ typeName }` : `Редактирование: ${ typeName }`;
             const instanceName = this.options.instanceName;
             const recordId = recordData && recordData.obj ? recordData.obj.id : null;
 
@@ -3005,8 +2994,8 @@ class IntegramTable {
                 this.attachTabHandlers(modal);
             }
 
-            // Load reference options for dropdowns
-            this.loadReferenceOptions(metadata.reqs, recordId || 0);
+            // Load reference options for dropdowns (scoped to this modal)
+            this.loadReferenceOptions(metadata.reqs, recordId || 0, modal);
 
             // Attach date/datetime picker handlers
             this.attachDatePickerHandlers(modal);
@@ -3067,10 +3056,11 @@ class IntegramTable {
             }
 
             // Main value field
+            const typeName = this.getMetadataName(metadata);
             const mainValue = recordData && recordData.obj ? recordData.obj.val : '';
             html += `
                 <div class="form-group">
-                    <label for="field-main">${ metadata.val } <span class="required">*</span></label>
+                    <label for="field-main">${ typeName } <span class="required">*</span></label>
                     <input type="text" class="form-control" id="field-main" name="main" value="${ this.escapeHtml(mainValue) }" required>
                 </div>
             `;
@@ -3245,7 +3235,7 @@ class IntegramTable {
                 html += `<div class="subordinate-table-wrapper"><table class="subordinate-table"><thead><tr>`;
 
                 // Header: main value column + requisite columns
-                html += `<th>${ metadata.val }</th>`;
+                html += `<th>${ this.getMetadataName(metadata) }</th>`;
                 reqs.forEach(req => {
                     const attrs = this.parseAttrs(req.attrs);
                     const fieldName = attrs.alias || req.val;
@@ -3390,7 +3380,8 @@ class IntegramTable {
             modal.style.zIndex = baseZIndex + 1;
             modal.dataset.modalDepth = modalDepth;
 
-            const title = `Создание: ${ metadata.val }`;
+            const typeName = this.getMetadataName(metadata);
+            const title = `Создание: ${ typeName }`;
 
             // Build form for regular fields only (no nested subordinate tables in create mode)
             const reqs = metadata.reqs || [];
@@ -3435,7 +3426,7 @@ class IntegramTable {
                 <div class="edit-form-body">
                     <form id="subordinate-edit-form" class="edit-form">
                         <div class="form-group">
-                            <label for="sub-field-main">${ metadata.val } <span class="required">*</span></label>
+                            <label for="sub-field-main">${ typeName } <span class="required">*</span></label>
                             ${ mainFieldHtml }
                         </div>
             `;
@@ -3520,8 +3511,8 @@ class IntegramTable {
             document.body.appendChild(overlay);
             document.body.appendChild(modal);
 
-            // Load reference options
-            this.loadReferenceOptions(regularFields, 0);
+            // Load reference options (scoped to this modal)
+            this.loadReferenceOptions(regularFields, 0, modal);
 
             // Attach date picker handlers
             this.attachDatePickerHandlers(modal);
@@ -3640,9 +3631,11 @@ class IntegramTable {
             });
         }
 
-        async loadReferenceOptions(reqs, recordId) {
+        async loadReferenceOptions(reqs, recordId, modalElement) {
             // Load reference options for the new form-reference-editor elements
-            const formRefEditors = document.querySelectorAll('.form-reference-editor');
+            // Scope query to the specific modal to avoid affecting other open modals
+            const container = modalElement || document;
+            const formRefEditors = container.querySelectorAll('.form-reference-editor');
 
             for (const wrapper of formRefEditors) {
                 const refReqId = wrapper.dataset.refId;
@@ -3870,14 +3863,15 @@ class IntegramTable {
             modal.dataset.overlayRef = 'true';
             modal._overlayElement = overlay;
 
-            const title = `Создание: ${metadata.val}`;
+            const typeName = this.getMetadataName(metadata);
+            const title = `Создание: ${typeName}`;
 
             const reqs = metadata.reqs || [];
             const regularFields = reqs.filter(req => !req.arr_id);
 
             let attributesHtml = `
                 <div class="form-group">
-                    <label for="field-main-form-ref-create">${metadata.val} <span class="required">*</span></label>
+                    <label for="field-main-form-ref-create">${typeName} <span class="required">*</span></label>
                     <input type="text" class="form-control" id="field-main-form-ref-create" name="main" value="${this.escapeHtml(initialValue)}" required>
                 </div>
             `;


### PR DESCRIPTION
## Summary

Fixes #255 — reference field dropdown lists on the record editing form were broken, showing "undefined" for type names and failing to load options correctly.

### Root causes found and fixed:

- **`metadata.val` undefined**: `fetchMetadata()` did not handle the case where the API returns an array instead of an object. Added array unwrapping and introduced `getMetadataName()` helper with a fallback chain (`val` → `name` → `title` → `id`) to prevent "undefined" from appearing in form titles and field labels.

- **Duplicate `fetchReferenceOptions` method**: The class had two definitions of `fetchReferenceOptions()` — the second one silently overwrote the first. The overwriting version was missing required `JSON` and `LIMIT` query parameters, breaking the API call for both inline table editing and form reference fields. Removed the dead first definition and added the missing parameters to the surviving one.

- **Global DOM query in `loadReferenceOptions`**: Used `document.querySelectorAll('.form-reference-editor')` which found ALL reference editors across all open modals. This caused duplicate event listeners and incorrect `recordId` being passed when subordinate create forms were opened alongside parent edit forms. Now accepts a `modalElement` parameter to scope the query to the current modal.

## Test plan

- [ ] Open a record edit form — verify type name shows correctly in title (not "undefined")
- [ ] Verify reference field dropdowns load options correctly
- [ ] Test search filtering within reference field dropdowns
- [ ] Test the "+" button to create new records from reference fields
- [ ] Open a subordinate table create form and verify its reference fields work independently
- [ ] Test inline table cell reference editing still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)