### PR TITLE
Fix issue #270: Add cascade offset for nested modal forms

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1667,6 +1667,11 @@ class IntegramTable {
             modal.dataset.overlayRef = 'true';
             modal.dataset.isReferenceCreate = 'true'; // Mark this as a special reference creation modal
 
+            // Add cascade offset for nested modals (6px per level)
+            const cascadeOffset = (modalDepth - 1) * 6;
+            modal.style.left = `${cascadeOffset}px`;
+            modal.style.top = `${cascadeOffset}px`;
+
             // Store reference to overlay on modal for proper cleanup
             modal._overlayElement = overlay;
 
@@ -2917,6 +2922,11 @@ class IntegramTable {
             modal.dataset.modalDepth = modalDepth;
             modal.dataset.overlayRef = 'true';
 
+            // Add cascade offset for nested modals (6px per level)
+            const cascadeOffset = (modalDepth - 1) * 6;
+            modal.style.left = `${cascadeOffset}px`;
+            modal.style.top = `${cascadeOffset}px`;
+
             // Store reference to overlay on modal for proper cleanup
             modal._overlayElement = overlay;
 
@@ -3404,6 +3414,11 @@ class IntegramTable {
             modal.style.zIndex = baseZIndex + 1;
             modal.dataset.modalDepth = modalDepth;
 
+            // Add cascade offset for nested modals (6px per level)
+            const cascadeOffset = (modalDepth - 1) * 6;
+            modal.style.left = `${cascadeOffset}px`;
+            modal.style.top = `${cascadeOffset}px`;
+
             const typeName = this.getMetadataName(metadata);
             const title = `Создание: ${ typeName }`;
 
@@ -3885,6 +3900,12 @@ class IntegramTable {
             modal.style.zIndex = baseZIndex + 1;
             modal.dataset.modalDepth = modalDepth;
             modal.dataset.overlayRef = 'true';
+
+            // Add cascade offset for nested modals (6px per level)
+            const cascadeOffset = (modalDepth - 1) * 6;
+            modal.style.left = `${cascadeOffset}px`;
+            modal.style.top = `${cascadeOffset}px`;
+
             modal._overlayElement = overlay;
 
             const typeName = this.getMetadataName(metadata);


### PR DESCRIPTION
## Summary
Fixes #270

Добавлен каскадный эффект для вложенных модальных форм - каждая новая форма сдвигается на 6 пикселей вправо и вниз относительно предыдущей, чтобы визуально показать уровень вложенности.

## Проблема
При открытии нескольких вложенных форм создания/редактирования все модальные окна открывались в одной позиции, полностью перекрывая друг друга. Пользователь не мог видеть:
- Сколько форм открыто
- На каком уровне вложенности он находится
- Какие формы уже открыты

## Решение
Реализован каскадный эффект смещения:
- **Формула:** `offset = (modalDepth - 1) * 6px`
- Каждый уровень вложенности смещает модальное окно на 6px вправо и 6px вниз

**Визуальный эффект:**
```
┌─────────────────┐
│  Уровень 1      │ (0px, 0px)
│  ┌─────────────────┐
│  │  Уровень 2      │ (6px, 6px)
└──│  ┌─────────────────┐
   │  │  Уровень 3      │ (12px, 12px)
   └──│  ┌─────────────────┐
      │  │  Уровень 4      │ (18px, 18px)
      └──│                 │
         └─────────────────┘
```

Теперь видны края предыдущих форм, что создает визуальную "лестницу" и четко показывает структуру вложенности.

## Изменения
Добавлено смещение в 4 функции рендеринга модальных окон:
1. **renderCreateFormForReference** (строка ~1670) - создание записи из inline editor
2. **renderEditFormModal** (строка ~2925) - главная форма редактирования/создания
3. **openSubordinateCreateForm** (строка ~3417) - создание подчиненных записей
4. **renderCreateFormForFormReference** (строка ~3903) - создание из reference поля в форме

Код добавлен после установки z-index:
```javascript
// Add cascade offset for nested modals (6px per level)
const cascadeOffset = (modalDepth - 1) * 6;
modal.style.left = `${cascadeOffset}px`;
modal.style.top = `${cascadeOffset}px`;
```

## Примеры уровней
- **Уровень 1** (modalDepth=1): смещение 0px
- **Уровень 2** (modalDepth=2): смещение 6px
- **Уровень 3** (modalDepth=3): смещение 12px
- **Уровень 4** (modalDepth=4): смещение 18px
- **Уровень 5** (modalDepth=5): смещение 24px

## Test plan
- [x] Открыть форму редактирования записи
- [x] Нажать "+" в reference поле для создания нового значения
- [x] В открывшейся форме нажать "+" в другом reference поле
- [x] Продолжить вложение на 4-5 уровней
- [x] Проверить что каждая форма смещена на 6px вправо и вниз
- [x] Проверить что видны края всех предыдущих форм
- [x] Проверить что z-index работает корректно (верхняя форма активна)
- [x] Проверить закрытие форм - каждая закрывается со своим overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)