### PR TITLE
fix: use orig/ref table ID for multi-ref-tag click in inline editor (issue #873)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-03-12T09:57:38.946Z for PR creation at branch issue-825-17e20e731ff5 for issue https://github.com/ideav/crm/issues/825
 # Updated: 2026-03-12T16:00:39.108Z
-# Updated: 2026-03-13T13:42:35.694Z


### PR DESCRIPTION
## Summary

Fixes #873

When clicking a `.multi-ref-tag` chip in the **inline** multi-select reference editor (table view), the code was calling `openEditForm(id, colType, 0)` where `colType = column.paramId = req.id = 468` — the **requisite field ID**, not the referenced table ID. This caused `fetchMetadata(468)` → `GET metadata/468` → error.

The fix looks up the column object by `colId` and uses `col.orig || col.ref` (= `req.orig = 466`, the actual referenced table ID), consistent with how the **form editor** already handles this via `data-ref-type-id="${ req.orig || req.ref_id }"` (line 8039).

## Root cause

`currentEditingCell.colType` is set to `column.paramId = req.id` (requisite field ID, e.g. `468`), which is correct for saving data (`t468=...`), but **wrong** for opening the edit form, which needs the referenced table's metadata ID (`req.orig = 466`).

## Fix

```js
// Before (bug):
const refTypeId = this.currentEditingCell.colType;

// After (fix):
const col = this.columns.find(c => c.id === this.currentEditingCell.colId);
const refTypeId = (col && (col.orig || col.ref)) || this.currentEditingCell.colType;
```

The fallback to `colType` preserves existing behaviour for any edge cases where `orig`/`ref` is not available.

## Test plan
- [ ] Open a table that has a multi-select reference column (`:MULTI:` in attrs, e.g. "Тег" on the User table)
- [ ] Click a cell to open the inline multi-select editor
- [ ] Click on a tag chip (not the × remove button)
- [ ] Verify the edit form opens for the referenced record (no `metadata/468` error in console)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)