### PR TITLE
feat: add create-record button to multi-reference inline editor (issue #875)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-03-12T09:57:38.946Z for PR creation at branch issue-825-17e20e731ff5 for issue https://github.com/ideav/crm/issues/825
 # Updated: 2026-03-12T16:00:39.108Z
-# Updated: 2026-03-13T13:46:53.430Z


### PR DESCRIPTION
## Summary

- Added the `inline-editor-reference-add` ("+" button) to `inline-editor-multi-reference` fields, matching the behavior already present in single-reference fields
- The button appears when the user types text in the search input and is hidden when the input is empty
- Clicking the button opens the create-record modal pre-filled with the typed search value
- After a new record is created, it is automatically added to the multi-reference selection (not replacing it) and the editor re-renders to show the new tag

## Implementation details

In `renderMultiReferenceEditor` (`js/integram-table.js`):
- Extract `column`, `hasGranted`, `origType` from `this.columns` (same logic as single reference)
- Set `this.currentEditingCell.isMultiReference = true` and store `origType`
- Store the `renderEditor` closure on `currentEditingCell.renderEditor` so it can be called after record creation
- Render the `+` button HTML when `showAddButton` is true
- Toggle button visibility based on search input length
- Wire up click handler to call `openCreateFormForReference`

In `saveRecordForReference`:
- If `currentEditingCell.isMultiReference` is true, push the new record into `selectedItems`, call `saveMultiReferenceEdit`, and re-render via `currentEditingCell.renderEditor()` instead of replacing the field value

## Test plan

- [ ] Open an inline editor for a multi-select reference field where `granted=1` and `orig` is set
- [ ] Verify the "+" button is hidden initially
- [ ] Type in the search box — verify the "+" button appears
- [ ] Click the "+" button — verify the create-record modal opens with the typed text pre-filled
- [ ] Save the new record — verify it appears as a tag in the multi-reference editor
- [ ] Verify existing selected items are preserved (not replaced)
- [ ] Verify single-reference fields are unaffected

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)