### PR TITLE
feat: add 'В виде карточек' link in view settings for table data source

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -6455,7 +6455,7 @@ class IntegramTable{
             modal.innerHTML = `
                 <h3>Настройка представления</h3>
                 <div class="column-settings-list">
-                    ${ this.getDataSourceType() === 'table' && (this.objectTableId || this.options.tableTypeId) ? `<div class="table-settings-item"><a href="/${window.db}/object/${ this.objectTableId || this.options.tableTypeId }">Перейти в старый интерфейс</a></div>` : '' }
+                    ${ this.getDataSourceType() === 'table' && (this.objectTableId || this.options.tableTypeId) ? `<div class="table-settings-item"><a href="/${window.db}/cards/${ this.objectTableId || this.options.tableTypeId }">В виде карточек</a></div><div class="table-settings-item"><a href="/${window.db}/object/${ this.objectTableId || this.options.tableTypeId }">Перейти в старый интерфейс</a></div>` : '' }
 
                     <div class="table-settings-item">
                         <label>Отступы:</label>


### PR DESCRIPTION
Fixes #1358

## Changes

In `openTableSettings()`, added a **«В виде карточек»** link pointing to `/{db}/cards/{tableTypeId}` immediately before the existing «Перейти в старый интерфейс» link.

The link is shown under the same condition — only when `getDataSourceType() === 'table'` and `objectTableId || options.tableTypeId` is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)