### PR TITLE
fix: change parent record link to open edit form instead of table view (issue #573)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-18T18:41:49.117Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/573
-Your prepared branch: issue-573-018e13c4ba96
-Your prepared working directory: /tmp/gh-issue-solver-1772197708962
-
-Proceed.
-
-
-Run timestamp: 2026-02-27T13:08:30.450Z


### PR DESCRIPTION
## Summary

- Changed `parentRecordLink` in `.integram-table-title` from `/{dbName}/table/{parentRecordId}` to `/{dbName}/edit_obj/{parentRecordId}`
- Clicking on the parent record name in the breadcrumb now opens the record for editing instead of navigating to a table view

## Changes

**File:** `assets/js/integram-table.js` (line 267)

```diff
-                const parentRecordLink = `/${ dbName }/table/${ parentRecordId }`;
+                const parentRecordLink = `/${ dbName }/edit_obj/${ parentRecordId }`;
```

## Test plan

- [ ] Navigate to a table with F_U > 1 (a child table of a parent record)
- [ ] Verify the breadcrumb shows the parent type and parent record name
- [ ] Click on the parent record name link
- [ ] Confirm it opens the edit form (`/edit_obj/{id}`) instead of the table view (`/table/{id}`)

Fixes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)