### PR TITLE
fix: match 'Новая таблица' button height to search input in .tables-actions

### DIFF
--- a/css/tables.css
+++ b/css/tables.css
@@ -29,6 +29,12 @@
     gap: 1rem;
 }
 
+/* Match button height to search input (issue #1350) */
+.tables-actions #add-table-btn {
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+}
+
 /* Search Box */
 .search-box {
     position: relative;


### PR DESCRIPTION
Fixes #1350

## Problem

In `.tables-actions`, the search input (`.search-input`) has vertical padding `0.625rem`, while the button (`#add-table-btn` with `.btn-primary.btn-small`) has only `0.5rem`, making the button visually shorter.

## Fix

Added a CSS rule in `tables.css` to override the button's vertical padding to `0.625rem`, matching the search input:

```css
.tables-actions #add-table-btn {
    padding-top: 0.625rem;
    padding-bottom: 0.625rem;
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)