### PR TITLE
fix: add mobile responsive styles for edit form modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,14 +189,3 @@ Proceed.
 
 
 Run timestamp: 2026-03-02T19:31:45.523Z
-
----
-
-Issue to solve: https://github.com/ideav/crm/issues/695
-Your prepared branch: issue-695-1f3d8b1a23b2
-Your prepared working directory: /tmp/gh-issue-solver-1772553392710
-
-Proceed.
-
-
-Run timestamp: 2026-03-03T15:56:34.278Z


### PR DESCRIPTION
## Summary

Fixes #695

The edit form modal had a fixed `min-width: 600px` which caused it to overflow the viewport on mobile devices (e.g., iPhone 14 Pro Max with 430px width). This resulted in the form title being cut off on the left and the "Cancel" button being cut off on the right.

## Root Cause

In `css/integram-table.css`, the `.edit-form-modal` class had:
```css
min-width: 600px;
```

This prevented the modal from shrinking below 600px, even though the iPhone 14 Pro Max viewport is only 430px wide.

## Solution

Added a mobile-responsive media query `@media (max-width: 640px)` that:

1. **Removes min-width constraint** - The modal can now shrink to fit the screen
2. **Uses full width with small margins** - `width: calc(100% - 16px)` with 8px margins on each side
3. **Adjusts padding and font sizes** - Slightly reduced to better fit mobile screens
4. **Applies same fixes to other modals** - Form field settings, column settings, grouping settings, and subordinate form modals

## Changes

### `css/integram-table.css`
- Added new `@media (max-width: 640px)` responsive styles section at the end of the file
- Override `.edit-form-modal` to remove `min-width` and use full width on mobile
- Adjusted header, body, and footer padding for mobile
- Applied same responsive treatment to other modal types

## Test plan
- [ ] Open the app on a mobile device or in mobile emulation mode (e.g., iPhone 14 Pro Max - 430x932)
- [ ] Open a record editing form
- [ ] Verify the form title is fully visible (not cut off on the left)
- [ ] Verify the "Cancel" button is fully visible (not cut off on the right)
- [ ] Verify all form fields are accessible and usable
- [ ] Verify the "Save" and "Cancel" buttons work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)