### PR TITLE
'js/integram-table.js Я пытаюсь отредактировать роль  кнопкой .edit-icon и получаю ошибку'

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-03-12T09:57:38.946Z for PR creation at branch issue-825-17e20e731ff5 for issue https://github.com/ideav/crm/issues/825
 # Updated: 2026-03-12T16:00:39.108Z
-# Updated: 2026-03-14T11:45:08.845Z


### PR DESCRIPTION
## Summary

Fixes #921 — regression introduced by PR #916.

- After PR #916, clicking the `.edit-icon` on a reference field cell (e.g. "role" in a user row) that had just been filled for the first time threw `Error: Record 557 not found` — where 557 was the **user's** row ID, not the role's ID (520).
- Root cause: `updateCellDisplay()` reconstructed the edit icon using `cell.dataset.recordId` (the parent row's ID = 557) instead of the reference record's own ID (= 520).

## Root Cause

PR #916 added code in `updateCellDisplay()` to construct a new `.edit-icon` when a previously empty cell gets its first value. It used `cell.dataset.recordId` as the `recordId` argument to `openEditForm`. However, `data-record-id` stores the **parent row's** record ID (e.g. the user's ID 557), while for reference fields the edit icon must use the **referenced record's** ID (e.g. the role's ID 520).

In `renderCell()`, the existing edit icon is correctly built using `refValueId` (the parsed reference ID from `"id:Value"` format). But `data-ref-value-id` was only set during initial render and never updated after an inline edit save.

## Fix

Two changes in `js/integram-table.js`:

1. **`saveReferenceEdit()`**: After a successful save, set `cell.dataset.refValueId = selectedId` — this ensures the `data-ref-value-id` attribute reflects the newly selected reference record ID.

2. **`updateCellDisplay()`**: When constructing the edit icon, use `cell.dataset.refValueId || cell.dataset.recordId` as the record ID — for reference fields this picks the reference's own ID; for non-reference fields it falls back to the row's record ID as before.

## Test plan

- [ ] Fill in an empty reference cell (e.g. role in a user row) using inline editing — verify the pencil edit icon appears immediately and clicking it opens the correct record (not the parent row's record)
- [ ] Verify existing non-empty reference cells still show the edit icon and open the correct record
- [ ] Verify non-reference cells (text, date, etc.) that go from empty to filled still show the edit icon correctly
- [ ] Verify multi-select reference fields still do NOT show an edit icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)