### PR TITLE
fix: resolve issues #366, #367, #369 - file upload, export, checkbox selection

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -1806,3 +1806,93 @@ td:has(.inline-editor-file) {
     margin-right: 10px;
     font-size: 16px;
 }
+
+/* Checkbox selection mode */
+.integram-table-checkbox-toggle {
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 18px;
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    transition: background-color 0.2s;
+}
+
+.integram-table-checkbox-toggle:hover {
+    background-color: var(--md-hover);
+}
+
+.integram-table-checkbox-toggle.active {
+    background-color: var(--md-selected);
+    color: var(--md-primary);
+}
+
+.checkbox-column-header,
+.checkbox-column-cell,
+.checkbox-column-filter {
+    width: 36px !important;
+    min-width: 36px !important;
+    max-width: 36px !important;
+    text-align: center;
+    padding: 4px !important;
+}
+
+.checkbox-column-header input[type="checkbox"],
+.checkbox-column-cell input[type="checkbox"] {
+    cursor: pointer;
+    width: 16px;
+    height: 16px;
+}
+
+tr.row-selected {
+    background-color: var(--md-selected) !important;
+}
+
+.integram-bulk-delete-btn {
+    margin-left: 4px;
+    font-size: 12px;
+}
+
+.bulk-delete-confirm {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: 8px;
+    padding: 4px 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 13px;
+}
+
+.bulk-delete-confirm-btn {
+    font-size: 12px !important;
+}
+
+.bulk-delete-cancel-btn {
+    font-size: 12px !important;
+}
+
+/* Bulk delete progress */
+.bulk-delete-progress-bar-container {
+    width: 100%;
+    height: 8px;
+    background: #e0e0e0;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 8px;
+}
+
+.bulk-delete-progress-bar {
+    height: 100%;
+    background: var(--md-primary, #1976d2);
+    border-radius: 4px;
+    transition: width 0.3s ease;
+}
+
+.bulk-delete-progress-text {
+    text-align: center;
+    font-size: 14px;
+    color: var(--md-text-secondary);
+}


### PR DESCRIPTION
## Summary
- **#366** Fix file upload dialog reopening: added `stopPropagation()` to selectBtn and dropzone click handlers to prevent double `fileInput.click()` calls from event bubbling (selectBtn is nested inside dropzone). Also reset file input value after change event.
- **#367** Fix export fetching only 21 records: strip existing LIMIT parameter from apiUrl before appending export LIMIT, and detect auto-detected JSON_OBJ table format to route through the correct export path with proper LIMIT=0,1000000.
- **#369** Add checkbox row selection with bulk delete: checkbox toggle icon next to Settings, header select-all checkbox, red Delete button with count badge, confirmation popup, parallel `_m_del/{id}` API calls with progress bar, graceful error handling showing warnings for invalid JSON responses.

Closes #366
Closes #367
Closes #369

## Test plan
- [ ] Open a form with a FILE field, click "Выбрать файл", select a file - verify the file dialog does NOT reopen
- [ ] Open a table with more than 21 records, click Export > XLSX - verify all records are exported, not just 21
- [ ] Click the ☑ checkbox toggle icon - verify checkbox column appears on the left
- [ ] Check the header checkbox - verify all rows get selected
- [ ] With rows selected, click the red Delete button, then Confirm - verify records are deleted with progress bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)