### PR TITLE
Fix BOOLEAN detection for report data sources

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1082,9 +1082,16 @@ class IntegramTable {
         }
 
         renderCell(column, value, rowIndex, colIndex) {
-            // Use normalizeFormat to get correct display format from column.type
-            // (column.format is for filters, column.type is the actual base type ID)
-            const format = column.type ? this.normalizeFormat(column.type) : (column.format || 'SHORT');
+            // Determine display format:
+            // 1. For report data sources, column.format may already be a symbolic format like 'BOOLEAN'
+            // 2. For object/table data sources, use normalizeFormat(column.type) to convert type ID
+            // 3. Fall back to 'SHORT'
+            const validFormats = ['SHORT', 'CHARS', 'DATE', 'NUMBER', 'SIGNED', 'BOOLEAN',
+                                  'MEMO', 'DATETIME', 'FILE', 'HTML', 'BUTTON', 'PWD',
+                                  'GRANT', 'REPORT_COLUMN', 'PATH'];
+            const upperFormat = column.format ? String(column.format).toUpperCase() : '';
+            const format = validFormats.includes(upperFormat) ? upperFormat :
+                          (column.type ? this.normalizeFormat(column.type) : 'SHORT');
             let cellClass = '';
             let displayValue = value || '';
             let customStyle = '';


### PR DESCRIPTION
## Summary
Updated `renderCell` to properly detect BOOLEAN format for report data sources:
- For report tables (data-source-type="report"), `column.format` contains the symbolic format name like 'BOOLEAN' directly
- Check `column.format` first if it's a valid symbolic format
- Fall back to `normalizeFormat(column.type)` for object/table data sources
- Fall back to 'SHORT' if neither is available

## Changes
- Added check for valid symbolic format names in `column.format`
- Prioritizes `column.format` when it's already a symbolic format like 'BOOLEAN'
- Maintains backward compatibility with object/table data sources

## Test plan
- [ ] Verify BOOLEAN fields in report tables display as checkboxes ✓/✗
- [ ] Verify BOOLEAN fields in object/table data sources still work correctly
- [ ] Verify other field types are not affected

Fixes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)