### PR TITLE
fix: hide edit icon in report data source when no ID column exists

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1148,6 +1148,10 @@ class IntegramTable {
                 // Don't show edit icon in empty cells - no point editing nothing
                 const hasValue = value !== null && value !== undefined && value !== '';
                 let shouldShowEditIcon = hasValue && recordId && recordId !== '' && recordId !== '0';
+                // In report data source, hide edit icon when no corresponding ID column exists
+                if (shouldShowEditIcon && this.options.dataSource === 'report' && idColId === null) {
+                    shouldShowEditIcon = false;
+                }
                 if (shouldShowEditIcon && isInObjectFormat) {
                     const isFirstColumn = column.id === String(this.objectTableId);
                     const isReferenceField = column.ref_id != null;


### PR DESCRIPTION
## Summary
- In report data source mode (`dataSource='report'`), the edit icon was shown even when the report had no corresponding column with the "ID" suffix
- Without an ID column, the record ID cannot be reliably determined for the edit form
- Now suppresses the edit icon when `dataSource` is `'report'` and the column has no matching ID column (`idColId === null`)

## Test plan
- [ ] Load a report without ID columns and verify no edit icons are shown
- [ ] Load a report with ID columns (e.g., "TaskID" for "Task") and verify edit icons still appear correctly
- [ ] Verify object format (non-report) tables still show edit icons as before
- [ ] Verify table data source still shows edit icons as before

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)