### PR TITLE
fix: add null check for currentEditModal in tab handler (issue #739)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/739
-# Branch: issue-739-67471f0d4f44
-# Timestamp: 2026-03-07T20:29:33.742Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

Fixes #739

This PR fixes a `TypeError: Cannot read properties of undefined (reading 'recordId')` error that occurs when switching to a subordinate table tab in `.edit-form-tabs`.

### Root Cause

The error occurs at `integram-table.js` line 6889 where the code accesses `this.currentEditModal.recordId` without first checking if `this.currentEditModal` exists.

The `currentEditModal` property is only set when `modalDepth === 1` (i.e., for the parent form). When navigating tabs in a nested modal (where `modalDepth > 1`), `currentEditModal` might be undefined, causing the error.

### Solution

Added a null check for `this.currentEditModal` in the condition at line 6886, consistent with similar patterns already used elsewhere in the codebase (e.g., lines 7751, 9134, 9226).

**Before:**
```javascript
if (tabId.startsWith('sub-') && tab.dataset.arrId) {
```

**After:**
```javascript
if (tabId.startsWith('sub-') && tab.dataset.arrId && this.currentEditModal) {
```

### Testing

The fix follows the existing defensive coding pattern used throughout the codebase. If `currentEditModal` is undefined, the subordinate table loading is safely skipped, preventing the runtime error.

---
*Generated with [Claude Code](https://claude.ai/code)*