### PR TITLE
Fix subordinate table editing overwriting parent form's record ID (#412)

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -3783,16 +3783,19 @@ class IntegramTable {
             document.body.appendChild(overlay);
             document.body.appendChild(modal);
 
-            // Store modal context for subordinate tables
-            this.currentEditModal = {
-                modal,
-                recordId,
-                typeId,
-                metadata,
-                recordData,
-                subordinateTables,
-                recordReqs
-            };
+            // Store modal context for subordinate tables - ONLY for the first level (parent form)
+            // Don't overwrite when opening subordinate record forms (nested modals)
+            if (modalDepth === 1) {
+                this.currentEditModal = {
+                    modal,
+                    recordId,
+                    typeId,
+                    metadata,
+                    recordData,
+                    subordinateTables,
+                    recordReqs
+                };
+            }
 
             // Attach tab switching handlers
             if (hasSubordinateTables) {


### PR DESCRIPTION
## Summary
- Fixed `this.currentEditModal` being overwritten when opening subordinate record edit forms
- Now only sets `currentEditModal` for modalDepth === 1 (parent form level)
- Nested modals (subordinate record forms) no longer overwrite parent form context

## Problem
When editing a row in a subordinate table from within a parent edit form:
1. Opening the subordinate record's edit form overwrote `this.currentEditModal`
2. The parent form's `recordId` was replaced with the subordinate record's ID
3. After saving the subordinate record, the main table was reloaded instead of just refreshing the subordinate table tab

## Test plan
- [ ] Open a parent record edit form that has subordinate tables
- [ ] Click on a row in a subordinate table to edit it
- [ ] Save the subordinate record
- [ ] Verify the subordinate table tab refreshes (not the entire main table)
- [ ] Verify the parent form still displays the correct record

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)