### PR TITLE
fix: show table name in breadcrumb title as plain black text

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -107,6 +107,17 @@
     color: var(--md-primary-dark, #1565c0);
 }
 
+/* Table name (first .integram-title-link as span) shown as plain black text (issue #1345) */
+span.integram-title-link:not(.integram-parent-record-link) {
+    color: var(--text-primary, #212121);
+    cursor: default;
+}
+
+span.integram-title-link:not(.integram-parent-record-link):hover {
+    text-decoration: none;
+    color: var(--text-primary, #212121);
+}
+
 .integram-table-controls {
     display: flex;
     align-items: center;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -313,7 +313,8 @@ class IntegramTable{
                 const parentTypeLink = `/${ dbName }/table/${ parentTypeId }`;
                 // Parent record link is now a clickable span that opens modal edit form (issue #575)
 
-                return `<div class="integram-table-title-area">${ this.renderCheckboxToggleHtml() }<div class="integram-table-title"><a href="${ parentTypeLink }" class="integram-title-link">${ parentTypeName }</a> <span class="integram-title-link integram-parent-record-link" data-parent-record-id="${ parentRecordId }" data-parent-type-id="${ parentTypeId }" style="cursor: pointer;">${ parentVal }</span>${ currentTitle ? ': ' + currentTitle : '' }</div>${ createBtnHtml }</div>`;
+                // Table name shown as plain black text (issue #1345); record value remains clickable (issue #575)
+                return `<div class="integram-table-title-area">${ this.renderCheckboxToggleHtml() }<div class="integram-table-title"><span class="integram-title-link">${ parentTypeName }</span> <span class="integram-title-link integram-parent-record-link" data-parent-record-id="${ parentRecordId }" data-parent-type-id="${ parentTypeId }" style="cursor: pointer;">${ parentVal }</span>${ currentTitle ? ': ' + currentTitle : '' }</div>${ createBtnHtml }</div>`;
             }
 
             // No parent info, just show the title


### PR DESCRIPTION
Fixes #1345

## Changes

**`js/integram-table.js`** — the first breadcrumb element (parent table name) is now rendered as `<span class="integram-title-link">` instead of `<a href>`, removing the navigation link. The second element (parent record value `.integram-parent-record-link`) remains a clickable span that opens the edit form.

**`css/integram-table.css`** — added rules so `span.integram-title-link:not(.integram-parent-record-link)` renders as plain black text (`--text-primary`) with no hover effects, while `<a class="integram-title-link">` retains blue link styling for future use.

Result:
```html
<span class="integram-title-link">Меню</span>          ← plain black text
<span class="integram-title-link integram-parent-record-link" ...>ОРГАНАЙЗЕР</span>  ← clickable
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)