### PR TITLE
Fix #463 #464: Delete button and drag-and-drop field reordering

### DIFF
--- a/assets/css/integram-table.css
+++ b/assets/css/integram-table.css
@@ -884,6 +884,21 @@
     background-color: var(--md-selected);
 }
 
+.edit-form-footer .btn-danger {
+    background-color: #d32f2f;
+    color: white;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+.edit-form-footer .btn-danger:hover {
+    background-color: #b71c1c;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
+}
+
+.edit-form-footer .btn-danger:active {
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
 /* Subordinate table indicator */
 .subordinate-table-indicator {
     display: flex;
@@ -1244,6 +1259,48 @@
 
 .form-field-settings-footer .btn-secondary:active {
     background-color: var(--md-selected);
+}
+
+.form-field-settings-item {
+    cursor: grab;
+}
+
+.form-field-settings-item.dragging {
+    opacity: 0.4;
+}
+
+.form-field-settings-item.drag-over {
+    border-top: 2px solid var(--md-primary, #1976d2);
+}
+
+.form-field-settings-item .drag-handle {
+    margin-right: 8px;
+    color: var(--md-text-secondary, #666);
+    cursor: grab;
+    font-size: 14px;
+    user-select: none;
+}
+
+.form-field-settings-extra {
+    padding: 12px 24px;
+    border-top: 1px solid var(--md-divider, #e0e0e0);
+}
+
+.form-field-settings-extra label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    margin: 0;
+    font-size: 14px;
+    color: var(--md-text-primary);
+    user-select: none;
+}
+
+.form-field-settings-extra input[type="checkbox"] {
+    margin-right: 16px;
+    cursor: pointer;
+    width: 18px;
+    height: 18px;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary

### Issue #463 — Delete button on edit form
- Red "Удалить" button added to edit form footer (hidden by default)
- "Показывать кнопку «Удалить»" checkbox added to form field settings
- Confirmation dialog shown before deleting
- Deletes via `POST _m_del/{recordId}?JSON`
- Show/hide preference persisted in cookie per type (`{prefix}-form-show-delete-{typeId}`)

### Issue #464 — Draggable field reordering
- Field settings items now have a drag handle (☰) and support drag-and-drop reordering
- Field order saved in cookie per type (`{prefix}-form-order-{typeId}`)
- `renderAttributesForm` renders fields in saved order
- `applyFormFieldSettings` reorders DOM elements when settings are applied
- Settings dialog displays fields in the currently saved order

## Test plan
- [ ] Open any record edit form — verify Delete button is NOT visible by default
- [ ] Click ⚙️ settings, check "Показывать кнопку Удалить", save
- [ ] Verify red Delete button now appears in the form footer
- [ ] Click Delete, confirm — verify record is deleted and table reloads
- [ ] Open ⚙️ settings, drag fields to reorder them, save
- [ ] Verify edit form fields now display in the new order
- [ ] Close and reopen the form — verify order persists
- [ ] Open settings again — verify items show in the saved order

Closes #463
Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)