### PR TITLE
fix: re-query .file-name to avoid detached-node crash on second file upload

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -10299,11 +10299,14 @@ class IntegramTable{
                 // Store the file object in the upload container for later submission
                 uploadContainer._fileToUpload = file;
 
-                // Update UI - replace link with plain text since it's a new upload
-                if (fileName.tagName === 'A') {
-                    fileName.outerHTML = `<span class="file-name">${ this.escapeHtml(file.name) }</span>`;
-                } else {
-                    fileName.textContent = file.name;
+                // Update UI - replace link with plain text since it's a new upload.
+                // Re-query from uploadContainer to avoid using a stale reference that may have
+                // been detached from the DOM by a previous outerHTML replacement (issue #1311).
+                const currentFileName = uploadContainer.querySelector('.file-name');
+                if (currentFileName && currentFileName.tagName === 'A') {
+                    currentFileName.outerHTML = `<span class="file-name">${ this.escapeHtml(file.name) }</span>`;
+                } else if (currentFileName) {
+                    currentFileName.textContent = file.name;
                 }
                 dropzone.style.display = 'none';
                 preview.style.display = 'flex';


### PR DESCRIPTION
## Root cause

`attachFormFileUploadHandlers` captures `fileName = uploadContainer.querySelector('.file-name')` once in a closure.

On the **first** file selection `handleFormFileSelection` runs:
```js
if (fileName.tagName === 'A') {
    fileName.outerHTML = `<span class="file-name">...</span>`;  // replaces the element
```
The `<a>` element is replaced by a `<span>` — the old `fileName` reference now points to a **detached** node (no parent).

On a **second** file selection the same closure fires again. `fileName.tagName` is still `'A'` (stale ref), so it tries `outerHTML` on the detached node → crash:
```
NoModificationAllowedError: Failed to set the 'outerHTML' property on 'Element':
This element has no parent node.   (integram-table.js:10228)
```

## Fix

Re-query `.file-name` from `uploadContainer` each time `handleFormFileSelection` runs, so we always operate on the current live element instead of the stale closure reference.

## Test plan
- [ ] Open a record edit modal with a FILE field
- [ ] Select a file — verify it shows correctly
- [ ] Select a **different** file — verify no error, new name shown
- [ ] Remove the file, select again — verify no error

Fixes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)