### PR TITLE
feat: show object value in .navbar-workspace and title on edit form open (#1213)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -8726,6 +8726,14 @@ class IntegramTable{
             const firstColumnValue = !isCreate && recordData && recordData.obj ? recordData.obj.val : null;
             const title = isCreate ? `Создание: ${ typeName }` : `Редактирование: ${ firstColumnValue || typeName }`;
             const instanceName = this.options.instanceName;
+
+            // Save and update navbar-workspace + document.title with object value
+            const navbarWorkspace = document.querySelector('.navbar-workspace');
+            const prevWorkspaceText = navbarWorkspace ? navbarWorkspace.textContent : null;
+            const prevDocTitle = document.title;
+            const objectValue = firstColumnValue || typeName;
+            if (navbarWorkspace) navbarWorkspace.textContent = objectValue;
+            document.title = objectValue;
             const recordId = recordData && recordData.obj ? recordData.obj.id : null;
             // Issue #616: For create mode, use F_U from URL as parent when F_U > 1
             const defaultParentId = (this.options.parentId && parseInt(this.options.parentId) > 1) ? this.options.parentId : 1;
@@ -8902,6 +8910,9 @@ class IntegramTable{
                 if (modalDepth === 1) {
                     this.currentEditModal = null;
                 }
+                // Restore navbar-workspace and document.title
+                if (navbarWorkspace && prevWorkspaceText !== null) navbarWorkspace.textContent = prevWorkspaceText;
+                document.title = prevDocTitle;
             };
 
             // Attach close handlers to buttons with data-close-modal attribute


### PR DESCRIPTION
## Summary
- When an edit form modal opens, saves current `.navbar-workspace` text and `document.title`, then sets both to the record's display value (`firstColumnValue || typeName`)
- When the modal closes, restores the saved values
- Uses closure variables — nested modals each save/restore their own previous state correctly

## Test plan
- [ ] Open a record for editing — navbar center and browser tab title should show the record's value (e.g. "Иванов Иван")
- [ ] Close the modal — navbar and title should revert to previous values
- [ ] Open a nested edit form — should update to nested record's value; closing it should restore parent record's value

Closes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)