### PR TITLE
fix: validate formData[0].Pay as URL and navigate instead of injecting form

### DIFF
--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -511,17 +511,12 @@ class CabinetController {
 
             const formData = await formResp.json();
             if (Array.isArray(formData) && formData.length > 0 && formData[0].Pay) {
-                // Inject payment form into tariff section and submit
-                const section = document.getElementById('section-tariff');
-                if (section) {
-                    const tmp = document.createElement('div');
-                    tmp.innerHTML = formData[0].Pay;
-                    const form = tmp.querySelector('form');
-                    if (form) {
-                        section.appendChild(form);
-                        form.submit();
-                        return;
-                    }
+                try {
+                    new URL(formData[0].Pay);
+                    window.location.href = formData[0].Pay;
+                    return;
+                } catch {
+                    // not a valid URL, fall through to error
                 }
             }
             showToast('Ошибка оплаты, обратитесь в поддержку', 'error');
@@ -559,17 +554,12 @@ class CabinetController {
 
             const formData = await formResp.json();
             if (Array.isArray(formData) && formData.length > 0 && formData[0].Pay) {
-                // Inject payment form into balance section and submit
-                const section = document.getElementById('section-balance');
-                if (section) {
-                    const tmp = document.createElement('div');
-                    tmp.innerHTML = formData[0].Pay;
-                    const form = tmp.querySelector('form');
-                    if (form) {
-                        section.appendChild(form);
-                        form.submit();
-                        return;
-                    }
+                try {
+                    new URL(formData[0].Pay);
+                    window.location.href = formData[0].Pay;
+                    return;
+                } catch {
+                    // not a valid URL, fall through to error
                 }
             }
             showToast('Ошибка оплаты, обратитесь в поддержку', 'error');


### PR DESCRIPTION
Fixes #1348

## Changes

Replaced the form-inject-and-submit pattern in both `topUp()` and `addFunds()` with a URL validity check:

```js
try {
    new URL(formData[0].Pay);
    window.location.href = formData[0].Pay;
    return;
} catch {
    // not a valid URL, fall through to error
}
```

If `formData[0].Pay` is a valid URL, the user is redirected directly. If not, the existing error toast is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)