### PR TITLE
fix: check InviteID for inviteRequestAccept success (#1207)

### DIFF
--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -1204,8 +1204,16 @@ class CabinetController {
                 }
 
                 const acceptData = await response.json();
-                if (!Array.isArray(acceptData) || acceptData.length === 0 || acceptData[0]['Статус'] !== '372') {
-                    throw new Error('Операция не выполнена');
+                const acceptTabType = btn ? btn.dataset.tabType : 'requests';
+                if (acceptTabType === 'requests') {
+                    // inviteRequestAccept: success = non-empty InviteID
+                    if (!Array.isArray(acceptData) || acceptData.length === 0 || !acceptData[0].InviteID) {
+                        throw new Error('Операция не выполнена');
+                    }
+                } else {
+                    if (!Array.isArray(acceptData) || acceptData.length === 0 || acceptData[0]['Статус'] !== '372') {
+                        throw new Error('Операция не выполнена');
+                    }
                 }
             } else if (action === 'reject') {
                 // Invitations use report/inviteAccept; requests use report/inviteRequestAccept (236472)
@@ -1228,8 +1236,15 @@ class CabinetController {
                 }
 
                 const rejectData = await response.json();
-                if (!Array.isArray(rejectData) || rejectData.length === 0 || rejectData[0]['Статус'] !== '373') {
-                    throw new Error('Операция не выполнена');
+                if (tabType === 'requests') {
+                    // inviteRequestAccept: success = non-empty InviteID
+                    if (!Array.isArray(rejectData) || rejectData.length === 0 || !rejectData[0].InviteID) {
+                        throw new Error('Операция не выполнена');
+                    }
+                } else {
+                    if (!Array.isArray(rejectData) || rejectData.length === 0 || rejectData[0]['Статус'] !== '373') {
+                        throw new Error('Операция не выполнена');
+                    }
                 }
             } else {
                 // Action endpoint: /my/_invite_action/?JSON&id=<id>&action=<action>


### PR DESCRIPTION
## Summary
- For the "Запросы к моей базе" tab, `inviteRequestAccept` returns `Статус` as a human-readable string (e.g. `"Принято"`) rather than a numeric code (`"372"`/`"373"`)
- Changed success detection for both **accept** and **reject** actions on requests to check for a non-empty `InviteID` field in the response, as specified in issue #1207
- Invitation actions (inviteAccept) retain the existing `Статус` numeric check

## Test plan
- [ ] Accept a "Запрос к моей базе" → should show success toast and reload list
- [ ] Reject a "Запрос к моей базе" → should show success toast and reload list
- [ ] Accept/reject an invitation (Приглашенные мной) → behaviour unchanged

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)