### PR TITLE
Fix issue #268: Null reference error when saving nested create forms

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1849,7 +1849,9 @@ class IntegramTable {
 
                 // Close the create form modal
                 modal.remove();
-                document.querySelector('.edit-form-overlay:last-of-type').remove();
+                if (modal._overlayElement) {
+                    modal._overlayElement.remove();
+                }
                 window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
 
                 // Show success message
@@ -4276,7 +4278,9 @@ class IntegramTable {
 
                 // Close modal
                 modal.remove();
-                document.querySelector('.edit-form-overlay').remove();
+                if (modal._overlayElement) {
+                    modal._overlayElement.remove();
+                }
 
                 // Show success message
                 this.showToast('Запись успешно сохранена', 'success');


### PR DESCRIPTION
## Summary
Fixes #268

When saving records in deeply nested create forms (infinite nesting), the application threw a `TypeError: Cannot read properties of null (reading 'remove')` error.

## Problem
The error occurred in two save functions that attempted to remove modal overlays using `document.querySelector()`:

**Error Stack:**
```
integram-table.js:1873 Error saving record for reference: TypeError: Cannot read properties of null (reading 'remove')
    at IntegramTable.saveRecordForReference (integram-table.js:1852:74)
```

**Root Cause:**
- `saveRecordForReference` (line 1852): Used `document.querySelector('.edit-form-overlay:last-of-type').remove()`
- `saveRecord` (line 4279): Used `document.querySelector('.edit-form-overlay').remove()`
- In nested modal scenarios, these selectors could:
  - Fail to find the correct overlay
  - Return `null` if the overlay was already removed
  - Select the wrong overlay when multiple are present

## Solution
Use the stored overlay reference (`modal._overlayElement`) instead of DOM queries:

1. Each modal already stores a reference to its overlay during creation
2. Changed both functions to use `modal._overlayElement.remove()` with null checks
3. This works correctly even with infinite nesting levels

## Changes
- **saveRecordForReference** (line 1852): Use `modal._overlayElement` with null check
- **saveRecord** (line 4279): Use `modal._overlayElement` with null check

## Test plan
- [x] Open a record edit form with a reference field
- [x] Click "+" to create a new value (opens nested modal #1)
- [x] In that create form, click "+" on another reference field (opens nested modal #2)
- [x] Continue nesting to test infinite depth
- [x] Save the deepest nested form - verify no errors
- [x] Save intermediate forms - verify no errors
- [x] Verify all modals close correctly
- [x] Verify all overlays are removed from DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)