### PR TITLE
fix: prevent datetime value from leaking into data-record-id attribute

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -199,23 +199,25 @@ class IntegramTable {
                 // Check if there are more records (we requested pageSize + 1)
                 this.hasMore = newRows.length > this.options.pageSize;
 
-                // Keep only pageSize records
+                // Keep only pageSize records; also trim rawData to stay aligned
+                let rawData = json.rawData || [];
                 if (this.hasMore) {
                     newRows = newRows.slice(0, this.options.pageSize);
+                    rawData = rawData.slice(0, this.options.pageSize);
                 }
 
                 // Append or replace data
                 if (append) {
                     this.data = this.data.concat(newRows);
                     // Append raw object data if present
-                    if (json.rawData) {
-                        this.rawObjectData = this.rawObjectData.concat(json.rawData);
+                    if (rawData.length > 0) {
+                        this.rawObjectData = this.rawObjectData.concat(rawData);
                     }
                 } else {
                     this.data = newRows;
                     this.loadedRecords = 0;
                     // Replace raw object data if present
-                    this.rawObjectData = json.rawData || [];
+                    this.rawObjectData = rawData;
                 }
 
                 this.loadedRecords += newRows.length;
@@ -405,7 +407,8 @@ class IntegramTable {
 
             return {
                 columns: this.columns,
-                rows: rows
+                rows: rows,
+                rawData: Array.isArray(data) ? data : []  // Preserve raw data with 'i' keys for record IDs
             };
         }
 


### PR DESCRIPTION
## Summary
- `loadDataFromTable()` did not return `rawData` (the `{i, u, o, r}` array), so `rawObjectData` was always empty when using `dataSource='table'`
- This caused `isInObjectFormat` to be `false` in `renderCell()` despite being in object format, falling through to `determineParentRecordId()` which matched a wrong column and returned a datetime value as the record ID
- Now `loadDataFromTable()` returns `rawData` so record IDs are correctly extracted from the `i` field
- Also trims `rawData` in sync with `newRows` when `hasMore` is true to keep arrays aligned

## Test plan
- [ ] Load a table with `dataSource='table'` and verify `data-record-id` contains numeric IDs, not datetime values
- [ ] Edit a datetime cell inline and verify the correct record is updated
- [ ] Verify the edit icon onclick passes the correct record ID
- [ ] Test with pagination (scroll to load more) and verify record IDs remain correct
- [ ] Verify tables loaded via `parseObjectFormat` and `parseJsonDataArray` still work correctly

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)