### PR TITLE
fix: match button vertical padding to mobile search input height

### DIFF
--- a/css/tables.css
+++ b/css/tables.css
@@ -588,6 +588,12 @@
         font-size: 0.85rem;
     }
 
+    /* Match button height to reduced mobile search input padding (issue #1354) */
+    .tables-actions #add-table-btn {
+        padding-top: 0.4rem;
+        padding-bottom: 0.4rem;
+    }
+
     .search-box {
         flex: 1;
         min-width: 0;


### PR DESCRIPTION
Fixes #1354

## Problem

PR #1351 set `padding-top/bottom: 0.625rem` on `#add-table-btn` globally, but on mobile the `.search-input` uses `padding: 0.4rem` (smaller). This caused the button to be **taller** than the search field on mobile — the opposite of the intended fix.

## Fix

Added a matching override inside the `@media (max-width: 768px)` block:

```css
.tables-actions #add-table-btn {
    padding-top: 0.4rem;
    padding-bottom: 0.4rem;
}
```

Now the button matches the search input height on both desktop (`0.625rem`) and mobile (`0.4rem`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)