### PR TITLE
fix: navigate to /{db}/tables after successful _d_del_req (#1217)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -5674,7 +5674,7 @@ class IntegramTable{
                 if (result.success) {
                     closeColEdit();
                     this.closeColumnSettings();
-                    this.loadData(0);
+                    window.location.href = '/' + (window.db || window.location.pathname.split('/')[1]) + '/tables';
                 } else if (result.hasData) {
                     // Show forced delete option
                     delBtn.style.display = 'none';
@@ -5685,7 +5685,7 @@ class IntegramTable{
                         if (result2.success) {
                             closeColEdit();
                             this.closeColumnSettings();
-                            this.loadData(0);
+                            window.location.href = '/' + (window.db || window.location.pathname.split('/')[1]) + '/tables';
                         } else {
                             showStatus('Ошибка удаления: ' + result2.error, true);
                         }


### PR DESCRIPTION
## Summary
- After successfully deleting a column via `_d_del_req` (both normal and forced delete), navigate to `/{window.db}/tables` instead of calling `this.loadData(0)`
- Uses `window.db` with fallback to the first path segment

## Test plan
- [ ] Delete a column without data → should navigate to `/{db}/tables`
- [ ] Delete a column with data (forced confirm) → should navigate to `/{db}/tables`
- [ ] Failed delete → no navigation, error shown as before

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)