### PR TITLE
Fix #482: Apply fieldHooks immediately on form open

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -5286,7 +5286,7 @@ class IntegramTable {
 
                     const refReqId = targetWrapper.dataset.refId;
 
-                    watchedHiddenInput.addEventListener('change', async () => {
+                    const applyHook = async () => {
                         const isEmpty = !watchedHiddenInput.value;
                         targetWrapper._extraParams = isEmpty ? (hook.onEmpty || {}) : (hook.onFilled || {});
                         try {
@@ -5298,7 +5298,11 @@ class IntegramTable {
                         } catch (error) {
                             console.error('Error reloading reference options for hook target:', error);
                         }
-                    });
+                    };
+
+                    watchedHiddenInput.addEventListener('change', applyHook);
+                    // Also apply immediately on form open based on current watched field value
+                    applyHook();
                 }
             }
         }


### PR DESCRIPTION
## Summary

- `integramTableOverrides.fieldHooks` hooks now fire immediately when the edit form opens, in addition to firing on field value changes
- This ensures the target field's dropdown options are filtered correctly from the start based on the existing value of the watched field (e.g. when editing an existing record)

## Test plan

- [ ] Configure a `fieldHooks` rule watching field A targeting field B
- [ ] Open an edit form for an existing record where field A already has a value → verify field B options are immediately filtered with `onFilled` params (no manual change needed)
- [ ] Open a form where field A is empty → verify field B options use `onEmpty` params from the start
- [ ] Change field A value → verify field B still re-filters correctly

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)