### PR TITLE
feat: add password reset functionality to login form (#1201)

### DIFF
--- a/index.html
+++ b/index.html
@@ -687,16 +687,23 @@ mark.search-highlight {
                         </div>
                     </div>
                     <div class="database-field-group">
-                        <label for="login-email" class="database-field-label">Email / имя пользователя</label>
+                        <label for="login-email" class="database-field-label" id="login-email-label">Email / имя пользователя</label>
                         <input type="text" id="login-email" name="email" required placeholder="your@email.com или имя пользователя" class="database-field-input">
                     </div>
-                    <div class="database-field-group">
+                    <div class="database-field-group" id="login-password-group">
                         <label for="login-password" class="database-field-label">Пароль</label>
                         <input type="password" id="login-password" name="password" required class="database-field-input">
                     </div>
+                    <div id="reset-hint" style="display:none; font-size:0.85rem; color:var(--text-secondary); margin-bottom:0.5rem;">Введите имя пользователя или email, мы попробуем найти вашу учетную запись и пришлем новый пароль на вашу почту</div>
                     <br />
-                    <button type="submit" class="btn-primary">Войти</button>
+                    <button type="submit" id="login-submit-btn" class="btn-primary">Войти</button>
+                    <button type="button" id="reset-submit-btn" class="btn-primary" style="display:none;">Сбросить пароль</button>
                 </form>
+                <div id="reset-message" style="display:none; margin-top:0.75rem; padding:0.5rem 0.75rem; border-radius:var(--radius-sm); font-size:0.9rem;"></div>
+                <div style="text-align:center; margin-top:0.75rem;">
+                    <a href="#" id="reset-link" style="font-size:0.85rem; color:var(--link-color); text-decoration:none;">Сбросить пароль</a>
+                    <a href="#" id="back-to-login-link" style="display:none; font-size:0.85rem; color:var(--link-color); text-decoration:none;">Войти с паролем</a>
+                </div>
 
                 <div id="yandex-divider" class="auth-divider" style="display:none;">или</div>
                 <div class="oauth-buttons-container">

--- a/js/app.js
+++ b/js/app.js
@@ -592,6 +592,123 @@ class App {
             });
         }
 
+        // Password reset toggle
+        const resetLink = document.getElementById('reset-link');
+        const backToLoginLink = document.getElementById('back-to-login-link');
+        const resetSubmitBtn = document.getElementById('reset-submit-btn');
+        const loginSubmitBtn = document.getElementById('login-submit-btn');
+        const resetHint = document.getElementById('reset-hint');
+        const loginPasswordGroup = document.getElementById('login-password-group');
+        const loginEmailLabel = document.getElementById('login-email-label');
+        const loginEmailInput = document.getElementById('login-email');
+        const resetMessage = document.getElementById('reset-message');
+
+        function enterResetMode() {
+            if (loginSubmitBtn) loginSubmitBtn.style.display = 'none';
+            if (resetSubmitBtn) resetSubmitBtn.style.display = '';
+            if (resetHint) resetHint.style.display = '';
+            if (loginPasswordGroup) loginPasswordGroup.style.display = 'none';
+            if (resetLink) resetLink.style.display = 'none';
+            if (backToLoginLink) backToLoginLink.style.display = '';
+            if (loginEmailLabel) loginEmailLabel.textContent = 'Имя пользователя или Email';
+            if (loginEmailInput) {
+                loginEmailInput.type = 'text';
+                loginEmailInput.placeholder = 'username или email';
+                loginEmailInput.removeAttribute('required');
+            }
+            const loginPassword = document.getElementById('login-password');
+            if (loginPassword) loginPassword.removeAttribute('required');
+            if (resetMessage) resetMessage.style.display = 'none';
+        }
+
+        function exitResetMode() {
+            if (loginSubmitBtn) loginSubmitBtn.style.display = '';
+            if (resetSubmitBtn) resetSubmitBtn.style.display = 'none';
+            if (resetHint) resetHint.style.display = 'none';
+            if (loginPasswordGroup) loginPasswordGroup.style.display = '';
+            if (resetLink) resetLink.style.display = '';
+            if (backToLoginLink) backToLoginLink.style.display = 'none';
+            if (loginEmailLabel) loginEmailLabel.textContent = 'Email / имя пользователя';
+            if (loginEmailInput) {
+                loginEmailInput.type = 'text';
+                loginEmailInput.placeholder = 'your@email.com или имя пользователя';
+                loginEmailInput.setAttribute('required', '');
+            }
+            const loginPassword = document.getElementById('login-password');
+            if (loginPassword) loginPassword.setAttribute('required', '');
+            if (resetMessage) resetMessage.style.display = 'none';
+        }
+
+        if (resetLink) {
+            resetLink.addEventListener('click', (e) => {
+                e.preventDefault();
+                enterResetMode();
+            });
+        }
+
+        if (backToLoginLink) {
+            backToLoginLink.addEventListener('click', (e) => {
+                e.preventDefault();
+                exitResetMode();
+            });
+        }
+
+        if (resetSubmitBtn) {
+            resetSubmitBtn.addEventListener('click', async () => {
+                const loginVal = loginEmailInput ? loginEmailInput.value.trim() : '';
+                if (!loginVal) {
+                    showToast('Введите имя пользователя или email', 'error');
+                    return;
+                }
+                const dbSelect = document.getElementById('auth-db-select');
+                const customInput = document.getElementById('auth-db-custom');
+                let selectedDb = dbSelect ? dbSelect.value : 'my';
+                if (selectedDb === '__other__') {
+                    selectedDb = customInput ? customInput.value.trim() : '';
+                    if (!selectedDb) {
+                        showToast('Введите имя базы данных', 'error');
+                        return;
+                    }
+                }
+                resetSubmitBtn.disabled = true;
+                try {
+                    const url = `auth?JSON&reset&db=${encodeURIComponent(selectedDb)}&login=${encodeURIComponent(loginVal)}`;
+                    const response = await fetch(url);
+                    const text = await response.text();
+                    let data = null;
+                    try { data = JSON.parse(text); } catch (e) { data = null; }
+                    if (resetMessage) {
+                        resetMessage.style.display = '';
+                        if (data === null) {
+                            resetMessage.style.background = 'var(--bg-secondary)';
+                            resetMessage.style.color = 'var(--text-primary)';
+                            resetMessage.textContent = text;
+                        } else {
+                            const msg = (data.message || '').toUpperCase();
+                            const isError = msg.includes('WRONG') || msg.includes('ERROR');
+                            if (!isError) {
+                                resetMessage.style.background = 'var(--bg-secondary)';
+                                resetMessage.style.color = 'var(--text-primary)';
+                                resetMessage.textContent = data.details || data.message || text;
+                            } else {
+                                resetMessage.style.background = 'var(--bg-secondary)';
+                                resetMessage.style.color = 'var(--error-color, #ef4444)';
+                                resetMessage.textContent = Object.entries(data).map(([k, v]) => `${k}: ${v}`).join(', ');
+                            }
+                        }
+                    }
+                } catch (err) {
+                    if (resetMessage) {
+                        resetMessage.style.display = '';
+                        resetMessage.style.color = 'var(--error-color, #ef4444)';
+                        resetMessage.textContent = err.message || 'Ошибка при сбросе пароля';
+                    }
+                } finally {
+                    resetSubmitBtn.disabled = false;
+                }
+            });
+        }
+
         // Register form
         const registerForm = document.getElementById('register-form');
         if (registerForm) {


### PR DESCRIPTION
## Summary
- Adds a "Сбросить пароль" link below the "Войти" button in the login form
- Clicking it hides the login button and password field, shows a hint text and "Сбросить пароль" button, and replaces the link with "Войти с паролем"
- "Войти с паролем" restores the original login form state
- The reset button validates the login field is filled, calls `auth?JSON&reset&db=...&login=...`, and shows: `details` on success, all fields on error, or raw response if JSON is invalid

## Test plan
- [ ] Click "Сбросить пароль" link — verify login button and password field hide, hint and reset button appear
- [ ] Click "Войти с паролем" — verify form restores to original state
- [ ] Submit reset with empty login field — should show toast error
- [ ] Submit reset with a valid login — verify API is called and response is shown

Closes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)