### PR TITLE
fix: use metadata id for data-column-id in object format

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -379,9 +379,9 @@ class IntegramTable {
             // Convert metadata to columns format
             const columns = [];
 
-            // First column: id -> type, val -> name, type -> column type
+            // First column: use metadata.id as column id (not sequential index)
             columns.push({
-                id: '0',
+                id: String(metadata.id),
                 type: metadata.type || 'SHORT',
                 format: metadata.type || 'SHORT',
                 name: metadata.val || 'Значение',
@@ -390,14 +390,14 @@ class IntegramTable {
                 orig: metadata.id // Store the original table id
             });
 
-            // Remaining columns from reqs array
+            // Remaining columns from reqs array: use req.id as column id (not sequential index)
             if (metadata.reqs && Array.isArray(metadata.reqs)) {
                 metadata.reqs.forEach((req, idx) => {
                     const attrs = this.parseAttrs(req.attrs);
                     const isReference = req.hasOwnProperty('ref_id');
 
                     columns.push({
-                        id: String(idx + 1),
+                        id: String(req.id),
                         type: req.type || 'SHORT',
                         format: req.type || 'SHORT',
                         name: attrs.alias || req.val,


### PR DESCRIPTION
## Summary
- In `parseObjectFormat()`, column `id` was incorrectly set to sequential indices (`'0'`, `'1'`, `'2'`, ...) instead of the actual metadata IDs (`metadata.id`, `req.id`)
- First column now uses `String(metadata.id)` instead of `'0'`
- Requisite columns now use `String(req.id)` instead of `String(idx + 1)`
- This fixes `data-column-id` HTML attributes and ensures filter parameters (`FR_{colId}`) use correct server-side IDs

## Test plan
- [ ] Load a table in object format and inspect `data-column-id` attributes on `<th>` elements — should match metadata IDs
- [ ] Apply filters in object format and verify the API request sends correct `FR_{id}` parameters
- [ ] Verify column reordering, visibility toggling, and width resizing still work
- [ ] Verify the "+" button on column headers still opens the correct create form
- [ ] Verify cookie-based state persistence works after the ID change (may need to clear old cookies)

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)