### PR TITLE
fix: use column ID to find correct data array index in updateCellDisplay

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -2454,9 +2454,11 @@ class IntegramTable {
 
             // Update the data array as well
             const rowIndex = parseInt(cell.dataset.row);
-            const colIndex = parseInt(cell.dataset.col);
+            const colId = cell.dataset.colId;
+            const column = this.columns.find(c => c.id === colId);
+            const dataIndex = column ? this.columns.indexOf(column) : parseInt(cell.dataset.col);
             if (this.data[rowIndex]) {
-                this.data[rowIndex][colIndex] = newValue;
+                this.data[rowIndex][dataIndex] = newValue;
             }
         }
 


### PR DESCRIPTION
## Summary
- `updateCellDisplay()` used `cell.dataset.col` (visual column index from `orderedColumns`) to index into `this.data`, but `this.data` uses the original `this.columns` order
- When columns are reordered, this wrote the edited value to the wrong position in the data array, causing `determineParentRecord()` to read corrupted data (e.g. a datetime value instead of a record ID)
- Now uses `cell.dataset.colId` to find the column and compute the correct data array index via `this.columns.indexOf()`, consistent with how `cancelInlineEdit()` already handles this

Fixes #354

## Test plan
- [ ] Open a report-based table with reordered columns
- [ ] Inline edit a simple requisite cell and save
- [ ] Verify `parentRecordId` is not corrupted with datetime after save
- [ ] Verify the edited value appears in the correct cell after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)