### PR TITLE
fix: avoid redundant /metadata/{id} fetch when globalMetadata already loaded (issue #783)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/783
-# Branch: issue-783-a80e63d46827
-# Timestamp: 2026-03-10T10:13:47.680Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

Fixes #783

When the table initializes, it fetches `/metadata` (all tables metadata, ~7kB) via `loadGlobalMetadata()`. However, `loadDataFromTable()` and `parseJSONObjArray()` were then making a second fetch to `/metadata/{id}` (e.g. `/metadata/18`) even though this specific table's metadata is already contained in the global metadata response.

The fix routes those calls through the existing `fetchMetadata()` method which already has cache lookup logic (added in issue #779). If `globalMetadata` is loaded, it uses the cached item; if not yet available (race condition on first load), it gracefully falls back to a direct fetch.

## Changes

- **`loadDataFromTable()`**: Replace direct `fetch('/metadata/{id}')` call with `this.fetchMetadata(tableTypeId)` which uses `globalMetadata` cache
- **`parseJSONObjArray()`**: Same fix — use `this.fetchMetadata(typeId)` instead of direct fetch  
- **`openCreateRecordForm()` (global function)**: Check `_integramTableInstances` globalMetadata cache before making a network request, with fallback to direct fetch

## How it works

The `fetchMetadata()` method already implements the right logic:
```js
async fetchMetadata(typeId) {
    // Use globalMetadata if available - it already contains metadata for all tables (issue #779)
    if (this.globalMetadata) {
        const cachedItem = this.globalMetadata.find(item => item.id === typeId || item.id === Number(typeId));
        if (cachedItem) {
            return cachedItem;  // ✅ No network request needed
        }
    }
    // Fall back to direct fetch if cache miss
    const response = await fetch(`${apiBase}/metadata/${typeId}`);
    ...
}
```

By routing `loadDataFromTable()` and `parseJSONObjArray()` through this method instead of bypassing it with direct `fetch()` calls, the second redundant `/metadata/{id}` request is eliminated.

## Test plan

- [ ] Open a page with an IntegramTable using `dataSource='table'` and observe the Network tab
- [ ] Verify only one `/metadata` request is made (not both `/metadata` AND `/metadata/{id}`)
- [ ] Verify table still loads correctly with all columns and data
- [ ] Verify table still works when navigating directly to the page (first load, no cached global metadata yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)