### PR TITLE
Remove #toggleEditBtn button from forms.html (not visible in run mode)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,6 @@
+# Auto-generated file for PR creation
+# Issue: https://github.com/ideav/crm/issues/753
+# Branch: issue-753-2fbd594354c1
+# Timestamp: 2026-03-08T08:30:32.007Z
+# This file was created with --gitkeep-file (default)
+# It will be removed when the task is complete

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/753
-# Branch: issue-753-2fbd594354c1
-# Timestamp: 2026-03-08T08:30:32.007Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete

--- a/templates/forms.html
+++ b/templates/forms.html
@@ -556,10 +556,6 @@
             <span class="edit-mode-badge hidden" id="editModeBadge">
                 <t9n>[RU]Режим редактирования[EN]Edit Mode</t9n>
             </span>
-            <button class="btn btn-secondary hidden" id="toggleEditBtn" onclick="toggleEditMode()">
-                <i class="pi pi-pencil"></i>
-                <t9n>[RU]Редактировать[EN]Edit</t9n>
-            </button>
             <button class="btn btn-primary hidden" id="addPanelBtn" onclick="showAddPanelModal()">
                 <i class="pi pi-plus"></i>
                 <t9n>[RU]Добавить панель[EN]Add Panel</t9n>
@@ -1899,30 +1895,14 @@ function submitDataEntryForm(event, panelId, tableType) {
 // ============================================================
 function updateEditModeUI() {
     const badge = document.getElementById('editModeBadge');
-    const toggleBtn = document.getElementById('toggleEditBtn');
     const addBtn = document.getElementById('addPanelBtn');
 
     if (FormConstructor.editMode) {
         badge.classList.remove('hidden');
         addBtn.classList.remove('hidden');
-        toggleBtn.classList.add('hidden');
     } else {
         badge.classList.add('hidden');
-        if (FormConstructor.currentFormId) {
-            toggleBtn.classList.remove('hidden');
-        }
     }
-}
-
-function toggleEditMode() {
-    const url = new URL(window.location);
-    if (FormConstructor.editMode) {
-        url.searchParams.delete('EDIT');
-        url.searchParams.delete('edit');
-    } else {
-        url.searchParams.set('EDIT', '1');
-    }
-    window.location.href = url.toString();
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Removed the `#toggleEditBtn` button from `templates/forms.html` so it is not visible in run mode
- Removed the `toggleEditBtn` references from the `updateEditModeUI()` JavaScript function
- Removed the `toggleEditMode()` function which was only used by the removed button

### 📋 Issue Reference
Fixes #753

### 🔧 Changes Made
1. **HTML** - Removed the Edit button element that was shown in run mode
2. **JavaScript** - Cleaned up `updateEditModeUI()` function to remove references to the deleted button
3. **JavaScript** - Removed the unused `toggleEditMode()` function

### ✅ How to Test
1. Open forms.html in run mode (without `?EDIT=1` parameter)
2. Verify the Edit button is no longer visible
3. Open forms.html in edit mode (with `?EDIT=1` parameter)  
4. Verify edit mode still works correctly (badge visible, Add Panel button visible)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)