### PR TITLE
Fix #461: Make tasks/deals row clickable above contacts overlay

### DIFF
--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -380,6 +380,8 @@
         align-items: center;
         gap: 2px;
         margin-top: 8px;
+        position: relative;
+        z-index: 1;
     }
 
     .kanban-add-task-button {


### PR DESCRIPTION
## Summary
- Added `position: relative` and `z-index: 1` to `.kanban-card-tasks-row` so buttons render above the absolutely-positioned `.kanban-card-contacts` overlay

## What was wrong
`.kanban-card-contacts` uses `position: absolute; bottom: 8px; right: 8px;` which overlaps the `.kanban-card-tasks-row` at the bottom of the card, making its buttons unclickable.

## Test plan
- [ ] Open kanban board
- [ ] Verify "Задачи" and "Сделки" buttons and their "+" buttons are all clickable
- [ ] Verify contact icons (phone/email) at bottom-right still work

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)