### PR TITLE
Fix issue #266: Display reference fields as dropdowns in create forms

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1690,12 +1690,42 @@ class IntegramTable {
                 const fieldName = attrs.alias || req.val;
                 const isRequired = attrs.required;
 
-                attributesHtml += `
-                    <div class="form-group">
-                        <label for="field-ref-${req.id}">${fieldName}${isRequired ? ' <span class="required">*</span>' : ''}</label>
-                        <input type="text" class="form-control" id="field-ref-${req.id}" name="t${req.id}"${isRequired ? ' required' : ''}>
-                    </div>
-                `;
+                attributesHtml += `<div class="form-group">`;
+                attributesHtml += `<label for="field-ref-${req.id}">${fieldName}${isRequired ? ' <span class="required">*</span>' : ''}</label>`;
+
+                // Check if this is a reference field
+                if (req.ref_id) {
+                    // Render as reference dropdown (same as in edit form)
+                    attributesHtml += `
+                        <div class="form-reference-editor" data-ref-id="${req.id}" data-required="${isRequired}" data-ref-type-id="${req.orig || req.ref_id}">
+                            <div class="inline-editor-reference form-ref-editor-box">
+                                <div class="inline-editor-reference-header">
+                                    <input type="text"
+                                           class="inline-editor-reference-search form-ref-search"
+                                           id="field-ref-${req.id}-search"
+                                           placeholder="Поиск..."
+                                           autocomplete="off">
+                                    <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button">×</button>
+                                    <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button">+</button>
+                                </div>
+                                <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-ref-${req.id}-dropdown">
+                                    <div class="inline-editor-reference-empty">Загрузка...</div>
+                                </div>
+                            </div>
+                            <input type="hidden"
+                                   class="form-ref-value"
+                                   id="field-ref-${req.id}"
+                                   name="t${req.id}"
+                                   value=""
+                                   data-ref-id="${req.id}">
+                        </div>
+                    `;
+                } else {
+                    // Render as simple text input
+                    attributesHtml += `<input type="text" class="form-control" id="field-ref-${req.id}" name="t${req.id}"${isRequired ? ' required' : ''}>`;
+                }
+
+                attributesHtml += `</div>`;
             });
 
             let formHtml = `
@@ -1719,6 +1749,9 @@ class IntegramTable {
             modal.innerHTML = formHtml;
             document.body.appendChild(overlay);
             document.body.appendChild(modal);
+
+            // Load reference options for dropdown fields
+            this.loadReferenceOptions(regularFields, parentRecordId, modal);
 
             // Attach save handler
             const saveBtn = modal.querySelector('#save-record-ref-btn');
@@ -3870,12 +3903,42 @@ class IntegramTable {
                 const fieldName = attrs.alias || req.val;
                 const isRequired = attrs.required;
 
-                attributesHtml += `
-                    <div class="form-group">
-                        <label for="field-form-ref-${req.id}">${fieldName}${isRequired ? ' <span class="required">*</span>' : ''}</label>
-                        <input type="text" class="form-control" id="field-form-ref-${req.id}" name="t${req.id}"${isRequired ? ' required' : ''}>
-                    </div>
-                `;
+                attributesHtml += `<div class="form-group">`;
+                attributesHtml += `<label for="field-form-ref-${req.id}">${fieldName}${isRequired ? ' <span class="required">*</span>' : ''}</label>`;
+
+                // Check if this is a reference field
+                if (req.ref_id) {
+                    // Render as reference dropdown (same as in edit form)
+                    attributesHtml += `
+                        <div class="form-reference-editor" data-ref-id="${req.id}" data-required="${isRequired}" data-ref-type-id="${req.orig || req.ref_id}">
+                            <div class="inline-editor-reference form-ref-editor-box">
+                                <div class="inline-editor-reference-header">
+                                    <input type="text"
+                                           class="inline-editor-reference-search form-ref-search"
+                                           id="field-form-ref-${req.id}-search"
+                                           placeholder="Поиск..."
+                                           autocomplete="off">
+                                    <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button">×</button>
+                                    <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button">+</button>
+                                </div>
+                                <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-form-ref-${req.id}-dropdown">
+                                    <div class="inline-editor-reference-empty">Загрузка...</div>
+                                </div>
+                            </div>
+                            <input type="hidden"
+                                   class="form-ref-value"
+                                   id="field-form-ref-${req.id}"
+                                   name="t${req.id}"
+                                   value=""
+                                   data-ref-id="${req.id}">
+                        </div>
+                    `;
+                } else {
+                    // Render as simple text input
+                    attributesHtml += `<input type="text" class="form-control" id="field-form-ref-${req.id}" name="t${req.id}"${isRequired ? ' required' : ''}>`;
+                }
+
+                attributesHtml += `</div>`;
             });
 
             let formHtml = `
@@ -3899,6 +3962,9 @@ class IntegramTable {
             modal.innerHTML = formHtml;
             document.body.appendChild(overlay);
             document.body.appendChild(modal);
+
+            // Load reference options for dropdown fields
+            this.loadReferenceOptions(regularFields, parentRecordId, modal);
 
             // Attach save handler
             const saveBtn = modal.querySelector('#save-form-ref-btn');


### PR DESCRIPTION
## Summary
Fixes #266

When creating new records via the "+" button in reference fields, all fields (including other reference fields within the create form) were being rendered as simple text inputs instead of searchable dropdown selectors.

## Problem
The create form rendering functions (`renderCreateFormForReference` and `renderCreateFormForFormReference`) were rendering ALL fields as simple text inputs without checking if they were reference fields.

## Solution
Updated both functions to:
1. Detect reference fields by checking `req.ref_id`
2. Render reference fields with the same dropdown structure used in edit forms (`form-reference-editor`)
3. Render non-reference fields as simple text inputs (unchanged)
4. Call `loadReferenceOptions()` to populate the dropdowns after modal creation

## Changes
- **renderCreateFormForReference** (inline table editor): Now renders reference fields as dropdowns
- **renderCreateFormForFormReference** (form reference fields): Now renders reference fields as dropdowns
- Both functions now call `this.loadReferenceOptions()` to populate dropdowns
- Uses `req.orig || req.ref_id` for correct metadata type (consistent with fix #263)

## Test plan
- [x] Open a record edit form with a reference field
- [x] Click the "+" button to create a new value
- [x] Verify reference fields within the create form display as searchable dropdowns (not text inputs)
- [x] Test selecting values from reference dropdowns
- [x] Verify non-reference fields still display as text inputs
- [x] Test creating and saving new records with reference field values
- [x] Test nested create forms (clicking "+" in a create form's reference field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)