### PR TITLE
revert: rollback setTimeout autocomplete workaround (0eb669f, 86b2c80)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1388,7 +1388,7 @@ class IntegramTable{
                                        data-column-id="${ column.id }"
                                        value="${ displayValue }"
                                        placeholder="${ placeholder }"
-                                       autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                       autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                             </div>
                         </td>
                     `;
@@ -1485,7 +1485,7 @@ class IntegramTable{
                                data-column-id="${ column.id }"
                                value="${ displayValue }"
                                placeholder="${ placeholder }"
-                               autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                               autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                     </div>
                 </td>
             `;
@@ -3060,7 +3060,7 @@ class IntegramTable{
                     break;
                 default:
                     // SHORT, CHARS, etc. - text input
-                    editorHtml = `<input type="text" class="inline-editor inline-editor-text" value="${ escapedValue }" autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},100)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},100)">`;
+                    editorHtml = `<input type="text" class="inline-editor inline-editor-text" value="${ escapedValue }" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">`;
             }
 
             cell.innerHTML = editorHtml;
@@ -3283,7 +3283,7 @@ class IntegramTable{
                             <input type="text"
                                    class="inline-editor-reference-search"
                                    placeholder="Поиск..."
-                                   autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                   autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                             ${buttonHtml}
                         </div>
                         <div class="inline-editor-reference-dropdown">
@@ -3613,7 +3613,7 @@ class IntegramTable{
                                 <input type="text"
                                        class="inline-editor-reference-search"
                                        placeholder="Добавить..."
-                                       autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                       autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                 ${addButtonHtml}
                             </div>
                             <div class="inline-editor-reference-dropdown" style="display:none;">
@@ -4088,7 +4088,7 @@ class IntegramTable{
                                            class="inline-editor-reference-search form-ref-search"
                                            id="field-ref-${req.id}-search"
                                            placeholder="Поиск..."
-                                           autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                           autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                     <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
                                     <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button"><i class="pi pi-plus"></i></button>
                                 </div>
@@ -5659,7 +5659,7 @@ class IntegramTable{
                 <div class="col-edit-section">
                     <div class="col-edit-row">
                         <label class="col-edit-label">Название:</label>
-                        <input type="text" id="col-edit-name-${instanceName}" class="form-control form-control-sm col-edit-input" value="${ this.escapeHtml(currentName) }" placeholder="Введите название колонки" autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                        <input type="text" id="col-edit-name-${instanceName}" class="form-control form-control-sm col-edit-input" value="${ this.escapeHtml(currentName) }" placeholder="Введите название колонки" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                     </div>
                     <div class="col-edit-row">
                         <label class="col-edit-label">Базовый тип:</label>
@@ -5682,7 +5682,7 @@ class IntegramTable{
                     ${ isRef ? `
                     <div class="col-edit-row">
                         <label class="col-edit-label">Псевдоним:</label>
-                        <input type="text" id="col-edit-alias-${instanceName}" class="form-control form-control-sm col-edit-input" value="${ this.escapeHtml(currentAlias) }" placeholder="Введите псевдоним колонки" autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                        <input type="text" id="col-edit-alias-${instanceName}" class="form-control form-control-sm col-edit-input" value="${ this.escapeHtml(currentAlias) }" placeholder="Введите псевдоним колонки" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                     </div>
                     <div class="col-edit-row">
                         <label class="col-edit-check-label">
@@ -6073,7 +6073,7 @@ class IntegramTable{
                 <h3 style="margin: 0 0 20px 0; font-weight: 500; font-size: 20px;">Добавить новую колонку</h3>
                 <div style="margin-bottom: 16px; position: relative;">
                     <label style="display: block; margin-bottom: 6px; font-weight: 500; font-size: 14px;">Имя колонки:</label>
-                    <input type="text" id="new-column-name-${instanceName}" class="form-control" placeholder="Введите имя колонки" style="width: 100%; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 4px; font-size: 14px; box-sizing: border-box;" autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                    <input type="text" id="new-column-name-${instanceName}" class="form-control" placeholder="Введите имя колонки" style="width: 100%; padding: 10px 12px; border: 1px solid #dee2e6; border-radius: 4px; font-size: 14px; box-sizing: border-box;" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                     <div id="column-name-suggestions-${instanceName}" style="display: none; position: absolute; top: 100%; left: 0; right: 0; background: #fff; border: 1px solid #dee2e6; border-radius: 4px; box-shadow: 0 4px 8px rgba(0,0,0,0.1); max-height: 250px; overflow-y: auto; z-index: 1003;"></div>
                 </div>
                 <div style="margin-bottom: 16px;">
@@ -6608,7 +6608,7 @@ class IntegramTable{
                             <option value="100" ${ this.settings.pageSize === 100 ? 'selected' : '' }>100</option>
                             <option value="custom">Свой вариант</option>
                         </select>
-                        <input type="number" id="custom-page-size" class="form-control form-control-sm" style="display: none; width: 80px; margin-left: 10px;" placeholder="Число" autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                        <input type="number" id="custom-page-size" class="form-control form-control-sm" style="display: none; width: 80px; margin-left: 10px;" placeholder="Число" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                     </div>
 
                     <div class="table-settings-item">
@@ -8523,7 +8523,7 @@ class IntegramTable{
                     <input type="text"
                            class="filter-ref-search"
                            placeholder="Поиск..."
-                           autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                           autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                     <button type="button" class="filter-ref-clear" title="Очистить выбор">✕</button>
                 </div>
                 <div class="filter-ref-options">
@@ -9282,7 +9282,7 @@ class IntegramTable{
                                            class="inline-editor-reference-search form-ref-search"
                                            id="field-${ req.id }-search"
                                            placeholder="Добавить..."
-                                           autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                           autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                 </div>
                                 <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${ req.id }-dropdown" style="display:none;">
                                     <div class="inline-editor-reference-empty">Загрузка...</div>
@@ -9308,7 +9308,7 @@ class IntegramTable{
                                            class="inline-editor-reference-search form-ref-search"
                                            id="field-${ req.id }-search"
                                            placeholder="Поиск..."
-                                           autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                           autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                     <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
                                     <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button"><i class="pi pi-plus"></i></button>
                                 </div>
@@ -9655,7 +9655,7 @@ class IntegramTable{
                         + Добавить
                     </button>
                     <div class="subordinate-search-wrapper">
-                        <input type="text" class="subordinate-search-input" placeholder="Поиск..." value="${ this.escapeHtml(searchTerm) }" autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                        <input type="text" class="subordinate-search-input" placeholder="Поиск..." value="${ this.escapeHtml(searchTerm) }" autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                         <button type="button" class="subordinate-search-clear" title="Очистить поиск"${ searchTerm ? '' : ' style="display: none;"' }><i class="pi pi-times"></i></button>
                     </div>
                     <a href="${subordinateTableUrl}" class="subordinate-table-link" title="Открыть в таблице" target="_blank">
@@ -10148,7 +10148,7 @@ class IntegramTable{
                                            class="inline-editor-reference-search form-ref-search"
                                            id="sub-field-${ req.id }-search"
                                            placeholder="Поиск..."
-                                           autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                           autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                     <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
                                     <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button"><i class="pi pi-plus"></i></button>
                                 </div>
@@ -11207,7 +11207,7 @@ class IntegramTable{
                                            class="inline-editor-reference-search form-ref-search"
                                            id="field-form-ref-${req.id}-search"
                                            placeholder="Поиск..."
-                                           autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                           autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                     <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
                                     <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button"><i class="pi pi-plus"></i></button>
                                 </div>
@@ -13844,7 +13844,7 @@ class IntegramCreateFormHelper {
                                        class="inline-editor-reference-search form-ref-search"
                                        id="field-${req.id}-search"
                                        placeholder="Добавить..."
-                                       autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                       autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                             </div>
                             <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${req.id}-dropdown" style="display:none;">
                                 <div class="inline-editor-reference-empty">Загрузка...</div>
@@ -13870,7 +13870,7 @@ class IntegramCreateFormHelper {
                                        class="inline-editor-reference-search form-ref-search"
                                        id="field-${req.id}-search"
                                        placeholder="Поиск..."
-                                       autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                       autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                 <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
                             </div>
                             <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${req.id}-dropdown">
@@ -15299,7 +15299,7 @@ class IntegramCreateFormHelper {
                                        class="inline-editor-reference-search form-ref-search"
                                        id="field-${fieldId}-search"
                                        placeholder="Добавить..."
-                                       autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                       autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                             </div>
                             <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${fieldId}-dropdown" style="display:none;">
                                 <div class="inline-editor-reference-empty">Загрузка...</div>
@@ -15324,7 +15324,7 @@ class IntegramCreateFormHelper {
                                        class="inline-editor-reference-search form-ref-search"
                                        id="field-${fieldId}-search"
                                        placeholder="Поиск..."
-                                       autocomplete="off" readonly onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)" onmousedown="setTimeout(()=>{this.removeAttribute('readonly')},10)">
+                                       autocomplete="off" readonly onfocus="this.removeAttribute('readonly')" onmousedown="this.removeAttribute('readonly')">
                                 <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
                             </div>
                             <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${fieldId}-dropdown">


### PR DESCRIPTION
## Summary

- Reverts commits `0eb669f` and `86b2c80` (`Update integram-table.js`)
- Restores direct `this.removeAttribute('readonly')` on `onfocus`/`onmousedown` for all text inputs
- Removes `setTimeout` delays (10ms/100ms) that were introduced as autocomplete workaround

## Changes

All occurrences in `js/integram-table.js` are reverted from:
```js
onfocus="setTimeout(()=>{this.removeAttribute('readonly')},10)"
```
back to:
```js
onfocus="this.removeAttribute('readonly')"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)