### PR TITLE
fix(sql): attach .col-title-wrapper hint listener inside ShowReport case

### DIFF
--- a/templates/sql.html
+++ b/templates/sql.html
@@ -840,6 +840,13 @@ function myApi(m,u,b,vars,index){ // Параметры: метод, адрес,
                     byId('warning').classList.remove('hidden');
                 }
                 $('#rbody').show();
+                // Attach col-title-wrapper change listener here, after elements exist
+                if (!window._colTitleHintBound) {
+                    window._colTitleHintBound = true;
+                    $(document).on('change', '.col-title-wrapper', function() {
+                        if (window.sqlHintAdvance) window.sqlHintAdvance(2);
+                    });
+                }
                 break;
 
         }


### PR DESCRIPTION
## Summary
- `.col-title-wrapper` elements are created dynamically in the `case 'select'` API response handler, not in the initial DOM
- Registering a `change` event listener on these elements at `DOMContentLoaded` silently fails because the elements don't exist yet
- Added the listener registration inside `case 'ShowReport'` using jQuery event delegation, with a one-time flag (`_colTitleHintBound`) to prevent duplicate registrations on repeated report loads

Fixes #1306

## Test plan
- [ ] Open sql.html workspace
- [ ] Select a table and run a query to trigger `ShowReport`
- [ ] Click a column title to activate editing, change the value, then blur
- [ ] Verify the hint advances to step 2 (`sqlHintAdvance(2)` fires correctly)
- [ ] Re-run the query; confirm no duplicate handlers are registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)