### PR TITLE
fix: add inactive Маркетплейс menu item and update Кооперации icon (#1185)

### DIFF
--- a/css/cabinet.css
+++ b/css/cabinet.css
@@ -197,6 +197,13 @@
     filter: none;
 }
 
+.cabinet-menu-item--disabled,
+.cabinet-menu-item--disabled:hover {
+    opacity: 0.45;
+    cursor: not-allowed;
+    background: none;
+}
+
 .menu-icon {
     font-size: var(--menu-icon-size, 1.25rem);
     width: 1.5rem;

--- a/templates/my/main.html
+++ b/templates/my/main.html
@@ -82,7 +82,7 @@
                     <span>Базы данных</span>
                 </button>
                 <button class="cabinet-menu-item" data-section="community">
-                    <span class="menu-icon"><i class="pi pi-key"></i></span>
+                    <span class="menu-icon"><i class="pi pi-share-alt"></i></span>
                     <span>Кооперации</span>
                 </button>
                 <button class="cabinet-menu-item" data-section="profile">
@@ -104,6 +104,10 @@
                 <button class="cabinet-menu-item" data-section="referrals">
                     <span class="menu-icon"><i class="pi pi-users"></i></span>
                     <span>Партнерская программа</span>
+                </button>
+                <button class="cabinet-menu-item cabinet-menu-item--disabled" disabled title="Скоро">
+                    <span class="menu-icon"><i class="pi pi-shop"></i></span>
+                    <span>Маркетплейс</span>
                 </button>
             </nav>
         </aside>


### PR DESCRIPTION
## Summary
- Changes `Кооперации` menu icon from `pi-key` to `pi-share-alt` — better represents cooperation/sharing semantics
- Adds inactive `Маркетплейс` menu item at the bottom of the left sidebar with `pi-shop` icon
- Adds `.cabinet-menu-item--disabled` CSS class (opacity 0.45, `cursor: not-allowed`) for the greyed-out inactive appearance

Closes #1185

## Test plan
- [ ] Left sidebar shows Маркетплейс item below Партнерская программа, visually dimmed and non-clickable
- [ ] Кооперации now shows share-alt icon instead of key icon
- [ ] Clicking Маркетплейс does nothing (button is `disabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)