### PR TITLE
fix: hide Delete button when bulk delete confirmation is shown (#371)

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -5595,8 +5595,12 @@ class IntegramTable {
             const existing = this.container.querySelector('.bulk-delete-confirm');
             if (existing) {
                 existing.remove();
+                btn.style.display = '';
                 return;
             }
+
+            // Hide delete button while confirmation is shown
+            btn.style.display = 'none';
 
             const confirmHtml = `
                 <div class="bulk-delete-confirm">
@@ -5614,6 +5618,7 @@ class IntegramTable {
             });
             confirmPopup.querySelector('.bulk-delete-cancel-btn').addEventListener('click', () => {
                 confirmPopup.remove();
+                btn.style.display = '';
             });
         }
 


### PR DESCRIPTION
## Summary
- Hide the "Удалить (N)" button when the confirmation popup ("Удалить N записей? Подтвердить удаление / Отмена") is displayed
- Restore the button when the user clicks "Отмена" or toggles the confirmation off

Closes #371

## Test plan
- [ ] Enable checkbox mode, select rows, click "Удалить" — verify the red button hides and confirmation appears
- [ ] Click "Отмена" — verify the red button reappears
- [ ] Click "Удалить" again, then click "Удалить" button area (toggle off) — verify button reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)