### PR TITLE
Fix #468: First column always at top of edit form

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -5408,11 +5408,18 @@ class IntegramTable {
                         }
                     });
 
-                    // Reorder: append groups in the saved order, then append any remaining
+                    // Ensure the first column (main field) is always at the top
+                    const mainGroup = groupMap['main'];
                     const orderedGroups = [];
                     const usedIds = new Set();
+                    if (mainGroup) {
+                        orderedGroups.push(mainGroup);
+                        usedIds.add('main');
+                    }
+
+                    // Reorder: append groups in the saved order, then append any remaining
                     order.forEach(fieldId => {
-                        if (groupMap[fieldId]) {
+                        if (groupMap[fieldId] && !usedIds.has(fieldId)) {
                             orderedGroups.push(groupMap[fieldId]);
                             usedIds.add(fieldId);
                         }
@@ -5425,8 +5432,8 @@ class IntegramTable {
                             if (match && !usedIds.has(match[1])) {
                                 orderedGroups.push(group);
                             }
-                        } else {
-                            orderedGroups.push(group); // Keep groups without field IDs (e.g., main field)
+                        } else if (!orderedGroups.includes(group)) {
+                            orderedGroups.push(group);
                         }
                     });
 


### PR DESCRIPTION
## Summary
- After adding drag-and-drop field reordering in form settings, the main field (first column) was being shown last
- The main field (`field-main`) was treated as a "remaining" group and appended after all saved-order fields
- Now the main field is always placed first before applying the saved field order

## Test plan
- [ ] Open edit form for any record type
- [ ] Go to form settings (gear icon) and drag fields to reorder them, then save
- [ ] Verify the first column (main field) stays at the top of the edit form
- [ ] Verify other fields respect the saved drag-and-drop order

🤖 Generated with [Claude Code](https://claude.com/claude-code)