### PR TITLE
Fix #457: Eliminate report/0 request and cache metadata in kanban

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1049,6 +1049,7 @@ var managersData = [];
 var taskTypesData = [];
 var currentStatusId = null;
 var currentStatusName = null;
+var kanbanFormTable = null; // Reusable IntegramTable instance for add/edit forms
 var currentFilterType = 'sales'; // 'sales' or 'partners'
 var currentProductId = 'all'; // 'all' or specific product ID
 var currentManagerId = null; // Selected manager ID, defaults to window.uid
@@ -1899,27 +1900,38 @@ async function openAddRecordModal(statusId, statusName){
     currentStatusId = statusId;
     currentStatusName = statusName;
 
-    // Create a hidden temporary container for IntegramTable
-    var tempContainer = document.createElement('div');
-    tempContainer.id = 'temp-kanban-add-container';
-    tempContainer.style.display = 'none';
-    document.body.appendChild(tempContainer);
-
     try {
-        // Create a proper IntegramTable instance
-        var tempTable = new IntegramTable('temp-kanban-add-container', {
-            apiUrl: '/' + db + '/report/0',
-            instanceName: 'kanbanAddClient'
-        });
+        // Create the IntegramTable instance once and reuse it (caches metadata)
+        if (!kanbanFormTable) {
+            var tempContainer = document.createElement('div');
+            tempContainer.id = 'temp-kanban-add-container';
+            tempContainer.style.display = 'none';
+            document.body.appendChild(tempContainer);
 
-        // Override loadData to trigger kanban reload after save
-        tempTable.loadData = function() {
-            loadKanbanData();
-            return Promise.resolve();
-        };
+            // Temporarily override init to prevent unnecessary report/0 request
+            var origInit = IntegramTable.prototype.init;
+            IntegramTable.prototype.init = function() {
+                this.loadColumnState();
+                this.loadSettings();
+            };
 
-        // Open create form for type 332 (Client)
-        await tempTable.openEditForm(null, 332, 0);
+            kanbanFormTable = new IntegramTable('temp-kanban-add-container', {
+                apiUrl: '/' + db + '/type/332',
+                instanceName: 'kanbanAddClient'
+            });
+
+            // Restore original init
+            IntegramTable.prototype.init = origInit;
+
+            // Override loadData to trigger kanban reload after save
+            kanbanFormTable.loadData = function() {
+                loadKanbanData();
+                return Promise.resolve();
+            };
+        }
+
+        // Open create form for type 332 (Client) — metadata is cached after first call
+        await kanbanFormTable.openEditForm(null, 332, 0);
 
         // Set the status field (requisite 4874) immediately after form renders
         // loadReferenceOptions runs async and will pick up this value to display the label
@@ -1927,17 +1939,9 @@ async function openAddRecordModal(statusId, statusName){
         if (hiddenInput) {
             hiddenInput.value = statusId;
         }
-
-        // Clean up temp container
-        setTimeout(function(){
-            var el = document.getElementById('temp-kanban-add-container');
-            if (el) el.remove();
-        }, 200);
     } catch(e) {
         console.error('Error opening add record form:', e);
         alert('Ошибка при подготовке формы: ' + e.message);
-        var el = document.getElementById('temp-kanban-add-container');
-        if (el) el.remove();
     }
 }
 


### PR DESCRIPTION
## Summary
- Eliminated the unnecessary `report/0?LIMIT=0,21` request when opening the add record form — report 0 does not exist
- Metadata for type 332 is now fetched once and cached across all subsequent `openAddRecordModal` calls via IntegramTable's built-in `metadataCache`
- The IntegramTable instance is created once and reused (stored in `kanbanFormTable` variable)

## What was wrong
1. `new IntegramTable()` constructor calls `init()` → `loadData()` → `fetch(report/0?LIMIT=0,21)` — an unnecessary request to a non-existent report
2. A new IntegramTable instance was created on every button click, so metadata for type 332 was re-fetched every time instead of being cached

## How it's fixed
- Temporarily overrides `IntegramTable.prototype.init` during construction to skip `loadData()` and `loadGlobalMetadata()` (prevents report/0 request)
- Restores the original `init` immediately after construction
- Stores the instance in a module-level variable for reuse — `openEditForm` checks `metadataCache[typeId]` before fetching, so metadata is only requested once

## Test plan
- [ ] Open kanban board, open browser DevTools Network tab
- [ ] Click "+" to add a new record
- [ ] Verify NO `report/0` request is made
- [ ] Verify the create form opens correctly
- [ ] Close the form and click "+" again — verify no new `metadata/332` request (cached)
- [ ] Fill in and save a record — verify kanban reloads with the new record

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)