### PR TITLE
Restrict column-add-btn visibility to top-level metadata ids only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,14 +79,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T15:21:44.003Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/257
-Your prepared branch: issue-257-b29a0c5aae9d
-Your prepared working directory: /tmp/gh-issue-solver-1770392359803
-
-Proceed.
-
-
-Run timestamp: 2026-02-06T15:39:21.417Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,3 +79,14 @@ Proceed.
 
 
 Run timestamp: 2026-02-06T15:21:44.003Z
+
+---
+
+Issue to solve: https://github.com/ideav/crm/issues/257
+Your prepared branch: issue-257-b29a0c5aae9d
+Your prepared working directory: /tmp/gh-issue-solver-1770392359803
+
+Proceed.
+
+
+Run timestamp: 2026-02-06T15:39:21.417Z

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -2667,19 +2667,8 @@ class IntegramTable {
                 return false;
             }
 
-            // Check top-level metadata ids
-            if (this.globalMetadata.some(item => item.id === typeId)) {
-                return true;
-            }
-
-            // Check requisite ids within metadata items
-            for (const item of this.globalMetadata) {
-                if (item.reqs && item.reqs.some(r => r.id === typeId)) {
-                    return true;
-                }
-            }
-
-            return false;
+            // Check top-level metadata ids only (not reqs)
+            return this.globalMetadata.some(item => item.id === typeId);
         }
 
         async openColumnCreateForm(columnId) {


### PR DESCRIPTION
## Summary
- Fixes the `shouldShowAddButton` method in `assets/js/integram-table.js` to only check top-level metadata ids, not search inside `reqs`
- The add button (`column-add-btn`) now only appears when a column's `type` or `orig` matches an `id` at the top level of the metadata response
- Removed the `reqs`-level loop that previously could also trigger the button to show

## Changes
The `shouldShowAddButton` method previously had two checks:
1. Top-level metadata ids (`this.globalMetadata.some(item => item.id === typeId)`)
2. Requisite ids inside metadata items (`item.reqs.some(r => r.id === typeId)`)

Per issue #257, only the top-level check (1) should be used. The reqs-level check (2) has been removed.

## Test plan
- [ ] Verify columns whose `type`/`orig` matches a top-level metadata `id` still show the add button
- [ ] Verify columns whose `type`/`orig` only matches a `reqs`-level `id` no longer show the add button

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)