### PR TITLE
fix: always show .integram-title-link as plain text when F_U is present

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -280,22 +280,9 @@ class IntegramTable{
         }
 
         /**
-         * Check if the current table type is a subordinate table (table requisite).
-         * A subordinate table appears as arr_id in some parent table's requisites in globalMetadata (issue #1338).
-         */
-        isSubordinateTableType() {
-            const currentTypeId = this.objectTableId || (this.options.tableTypeId ? Number(this.options.tableTypeId) : null);
-            if (!currentTypeId || !this.globalMetadata) return false;
-            return this.globalMetadata.some(item =>
-                item.reqs && item.reqs.some(req => Number(req.arr_id) === currentTypeId)
-            );
-        }
-
-        /**
          * Generate title HTML with parent info breadcrumb (issue #571)
          * Format: "{parent table name} {record value}: {current table name}"
-         * For independent tables: parent table name and record value are shown as links.
-         * For subordinate tables (table requisites): shown as plain text (issue #1338).
+         * When F_U parent parameter is present, breadcrumb is shown as plain text (issue #1338, #1341).
          */
         renderTitleHtml() {
             if (!this.options.title && !this.parentInfo) {
@@ -309,27 +296,13 @@ class IntegramTable{
                 ? `<button class="column-add-btn title-create-btn" onclick="window.${ instanceName }.openTitleCreateForm()" title="Создать запись"><i class="pi pi-plus"></i></button>`
                 : '';
 
-            // Extract database name from URL path for building links
-            const pathParts = window.location.pathname.split('/');
-            const dbName = pathParts.length >= 2 ? pathParts[1] : '';
-
-            // If we have parent info, show breadcrumb-style title
+            // If we have parent info (F_U parameter present), show breadcrumb-style title as plain text (issue #1341)
             if (this.parentInfo) {
                 const parentTypeName = this.escapeHtml(this.parentInfo.typ_name || '');
                 const parentVal = this.escapeHtml(this.parentInfo.val || '');
-                const parentTypeId = this.parentInfo.typ || '';
-                const parentRecordId = this.parentInfo.id || '';
                 const currentTitle = this.escapeHtml(this.options.title || '');
 
-                // For subordinate tables (table requisites): show as plain text, not links (issue #1338)
-                if (this.isSubordinateTableType()) {
-                    return `<div class="integram-table-title-area">${ this.renderCheckboxToggleHtml() }<div class="integram-table-title"><span class="integram-title-link">${ parentTypeName }</span> <span class="integram-title-link">${ parentVal }</span>${ currentTitle ? ': ' + currentTitle : '' }</div>${ createBtnHtml }</div>`;
-                }
-
-                // For independent tables: show as clickable links
-                const parentTypeLink = `/${ dbName }/table/${ parentTypeId }`;
-                // Parent record link is now a clickable span that opens modal edit form (issue #575)
-                return `<div class="integram-table-title-area">${ this.renderCheckboxToggleHtml() }<div class="integram-table-title"><a href="${ parentTypeLink }" class="integram-title-link">${ parentTypeName }</a> <span class="integram-title-link integram-parent-record-link" data-parent-record-id="${ parentRecordId }" data-parent-type-id="${ parentTypeId }" style="cursor: pointer;">${ parentVal }</span>${ currentTitle ? ': ' + currentTitle : '' }</div>${ createBtnHtml }</div>`;
+                return `<div class="integram-table-title-area">${ this.renderCheckboxToggleHtml() }<div class="integram-table-title"><span class="integram-title-link">${ parentTypeName }</span> <span class="integram-title-link">${ parentVal }</span>${ currentTitle ? ': ' + currentTitle : '' }</div>${ createBtnHtml }</div>`;
             }
 
             // No parent info, just show the title


### PR DESCRIPTION
Fixes #1341

## Changes

Simplified the breadcrumb title logic: whenever a parent record is indicated via the `F_U` parameter (i.e. `parentInfo` is set), the parent type name and parent record value in `.integram-title-link` are now always rendered as plain `<span>` elements — no clickable links regardless of table type.

This removes the `isSubordinateTableType()` check from #1340 in favour of the simpler rule requested in #1341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)