### PR TITLE
fix: take balance usage limit from PlanLimit in report/313 response

### DIFF
--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -358,7 +358,7 @@ class CabinetController {
             totalCount += parseInt(db.Count || '0', 10);
         });
 
-        const limit = 20000; // Free plan limit
+        const limit = parseInt(this.userData.PlanLimit || '0', 10) || 20000;
         const usagePercent = ((totalCount / limit) * 100).toFixed(2);
 
         // Profile section


### PR DESCRIPTION
## Summary

Fixes #1332

### Problem
`#balance-usage-limit` and `#balance-usage-percent` were calculated using a hardcoded limit of `20000`, ignoring the actual plan limit returned by the API.

### Fix
In `updateUsageInfo()` (`js/cabinet.js`), the limit is now read from `this.userData.PlanLimit` — the `PlanLimit` field of the first record in the `report/313` response (which is already loaded into `this.userData`). Falls back to `20000` if the field is absent or zero.

```js
// Before
const limit = 20000; // Free plan limit

// After
const limit = parseInt(this.userData.PlanLimit || '0', 10) || 20000;
```

Both `#balance-usage-limit` (displayed value) and `#balance-usage-percent` (ratio) now reflect the correct plan limit.

## Test plan
- [ ] Load cabinet page — `#balance-usage-limit` shows the value from `PlanLimit` in `report/313` (e.g. `3000`)
- [ ] `#balance-usage-percent` is calculated as `Count_total / PlanLimit * 100`
- [ ] If `PlanLimit` is absent from the response, falls back to `20000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)