### PR TITLE
Fix sidebar not collapsing when inline width style is set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,14 +189,3 @@ Proceed.
 
 
 Run timestamp: 2026-03-02T19:31:45.523Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/674
-Your prepared branch: issue-674-009dc7fb46d0
-Your prepared working directory: /tmp/gh-issue-solver-1772530909845
-
-Proceed.
-
-
-Run timestamp: 2026-03-03T09:41:51.634Z


### PR DESCRIPTION
## Root Cause

When the user resizes the sidebar using the drag handle, the code in `setupSidebarResize()` sets an **inline style** width directly on the sidebar element (`sidebar.style.width = width + 'px'`).

When the user then clicks the collapse toggle button, the CSS class rule `.app-sidebar.collapsed { width: 56px; }` is supposed to collapse the sidebar. However, **inline styles have higher CSS specificity** than class styles, so the inline width overrides the CSS class width, preventing the sidebar from visually collapsing.

This explains the observed behavior: item names are hidden (because `.app-sidebar.collapsed .menu-text { display: none; }` still works), but the sidebar itself stays at the user-set width instead of collapsing to 56px.

## Fix

In `setupSidebarToggle()`, added two behaviors:

1. **When collapsing**: Clear the inline `style.width` so the CSS class `width: 56px` can take effect
2. **When expanding**: Restore the saved width from the cookie so the sidebar returns to its previous size

Also applied the same inline width clearance during page load, when restoring a previously collapsed sidebar state from localStorage.

## Changes

- `js/main-app.js`: Fixed `setupSidebarToggle()` to manage inline width when toggling collapse state

Fixes #674

---
*This PR was created automatically by the AI issue solver*