### PR TITLE
fix: enforce 100 ruble minimum for top-up and add-funds

### DIFF
--- a/css/cabinet.css
+++ b/css/cabinet.css
@@ -558,6 +558,12 @@
     -moz-appearance: textfield;
 }
 
+.add-funds-hint {
+    font-size: 0.8rem;
+    color: var(--error-color, #dc3545);
+    margin-top: 0.25rem;
+}
+
 /* Databases List */
 .databases-list {
     display: grid;

--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -496,6 +496,11 @@ class CabinetController {
         const toPay = topupBtn && topupBtn.dataset.toPay;
         if (!toPay) return;
 
+        if (parseFloat(toPay) < 100) {
+            showToast('Минимальная сумма пополнения — 100 рублей', 'error');
+            return;
+        }
+
         if (topupBtn) topupBtn.disabled = true;
         try {
             const host = this.apiConfig.host;
@@ -533,11 +538,13 @@ class CabinetController {
         const amountInput = document.getElementById('add-funds-amount');
         const amount = amountInput && parseFloat(amountInput.value);
 
-        if (!amount || amount <= 0) {
-            showToast('Введите сумму пополнения', 'error');
+        const hint = document.getElementById('add-funds-hint');
+        if (!amount || amount < 100) {
+            if (hint) hint.style.display = '';
             if (amountInput) amountInput.focus();
             return;
         }
+        if (hint) hint.style.display = 'none';
 
         if (addFundsBtn) addFundsBtn.disabled = true;
         try {

--- a/templates/my/main.html
+++ b/templates/my/main.html
@@ -452,9 +452,10 @@
 
                 <div class="balance-actions">
                     <div class="add-funds-row">
-                        <input type="number" id="add-funds-amount" class="add-funds-amount-input" min="1" step="1" placeholder="Сумма пополнения, руб." autocomplete="off">
+                        <input type="number" id="add-funds-amount" class="add-funds-amount-input" min="100" step="1" value="100" placeholder="Сумма пополнения, руб." autocomplete="off" autocorrect="off" autocapitalize="off" inputmode="numeric">
                         <button type="button" id="add-funds-btn" class="btn-primary">Пополнить счет</button>
                     </div>
+                    <div id="add-funds-hint" class="add-funds-hint" style="display:none;">Минимальная сумма пополнения — 100 рублей</div>
                 </div>
             </section>
 


### PR DESCRIPTION
Fixes #1352

## Changes

**`templates/my/main.html`**
- `#add-funds-amount`: `min="1"` → `min="100"`, added `value="100"` (default)
- Added `inputmode="numeric" autocorrect="off" autocapitalize="off"` to prevent browser from suggesting emails in a numeric field
- Added `<div id="add-funds-hint" class="add-funds-hint">` warning below the row (hidden by default)

**`js/cabinet.js`**
- `addFunds()`: show inline hint and focus input when `amount < 100` instead of a toast
- `topUp()`: guard against `toPay < 100` with an error toast before sending the request

**`css/cabinet.css`**
- Added `.add-funds-hint` — small red text for the minimum amount warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)