### PR TITLE
Make table header sticky at 49px from top edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,14 +145,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-16T07:26:37.486Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/516
-Your prepared branch: issue-516-b07109677c36
-Your prepared working directory: /tmp/gh-issue-solver-1771438698759
-
-Proceed.
-
-
-Run timestamp: 2026-02-18T18:18:20.144Z


### PR DESCRIPTION
## Summary
- Changed table header sticky position from `top: 0` to `top: 49px` so the header stays visible 49px below the top edge of the viewport
- Updated filter row sticky position to `top: 93px` to maintain proper stacking below the header

## Changes
- `assets/css/integram-table.css`:
  - `.integram-table th`: `top: 0` → `top: 49px`
  - `.filter-row td`: Uncommented and updated `top: 93px` (was commented-out `top: 44px`)

## Test plan
- [ ] Open a page with the IntegramTable component
- [ ] Scroll down the page and verify that the table header becomes sticky at 49px from the top
- [ ] Verify that the filter row (when enabled) stays below the header when scrolling

Fixes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)