### PR TITLE
Fix #465: Auto-create deal when product filter is active

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -5660,6 +5660,12 @@ class IntegramTable {
                 // Show success message
                 this.showToast('Запись успешно сохранена', 'success');
 
+                // Dispatch event for external listeners
+                const savedId = isCreate ? (result.id || result.i || null) : recordId;
+                document.dispatchEvent(new CustomEvent('integram-record-saved', {
+                    detail: { isCreate, recordId: savedId, typeId, result }
+                }));
+
                 // Check if we edited a record from a subordinate table
                 let refreshedSubordinateTable = false;
                 if (!isCreate && this.currentEditModal && this.currentEditModal.subordinateTables) {

--- a/templates/kanban.html
+++ b/templates/kanban.html
@@ -1957,6 +1957,26 @@ function closeAddRecordModal(){
     currentStatusName = null;
 }
 
+// Auto-create deal when a product filter is selected and a new client is created
+document.addEventListener('integram-record-saved', function(e) {
+    var detail = e.detail;
+    if (detail.isCreate && String(detail.typeId) === String(clientTypeId) && currentProductId !== 'all') {
+        var params = new URLSearchParams();
+        params.append('t449', currentProductId);
+        params.append('_xsrf', xsrf);
+
+        fetch('/' + db + '/_m_new/' + dealTypeId + '?JSON&up=' + detail.recordId, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString()
+        }).then(function() {
+            console.log('Deal auto-created for client', detail.recordId, 'with product', currentProductId);
+        }).catch(function(err) {
+            console.error('Error auto-creating deal:', err);
+        });
+    }
+});
+
 function submitAddRecord(){
     // Get form values
     var name = $('#recordName').val().trim();


### PR DESCRIPTION
## Summary
- When a product filter is selected (not "Все") in the kanban radio group and a new client record is created, a deal record is automatically created as a child of the new client with `t449={selected product ID}`
- Added `integram-record-saved` custom event to `IntegramTable.saveRecord()` — fires after successful save with `{ isCreate, recordId, typeId, result }` detail
- Kanban listens for this event and creates the deal via `POST /_m_new/430?JSON&up={clientId}`

## Test plan
- [ ] Select a specific product in the kanban filter (not "Все")
- [ ] Click "+" to create a new client
- [ ] Fill in and save the form
- [ ] Verify a deal record is auto-created as a child of the new client with the selected product
- [ ] Select "Все" product filter, create a new client — verify NO deal is auto-created

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)