### PR TITLE
fix: validate columnOrder/visibleColumns against current columns to prevent empty table

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -181,14 +181,18 @@ class IntegramTable {
                 // Process columns to hide ID and Style suffixes
                 this.processColumnVisibility();
 
-                if (this.columnOrder.length === 0) {
+                const currentColumnIds = new Set(this.columns.map(c => c.id));
+
+                // Validate columnOrder against current columns; reset if stale (no matches)
+                if (this.columnOrder.length === 0 || !this.columnOrder.some(id => currentColumnIds.has(id))) {
                     this.columnOrder = this.columns.map(c => c.id);
                 }
-                if (this.visibleColumns.length === 0) {
+                // Validate visibleColumns; reset if stale (no matches after filtering)
+                const validVisible = this.visibleColumns.filter(id => currentColumnIds.has(id) && !this.idColumns.has(id));
+                if (this.visibleColumns.length === 0 || validVisible.length === 0) {
                     this.visibleColumns = this.columns.filter(c => !this.idColumns.has(c.id)).map(c => c.id);
                 } else {
-                    // Filter out style columns from visibleColumns if loaded from cookie
-                    this.visibleColumns = this.visibleColumns.filter(id => !this.idColumns.has(id));
+                    this.visibleColumns = validVisible;
                 }
 
                 if (this.options.onDataLoad) {


### PR DESCRIPTION
## Summary
- Validates that `columnOrder` and `visibleColumns` (loaded from cookies) reference column IDs that actually exist in the current `this.columns`
- When no matches are found (stale cookie state), resets to defaults derived from current columns
- Fixes the empty table rendering where `<tr>` rows had no `<th>`/`<td>` cells because `orderedColumns` was empty

## Root cause
After the JSON_DATA parser fix (#301/#302), column IDs use format `"0"`, `"1"`, `"2"` while cookie-saved state may contain IDs from a previous report-based session. The `render()` method maps `columnOrder` IDs to column objects, and when none match, produces empty rows.

## Test plan
- [ ] Load a table with JSON_DATA format — columns and data should render correctly
- [ ] Load a table with existing cookie state that matches — column order/visibility preserved
- [ ] Load a table where cookie state has stale IDs — should auto-reset and show all columns
- [ ] Verify report-based tables still work correctly with saved column state

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)