### PR TITLE
feat: improve hints UX — non-modal, draggable, event-driven, mobile toggle

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1045,35 +1045,80 @@ localize();
 <script src="/js/bootstrap4.5.2.min.js"></script>
 <script src="/js/main.js"></script>
 <!-- Workspace hints -->
-<div id="upload-hints-overlay" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); z-index:2000; align-items:center; justify-content:center;">
-    <div style="background:var(--card-bg,#fff); border-radius:12px; padding:1.5rem; width:90%; max-width:440px; box-shadow:0 8px 32px rgba(0,0,0,0.2); animation:slideIn 0.15s ease-out;">
-        <div id="upload-hint-1" style="display:none;">
-            <h3 style="margin:0 0 0.75rem; font-size:1.1rem; color:var(--text-primary);">Выбор файла и параметры импорта</h3>
-            <p style="color:var(--text-secondary); font-size:0.95rem; line-height:1.5; margin:0 0 1rem;">Выберите таблицу из списка, затем вставьте текст данных или загрузите файл (JSON, CSV, TXT). Нажмите «Настроить», чтобы задать разделитель полей, кодировку и указать, содержит ли первая строка заголовки.</p>
-            <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
-                <button onclick="uploadHintClose()" style="padding:0.4rem 1rem; border:1px solid var(--border-color); border-radius:6px; background:none; color:var(--text-secondary); cursor:pointer;">Закрыть</button>
-                <button onclick="uploadHintShow(2)" style="padding:0.4rem 1rem; border:none; border-radius:6px; background:var(--button-primary,#0d6efd); color:#fff; cursor:pointer;">Далее →</button>
-            </div>
+<style>
+#upload-hint-box {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: 90%;
+    max-width: 380px;
+    background: var(--card-bg, #fff);
+    border-radius: 12px;
+    padding: 1.25rem 1.25rem 1rem;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.18);
+    z-index: 2000;
+    display: none;
+    cursor: default;
+    user-select: none;
+    -webkit-user-select: none;
+}
+#upload-hint-box .hint-drag-handle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2rem;
+    cursor: grab;
+    border-radius: 12px 12px 0 0;
+}
+#upload-hint-box .hint-drag-handle:active { cursor: grabbing; }
+#upload-hint-mobile-toggle {
+    display: none;
+    position: fixed;
+    right: 1rem;
+    z-index: 2001;
+    background: var(--button-primary, #0d6efd);
+    color: #fff;
+    border: none;
+    border-radius: 50%;
+    width: 2.4rem;
+    height: 2.4rem;
+    font-size: 1.2rem;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+    align-items: center;
+    justify-content: center;
+}
+@media (max-width: 767px) {
+    #upload-hint-box { right: 0.5rem; left: 0.5rem; width: auto; max-width: none; }
+    #upload-hint-mobile-toggle { display: flex; }
+}
+</style>
+<div id="upload-hint-box">
+    <div class="hint-drag-handle" id="upload-hint-drag-handle"></div>
+    <div id="upload-hint-1" style="display:none;">
+        <h3 style="margin:0 0 0.75rem; font-size:1.05rem; color:var(--text-primary);">Выбор файла и параметры импорта</h3>
+        <p style="color:var(--text-secondary); font-size:0.9rem; line-height:1.5; margin:0 0 1rem;">Выберите таблицу из списка, затем вставьте текст данных или загрузите файл (JSON, CSV, TXT). Нажмите «Настроить», чтобы задать разделитель полей, кодировку и наличие заголовков. Затем нажмите «Проверить» — появится следующий совет.</p>
+        <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
+            <button onclick="uploadHintClose()" style="padding:0.35rem 0.9rem; border:1px solid var(--border-color); border-radius:6px; background:none; color:var(--text-secondary); cursor:pointer; font-size:0.85rem;">Закрыть</button>
         </div>
-        <div id="upload-hint-2" style="display:none;">
-            <h3 style="margin:0 0 0.75rem; font-size:1.1rem; color:var(--text-primary);">Сопоставление полей файла с колонками</h3>
-            <p style="color:var(--text-secondary); font-size:0.95rem; line-height:1.5; margin:0 0 1rem;">После нажатия «Проверить» появится список колонок. Перетащите их в нужном порядке, чтобы они совпадали с колонками вашего файла. При необходимости задайте формулы для вычисляемых полей.</p>
-            <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
-                <button onclick="uploadHintShow(1)" style="padding:0.4rem 1rem; border:1px solid var(--border-color); border-radius:6px; background:none; color:var(--text-secondary); cursor:pointer;">← Назад</button>
-                <button onclick="uploadHintClose()" style="padding:0.4rem 1rem; border:1px solid var(--border-color); border-radius:6px; background:none; color:var(--text-secondary); cursor:pointer;">Закрыть</button>
-                <button onclick="uploadHintShow(3)" style="padding:0.4rem 1rem; border:none; border-radius:6px; background:var(--button-primary,#0d6efd); color:#fff; cursor:pointer;">Далее →</button>
-            </div>
+    </div>
+    <div id="upload-hint-2" style="display:none;">
+        <h3 style="margin:0 0 0.75rem; font-size:1.05rem; color:var(--text-primary);">Сопоставление полей файла с колонками</h3>
+        <p style="color:var(--text-secondary); font-size:0.9rem; line-height:1.5; margin:0 0 1rem;">Перетащите колонки в нужном порядке, чтобы они совпадали с колонками вашего файла. При необходимости задайте формулы для вычисляемых полей. Затем нажмите «Загрузить» — появится следующий совет.</p>
+        <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
+            <button onclick="uploadHintClose()" style="padding:0.35rem 0.9rem; border:1px solid var(--border-color); border-radius:6px; background:none; color:var(--text-secondary); cursor:pointer; font-size:0.85rem;">Закрыть</button>
         </div>
-        <div id="upload-hint-3" style="display:none;">
-            <h3 style="margin:0 0 0.75rem; font-size:1.1rem; color:var(--text-primary);">Запуск загрузки и проверка результата</h3>
-            <p style="color:var(--text-secondary); font-size:0.95rem; line-height:1.5; margin:0 0 1rem;">Нажмите «Загрузить» и подтвердите операцию. По завершении откройте «Статистику» — там отображается количество загруженных, пропущенных и ошибочных записей. При наличии ошибок они будут показаны в отдельном блоке.</p>
-            <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
-                <button onclick="uploadHintShow(2)" style="padding:0.4rem 1rem; border:1px solid var(--border-color); border-radius:6px; background:none; color:var(--text-secondary); cursor:pointer;">← Назад</button>
-                <button onclick="uploadHintClose()" style="padding:0.4rem 1rem; border:none; border-radius:6px; background:var(--button-primary,#0d6efd); color:#fff; cursor:pointer;">Понятно</button>
-            </div>
+    </div>
+    <div id="upload-hint-3" style="display:none;">
+        <h3 style="margin:0 0 0.75rem; font-size:1.05rem; color:var(--text-primary);">Запуск загрузки и проверка результата</h3>
+        <p style="color:var(--text-secondary); font-size:0.9rem; line-height:1.5; margin:0 0 1rem;">Подтвердите операцию нажав «Да, грузим». По завершении откройте «Статистику» — там отображается количество загруженных, пропущенных и ошибочных записей. При наличии ошибок они будут показаны в отдельном блоке.</p>
+        <div style="display:flex; justify-content:flex-end; gap:0.5rem;">
+            <button onclick="uploadHintClose()" style="padding:0.35rem 0.9rem; border:none; border-radius:6px; background:var(--button-primary,#0d6efd); color:#fff; cursor:pointer; font-size:0.85rem;">Понятно</button>
         </div>
     </div>
 </div>
+<button id="upload-hint-mobile-toggle" title="Переместить подсказку" aria-label="Переместить подсказку вверх/вниз" style="bottom:5rem;"></button>
 <script>
 (function() {
     function getCookie(name) {
@@ -1098,19 +1143,25 @@ localize();
     }
 
     var WORKSPACE = 'upload';
+    var hintBox = null;
+    var hintAtTop = false;
 
     window.uploadHintShow = function(n) {
+        if (!hintBox) return;
         [1, 2, 3].forEach(function(i) {
             var el = document.getElementById('upload-hint-' + i);
             if (el) el.style.display = (i === n) ? '' : 'none';
         });
-        var overlay = document.getElementById('upload-hints-overlay');
-        if (overlay) overlay.style.display = 'flex';
+        hintBox.style.display = 'block';
+        // Update mobile toggle icon
+        var tog = document.getElementById('upload-hint-mobile-toggle');
+        if (tog) tog.innerHTML = hintAtTop ? '&#8595;' : '&#8593;';
     };
 
     window.uploadHintClose = function() {
-        var overlay = document.getElementById('upload-hints-overlay');
-        if (overlay) overlay.style.display = 'none';
+        if (hintBox) hintBox.style.display = 'none';
+        var tog = document.getElementById('upload-hint-mobile-toggle');
+        if (tog) tog.style.display = 'none';
         var seen = getCookie('hints_seen_workspaces') || '';
         var list = seen ? seen.split(',') : [];
         if (list.indexOf(WORKSPACE) === -1) {
@@ -1119,12 +1170,80 @@ localize();
         }
     };
 
+    // Advance hint when user performs the advised action
+    window.uploadHintAdvance = function(toStep) {
+        if (!hintBox || hintBox.style.display === 'none') return;
+        uploadHintShow(toStep);
+    };
+
     document.addEventListener('DOMContentLoaded', function() {
+        hintBox = document.getElementById('upload-hint-box');
+
         var mode = getCookie('hints_mode');
         if (mode === 'off') return;
         var seen = getCookie('hints_seen_workspaces') || '';
         var list = seen ? seen.split(',') : [];
         if (list.indexOf(WORKSPACE) !== -1) return;
+
+        // Bind action triggers: "Настроить" or "Проверить" → advance hint 1 → 2
+        var tuneBtn = document.getElementById('tune-btn');
+        var tryBtn = document.querySelector('#try button');
+        function onStep1Action() { uploadHintAdvance(2); }
+        if (tuneBtn) tuneBtn.addEventListener('click', onStep1Action);
+        if (tryBtn) tryBtn.addEventListener('click', onStep1Action);
+
+        // "Загрузить" → advance hint 2 → 3
+        var doUploadBtn = document.getElementById('do-upload');
+        if (doUploadBtn) doUploadBtn.addEventListener('click', function() { uploadHintAdvance(3); });
+
+        // Dragging support (desktop)
+        var handle = document.getElementById('upload-hint-drag-handle');
+        if (handle && hintBox) {
+            var dragging = false, startX, startY, origLeft, origBottom, origTop, origRight;
+            handle.addEventListener('mousedown', function(e) {
+                dragging = true;
+                startX = e.clientX;
+                startY = e.clientY;
+                var rect = hintBox.getBoundingClientRect();
+                origLeft = rect.left;
+                origTop = rect.top;
+                hintBox.style.right = 'auto';
+                hintBox.style.bottom = 'auto';
+                hintBox.style.left = origLeft + 'px';
+                hintBox.style.top = origTop + 'px';
+                e.preventDefault();
+            });
+            document.addEventListener('mousemove', function(e) {
+                if (!dragging) return;
+                var dx = e.clientX - startX;
+                var dy = e.clientY - startY;
+                var newLeft = origLeft + dx;
+                var newTop = origTop + dy;
+                var maxLeft = window.innerWidth - hintBox.offsetWidth;
+                var maxTop = window.innerHeight - hintBox.offsetHeight;
+                newLeft = Math.max(0, Math.min(newLeft, maxLeft));
+                newTop = Math.max(0, Math.min(newTop, maxTop));
+                hintBox.style.left = newLeft + 'px';
+                hintBox.style.top = newTop + 'px';
+            });
+            document.addEventListener('mouseup', function() { dragging = false; });
+        }
+
+        // Mobile toggle: snap hint to top or bottom
+        var mobileToggle = document.getElementById('upload-hint-mobile-toggle');
+        if (mobileToggle) {
+            mobileToggle.innerHTML = '&#8593;';
+            mobileToggle.addEventListener('click', function() {
+                if (!hintBox) return;
+                hintAtTop = !hintAtTop;
+                hintBox.style.top = hintAtTop ? '1rem' : 'auto';
+                hintBox.style.bottom = hintAtTop ? 'auto' : '1.5rem';
+                mobileToggle.style.top = hintAtTop ? 'auto' : '5rem';
+                mobileToggle.style.bottom = hintAtTop ? '1rem' : 'auto';
+                mobileToggle.innerHTML = hintAtTop ? '&#8595;' : '&#8593;';
+            });
+        }
+
         uploadHintShow(1);
     });
 })();


### PR DESCRIPTION
## Summary

Resolves #1271.

Reworks the hints popup in `templates/upload.html` (introduced in #1269) based on four requirements from the issue:

- **Event-driven progression**: hint 2 appears automatically when the user clicks «Настроить» or «Проверить»; hint 3 appears when «Загрузить» is clicked. No manual «Далее» button needed — the next hint appears after the user completes the advised action.
- **Non-modal, no blur**: the overlay backdrop is removed. The hint is now a floating panel anchored to the bottom-right corner so the user can read it and interact with the page at the same time.
- **Draggable on desktop**: the hint box has an invisible grab handle at the top; dragging moves it anywhere within the viewport.
- **Mobile snap toggle**: on screens ≤767px a circular arrow button (↑/↓) appears that snaps the hint box between the bottom and top of the screen, since touch drag is not available.

## Test plan

- [ ] Clear `hints_seen_workspaces` cookie and open `/upload` — hint 1 should appear as a non-blocking floating panel (no backdrop/blur)
- [ ] Click «Настроить» or «Проверить» while hint 1 is visible — hint 2 should replace it automatically
- [ ] Click «Загрузить» while hint 2 is visible — hint 3 should appear
- [ ] Click «Понятно» on hint 3 — panel closes and workspace remains fully accessible
- [ ] On desktop: drag the hint box by its top edge to a different screen position — it should stay within viewport bounds
- [ ] On mobile (≤767px): toggle button (↑) should be visible; clicking it moves the hint panel to the top; clicking again moves it back to the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)