### PR TITLE
feat: show info modal on table/18 for DB owner

### DIFF
--- a/templates/table.html
+++ b/templates/table.html
@@ -174,6 +174,84 @@
     });
 })();
 </script>
+<!-- Info modal for table/18 (users list) -->
+<style>
+#table-info-modal-18-overlay {
+    display: none;
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0,0,0,0.45);
+    z-index: 3000;
+    align-items: center;
+    justify-content: center;
+}
+#table-info-modal-18-overlay.visible {
+    display: flex;
+}
+#table-info-modal-18 {
+    background: var(--card-bg, #fff);
+    border-radius: 12px;
+    padding: 1.5rem 1.5rem 1.25rem;
+    box-shadow: 0 8px 40px rgba(0,0,0,0.32);
+    width: 90%;
+    max-width: 440px;
+    z-index: 3001;
+}
+#table-info-modal-18 p {
+    color: var(--text-secondary, #555);
+    font-size: 0.9rem;
+    line-height: 1.6;
+    margin: 0 0 1.25rem;
+}
+#table-info-modal-18 .modal-footer {
+    display: flex;
+    justify-content: flex-end;
+}
+</style>
+<div id="table-info-modal-18-overlay">
+    <div id="table-info-modal-18">
+        <p>Интеграм поставляется не в виде чистого листа, как Google-sheets или Airtable, а в нём уже есть некоторые таблицы, необходимые в любом проекте: пользователи, роли, запросы, доступы и прочее. Это список пользователей, зарегистрированных в этой базе Интеграма.<br><br>Изначально в списке только один пользователь&nbsp;— администратор, это вы. Администратор может добавлять сюда других пользователей, назначая им <i>Роль</i>, а для <i>Роли</i> можно задавать доступы к таблицам и рабочим местам системы.</p>
+        <div class="modal-footer">
+            <button onclick="tableInfoModal18Close()" style="padding:0.4rem 1.1rem; border:none; border-radius:6px; background:var(--button-primary,#0d6efd); color:#fff; cursor:pointer; font-size:0.9rem;">Понятно</button>
+        </div>
+    </div>
+</div>
+<script>
+(function() {
+    function getCookie(name) {
+        var prefix = name + '=';
+        var parts = document.cookie.split(';');
+        for (var i = 0; i < parts.length; i++) {
+            var part = parts[i].trim();
+            if (part.indexOf(prefix) === 0) {
+                return decodeURIComponent(part.substring(prefix.length));
+            }
+        }
+        return null;
+    }
+    function setCookie(name, value, days) {
+        var d = new Date();
+        d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
+        document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + d.toUTCString() + '; path=/';
+    }
+    window.tableInfoModal18Close = function() {
+        var overlay = document.getElementById('table-info-modal-18-overlay');
+        if (overlay) overlay.classList.remove('visible');
+        setCookie('table_info_18_seen', '1', 365);
+    };
+    document.addEventListener('DOMContentLoaded', function() {
+        var path = window.location.pathname;
+        var isTable18 = /\/table\/18(\/.*)?$/.test(path);
+        if (!isTable18) return;
+        if (typeof user === 'undefined' || typeof db === 'undefined') return;
+        if (user !== db) return;
+        if (getCookie('hints_mode') === 'off') return;
+        if (getCookie('table_info_18_seen') === '1') return;
+        var overlay = document.getElementById('table-info-modal-18-overlay');
+        if (overlay) overlay.classList.add('visible');
+    });
+})();
+</script>
 <script>
 // Workspace-specific hint configuration for 'table'.
 // Texts and steps are defined here; the display mechanism is in /js/hints.js.


### PR DESCRIPTION
## Summary

Fixes #1328

Same pattern as the table/440 modal (merged in PR #1323): a one-time informational modal shown to the DB owner when visiting `/table/18` (the users list table).

### Modal content
Explains that Integram comes pre-loaded with system tables (users, roles, requests, access), and that the owner can add more users with assigned roles.

### Conditions for showing the modal (all must be true):
1. Current URL pathname matches `/table/18`
2. `user === db` (the current user is the database owner)
3. `hints_mode` cookie ≠ `'off'`
4. `table_info_18_seen` cookie not set

### Implementation details:
- Added modal HTML/CSS/JS in `templates/table.html` (separate IDs: `table-info-modal-18-overlay`, `table-info-modal-18`)
- Uses the same z-index (3000/3001) and visual style as the table/440 modal
- "Понятно" button sets `table_info_18_seen=1` cookie (365 days) and closes the modal

## Test plan
- [ ] Log in as DB owner (`user === db`), navigate to `/table/18` — modal should appear
- [ ] Click "Понятно" — modal closes and `table_info_18_seen=1` cookie is set
- [ ] Reload `/table/18` — modal does NOT appear again
- [ ] Navigate to `/table/440` — table/440 modal still works independently
- [ ] As a non-owner user on `/table/18` — modal does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)