### PR TITLE
Render main field input type based on table's base type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-16T07:26:37.486Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/512
-Your prepared branch: issue-512-274d1780067f
-Your prepared working directory: /tmp/gh-issue-solver-1771434242066
-
-Proceed.
-
-
-Run timestamp: 2026-02-18T17:04:03.427Z


### PR DESCRIPTION
## Summary
- Renders the first column (main field) input element on record create/edit forms according to the table's base type (e.g., DATETIME for type=4)
- Supports DATE, DATETIME, NUMBER, SIGNED, BOOLEAN, MEMO, and text input types
- Sets default date/datetime values to current date/time when creating new records

## Changes
- Modified `IntegramTable.renderAttributesForm` to render main field according to `metadata.type`
- Modified `IntegramCreateFormHelper.renderAttributesForm` similarly
- Modified `renderCreateFormForReference` to support type-based main field
- Modified `renderCreateFormForFormReference` to support type-based main field
- Added `attachDatePickerHandlers` calls to reference create forms

## Test plan
- [ ] Create a record in a table with base type DATETIME (type=4) - verify datetime picker is shown
- [ ] Create a record in a table with base type DATE (type=9) - verify date picker is shown
- [ ] Create a record in a table with base type NUMBER (type=13) - verify number input is shown
- [ ] Create a record in a table with base type MEMO (type=12) - verify textarea is shown
- [ ] Verify default date/datetime values are set to current date/time in create mode
- [ ] Edit existing records and verify correct input types are shown with saved values

Fixes #512

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)