### PR TITLE
fix: truncate .navbar-workspace values to 32 chars with ellipsis (#1215)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -8732,8 +8732,9 @@ class IntegramTable{
             const prevWorkspaceText = navbarWorkspace ? navbarWorkspace.textContent : null;
             const prevDocTitle = document.title;
             const objectValue = firstColumnValue || typeName;
-            if (navbarWorkspace) navbarWorkspace.textContent = objectValue;
-            document.title = objectValue;
+            const truncatedValue = objectValue && objectValue.length > 32 ? objectValue.slice(0, 32) + '...' : objectValue;
+            if (navbarWorkspace) navbarWorkspace.textContent = truncatedValue;
+            document.title = truncatedValue;
             const recordId = recordData && recordData.obj ? recordData.obj.id : null;
             // Issue #616: For create mode, use F_U from URL as parent when F_U > 1
             const defaultParentId = (this.options.parentId && parseInt(this.options.parentId) > 1) ? this.options.parentId : 1;

--- a/js/main-app.js
+++ b/js/main-app.js
@@ -1514,7 +1514,7 @@ class MainAppController {
         // Update navbar-workspace with active menu item name
         const navbarWorkspace = document.querySelector('.navbar-workspace');
         if (navbarWorkspace && activeMenuName) {
-            navbarWorkspace.textContent = activeMenuName;
+            navbarWorkspace.textContent = activeMenuName.length > 32 ? activeMenuName.slice(0, 32) + '...' : activeMenuName;
         }
     }
 


### PR DESCRIPTION
## Summary
- Values displayed in `.navbar-workspace` (both active menu item name and edit form object value) are now capped at 32 characters
- If the value exceeds 32 characters, it is sliced and `...` is appended

## Test plan
- [ ] Navigate to a menu item with a short name (≤32 chars) — displayed as-is
- [ ] Navigate to a menu item with a long name (>32 chars) — truncated with `...`
- [ ] Open an edit form for a record with a long value — navbar and title truncated to 32 + `...`

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)