### PR TITLE
Fix issue #272: Correct modal centering with cascade offset

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1669,8 +1669,7 @@ class IntegramTable {
 
             // Add cascade offset for nested modals (6px per level)
             const cascadeOffset = (modalDepth - 1) * 6;
-            modal.style.left = `${cascadeOffset}px`;
-            modal.style.top = `${cascadeOffset}px`;
+            modal.style.transform = `translate(calc(-50% + ${cascadeOffset}px), calc(-50% + ${cascadeOffset}px))`;
 
             // Store reference to overlay on modal for proper cleanup
             modal._overlayElement = overlay;
@@ -2924,8 +2923,7 @@ class IntegramTable {
 
             // Add cascade offset for nested modals (6px per level)
             const cascadeOffset = (modalDepth - 1) * 6;
-            modal.style.left = `${cascadeOffset}px`;
-            modal.style.top = `${cascadeOffset}px`;
+            modal.style.transform = `translate(calc(-50% + ${cascadeOffset}px), calc(-50% + ${cascadeOffset}px))`;
 
             // Store reference to overlay on modal for proper cleanup
             modal._overlayElement = overlay;
@@ -3416,8 +3414,7 @@ class IntegramTable {
 
             // Add cascade offset for nested modals (6px per level)
             const cascadeOffset = (modalDepth - 1) * 6;
-            modal.style.left = `${cascadeOffset}px`;
-            modal.style.top = `${cascadeOffset}px`;
+            modal.style.transform = `translate(calc(-50% + ${cascadeOffset}px), calc(-50% + ${cascadeOffset}px))`;
 
             const typeName = this.getMetadataName(metadata);
             const title = `Создание: ${ typeName }`;
@@ -3903,8 +3900,7 @@ class IntegramTable {
 
             // Add cascade offset for nested modals (6px per level)
             const cascadeOffset = (modalDepth - 1) * 6;
-            modal.style.left = `${cascadeOffset}px`;
-            modal.style.top = `${cascadeOffset}px`;
+            modal.style.transform = `translate(calc(-50% + ${cascadeOffset}px), calc(-50% + ${cascadeOffset}px))`;
 
             modal._overlayElement = overlay;
 


### PR DESCRIPTION
## Summary
Fixes #272

После PR #271 модальные окна перестали центрироваться и появлялись вне экрана. Исправлено использованием `transform` вместо `left/top` для каскадного смещения.

## Проблема

После добавления каскадного смещения в PR #271, модальные окна уходили в левый верхний угол экрана вместо центрирования.

**Скриншот проблемы:**
![Image](https://github.com/user-attachments/assets/71f5da8d-6fda-4252-9d6b-e0c1c066e1a3)

## Причина

**CSS центрирование:**
```css
.edit-form-modal {
    position: fixed;
    top: 50%;
    left: 50%;
    transform: translate(-50%, -50%);
}
```

**Код из PR #271:**
```javascript
modal.style.left = `${cascadeOffset}px`;
modal.style.top = `${cascadeOffset}px`;
```

Inline стили `left` и `top` из JS **перезаписали** CSS правила `left: 50%` и `top: 50%`, сломав центрирование.

## Решение

Использовать `transform` для комбинирования центрирования и каскадного смещения:

**Было:**
```javascript
modal.style.left = `${cascadeOffset}px`;
modal.style.top = `${cascadeOffset}px`;
```

**Стало:**
```javascript
modal.style.transform = `translate(calc(-50% + ${cascadeOffset}px), calc(-50% + ${cascadeOffset}px))`;
```

### Как это работает:

- `-50%` - центрирование (от CSS)
- `+ ${cascadeOffset}px` - каскадное смещение (6px * уровень)

**Примеры для разных уровней:**

| Уровень | cascadeOffset | transform |
|---------|--------------|-----------|
| 1 | 0px | `translate(-50%, -50%)` - центр |
| 2 | 6px | `translate(calc(-50% + 6px), calc(-50% + 6px))` - центр + 6px |
| 3 | 12px | `translate(calc(-50% + 12px), calc(-50% + 12px))` - центр + 12px |
| 4 | 18px | `translate(calc(-50% + 18px), calc(-50% + 18px))` - центр + 18px |

## Изменения

Обновлены 4 функции рендеринга модальных окон:
1. **renderCreateFormForReference** (строка ~1672) - создание из inline editor
2. **renderEditFormModal** (строка ~2926) - главная форма
3. **openSubordinateCreateForm** (строка ~3417) - подчиненные записи
4. **renderCreateFormForFormReference** (строка ~3903) - создание из reference поля

## Результат

✅ Модальные окна остаются в центре экрана  
✅ Каскадное смещение работает корректно (6px на уровень)  
✅ Обе функции работают вместе гармонично

**Визуальный эффект:**
```
        ┌─────────────────┐
        │  Уровень 1      │ (центр экрана)
        │  ┌─────────────────┐
        │  │  Уровень 2      │ (центр + 6px)
        └──│  ┌─────────────────┐
           │  │  Уровень 3      │ (центр + 12px)
           └──│                 │
              └─────────────────┘
```

## Test plan

- [x] Открыть форму редактирования - проверить центрирование
- [x] Открыть вложенные формы (2-3 уровня)
- [x] Проверить что каждая форма центрирована + смещена на 6px
- [x] Проверить на разных разрешениях экрана
- [x] Проверить что модальные окна не выходят за границы экрана
- [x] Проверить каскадный эффект визуально

🤖 Generated with [Claude Code](https://claude.com/claude-code)