### PR TITLE
feat: add 'Выйти везде' item to user menu dropdown (#1209)

### DIFF
--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -1866,6 +1866,14 @@ class CabinetController {
                 window.location.href = 'index.html';
             });
         }
+
+        const logoutEverywhereBtn = document.getElementById('logout-everywhere-btn');
+        if (logoutEverywhereBtn) {
+            logoutEverywhereBtn.addEventListener('click', async () => {
+                try { await fetch('/my/exit'); } catch (e) {}
+                window.location.href = '/my';
+            });
+        }
     }
 
     isDatePassed(dateStr) {

--- a/js/main-app.js
+++ b/js/main-app.js
@@ -1450,6 +1450,15 @@ class MainAppController {
                 window.location.href = '/';
             });
         }
+
+        const logoutEverywhereBtn = document.getElementById('logout-everywhere-btn');
+        if (logoutEverywhereBtn) {
+            logoutEverywhereBtn.addEventListener('click', async () => {
+                const dbName = typeof db !== 'undefined' ? db : '';
+                try { await fetch('/' + dbName + '/exit'); } catch (e) {}
+                window.location.href = '/' + dbName;
+            });
+        }
     }
 
     highlightActiveMenuItem() {

--- a/templates/main.html
+++ b/templates/main.html
@@ -58,6 +58,10 @@
                         <span class="user-menu-value" id="theme-value">Темная</span>
                     </button>
                     <div class="user-menu-divider"></div>
+                    <button id="logout-everywhere-btn" class="user-menu-item user-menu-item-danger" type="button" title="Выйти на всех устройствах, где совершен вход">
+                        <i class="user-menu-icon pi pi-sign-out"></i>
+                        <span>Выйти везде</span>
+                    </button>
                     <button id="logout-btn" class="user-menu-item user-menu-item-danger" type="button">
                         <i class="user-menu-icon pi pi-sign-out"></i>
                         <span>Выйти</span>

--- a/templates/my/main.html
+++ b/templates/my/main.html
@@ -62,6 +62,10 @@
                         <span class="user-menu-value" id="theme-value">Темная</span>
                     </button>
                     <div class="user-menu-divider"></div>
+                    <button id="logout-everywhere-btn" class="user-menu-item user-menu-item-danger" type="button" title="Выйти на всех устройствах, где совершен вход">
+                        <span class="user-menu-icon"><i class="pi pi-sign-out"></i></span>
+                        <span>Выйти везде</span>
+                    </button>
                     <button id="logout-btn" class="user-menu-item user-menu-item-danger" type="button">
                         <span class="user-menu-icon"><i class="pi pi-sign-out"></i></span>
                         <span>Выйти</span>


### PR DESCRIPTION
## Summary
- Adds a **Выйти везде** button to `.user-menu-dropdown` in both `templates/my/main.html` (cabinet) and `templates/main.html` (database view)
- Button has `title="Выйти на всех устройствах, где совершен вход"`
- On click: calls `/{db}/exit` API endpoint, then navigates to `/{db}`
- Placed directly above the existing **Выйти** button

## Test plan
- [ ] Open user menu in личный кабинет (`/my`) — verify "Выйти везде" appears above "Выйти"
- [ ] Hover "Выйти везде" — verify tooltip shows "Выйти на всех устройствах, где совершен вход"
- [ ] Click "Выйти везде" — verify `/my/exit` is called and page redirects to `/my`
- [ ] Open user menu in a database view — same checks with `/{db}/exit` and `/{db}` redirect

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)