### PR TITLE
fix: remove api/ prefix from URL in forms.html (issue #721)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,7 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/706
-# Branch: issue-706-fe2cb0fd17f5
-# Timestamp: 2026-03-07T18:21:38.064Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete
-# Updated: 2026-03-07T18:33:51.058Z

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -730,7 +730,7 @@ document.addEventListener('DOMContentLoaded', function() {
 // ============================================================
 function apiRequest(method, endpoint, data, callback) {
     const xhr = new XMLHttpRequest();
-    xhr.open(method, '/api/' + FormConstructor.db + '/' + endpoint, true);
+    xhr.open(method, '/' + FormConstructor.db + '/' + endpoint, true);
     xhr.setRequestHeader('X-Authorization', FormConstructor.token);
 
     if (method === 'POST') {


### PR DESCRIPTION
## Summary
- Remove the unnecessary `/api/` prefix from API request URLs in the `apiRequest` function in `templates/forms.html`

## Problem
The form constructor was using incorrect API URL format:
- **Before:** `https://ideav.ru/api/ru2/object/137?JSON_OBJ&LIMIT=1000`
- **After:** `https://ideav.ru/ru2/object/137?JSON_OBJ&LIMIT=1000`

Per [BASIC_RULES.md](https://github.com/ideav/upsound/blob/main/BASIC_RULES.md), the correct URL format is `/{db}/{cmd}/{id}`, not `/api/{db}/{cmd}/{id}`.

## Changes
Modified `templates/forms.html`:
- Changed `xhr.open(method, '/api/' + FormConstructor.db + '/' + endpoint, true);`
- To: `xhr.open(method, '/' + FormConstructor.db + '/' + endpoint, true);`

## Test plan
- [ ] Open the form constructor page (e.g., `/ru2/forms/`)
- [ ] Verify forms list loads correctly
- [ ] Verify panels load correctly when viewing a form
- [ ] Verify panel creation/editing works in edit mode

Fixes #721

🤖 Generated with [Claude Code](https://claude.ai/code)