### PR TITLE
fix: hide 'Add Panel' button when no specific form is selected (issue #771)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/771
-# Branch: issue-771-d80cd3e2d14d
-# Timestamp: 2026-03-09T07:16:32.594Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

- **Root cause**: In `updateEditModeUI()`, the 'Add Panel' button was shown whenever `editMode` was `true`, without checking if a specific form was selected (`currentFormId`). This caused the button to appear on the form list page even when no form was being edited.
- **Fix**: Added `&& FormConstructor.currentFormId` condition so the button only shows when both edit mode is active AND a specific form is selected.

## Changes

`templates/forms.html` — Line 1982: Added `&& FormConstructor.currentFormId` to the condition that controls visibility of the 'Add Panel' button.

**Before:**
```javascript
if (FormConstructor.editMode) {
    addBtn.classList.remove('hidden');
```

**After:**
```javascript
if (FormConstructor.editMode && FormConstructor.currentFormId) {
    addBtn.classList.remove('hidden');
```

## Behavior

| Scenario | Before (broken) | After (fixed) |
|---|---|---|
| Form list page, no EDIT param | Button hidden ✅ | Button hidden ✅ |
| Form list page, with EDIT param | Button shown ❌ | Button hidden ✅ |
| Specific form open, no EDIT param | Button hidden ✅ | Button hidden ✅ |
| Specific form open, with EDIT param | Button shown ✅ | Button shown ✅ |

Fixes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)