### PR TITLE
fix: use _m_save for first column in saveReferenceEdit (issue #775)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/775
-# Branch: issue-775-42f892ba6abd
-# Timestamp: 2026-03-10T07:14:09.079Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -2915,7 +2915,10 @@ class IntegramTable {
 
                 params.append(`t${colType}`, selectedId);
 
-                const url = `${apiBase}/_m_set/${parentInfo.parentRecordId}?JSON`;
+                // Use _m_save for first column (issue #775), _m_set for requisites
+                const url = parentInfo.isFirstColumn
+                    ? `${apiBase}/_m_save/${parentInfo.parentRecordId}?JSON`
+                    : `${apiBase}/_m_set/${parentInfo.parentRecordId}?JSON`;
 
 
                 const response = await fetch(url, {


### PR DESCRIPTION
## Summary

Fixes #775

When the table component works with an **object-type** (`object`) source, editing the first column (the column whose `id` matches the table's own ID) via a reference field dropdown was incorrectly using `_m_set/{recordId}` instead of `_m_save/{recordId}`.

### Root Cause

The `saveReferenceEdit` method unconditionally used `_m_set` for all reference field saves. However, `saveInlineEdit` already had the correct logic — it checks `parentInfo.isFirstColumn` and uses `_m_save` for the first column and `_m_set` for requisites.

### Fix

Applied the same conditional endpoint selection to `saveReferenceEdit`:

```js
// Before (always used _m_set):
const url = `${apiBase}/_m_set/${parentInfo.parentRecordId}?JSON`;

// After (uses _m_save for first column, _m_set for requisites):
const url = parentInfo.isFirstColumn
    ? `${apiBase}/_m_save/${parentInfo.parentRecordId}?JSON`
    : `${apiBase}/_m_set/${parentInfo.parentRecordId}?JSON`;
```

### How `isFirstColumn` is determined

In `determineParentRecord()`:
- For **object format** data: `isFirstColumn` is `true` when `colId === String(this.objectTableId)` 
- For **non-object format** (report columns): `isFirstColumn` is `true` when the column type matches a top-level metadata item

This is the same logic already used by `saveInlineEdit`.

## Test plan

- [ ] Open a table component with an object-type source
- [ ] Click on a reference field in the first column (the column with the same ID as the table)
- [ ] Select a value from the dropdown
- [ ] Verify the save uses `_m_save/{id}` (not `_m_set/{id}`)
- [ ] Verify save works correctly and the value is updated in the table
- [ ] Verify reference fields in non-first columns still use `_m_set/{id}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)