### PR TITLE
Fix login/registration form input field format to match Database section

### DIFF
--- a/index.html
+++ b/index.html
@@ -672,24 +672,20 @@ mark.search-highlight {
             <div id="login-section">
                 <form id="login-form">
                     <!-- DB selector -->
-                    <div class="form-group" id="auth-db-group">
-                        <label for="auth-db-select">База данных</label>
-                        <select id="auth-db-select" class="auth-db-select">
+                    <div id="auth-db-group" style="margin-bottom:1rem;">
+                        <label for="auth-db-select" class="mb-0">База данных</label>
+                        <select id="auth-db-select" class="form-control pe-1 ps-1 mb-2" style="border: 1px solid lightgray !important;">
                             <option value="my">Личный кабинет</option>
                         </select>
                         <div id="auth-db-custom-group" style="display:none; margin-top:0.5rem;">
-                            <input type="text" id="auth-db-custom" class="auth-db-custom-input" placeholder="Введите имя базы данных" autocomplete="off">
+                            <input type="text" id="auth-db-custom" class="form-control pe-1 ps-1 mb-2" placeholder="Введите имя базы данных" autocomplete="off" style="border: 1px solid lightgray !important;">
                             <a href="#" id="auth-db-back" class="auth-db-back-link">&#8592; Вернуться к выбору</a>
                         </div>
                     </div>
-                    <div class="form-group">
-                        <label for="login-email">Email адрес</label>
-                        <input type="email" id="login-email" name="email" required placeholder="your@email.com">
-                    </div>
-                    <div class="form-group">
-                        <label for="login-password">Пароль</label>
-                        <input type="password" id="login-password" name="password" required>
-                    </div>
+                    <label for="login-email" class="mb-0">Email адрес</label>
+                    <input type="email" id="login-email" name="email" required placeholder="your@email.com" class="form-control pe-1 ps-1 mb-2" style="border: 1px solid lightgray !important;">
+                    <label for="login-password" class="mb-0">Пароль</label>
+                    <input type="password" id="login-password" name="password" required class="form-control pe-1 ps-1 mb-2" style="border: 1px solid lightgray !important;">
                     <button type="submit" class="btn-primary">Войти</button>
                 </form>
 
@@ -707,18 +703,12 @@ mark.search-highlight {
             <!-- Register form -->
             <div id="register-section" style="display:none;">
                 <form id="register-form">
-                    <div class="form-group">
-                        <label for="reg-email">Email адрес</label>
-                        <input type="email" id="reg-email" name="email" required placeholder="your@email.com">
-                    </div>
-                    <div class="form-group">
-                        <label for="reg-password">Пароль</label>
-                        <input type="password" id="reg-password" name="password" required minlength="6">
-                    </div>
-                    <div class="form-group">
-                        <label for="reg-confirm-password">Подтвердите пароль</label>
-                        <input type="password" id="reg-confirm-password" name="confirm-password" required>
-                    </div>
+                    <label for="reg-email" class="mb-0">Email адрес</label>
+                    <input type="email" id="reg-email" name="email" required placeholder="your@email.com" class="form-control pe-1 ps-1 mb-2" style="border: 1px solid lightgray !important;">
+                    <label for="reg-password" class="mb-0">Пароль</label>
+                    <input type="password" id="reg-password" name="password" required minlength="6" class="form-control pe-1 ps-1 mb-2" style="border: 1px solid lightgray !important;">
+                    <label for="reg-confirm-password" class="mb-0">Подтвердите пароль</label>
+                    <input type="password" id="reg-confirm-password" name="confirm-password" required class="form-control pe-1 ps-1 mb-2" style="border: 1px solid lightgray !important;">
                     <button type="submit" class="btn-primary">Зарегистрироваться</button>
                 </form>
 


### PR DESCRIPTION
Resolves #1180

## Summary
- Updated label/input field format in the login and registration forms (`index.html`) to match the same pattern used in the Database section of `templates/main.html`
- Labels now use `class="mb-0"` (no bottom margin), matching the reference format
- Inputs now use `class="form-control pe-1 ps-1 mb-2"` with `style="border: 1px solid lightgray !important;"`, matching the reference format
- Removed `<div class="form-group">` wrappers from login/register input fields (label and input are now siblings, not wrapped)
- Applied changes to all input fields in both the login form and the registration form

## Test plan
- [ ] Open `index.html` and click "Войти" button to open the auth panel
- [ ] Verify the Email and Password fields in the login form visually match the input style from the Database section in `templates/main.html`
- [ ] Switch to "Регистрация" tab and verify the same format is applied to Email, Password, and Confirm Password fields
- [ ] Verify the Database selector field also follows the same format
- [ ] Confirm form submission still works correctly for both login and registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)