### PR TITLE
Show edit-icon for table cells with matching col type

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1285,9 +1285,14 @@ class IntegramTable {
                     shouldShowEditIcon = false;
                 }
                 if (shouldShowEditIcon && isInObjectFormat) {
+                    // For table data source (data-source-type="table"), show edit icon when
+                    // data-col-type (paramId) matches window.id (objectTableId)
+                    const isTableDataSource = this.getDataSourceType() === 'table';
+                    const colTypeMatchesTableId = String(column.paramId) === String(this.objectTableId);
                     const isFirstColumn = column.id === String(this.objectTableId);
                     const isReferenceField = column.ref_id != null;
-                    shouldShowEditIcon = isFirstColumn || isReferenceField;
+                    // Show edit icon for: first column, reference fields, or table source with matching col type
+                    shouldShowEditIcon = isFirstColumn || isReferenceField || (isTableDataSource && colTypeMatchesTableId);
                 }
 
                 if (shouldShowEditIcon) {


### PR DESCRIPTION
## Summary
- Added check for table data source (`data-source-type="table"`)
- Show edit icon when `data-col-type` (column.paramId) matches `window.id` (objectTableId)
- Maintains existing behavior for first column and reference fields

## Changes
The edit icon is now shown for cells that meet these conditions:
- `data-source-type="table"` (table data source)
- `data-col-type` matches `window.id` (the metadata type ID for the table)

## Test plan
- [ ] Verify edit icon appears for cells in table data source where col type matches table ID
- [ ] Verify edit icon still works for first column cells
- [ ] Verify edit icon still works for reference field cells

Fixes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)