### PR TITLE
fix: don't mask empty PASSWORD fields with asterisks

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1190,7 +1190,8 @@ class IntegramTable {
                     break;
                 case 'PWD':
                     cellClass = 'pwd-cell';
-                    displayValue = '******';
+                    // Only mask with asterisks if there's a value, show empty if empty
+                    displayValue = (value !== null && value !== undefined && value !== '') ? '******' : '';
                     break;
                 case 'FILE':
                     cellClass = 'file-cell';
@@ -6285,7 +6286,8 @@ class IntegramTable {
                             value = cellValue ? 'Да' : 'Нет';
                             break;
                         case 'PWD':
-                            value = '******';
+                            // Only mask with asterisks if there's a value
+                            value = (cellValue !== null && cellValue !== undefined && cellValue !== '') ? '******' : '';
                             break;
                         case 'HTML':
                         case 'BUTTON':
@@ -6332,7 +6334,8 @@ class IntegramTable {
                             value = cellValue ? 'Да' : 'Нет';
                             break;
                         case 'PWD':
-                            value = '******';
+                            // Only mask with asterisks if there's a value
+                            value = (cellValue !== null && cellValue !== undefined && cellValue !== '') ? '******' : '';
                             break;
                         case 'HTML':
                         case 'BUTTON':


### PR DESCRIPTION
## Summary
- Only show '******' for PASSWORD/PWD fields when there's an actual value
- Show empty string for empty password fields so users can see whether the field is empty or not

Fixes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)