### PR TITLE
feat: show GRANT and REPORT_COLUMN fields as dropdowns for first column

### DIFF
--- a/assets/js/integram-table.js
+++ b/assets/js/integram-table.js
@@ -6175,6 +6175,24 @@ class IntegramTable {
                 mainFieldHtml = `<input type="number" class="form-control" id="field-main" name="main" value="${ this.escapeHtml(mainValue) }" required step="0.01">`;
             } else if (mainFieldType === 'MEMO') {
                 mainFieldHtml = `<textarea class="form-control memo-field" id="field-main" name="main" rows="4" required>${ this.escapeHtml(mainValue) }</textarea>`;
+            } else if (mainFieldType === 'GRANT') {
+                // GRANT field (dropdown with options from GET grants API - issue #581)
+                mainFieldHtml = `
+                    <select class="form-control form-grant-select" id="field-main" name="main" required data-grant-type="grant">
+                        <option value="">Загрузка...</option>
+                    </select>
+                `;
+                // Store current value for later selection after options load
+                mainFieldHtml += `<input type="hidden" id="field-main-current-value" value="${ this.escapeHtml(mainValue) }">`;
+            } else if (mainFieldType === 'REPORT_COLUMN') {
+                // REPORT_COLUMN field (dropdown with options from GET rep_cols API - issue #581)
+                mainFieldHtml = `
+                    <select class="form-control form-grant-select" id="field-main" name="main" required data-grant-type="rep_col">
+                        <option value="">Загрузка...</option>
+                    </select>
+                `;
+                // Store current value for later selection after options load
+                mainFieldHtml += `<input type="hidden" id="field-main-current-value" value="${ this.escapeHtml(mainValue) }">`;
             } else {
                 // Default: text input (SHORT, CHARS, etc.)
                 mainFieldHtml = `<input type="text" class="form-control" id="field-main" name="main" value="${ this.escapeHtml(mainValue) }" required>`;
@@ -10024,6 +10042,24 @@ class IntegramCreateFormHelper {
             mainFieldHtml = `<input type="number" class="form-control" id="field-main" name="main" value="${ this.escapeHtml(mainValue) }" required step="0.01">`;
         } else if (mainFieldType === 'MEMO') {
             mainFieldHtml = `<textarea class="form-control memo-field" id="field-main" name="main" rows="4" required>${ this.escapeHtml(mainValue) }</textarea>`;
+        } else if (mainFieldType === 'GRANT') {
+            // GRANT field (dropdown with options from GET grants API - issue #581)
+            mainFieldHtml = `
+                <select class="form-control form-grant-select" id="field-main" name="main" required data-grant-type="grant">
+                    <option value="">Загрузка...</option>
+                </select>
+            `;
+            // Store current value for later selection after options load
+            mainFieldHtml += `<input type="hidden" id="field-main-current-value" value="${ this.escapeHtml(mainValue) }">`;
+        } else if (mainFieldType === 'REPORT_COLUMN') {
+            // REPORT_COLUMN field (dropdown with options from GET rep_cols API - issue #581)
+            mainFieldHtml = `
+                <select class="form-control form-grant-select" id="field-main" name="main" required data-grant-type="rep_col">
+                    <option value="">Загрузка...</option>
+                </select>
+            `;
+            // Store current value for later selection after options load
+            mainFieldHtml += `<input type="hidden" id="field-main-current-value" value="${ this.escapeHtml(mainValue) }">`;
         } else {
             // Default: text input (SHORT, CHARS, etc.)
             mainFieldHtml = `<input type="text" class="form-control" id="field-main" name="main" value="${ this.escapeHtml(mainValue) }" required>`;


### PR DESCRIPTION
## Summary

Fixes #581

This PR extends the dropdown feature from #578 to also apply to the first (main) column of tables. When the main field type is GRANT or REPORT_COLUMN, it now renders as a dropdown select element instead of a regular text input.

### Changes Made

- Added GRANT dropdown support for main field in `renderAttributesForm` method (IntegramTable class)
- Added REPORT_COLUMN dropdown support for main field in `renderAttributesForm` method (IntegramTable class)
- Added GRANT dropdown support for main field in `renderAttributesForm` method (IntegramCreateFormHelper class)
- Added REPORT_COLUMN dropdown support for main field in `renderAttributesForm` method (IntegramCreateFormHelper class)

### How It Works

- **GRANT fields**: Options loaded from `GET /grants` API endpoint
- **REPORT_COLUMN fields**: Options loaded from `GET /rep_cols` API endpoint
- The existing `loadGrantAndReportColumnOptions` method (from PR #578) handles loading options for both the main field and requisite fields

## Test plan

- [ ] Create a new record type where the main (first) field is of type GRANT - verify it shows as a dropdown
- [ ] Create a new record type where the main (first) field is of type REPORT_COLUMN - verify it shows as a dropdown
- [ ] Edit an existing record with GRANT type main field - verify the current value is pre-selected
- [ ] Edit an existing record with REPORT_COLUMN type main field - verify the current value is pre-selected
- [ ] Verify that requisite fields with GRANT/REPORT_COLUMN types still work correctly (regression test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)