### PR TITLE
fix: display usage-units as integer

### DIFF
--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -367,7 +367,7 @@ class CabinetController {
         const usageLimitEl = document.getElementById('usage-limit');
         const usageBarFill = document.getElementById('usage-bar-fill');
 
-        if (usageUnits) usageUnits.textContent = totalCount.toFixed(2);
+        if (usageUnits) usageUnits.textContent = totalCount.toString();
         if (usagePercentEl) usagePercentEl.textContent = usagePercent + '%';
         if (usageLimitEl) usageLimitEl.textContent = limit.toString();
         if (usageBarFill) usageBarFill.style.width = Math.min(parseFloat(usagePercent), 100) + '%';
@@ -377,7 +377,7 @@ class CabinetController {
         const balanceUsagePercent = document.getElementById('balance-usage-percent');
         const balanceUsageLimit = document.getElementById('balance-usage-limit');
 
-        if (balanceUsageUnits) balanceUsageUnits.textContent = totalCount.toFixed(2);
+        if (balanceUsageUnits) balanceUsageUnits.textContent = totalCount.toString();
         if (balanceUsagePercent) balanceUsagePercent.textContent = usagePercent + '%';
         if (balanceUsageLimit) balanceUsageLimit.textContent = limit.toString();
     }


### PR DESCRIPTION
## Summary

Fixes #1334

`totalCount` is already an integer (accumulated via `parseInt`), but was displayed with `.toFixed(2)` — showing e.g. `1688.00` instead of `1688`.

Changed both occurrences to `.toString()`:
- `#usage-units` (profile section)
- `#balance-usage-units` (balance section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)