### PR TITLE
fix: highlight only empty required fields in table edit mode (issue #785)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/785
-# Branch: issue-785-d35bde6e4868
-# Timestamp: 2026-03-10T10:15:12.396Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## 🤖 AI-Powered Solution

Fixes #785

## 📋 Problem

PR #780 introduced `highlightRequiredCells()` to visually highlight required fields (columns with `:!NULL:` in their `attrs`) when a user enters edit mode for a row. However, it highlighted **all** required fields, including those that already have a value filled in.

## ✅ Fix

Modified `highlightRequiredCells()` in `js/integram-table.js` to only add the `required-field-editing` CSS class to cells that are **currently empty**. This is done by calling the existing `extractCellValue(td)` method and skipping the highlight if the value is non-empty.

```javascript
if (column && column.attrs && column.attrs.includes(':!NULL:')) {
    // Only highlight if the cell is currently empty (issue #785)
    const currentValue = this.extractCellValue(td);
    if (!currentValue) {
        td.classList.add('required-field-editing');
    }
}
```

## 📁 Files Changed
- `js/integram-table.js` — added empty-value check before applying `required-field-editing` class

---
*This PR was created automatically by the AI issue solver*