### PR TITLE
Display BOOLEAN type as checkbox icon in tables

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -265,6 +265,30 @@
     text-align: center;
 }
 
+/* Boolean checkbox icon styles */
+.boolean-check {
+    color: #4caf50;
+    font-weight: bold;
+    font-size: 16px;
+}
+
+.boolean-uncheck {
+    color: #9e9e9e;
+    font-size: 14px;
+}
+
+/* Subordinate table boolean styles */
+.subordinate-table .boolean-check {
+    color: #4caf50;
+    font-weight: bold;
+    font-size: 14px;
+}
+
+.subordinate-table .boolean-uncheck {
+    color: #9e9e9e;
+    font-size: 12px;
+}
+
 .integram-table .date-cell,
 .integram-table .datetime-cell {
     white-space: nowrap;

--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1149,7 +1149,10 @@ class IntegramTable {
                     break;
                 case 'BOOLEAN':
                     cellClass = 'boolean-cell';
-                    displayValue = value ? 'Да' : 'Нет';
+                    // Display as checkbox icon
+                    const boolValue = value === true || value === 1 || value === '1' || value === 'true' || value === 'Да';
+                    displayValue = boolValue ? '<span class="boolean-check">✓</span>' : '<span class="boolean-uncheck">✗</span>';
+                    return `<td class="${ cellClass }" data-row="${ rowIndex }" data-col="${ colIndex }" data-source-type="${ this.getDataSourceType() }" data-base-type="BOOLEAN"${ dataTypeAttrs }${ customStyle }>${ displayValue }</td>`;
                     break;
                 case 'DATE':
                     cellClass = 'date-cell';
@@ -2579,7 +2582,9 @@ class IntegramTable {
 
             switch (format) {
                 case 'BOOLEAN':
-                    displayValue = (newValue === '1' || newValue === 'true') ? 'Да' : 'Нет';
+                    // Display as checkbox icon
+                    const boolValue = newValue === '1' || newValue === 'true' || newValue === true;
+                    displayValue = boolValue ? '<span class="boolean-check">✓</span>' : '<span class="boolean-uncheck">✗</span>';
                     break;
                 case 'DATE':
                     if (newValue) {
@@ -4120,7 +4125,9 @@ class IntegramTable {
 
                 switch (baseFormat) {
                     case 'BOOLEAN':
-                        return value ? 'Да' : 'Нет';
+                        // Display as checkbox icon
+                        const boolVal = value === true || value === 1 || value === '1' || value === 'true' || value === 'Да';
+                        return boolVal ? '<span class="boolean-check">✓</span>' : '<span class="boolean-uncheck">✗</span>';
                     case 'DATE':
                         if (value) {
                             const dateObj = this.parseDDMMYYYY(value);


### PR DESCRIPTION
## Summary
- Updated `renderCell` to display BOOLEAN values as ✓/✗ icons instead of "Да"/"Нет" text
- Added `data-base-type="BOOLEAN"` attribute to boolean cells for storing base type
- Updated `formatSubordinateCellValue` to use checkbox icons in subordinate tables
- Updated `updateCellDisplay` to show checkbox icons after inline edit save
- Added CSS styles for `boolean-check` (green ✓) and `boolean-uncheck` (gray ✗) icons

## Test plan
- [ ] Verify BOOLEAN columns display as ✓ for true values in main tables
- [ ] Verify BOOLEAN columns display as ✗ for false values in main tables
- [ ] Verify BOOLEAN columns display correctly in subordinate tables of edit forms
- [ ] Verify inline editing of BOOLEAN cells updates to show correct icon after save

Fixes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)