### PR TITLE
fix: use correct t{arrId} parameter naming when creating subordinate records (issue #597)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-18T18:41:49.117Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/597
-Your prepared branch: issue-597-f34f8cccc4c6
-Your prepared working directory: /tmp/gh-issue-solver-1772349597263
-
-Proceed.
-
-
-Run timestamp: 2026-03-01T07:19:58.693Z


### PR DESCRIPTION
## Summary

Fixes #597

When creating a new subordinate record, the first column (main field) was being sent with incorrect parameter names:
- `main: значение` 
- `t0: значение`

Instead of the expected `t{tableId}` format:
- `t151: значение` (for table id 151)

## Root Cause

In the subordinate record creation handler (`assets/js/integram-table.js:7430-7440`), the code was:
1. Adding ALL form fields including `main` to the request parameters
2. Additionally appending the main value as `t0` (hardcoded)

This resulted in the main field value being sent twice with wrong parameter names.

## Solution

- Skip the `main` field in the form data loop to avoid sending it separately
- Use the correct parameter name `t${arrId}` instead of hardcoded `t0`

This aligns the subordinate record creation with all other record creation handlers in the codebase that correctly use `t${typeId}` naming.

## Test plan

- [ ] Create a new subordinate record in a table (e.g., type 151)
- [ ] Verify the request parameters show `t151: значение` instead of `main: значение` and `t0: значение`
- [ ] Verify the record is created successfully

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)