### PR TITLE
fix: correctly map type IDs to format names in mapTypeIdToFormat

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -133,13 +133,13 @@ class IntegramTable {
                 '9': 'DATE',       // Date
                 '13': 'NUMBER',    // Integer number
                 '14': 'SIGNED',    // Number with decimal part
-                '11': 'CHARS',     // Boolean (treat as string for filters)
+                '11': 'BOOLEAN',   // Boolean
                 '12': 'MEMO',      // Multiline text
                 '4': 'DATETIME',   // Date and time
-                '10': 'CHARS',     // File (treat as string for filters)
-                '2': 'CHARS',      // HTML (treat as string for filters)
-                '7': 'CHARS',      // Button (treat as string for filters)
-                '6': 'CHARS',      // Password (treat as string for filters)
+                '10': 'FILE',      // File
+                '2': 'HTML',       // HTML
+                '7': 'BUTTON',     // Button
+                '6': 'PWD',        // Password
                 '5': 'NUMBER',     // Grant (treat as number for filters)
                 '16': 'NUMBER',    // Report column (treat as number for filters)
                 '17': 'CHARS'      // Path (treat as string for filters)


### PR DESCRIPTION
## Summary
Update `mapTypeIdToFormat` to return correct format names:
- `'11'` -> `'BOOLEAN'` (was `'CHARS'`)
- `'10'` -> `'FILE'` (was `'CHARS'`)
- `'2'` -> `'HTML'` (was `'CHARS'`)
- `'7'` -> `'BUTTON'` (was `'CHARS'`)
- `'6'` -> `'PWD'` (was `'CHARS'`)

This fixes BOOLEAN fields in object format being displayed as SHORT instead of showing checkbox icons.

Fixes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)