### PR TITLE
fix: prevent browser autocomplete on .cards-field-filter inputs

### DIFF
--- a/templates/cards.html
+++ b/templates/cards.html
@@ -1710,6 +1710,9 @@
             input.placeholder = 'Фильтр...';
             input.value = self.fieldFilters[f.col.id] || '';
             input.dataset.filterCol = f.col.id;
+            input.autocomplete = 'off';
+            input.setAttribute('autocorrect', 'off');
+            input.setAttribute('autocapitalize', 'off');
             input.addEventListener('input', function() {
                 self.fieldFilters[f.col.id] = this.value;
                 // Server-side reload with filter


### PR DESCRIPTION
Fixes #1356

## Changes

Added `autocomplete="off"`, `autocorrect="off"`, `autocapitalize="off"` to the dynamically created filter `<input>` elements in `CardsView.prototype._renderFieldFilters`.

This prevents browsers from suggesting saved emails or other form data when users interact with the field filter inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)