### PR TITLE
Fix BOOLEAN type detection using normalizeFormat

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1082,7 +1082,9 @@ class IntegramTable {
         }
 
         renderCell(column, value, rowIndex, colIndex) {
-            const format = column.format || 'SHORT';
+            // Use normalizeFormat to get correct display format from column.type
+            // (column.format is for filters, column.type is the actual base type ID)
+            const format = column.type ? this.normalizeFormat(column.type) : (column.format || 'SHORT');
             let cellClass = '';
             let displayValue = value || '';
             let customStyle = '';


### PR DESCRIPTION
## Summary
- Updated `renderCell` to use `normalizeFormat(column.type)` to get the correct display format
- This correctly maps type '11' to 'BOOLEAN' instead of 'CHARS'
- `column.format` is kept for filter purposes (maps '11' -> 'CHARS' for string filters)
- `column.type` is now used for display formatting (maps '11' -> 'BOOLEAN' for checkbox display)

## Problem
BOOLEAN fields (type: "11" in metadata) were being displayed as text instead of checkbox icons because `mapTypeIdToFormat` was mapping '11' to 'CHARS' for filter purposes.

## Solution
Use `normalizeFormat(column.type)` which correctly converts the type ID to the display format using `getFormatById`, which properly maps '11' to 'BOOLEAN'.

## Test plan
- [ ] Verify BOOLEAN fields (type: "11") display as checkbox icons ✓/✗
- [ ] Verify inline editing of BOOLEAN fields works correctly
- [ ] Verify filters still work correctly for BOOLEAN fields

Fixes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)