### PR TITLE
fix: remove hardcoded CURLOPT_CAINFO path causing "error setting certificate file"

### DIFF
--- a/index.php
+++ b/index.php
@@ -3659,7 +3659,6 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
     								curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
     								curl_setopt($ch, CURLOPT_VERBOSE, true);
                                     curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 0);
-                                    curl_setopt($ch, CURLOPT_CAINFO, "/var/www/isboxon1/data/www/etc/ssl/certs/cacert.pem");
                                     #curl_setopt($ch, CURLOPT_CAPATH, "/var/www/isboxon1/data/www/etc/ssl/certs/cacert.pem");
                                     #curl_setopt($ch, CURLOPT_FAILONERROR, true);
     								curl_setopt($ch, CURLOPT_URL, $val);


### PR DESCRIPTION
## Summary

- Removes the hardcoded `CURLOPT_CAINFO` path `/var/www/isboxon1/data/www/etc/ssl/certs/cacert.pem` that was specific to one server
- This path does not exist on other deployments, causing `curl_exec` to fail with **"error setting certificate file"**
- Without this line, curl uses the system CA bundle which is available on all standard Linux installations

## Root cause

```php
// Before (broken on any server except isboxon1):
curl_setopt($ch, CURLOPT_CAINFO, "/var/www/isboxon1/data/www/etc/ssl/certs/cacert.pem");
```

The file `/var/www/isboxon1/data/www/etc/ssl/certs/cacert.pem` is server-specific and missing on production, causing curl to return the error immediately before even making the request.

## Test plan

- [ ] Verify curl requests to HTTPS endpoints work without the error
- [ ] Verify SSL certificate validation still works via system CA bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)