### PR TITLE
Fix FILE type requisite display in tables

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1165,7 +1165,13 @@ class IntegramTable {
                 case 'FILE':
                     cellClass = 'file-cell';
                     if (value && value !== '') {
-                        // Display as a download link if value exists
+                        // Check if value is already an HTML anchor tag (from object/ endpoint)
+                        if (typeof value === 'string' && value.trim().startsWith('<a')) {
+                            // Value is already HTML link - add file-link class and render as-is
+                            displayValue = value.replace('<a', '<a class="file-link"');
+                            return `<td class="${ cellClass }" data-row="${ rowIndex }" data-col="${ colIndex }" data-source-type="${ this.getDataSourceType() }"${ dataTypeAttrs }${ customStyle }>${ displayValue }</td>`;
+                        }
+                        // Display as a download link if value is a path
                         const apiBase = this.getApiBase();
                         const fileName = value.split('/').pop() || value;
                         displayValue = `<a href="${ apiBase }/file/${ value }" target="_blank" class="file-link" title="Скачать файл">${ this.escapeHtml(fileName) }</a>`;
@@ -4043,6 +4049,13 @@ class IntegramTable {
                             if (datetimeObj && !isNaN(datetimeObj.getTime())) {
                                 return this.formatDateTimeDisplay(datetimeObj);
                             }
+                        }
+                        break;
+                    case 'FILE':
+                        // Check if value is already an HTML anchor tag (from object/ endpoint)
+                        if (typeof value === 'string' && value.trim().startsWith('<a')) {
+                            // Value is already HTML link - add file-link class and return as-is
+                            return value.replace('<a', '<a class="file-link"');
                         }
                         break;
                 }


### PR DESCRIPTION
## Summary
- Updated `renderCell()` to detect HTML anchor tags in FILE values from `object/` endpoint
- When value is already an HTML link (starts with `<a`), render it as-is with `file-link` class instead of escaping
- Updated `formatSubordinateCellValue()` to handle FILE type in subordinate tables of edit forms
- Preserves the original link href and text from the API response

## Test plan
- [ ] Verify FILE type values from `object/` endpoint display as clickable hyperlinks in main tables
- [ ] Verify FILE type values display correctly in subordinate tables within edit forms
- [ ] Verify existing FILE path values (non-HTML) still work correctly

Fixes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)