### PR TITLE
fix: prevent Save button from stretching to full width in form field settings modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,14 +156,3 @@ Proceed.
 
 
 Run timestamp: 2026-02-18T18:41:49.117Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/612
-Your prepared branch: issue-612-f68711cabd99
-Your prepared working directory: /tmp/gh-issue-solver-1772398044024
-
-Proceed.
-
-
-Run timestamp: 2026-03-01T20:47:25.436Z


### PR DESCRIPTION
## Summary
- Fix the Save button ("СОХРАНИТЬ") in the form field settings modal stretching to full width
- Add `flex: 0 0 auto` and `width: auto` CSS properties to prevent Bootstrap 5.3 from stretching buttons

## Root Cause
Bootstrap 5.3 has default flex styling that can cause buttons inside flex containers to stretch to fill available space. This was causing the Save button in the form field settings modal to span across most of the modal width, as shown in the issue screenshot.

## Solution
Added the same CSS fix pattern that was already applied to other modals in issue #569:
- `.column-settings-modal .btn`
- `.add-column-modal .btn`

Now applied to `.form-field-settings-footer .btn` as well.

## Changes
- `assets/css/integram-table.css`: Added `flex: 0 0 auto` and `width: auto` to `.form-field-settings-footer .btn`

## Test Plan
- [ ] Open the form field settings modal (click the settings icon in the edit form footer)
- [ ] Verify the Save button ("СОХРАНИТЬ") has an adequate width, not stretching across the full modal width
- [ ] Verify the Cancel button ("ОТМЕНА") still appears correctly
- [ ] Verify both buttons are properly aligned to the right of the modal footer

Fixes #612

🤖 Generated with [Claude Code](https://claude.ai/code)