### PR TITLE
Fix issue #263: Use orig instead of ref_id for reference field metadata

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -3069,7 +3069,7 @@ class IntegramTable {
                 if (req.ref_id) {
                     const currentValue = reqValue || '';
                     html += `
-                        <div class="form-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.ref_id }">
+                        <div class="form-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.orig || req.ref_id }">
                             <div class="inline-editor-reference form-ref-editor-box">
                                 <div class="inline-editor-reference-header">
                                     <input type="text"
@@ -3432,7 +3432,7 @@ class IntegramTable {
                 // Reference field (searchable dropdown with clear/add buttons - same as inline table editor)
                 if (req.ref_id) {
                     formHtml += `
-                        <div class="form-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.ref_id }">
+                        <div class="form-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.orig || req.ref_id }">
                             <div class="inline-editor-reference form-ref-editor-box">
                                 <div class="inline-editor-reference-header">
                                     <input type="text"


### PR DESCRIPTION
## Summary
Fixes #263

When opening edit-form-modal to add values to reference fields (using the "+" button), the code now uses `req.orig` instead of `req.ref_id` for fetching metadata. This ensures the correct original type is used when creating new records in reference tables.

## Changes
- Updated `data-ref-type-id` attribute in form-reference-editor to use `req.orig || req.ref_id`
  - Falls back to `ref_id` if `orig` is not available for backward compatibility
- Applied fix to both:
  - Main record edit form modal
  - Subordinate record create form modal

## Test plan
- [x] Open a record edit form with reference fields that have the `orig` attribute
- [x] Click the "+" button in a reference field to create a new value
- [x] Verify the create modal opens with metadata from the `orig` type (not `ref_id`)
- [x] Successfully create and save the new reference value
- [x] Verify the newly created value appears in the reference dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)