### PR TITLE
fix: add edit icon immediately when empty cell gets its first value (#915)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-03-12T09:57:38.946Z for PR creation at branch issue-825-17e20e731ff5 for issue https://github.com/ideav/crm/issues/825
 # Updated: 2026-03-12T16:00:39.108Z
-# Updated: 2026-03-14T10:32:19.717Z


### PR DESCRIPTION
## Summary

Fixes #915

- When a user fills in an empty cell for the first time, the `.edit-icon` (pencil icon) was not appearing until the table was manually refreshed
- Root cause: `updateCellDisplay()` only restored an **existing** edit icon after a save, but never **added** one to a previously-empty cell (which had no edit icon to restore)

## Root Cause

In `renderCell()`, the edit icon is only added to the cell HTML when the value is non-empty (`hasValue = true`). For empty cells, no icon is rendered. When `updateCellDisplay()` is called after the first save, it checks `cell.querySelector('.edit-icon')` — finds nothing — and sets `cell.innerHTML = escapedValue` without any icon. The icon only appears after a full table re-render.

## Fix

Two-part change in `js/integram-table.js`:

1. **`renderCell()`**: After computing `typeId` in the edit icon block, save it as `editIconTypeId`. Include it as `data-edit-type-id` attribute on the TD element for inline-editable cells, so `updateCellDisplay` can reconstruct the edit icon later.

2. **`updateCellDisplay()`**: When there is no existing edit icon in the cell but the new value is non-empty and `data-edit-type-id` + `data-record-id` are set (i.e., the cell transitioned from empty to filled for the first time), construct and insert the edit icon immediately — no table refresh needed.

## Test plan

- [ ] Fill in an empty cell in an object-format table — verify the pencil edit icon appears immediately after saving (without refreshing)
- [ ] Verify existing non-empty cells still show the edit icon correctly
- [ ] Verify clearing a cell (setting it to empty) removes the edit icon on next render
- [ ] Verify multi-select reference fields still do NOT show an edit icon (they are excluded from `editIconTypeId` population)
- [ ] Verify report-format tables without ID columns still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)