### PR TITLE
fix: show tag dropdown in form multi-reference editor (issue #917)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-03-12T09:57:38.946Z for PR creation at branch issue-825-17e20e731ff5 for issue https://github.com/ideav/crm/issues/825
 # Updated: 2026-03-12T16:00:39.108Z
-# Updated: 2026-03-14T11:09:47.005Z


### PR DESCRIPTION
## Problem

When clicking `.edit-icon` on a user record and placing the cursor in the `.inline-editor-reference-search.form-ref-search` (the tag search input inside the edit form), the tag dropdown list did not appear.

Closes #917

## Root Cause

The CSS rule:
```css
.form-ref-editor-box .inline-editor-reference-dropdown {
    display: none;
}
```

sets `display: none` as the CSS default for the dropdown inside the form reference editor box.

In `initFormMultiReferenceEditor`, the focus and input event handlers used:
```js
dropdown.style.display = '';
```

Setting `style.display = ''` (empty string) **removes the inline style**, causing the browser to fall back to the CSS rule which sets `display: none`. So the dropdown was never actually shown.

The single-reference editor (`loadReferenceOptions`) already used `'block'` correctly (line 9452), but the multi-reference editor used `''`.

## Fix

Changed `dropdown.style.display = ''` to `dropdown.style.display = 'block'` in both the `focus` and `input` event handlers inside `initFormMultiReferenceEditor`, so that the inline style takes precedence over the CSS rule.

## Changes

- `js/integram-table.js`: Two lines changed in `initFormMultiReferenceEditor` — replace `''` with `'block'` for `dropdown.style.display` in focus and input handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)