### PR TITLE
feat: auto-set table title from metadata val/value in object format (#373)

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -349,6 +349,11 @@ class IntegramTable {
                 const metadataResponse = await fetch(metadataUrl);
                 const metadata = await metadataResponse.json();
 
+                // Auto-set table title from metadata if not explicitly provided
+                if (!this.options.title && (metadata.val || metadata.value || metadata.name)) {
+                    this.options.title = metadata.val || metadata.value || metadata.name;
+                }
+
                 // Convert metadata to columns format
                 const columns = [];
 
@@ -441,6 +446,11 @@ class IntegramTable {
          * }
          */
         async parseObjectFormat(metadata, append = false) {
+            // Auto-set table title from metadata if not explicitly provided
+            if (!this.options.title && (metadata.val || metadata.value)) {
+                this.options.title = metadata.val || metadata.value;
+            }
+
             // Convert metadata to columns format
             const columns = [];
 
@@ -568,6 +578,11 @@ class IntegramTable {
                 const metadataUrl = `${ apiBase }/metadata/${ typeId }`;
                 const metadataResponse = await fetch(metadataUrl);
                 const metadata = await metadataResponse.json();
+
+                // Auto-set table title from metadata if not explicitly provided
+                if (!this.options.title && (metadata.val || metadata.value)) {
+                    this.options.title = metadata.val || metadata.value;
+                }
 
                 // Convert metadata to columns format
                 const columns = [];


### PR DESCRIPTION
## Summary
- When `data-title` is not explicitly set on the component, automatically populate the table title from the `val` or `value` key in the metadata API response
- Applied in all three object-format metadata loading paths: `parseObjectFormat`, `parseJsonDataArray`, and `loadDataFromTable`

Closes #373

## Test plan
- [ ] Load a table without `data-title` using object format API — verify the title shows the `val` from metadata (e.g. "Клиент")
- [ ] Load a table with explicit `data-title` — verify the explicit title is preserved, not overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)