### PR TITLE
fix: restore plain text link style for Группы, Фильтры, Экспорт buttons

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,14 +178,3 @@ Proceed.
 
 
 Run timestamp: 2026-03-02T19:12:11.881Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/654
-Your prepared branch: issue-654-226105b03390
-Your prepared working directory: /tmp/gh-issue-solver-1772479776333
-
-Proceed.
-
-
-Run timestamp: 2026-03-02T19:29:37.691Z


### PR DESCRIPTION
## Summary

- Changed button styling for "Группы", "Фильтры", and "Экспорт" buttons from `btn-outline-secondary` to `btn-link text-dark`
- These buttons now appear as plain text links without borders, matching the expected appearance shown in issue screenshot

## Changes

Updated `assets/js/integram-table.js`:
- Line 1083: "Группы" button - changed class from `btn btn-sm btn-outline-secondary` to `btn btn-sm btn-link text-dark`
- Line 1091: "Фильтры" button - changed class from `btn btn-sm btn-outline-secondary` to `btn btn-sm btn-link text-dark`
- Line 1095: "Экспорт" button - changed class from `btn btn-sm btn-outline-secondary` to `btn btn-sm btn-link text-dark`

## Test Plan

- [ ] Verify buttons appear as plain text links without borders
- [ ] Verify buttons are still clickable and functional
- [ ] Verify hover state works correctly

Fixes #654

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)