### PR TITLE
Fix BOOLEAN cell rendering bug with string '0' values (#410)

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -1221,7 +1221,7 @@ class IntegramTable {
 
             // BOOLEAN cells use HTML icons, so skip HTML escaping for them
             if (format === 'BOOLEAN') {
-                const boolValue = value !== null && value !== undefined && value !== '' && value !== 0 && value !== false;
+                const boolValue = value !== null && value !== undefined && value !== '' && value !== 0 && value !== '0' && value !== false;
                 escapedValue = boolValue ? '<span class="boolean-check">✓</span>' : '<span class="boolean-uncheck">✗</span>';
                 // Store the original value for editing (1 or 0, or the actual value)
                 fullValueForEditing = boolValue ? '1' : '0';
@@ -4224,7 +4224,7 @@ class IntegramTable {
                 switch (baseFormat) {
                     case 'BOOLEAN':
                         // Display as checkbox icon: any non-empty value = YES, empty = NO
-                        const boolVal = value !== null && value !== undefined && value !== '' && value !== 0 && value !== false;
+                        const boolVal = value !== null && value !== undefined && value !== '' && value !== 0 && value !== '0' && value !== false;
                         return boolVal ? '<span class="boolean-check">✓</span>' : '<span class="boolean-uncheck">✗</span>';
                     case 'DATE':
                         if (value) {


### PR DESCRIPTION
## Summary
- Fixed inconsistent handling of string '0' values in BOOLEAN cells
- Added `!== '0'` check to `renderCell` and `formatSubordinateCellValue` functions
- Now matches the correct logic already present in `updateCellDisplay` and `renderInlineEditor`

## Problem
When the server returns '0' as a string (not a number), the condition `value !== 0` evaluated to true because string '0' is not equal to number 0. This caused:
- Wrong display (✓ instead of ✗)
- Wrong value stored in `data-full-value` ('1' instead of '0')
- Subsequent edits would show incorrect checkbox state

## Test plan
- [ ] Create a BOOLEAN field with value '0' (string from server)
- [ ] Verify it displays ✗ (unchecked) not ✓ (checked)
- [ ] Edit the field, verify checkbox reflects correct state
- [ ] Save and verify the display remains correct

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)