### PR TITLE
Fix issue #378: Remove id: prefix from reference fields in export

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -6069,6 +6069,15 @@ class IntegramTable {
                     const format = col.format || 'SHORT';
                     let value = cellValue || '';
 
+                    // Issue #378: For reference fields, remove "id:" prefix from "id:Value" format
+                    const isRefField = col.ref_id != null || (col.ref && col.ref !== 0);
+                    if (isRefField && value && typeof value === 'string') {
+                        const colonIndex = value.indexOf(':');
+                        if (colonIndex > 0) {
+                            value = value.substring(colonIndex + 1);
+                        }
+                    }
+
                     // Convert special formats to plain text
                     switch (format) {
                         case 'BOOLEAN':
@@ -6106,6 +6115,15 @@ class IntegramTable {
                     const cellValue = row[this.columns.indexOf(col)];
                     const format = col.format || 'SHORT';
                     let value = cellValue || '';
+
+                    // Issue #378: For reference fields, remove "id:" prefix from "id:Value" format
+                    const isRefField = col.ref_id != null || (col.ref && col.ref !== 0);
+                    if (isRefField && value && typeof value === 'string') {
+                        const colonIndex = value.indexOf(':');
+                        if (colonIndex > 0) {
+                            value = value.substring(colonIndex + 1);
+                        }
+                    }
 
                     // Convert special formats to plain text
                     switch (format) {


### PR DESCRIPTION
## Summary
Fixed export to xlsx/xls/csv - reference fields now export only the value without the "id:" prefix.

## Problem
Reference fields in JSON_OBJ format return values as `"id:Value"` (e.g., `"123:Активный"`).
When exporting, the full string including "id:" was being exported instead of just the value.

## Solution
Added processing in both `prepareExportDataFromRows()` and `prepareExportData()` functions to:
1. Detect reference fields via `col.ref_id` or `col.ref`
2. Strip the "id:" prefix from values in format "id:Value"

## Example
- Before: `123:Активный` exported as `123:Активный`
- After: `123:Активный` exported as `Активный`

## Test plan
- [ ] Export table with reference fields to xlsx
- [ ] Verify reference values don't have "id:" prefix
- [ ] Test csv and xls formats as well

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)