### PR TITLE
feat: add text-based filtering for reference field filters (issue #799)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/799
-# Branch: issue-799-096dcba9cdbe
-# Timestamp: 2026-03-10T16:06:48.379Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

Restores the ability to filter reference (REF) columns by entering text values, in addition to selecting from the dropdown. This addresses the request in #799 to keep both filtering methods available.

After PR #798, reference field filters only allowed selection from a dropdown. This PR adds back text-based filtering for partial text matching.

## Changes

- **`js/integram-table.js`**:
  - Added text filter types (`~`, `^`, `!`) to REF filterTypes for partial text matching
  - Added `this.refTextFilterTypes` Set to track which filter types use text input
  - Modified `renderFilterCell()` to show text input for text-based filters instead of dropdown
  - Added mode switching in `showFilterTypeMenu()` to re-render when switching between text input and dropdown modes

## Filter Types Available

Users can now choose between:

| Filter Type | Symbol | Input Mode | Description |
|-------------|--------|------------|-------------|
| Equals | `=` | Dropdown | Select exact match from list |
| In List | `(,)` | Dropdown | Select multiple values from list |
| Contains | `~` | Text Input | Enter partial text (matches anywhere in value) |
| Starts With | `^` | Text Input | Enter text prefix |
| Not Contains | `!` | Text Input | Enter text that should NOT appear |
| Not Empty | `%` | - | Filter for non-empty values |
| Empty | `!%` | - | Filter for empty values |

## Test Plan

- [ ] Open a table with reference (REF) format columns
- [ ] Verify default filter type shows dropdown trigger button
- [ ] Click on filter icon and select `~` (contains) filter type
- [ ] Verify text input appears instead of dropdown
- [ ] Enter partial text and verify filter works
- [ ] Change filter type back to `=` (equals)
- [ ] Verify dropdown trigger button appears again
- [ ] Verify dropdown selection still works correctly

Fixes #799

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)