### PR TITLE
feat: show GRANT and REPORT_COLUMN fields as dropdowns in edit form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-18T18:41:49.117Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/577
-Your prepared branch: issue-577-ac5f4dc30471
-Your prepared working directory: /tmp/gh-issue-solver-1772217177144
-
-Proceed.
-
-
-Run timestamp: 2026-02-27T18:32:58.526Z


### PR DESCRIPTION
## Summary

Fixes #577

This PR modifies the edit form in `assets/js/integram-table.js` to display GRANT (type 5) and REPORT_COLUMN (type 16) fields as dropdown select elements instead of regular text inputs. The dropdown options are fetched dynamically from the API:

- **GRANT fields**: Options loaded from `GET /grants`
- **REPORT_COLUMN fields**: Options loaded from `GET /rep_cols`

### Changes Made

- Added dropdown rendering for GRANT and REPORT_COLUMN types in `renderAttributesForm` method (IntegramTable class)
- Added dropdown rendering for GRANT and REPORT_COLUMN types in `renderAttributesForm` method (IntegramCreateFormHelper class)
- Added `loadGrantAndReportColumnOptions` method to both classes to fetch options from the respective APIs
- Options are loaded asynchronously with a "Loading..." placeholder shown during fetch
- Pre-selected values are preserved when editing existing records
- Error handling with "Error loading" message if API call fails

## Test plan

- [ ] Open an edit form for a record that has a GRANT type field - verify it shows as a dropdown
- [ ] Open an edit form for a record that has a REPORT_COLUMN type field - verify it shows as a dropdown
- [ ] Verify the dropdowns load options from the API (`GET /grants` and `GET /rep_cols`)
- [ ] Edit an existing record with GRANT/REPORT_COLUMN field - verify the current value is pre-selected
- [ ] Create a new record with GRANT/REPORT_COLUMN field - verify dropdown allows selection
- [ ] Save a record after changing GRANT/REPORT_COLUMN value - verify it saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)