### PR TITLE
fix: disable Save button on click to prevent double-submit

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -4071,7 +4071,12 @@ class IntegramTable{
             // Attach save handler
             const saveBtn = modal.querySelector('#save-record-ref-btn');
             saveBtn.addEventListener('click', async () => {
-                await this.saveRecordForReference(modal, typeId, parentRecordId);
+                saveBtn.disabled = true;
+                try {
+                    await this.saveRecordForReference(modal, typeId, parentRecordId);
+                } finally {
+                    saveBtn.disabled = false;
+                }
             });
 
             // Close modal helper function
@@ -8923,8 +8928,13 @@ class IntegramTable{
             // Attach save handler
             const saveBtn = modal.querySelector('#save-record-btn');
 
-            saveBtn.addEventListener('click', () => {
-                this.saveRecord(modal, isCreate, recordId, typeId, parentId, columnId);
+            saveBtn.addEventListener('click', async () => {
+                saveBtn.disabled = true;
+                try {
+                    await this.saveRecord(modal, isCreate, recordId, typeId, parentId, columnId);
+                } finally {
+                    saveBtn.disabled = false;
+                }
             });
 
             // Attach delete handler (edit mode only)
@@ -11075,7 +11085,12 @@ class IntegramTable{
             // Attach save handler
             const saveBtn = modal.querySelector('#save-form-ref-btn');
             saveBtn.addEventListener('click', async () => {
-                await this.saveRecordForFormReference(modal, overlay, typeId, parentRecordId, hiddenInput, searchInput, wrapper, dropdown);
+                saveBtn.disabled = true;
+                try {
+                    await this.saveRecordForFormReference(modal, overlay, typeId, parentRecordId, hiddenInput, searchInput, wrapper, dropdown);
+                } finally {
+                    saveBtn.disabled = false;
+                }
             });
 
             // Close modal helper
@@ -13537,8 +13552,13 @@ class IntegramCreateFormHelper {
 
         // Attach save handler
         const saveBtn = modal.querySelector('#save-record-btn');
-        saveBtn.addEventListener('click', () => {
-            this.saveRecord(modal, metadata);
+        saveBtn.addEventListener('click', async () => {
+            saveBtn.disabled = true;
+            try {
+                await this.saveRecord(modal, metadata);
+            } finally {
+                saveBtn.disabled = false;
+            }
         });
 
         // Close modal helper function
@@ -14542,8 +14562,13 @@ class IntegramCreateFormHelper {
 
         // Attach save handler
         const saveBtn = modal.querySelector('#save-record-btn');
-        saveBtn.addEventListener('click', () => {
-            this.saveEditedRecord(modal, metadata, recordId);
+        saveBtn.addEventListener('click', async () => {
+            saveBtn.disabled = true;
+            try {
+                await this.saveEditedRecord(modal, metadata, recordId);
+            } finally {
+                saveBtn.disabled = false;
+            }
         });
 
         // Close modal helper function


### PR DESCRIPTION
## Summary
- All async save handlers in `integram-table.js` now disable the «Сохранить» button before the async operation and re-enable it in a `finally` block
- This prevents double-submission if a user clicks the button multiple times while a save is in progress
- 5 handlers were missing this protection; the `col-edit-save` handler already had it (lines 5597+) and served as the reference implementation

## Affected handlers
| Button ID | Context | Fix |
|---|---|---|
| `save-record-ref-btn` | Reference creation modal | ✅ added |
| `save-record-btn` | Main record edit modal | ✅ added |
| `save-form-ref-btn` | Form reference creation modal | ✅ added |
| `save-record-btn` | Attributes form modal | ✅ added |
| `save-record-btn` | Edit form standalone modal | ✅ added |

## Test plan
- [ ] Open any record modal, click «Сохранить» rapidly multiple times — only one save request should be sent
- [ ] Verify the button is re-enabled after a save error (validation failure, network error)
- [ ] Verify existing `col-edit-save` behaviour is unchanged

Fixes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)