### PR TITLE
Display table requisites as links to subordinate tables

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -1337,6 +1337,45 @@
     font-style: italic;
 }
 
+/* Subordinate table link in main table cells */
+.subordinate-link-cell {
+    text-align: center;
+}
+
+.subordinate-table-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    color: var(--md-primary);
+    text-decoration: none;
+    padding: 4px 8px;
+    border-radius: 4px;
+    transition: var(--md-transition);
+}
+
+.subordinate-table-link:hover {
+    background-color: rgba(25, 118, 210, 0.08);
+    color: var(--md-primary-dark);
+}
+
+.subordinate-table-link .table-icon {
+    font-size: 16px;
+}
+
+.subordinate-table-link .subordinate-count {
+    font-size: 13px;
+    font-weight: 500;
+}
+
+/* Subordinate modal opened from main table */
+.subordinate-modal {
+    max-width: 800px;
+}
+
+.subordinate-modal .subordinate-table-container {
+    min-height: 200px;
+}
+
 /* Subordinate form modal (stacked on top of main modal) */
 /* z-index is set dynamically in JavaScript for proper stacking */
 .subordinate-form-modal {


### PR DESCRIPTION
## Summary
- Added `arr_id` attribute to column definitions when parsing metadata (in both `parseObjectFormat` and `parseJsonDataArray`)
- Added handling in `renderCell` for columns with `arr_id` to display as a clickable link with table icon (📋) and record count
- Added `openSubordinateTableFromCell` method to open subordinate table modal directly from the main table cell click
- Added CSS styles for the new subordinate link display

## Implementation Details
- Table requisites (columns with `arr_id`) now show a table icon with the record count in parentheses
- Clicking the link opens a modal with the subordinate table, allowing users to view and edit subordinate records
- The display uses the existing subordinate table rendering infrastructure

## Test plan
- [ ] Verify table requisites (with `arr_id`) display as clickable link with table icon and count
- [ ] Verify clicking the link opens the subordinate table modal
- [ ] Verify subordinate table data loads correctly
- [ ] Verify add/edit operations work within the subordinate table modal

Fixes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)