### PR TITLE
feat: add content display mode setting for panels (scroll/stretch)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/748
-# Branch: issue-748-e4d6d6436e24
-# Timestamp: 2026-03-08T05:58:46.999Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,6 @@
+# Auto-generated file for PR creation
+# Issue: https://github.com/ideav/crm/issues/748
+# Branch: issue-748-e4d6d6436e24
+# Timestamp: 2026-03-08T05:58:46.999Z
+# This file was created with --gitkeep-file (default)
+# It will be removed when the task is complete

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -150,6 +150,26 @@
     overflow: hidden;
 }
 
+/* Overflow Mode: Scroll - panel has fixed height with scrolling */
+.panel-card.overflow-scroll {
+    max-height: 500px;
+}
+
+.panel-card.overflow-scroll .panel-content {
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+/* Overflow Mode: Stretch - panel grows to fit content */
+.panel-card.overflow-stretch {
+    max-height: none;
+}
+
+.panel-card.overflow-stretch .panel-content {
+    max-height: none;
+    overflow-y: visible;
+}
+
 .panel-card.editing {
     border-color: #007bff;
     box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.1);
@@ -662,6 +682,14 @@
                 <label><t9n>[RU]Действие после отправки[EN]Next Action</t9n></label>
                 <input type="text" id="editPanelNextAction" placeholder="<t9n>[RU]URL или действие[EN]URL or action</t9n>">
             </div>
+            <div class="form-field" style="margin-top: 15px;">
+                <label><t9n>[RU]Режим отображения содержимого[EN]Content Display Mode</t9n></label>
+                <select id="editPanelOverflowMode">
+                    <option value=""><t9n>[RU]По умолчанию[EN]Default</t9n></option>
+                    <option value="scroll"><t9n>[RU]Скроллить (фиксированная высота)[EN]Scroll (fixed height)</t9n></option>
+                    <option value="stretch"><t9n>[RU]Растягивать (по размеру содержимого)[EN]Stretch (fit content)</t9n></option>
+                </select>
+            </div>
         </div>
         <div class="modal-footer">
             <button class="btn btn-danger" onclick="deletePanel()">
@@ -1044,6 +1072,7 @@ function loadPanelMetadataAndRender(panelsData, container, emptyState) {
         });
 
         FormConstructor.panels = panels;
+        FormConstructor.panelReqs = reqs;  // Store panel requisites for edit modal
         emptyState.classList.add('hidden');
 
         // Show add panel button in edit mode
@@ -1088,10 +1117,18 @@ function createPanelElement(panel, panelReqs) {
     const fontColor = panelReqs[254] || panelReqs['254'] || '#333333';
     const bgColor = panelReqs[255] || panelReqs['255'] || '#ffffff';
     const config = panelReqs[225] || panelReqs['225'] || '{}';
+    const overflowMode = panelReqs[258] || panelReqs['258'] || ''; // Overflow mode (scroll/stretch)
 
     // Apply colors
     if (fontColor) div.style.color = fontColor;
     if (bgColor) div.style.backgroundColor = bgColor;
+
+    // Apply overflow mode
+    if (overflowMode === 'scroll') {
+        div.classList.add('overflow-scroll');
+    } else if (overflowMode === 'stretch') {
+        div.classList.add('overflow-stretch');
+    }
 
     // Panel header
     let headerHtml = '<div class="panel-header">';
@@ -1837,10 +1874,19 @@ function showEditPanelModal(panelId) {
     const panel = FormConstructor.panels.find(p => p.id == panelId);
     if (!panel) return;
 
+    // Get panel requisites
+    const panelReqs = FormConstructor.panelReqs && FormConstructor.panelReqs[panelId] || {};
+
     document.getElementById('editPanelId').value = panelId;
     document.getElementById('editPanelName').value = panel.val || panel.name || '';
 
-    // TODO: Load panel settings
+    // Load panel settings from requisites
+    document.getElementById('editPanelColor').value = panelReqs[254] || panelReqs['254'] || '#333333';
+    document.getElementById('editPanelBgColor').value = panelReqs[255] || panelReqs['255'] || '#ffffff';
+    document.getElementById('editPanelFilter').value = panelReqs[181] || panelReqs['181'] || '';
+    document.getElementById('editPanelNextAction').value = panelReqs[257] || panelReqs['257'] || '';
+    document.getElementById('editPanelOverflowMode').value = panelReqs[258] || panelReqs['258'] || '';
+
     document.getElementById('editPanelModal').classList.remove('hidden');
 }
 
@@ -1939,13 +1985,15 @@ function savePanel() {
     const bgColor = document.getElementById('editPanelBgColor').value;
     const filter = document.getElementById('editPanelFilter').value;
     const nextAction = document.getElementById('editPanelNextAction').value;
+    const overflowMode = document.getElementById('editPanelOverflowMode').value;
 
     const data = {
         't138': name,
         't254': color,
         't255': bgColor,
         't181': filter,
-        't257': nextAction
+        't257': nextAction,
+        't258': overflowMode
     };
 
     apiRequest('POST', '_m_set/' + panelId + '?JSON', data, function(json) {


### PR DESCRIPTION
## Summary

Adds a new panel setting to the forms constructor that allows choosing between two content display modes:
- **Scroll** (fixed height): Panel maintains a fixed height with scrolling when content exceeds the available space
- **Stretch** (fit content): Panel grows to accommodate all content without scrolling

This addresses the user need to control how panels behave when their content doesn't fit within the default panel dimensions.

## 📋 Issue Reference
Fixes #748

## Technical Implementation

### CSS Classes
Added two CSS classes for the overflow modes:
```css
/* Scroll mode - fixed height with scrolling */
.panel-card.overflow-scroll {
    max-height: 500px;
}
.panel-card.overflow-scroll .panel-content {
    max-height: 400px;
    overflow-y: auto;
}

/* Stretch mode - grows to fit content */
.panel-card.overflow-stretch {
    max-height: none;
}
.panel-card.overflow-stretch .panel-content {
    max-height: none;
    overflow-y: visible;
}
```

### UI Changes
- Added "Content Display Mode" dropdown to the Edit Panel Modal with three options:
  - Default (no special handling)
  - Scroll (fixed height)
  - Stretch (fit content)

### Data Storage
- Overflow mode is stored in requisite `t258` of the panel record
- Setting is loaded when opening the Edit Panel Modal
- Setting is saved when clicking "Save" in the modal

### Code Changes
1. **CSS**: Added `.overflow-scroll` and `.overflow-stretch` classes
2. **Edit Panel Modal**: Added dropdown for selecting content display mode
3. **showEditPanelModal()**: Load existing overflow mode from panel requisites
4. **savePanel()**: Save overflow mode to `t258`
5. **createPanelElement()**: Apply appropriate CSS class based on stored overflow mode
6. **loadPanelMetadataAndRender()**: Store panel requisites in `FormConstructor.panelReqs` for access by edit modal

## Test Plan

- [ ] Open a form in edit mode
- [ ] Click settings (gear icon) on a panel
- [ ] Verify "Content Display Mode" dropdown appears with three options
- [ ] Select "Scroll (fixed height)" and save
- [ ] Verify panel has scrolling when content exceeds height
- [ ] Open settings again, verify "Scroll" option is selected
- [ ] Change to "Stretch (fit content)" and save  
- [ ] Verify panel grows to fit all content
- [ ] Open settings again, verify "Stretch" option is selected
- [ ] Change to "Default" and save
- [ ] Verify panel returns to default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)