### PR TITLE
Fix #430: Improve calendar filters to use backend APIs

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -543,7 +543,7 @@ function collapseOverdueSection() {
 // Initialize calendar on page load
 document.addEventListener('DOMContentLoaded', function() {
     initializeCalendar();
-    loadTaskStatuses();
+    loadFilterOptions();
     loadTasks();
     setupAutoRefresh();
 });
@@ -582,18 +582,25 @@ function initializeCalendar() {
     calendar.render();
 }
 
-// Load task statuses
-async function loadTaskStatuses() {
+// Load all filter options from API
+async function loadFilterOptions() {
     try {
-        const response = await fetch(`/${ window.db }/object/3882/?JSON_OBJ`);
-        const data = await response.json();
+        // Load executors
+        const executorResponse = await fetch(`/${ window.db }/report/5230?JSON_KV`);
+        const executors = await executorResponse.json();
+        populateExecutorFilter(executors);
 
-        if (Array.isArray(data)) {
-            taskStatuses = data;
-            populateStatusFilter();
-        }
+        // Load task types
+        const taskTypeResponse = await fetch(`/${ window.db }/report/5241?JSON_KV`);
+        const taskTypes = await taskTypeResponse.json();
+        populateTaskTypeFilter(taskTypes);
+
+        // Load statuses
+        const statusResponse = await fetch(`/${ window.db }/report/6804?JSON_KV`);
+        const statuses = await statusResponse.json();
+        populateStatusFilter(statuses);
     } catch (error) {
-        console.error('Error loading task statuses:', error);
+        console.error('Error loading filter options:', error);
     }
 }
 
@@ -605,14 +612,40 @@ async function loadTasks() {
         const startDate = formatDateForAPI(view.activeStart);
         const endDate = formatDateForAPI(view.activeEnd);
 
-        // Fetch tasks for the current date range
-        const response = await fetch(`/${ window.db }/report/4283?JSON_KV&FR_date=${ startDate }&TO_date=${ endDate }`);
+        // Build query parameters with filters
+        let queryParams = `JSON_KV&FR_date=${ startDate }&TO_date=${ endDate }`;
+
+        // Add executor filter
+        const executorValue = document.getElementById('executorFilter').value;
+        if (executorValue) {
+            queryParams += `&FR_6814=${ encodeURIComponent(executorValue) }`;
+        }
+
+        // Add task type filter
+        const taskTypeValue = document.getElementById('taskTypeFilter').value;
+        if (taskTypeValue) {
+            queryParams += `&FR_6611=${ encodeURIComponent(taskTypeValue) }`;
+        }
+
+        // Add status filter
+        const statusValue = document.getElementById('statusFilter').value;
+        if (statusValue) {
+            queryParams += `&FR_6820=${ encodeURIComponent(statusValue) }`;
+        }
+
+        // Add important filter
+        const importantOnly = document.getElementById('importantFilter').checked;
+        if (importantOnly) {
+            queryParams += `&FR_6756=%`;
+        }
+
+        // Fetch tasks with filters applied on backend
+        const response = await fetch(`/${ window.db }/report/4283?${ queryParams }`);
         const data = await response.json();
 
         if (Array.isArray(data)) {
             allTasks = data;
-            populateFilters();
-            applyFilters();
+            renderEvents();
         } else {
             console.error('Invalid tasks data format:', data);
         }
@@ -657,76 +690,73 @@ function parseDateFromAPI(dateStr) {
     return new Date(year, month, day, hours, minutes, seconds);
 }
 
-// Populate filters
-function populateFilters() {
-    // Extract unique executors
-    const executors = new Set();
-    const taskTypes = new Set();
-
-    allTasks.forEach(task => {
-        if (task['Исполнитель']) executors.add(task['Исполнитель']);
-        if (task['Тип задачи']) taskTypes.add(task['Тип задачи']);
-    });
-
-    // Populate executor filter
+// Populate executor filter
+function populateExecutorFilter(executors) {
     const executorFilter = document.getElementById('executorFilter');
     executorFilter.innerHTML = '<option value="">Все</option>';
-    Array.from(executors).sort().forEach(executor => {
-        const option = document.createElement('option');
-        option.value = executor;
-        option.textContent = executor;
-        executorFilter.appendChild(option);
-    });
 
-    // Populate task type filter
+    if (Array.isArray(executors)) {
+        executors.forEach(executor => {
+            const option = document.createElement('option');
+            option.value = executor.k || executor.id;
+            option.textContent = executor.v || executor.name || executor.k;
+            executorFilter.appendChild(option);
+        });
+
+        // Set default to current user if available
+        if (window.uid) {
+            executorFilter.value = window.uid;
+        }
+    }
+}
+
+// Populate task type filter
+function populateTaskTypeFilter(taskTypes) {
     const taskTypeFilter = document.getElementById('taskTypeFilter');
     taskTypeFilter.innerHTML = '<option value="">Все</option>';
-    Array.from(taskTypes).sort().forEach(type => {
-        const option = document.createElement('option');
-        option.value = type;
-        option.textContent = type;
-        taskTypeFilter.appendChild(option);
-    });
+
+    if (Array.isArray(taskTypes)) {
+        taskTypes.forEach(type => {
+            const option = document.createElement('option');
+            option.value = type.k || type.id;
+            option.textContent = type.v || type.name || type.k;
+            taskTypeFilter.appendChild(option);
+        });
+    }
 }
 
 // Populate status filter
-function populateStatusFilter() {
+function populateStatusFilter(statuses) {
     const statusFilter = document.getElementById('statusFilter');
     statusFilter.innerHTML = '<option value="">Все</option>';
 
-    taskStatuses.forEach(status => {
-        const option = document.createElement('option');
-        option.value = status.i;
-        option.textContent = status.n;
-        statusFilter.appendChild(option);
-    });
+    if (Array.isArray(statuses)) {
+        statuses.forEach(status => {
+            const option = document.createElement('option');
+            option.value = status.k || status.id;
+            option.textContent = status.v || status.name || status.k;
+            statusFilter.appendChild(option);
+        });
+    }
 }
 
 // Apply filters and render events
 function applyFilters() {
-    const executorValue = document.getElementById('executorFilter').value;
-    const taskTypeValue = document.getElementById('taskTypeFilter').value;
-    const statusValue = document.getElementById('statusFilter').value;
-    const importantOnly = document.getElementById('importantFilter').checked;
+    // Since filters are now applied on the backend, reload tasks with new filters
+    loadTasks();
+}
 
-    // Filter tasks
-    const filteredTasks = allTasks.filter(task => {
-        if (executorValue && task['Исполнитель'] !== executorValue) return false;
-        if (taskTypeValue && task['Тип задачи'] !== taskTypeValue) return false;
-        if (statusValue && task['Статус'] !== statusValue) return false;
-        if (importantOnly && task['Важно'] !== 'X') return false;
-        return true;
-    });
-
+// Render events (called after tasks are loaded)
+function renderEvents() {
     // Convert to FullCalendar events
-    const events = filteredTasks.map(task => convertTaskToEvent(task));
+    const events = allTasks.map(task => convertTaskToEvent(task));
 
     // Update calendar
     calendar.removeAllEvents();
     calendar.addEventSource(events);
 
     // Update overdue section
-    updateOverdueSection(filteredTasks);
+    updateOverdueSection(allTasks);
 }
 
 // Convert task to FullCalendar event


### PR DESCRIPTION
## Summary
This PR resolves issue #430 by improving the calendar filter implementation to use backend API endpoints and server-side filtering.

## Changes Made
- **Load executor filter options** from `report/5230?JSON_KV` instead of extracting from task data
- **Load task type filter options** from `report/5241?JSON_KV` instead of extracting from task data
- **Load status filter options** from `report/6804?JSON_KV` instead of `object/3882`
- **Pass filter parameters to backend** when loading tasks:
  - Executor: `FR_6814`
  - Task type: `FR_6611`
  - Status: `FR_6820`
  - Important: `FR_6756=%` (when checkbox is checked)
- **Set default executor** to current user (`window.uid`)
- **Move filtering logic** from client-side to server-side for better performance

## Benefits
- Filters are now populated from the correct API endpoints as specified in the issue
- Server-side filtering reduces client-side processing and improves performance
- Default executor is automatically set to the current user for better UX
- Consistent API usage across the application

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)