### PR TITLE
fix: show active menu item name in .navbar-workspace (#1211)

### DIFF
--- a/js/main-app.js
+++ b/js/main-app.js
@@ -1467,6 +1467,7 @@ class MainAppController {
         const currentPath = window.location.pathname;
         const currentSearch = window.location.search; // e.g. "?EDIT"
 
+        let activeMenuName = null;
         const menuItems = document.querySelectorAll('.app-menu-item');
         menuItems.forEach(item => {
             // Use data-href attribute which contains the actual href value (without db prefix)
@@ -1485,24 +1486,36 @@ class MainAppController {
             const hrefParts = dataHrefPath.split('/').filter(p => p);
             const lastPart = hrefParts[hrefParts.length - 1];
 
+            let isActive = false;
             // When dataHref contains a query string (e.g. "forms?EDIT"), match against both
             // the current path action and the current URL query string
             if (dataHrefQuery) {
                 if (currentAction && lastPart === currentAction && currentSearch === dataHrefQuery) {
-                    item.classList.add('active');
-                    this.expandParentMenus(item);
+                    isActive = true;
                 } else if (currentPath.includes(dataHrefPath) && currentSearch === dataHrefQuery) {
-                    item.classList.add('active');
-                    this.expandParentMenus(item);
+                    isActive = true;
                 }
             } else if (currentAction && lastPart === currentAction) {
-                item.classList.add('active');
-                this.expandParentMenus(item);
+                isActive = true;
             } else if (currentPath.includes(dataHref)) {
+                isActive = true;
+            }
+
+            if (isActive) {
                 item.classList.add('active');
                 this.expandParentMenus(item);
+                if (!activeMenuName) {
+                    const textSpan = item.querySelector('.menu-text');
+                    activeMenuName = textSpan ? textSpan.textContent.trim() : '';
+                }
             }
         });
+
+        // Update navbar-workspace with active menu item name
+        const navbarWorkspace = document.querySelector('.navbar-workspace');
+        if (navbarWorkspace && activeMenuName) {
+            navbarWorkspace.textContent = activeMenuName;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- `.navbar-workspace` previously showed `{_global_.action}` — the raw URL action slug
- Now after `highlightActiveMenuItem()` finds the active item, it reads the item's `.menu-text` content and sets it as the `.navbar-workspace` text
- Falls back to the template-rendered action value if no active menu item is matched

## Test plan
- [ ] Navigate to any menu item — navbar center should show the menu item's display name (e.g. "Контакты") instead of the URL slug
- [ ] Navigate to another item — name should update accordingly

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)