### PR TITLE
fix: correct mapTypeIdToFormat to return GRANT/REPORT_COLUMN for types 5/16

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-18T18:41:49.117Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/605
-Your prepared branch: issue-605-6e6d0dc08112
-Your prepared working directory: /tmp/gh-issue-solver-1772359299376
-
-Proceed.
-
-
-Run timestamp: 2026-03-01T10:01:41.286Z


### PR DESCRIPTION
## Summary

Fixes #605 — After PR #602, GRANTS-type columns (type `5`) in `.integram-table` were rendered as plain number inputs instead of dropdown selects when editing inline.

## Root Cause

In `mapTypeIdToFormat()`, types `'5'` (GRANT) and `'16'` (REPORT_COLUMN) were mapped to `'NUMBER'`. This function is used to set `column.format` when building column metadata. The `renderCell()` function stores this format in `data-col-format`, which is then read by `renderInlineEditor()` to decide the editor type.

Since `'NUMBER'` is a recognized format, `renderInlineEditor` would show a `<input type="number">` — even though `switch` cases for `'GRANT'` and `'REPORT_COLUMN'` already existed (added in PR #602). The dropdown code path was simply never reached.

## Fix

- Changed `mapTypeIdToFormat()` to return `'GRANT'` for type `'5'` and `'REPORT_COLUMN'` for type `'16'`
- Added `filterTypes['GRANT']` and `filterTypes['REPORT_COLUMN']` as aliases for `filterTypes['NUMBER']`, so that filter operators remain the same for these types

## Test plan

- [ ] Open table 116 ("Объекты") which has a first column with `"type": "5"` (GRANT)
- [ ] Click an editable cell in that column
- [ ] Verify a dropdown select is shown (not a number input)
- [ ] Verify that filtering on GRANT/REPORT_COLUMN columns still works with number filter operators

🤖 Generated with [Claude Code](https://claude.com/claude-code)