### PR TITLE
Fix #425: Add task edit form on click in calendar

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,3 +1,6 @@
+<!-- Import IntegramTable CSS for edit form styles -->
+<link rel="stylesheet" href="/assets/css/integram-table.css">
+
 <style>
     /* CSS Variables */
     :root {
@@ -453,6 +456,9 @@
 <!-- Include FullCalendar locally -->
 <script src="/assets/vendor/fullcalendar/index.global.min.js"></script>
 
+<!-- Include IntegramTable for edit form functionality -->
+<script src="/assets/js/integram-table.js"></script>
+
 <script>
 // Calendar functionality
 let calendar;
@@ -832,10 +838,39 @@ function handleEventClick(info) {
     openTaskDetail(taskId);
 }
 
-// Open task detail
-function openTaskDetail(taskId) {
-    // Open task in new window using form interface
-    window.open(`/${ window.db }/form/3882/${ taskId }`, `task_${ taskId }`, 'width=800,height=600');
+// Open task detail (Issue #425)
+async function openTaskDetail(taskId) {
+    // Create a temporary IntegramTable instance to use its edit form functionality
+    const tempContainer = document.createElement('div');
+    tempContainer.id = 'temp-table-container';
+    tempContainer.style.display = 'none';
+    document.body.appendChild(tempContainer);
+
+    try {
+        // Create IntegramTable instance with minimal configuration
+        const tempTable = new IntegramTable('temp-table-container', {
+            apiUrl: `/${ window.db }/report/0`,
+            instanceName: 'calendarTaskEdit'
+        });
+
+        // Task type ID is 3596 as per issue #425
+        const taskTypeId = 3596;
+
+        // Open edit form for the task
+        await tempTable.openEditForm(taskId, taskTypeId, 0);
+
+        // Clean up temp container after modal is opened
+        setTimeout(() => {
+            document.body.removeChild(tempContainer);
+        }, 100);
+    } catch (error) {
+        console.error('Error opening task edit form:', error);
+        alert('Ошибка при открытии формы редактирования задачи');
+        // Clean up on error
+        if (tempContainer.parentNode) {
+            document.body.removeChild(tempContainer);
+        }
+    }
 }
 
 // Handle event mount (for tooltips)


### PR DESCRIPTION
## Summary
Resolves issue #425 by implementing an edit form modal for tasks when clicked in the calendar, replacing the previous behavior of opening a new window.

## Changes Made

### 🎯 Task Edit Form Integration

**Before:**
- Clicking a task opened a new browser window with form interface
- Used: `window.open(/db/form/3882/{taskId})`

**After:**
- Clicking a task opens an inline modal edit form
- Reuses IntegramTable's proven edit form functionality
- Stays on the same page for better UX

### 📋 Implementation Details

**API Integration (as per issue requirements):**
- Fetches metadata: `GET /metadata/3596` (task type)
- Saves changes: `POST /_m_save/{taskId}`
- Field naming convention: `t3596` for task name, `t{fieldId}` for other fields
- Follows rules from: https://github.com/ideav/upsound/blob/main/BASIC_RULES.md

**Code Reuse (as requested):**
- ✅ Included `integram-table.css` for modal styles
- ✅ Included `integram-table.js` for edit form logic
- ✅ Modified `openTaskDetail()` to use IntegramTable's `openEditForm()` method
- ✅ Creates temporary table instance to access edit functionality
- ✅ Changes to table component automatically reflected in calendar

### 🔧 Technical Implementation

```javascript
async function openTaskDetail(taskId) {
    // Create temp IntegramTable instance
    const tempTable = new IntegramTable('temp-container', {...});
    
    // Open edit form with task type ID 3596    await tempTable.openEditForm(taskId, 3596, 0);
    
    // Clean up after modal opens
}
```

### ✨ Benefits

1. **Consistency:** Same edit form UI across table and calendar views
2. **Maintainability:** Changes to IntegramTable edit form automatically apply here
3. **No Duplication:** Reuses existing, tested code
4. **Better UX:** Modal stays in context instead of opening new window
5. **Proper Validation:** All field validation and error handling included

### 🧪 Testing Notes

- Tested clicking calendar events
- Tested clicking overdue tasks in header section
- Edit form loads correctly with task data
- Save functionality works as expected
- Modal closes properly after save/cancel

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)