### PR TITLE
Move templates/integram-table.html to experiments

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/ideav/crm/issues/801
-# Branch: issue-801-17052b668af0
-# Timestamp: 2026-03-10T17:07:20.460Z
-# This file was created with --gitkeep-file (default)
-# It will be removed when the task is complete


### PR DESCRIPTION
## Summary

- Moves `templates/integram-table.html` to `experiments/integram-table.html` as requested in issue #801
- The file is experimental in nature and belongs in the `experiments/` directory alongside other test/experiment files

## Changes

- `templates/integram-table.html` → `experiments/integram-table.html` (rename only, no content changes)

Fixes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)