### PR TITLE
refactor: replace edit_obj with object/?JSON_OBJ for parent info fetches

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -277,7 +277,7 @@ class IntegramTable{
 
         /**
          * Load parent info when F_U filter is present and > 1 (issue #571)
-         * Fetches parent record data from edit_obj/{parentId}?JSON
+         * Fetches parent record data using object/{parentTypeId}/?JSON_OBJ
          * Used to display breadcrumb-like title: "{parent table name} {record value}: {current table name}"
          */
         async loadParentInfo() {
@@ -288,19 +288,42 @@ class IntegramTable{
                     return;
                 }
 
+                const tableTypeId = this.options.tableTypeId;
+                if (!tableTypeId) {
+                    return;
+                }
+
+                // Wait for global metadata to determine parent type
+                await this.globalMetadataPromise;
+
+                if (!Array.isArray(this.globalMetadata)) {
+                    return;
+                }
+
+                // Find the child table type in global metadata to get parent type ID
+                const childTypeMeta = this.globalMetadata.find(m => String(m.id) === String(tableTypeId));
+                if (!childTypeMeta || !childTypeMeta.up || String(childTypeMeta.up) === '0') {
+                    return;
+                }
+
+                const parentTypeId = childTypeMeta.up;
+                const parentTypeMeta = this.globalMetadata.find(m => String(m.id) === String(parentTypeId));
+                const parentTypeName = parentTypeMeta ? (parentTypeMeta.val || '') : '';
+
                 const apiBase = this.getApiBase();
-                const response = await fetch(`${ apiBase }/edit_obj/${ parentId }?JSON`);
+                const response = await fetch(`${ apiBase }/object/${ parentTypeId }/?JSON_OBJ&t${ parentTypeId }=@${ parentId }`);
                 if (!response.ok) {
                     console.error('Failed to fetch parent info:', response.status);
                     return;
                 }
                 const data = await response.json();
-                if (data && data.obj) {
+                if (Array.isArray(data) && data.length > 0) {
+                    const item = data[0];
                     this.parentInfo = {
-                        id: data.obj.id,
-                        val: data.obj.val,
-                        typ: data.obj.typ,
-                        typ_name: data.obj.typ_name
+                        id: item.i,
+                        val: item.r ? (item.r[0] || '') : '',
+                        typ: parentTypeId,
+                        typ_name: parentTypeName
                     };
                     // Re-render if data is already loaded, so the title updates
                     if (this.columns.length > 0) {
@@ -15466,16 +15489,21 @@ async function openCreateRecordForm(tableTypeId, parentId, fieldValues = {}) {
         let parentInfo = null;
         if (String(parentId) !== '1') {
             try {
-                const parentUrl = `${apiBase}/edit_obj/${parentId}?JSON`;
-                const parentResponse = await fetch(parentUrl);
-                if (parentResponse.ok) {
-                    const parentData = await parentResponse.json();
-                    if (parentData && parentData.obj && parentData.obj.val) {
-                        parentInfo = {
-                            id: parentData.obj.id,
-                            val: parentData.obj.val,
-                            typ_name: parentData.obj.typ_name
-                        };
+                // Get parent type ID from child table metadata (metadata.up = parent type ID for child tables)
+                const parentTypeId = metadata && metadata.up && String(metadata.up) !== '0' ? String(metadata.up) : null;
+                if (parentTypeId) {
+                    const parentUrl = `${apiBase}/object/${parentTypeId}/?JSON_OBJ&t${parentTypeId}=@${parentId}`;
+                    const parentResponse = await fetch(parentUrl);
+                    if (parentResponse.ok) {
+                        const parentData = await parentResponse.json();
+                        if (Array.isArray(parentData) && parentData.length > 0) {
+                            const item = parentData[0];
+                            parentInfo = {
+                                id: item.i,
+                                val: item.r ? (item.r[0] || '') : '',
+                                typ_name: ''
+                            };
+                        }
                     }
                 }
             } catch (parentError) {

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -260,7 +260,7 @@
 
         /**
          * Load parent info when F_U filter is present and > 1 (issue #571)
-         * Fetches parent record data from edit_obj/{parentId}?JSON
+         * Fetches parent record data using object/{parentTypeId}/?JSON_OBJ
          * Used to display breadcrumb-like title: "{parent table name} {record value}: {current table name}"
          */
         async loadParentInfo() {
@@ -271,19 +271,42 @@
                     return;
                 }
 
+                const tableTypeId = this.options.tableTypeId;
+                if (!tableTypeId) {
+                    return;
+                }
+
+                // Wait for global metadata to determine parent type
+                await this.globalMetadataPromise;
+
+                if (!Array.isArray(this.globalMetadata)) {
+                    return;
+                }
+
+                // Find the child table type in global metadata to get parent type ID
+                const childTypeMeta = this.globalMetadata.find(m => String(m.id) === String(tableTypeId));
+                if (!childTypeMeta || !childTypeMeta.up || String(childTypeMeta.up) === '0') {
+                    return;
+                }
+
+                const parentTypeId = childTypeMeta.up;
+                const parentTypeMeta = this.globalMetadata.find(m => String(m.id) === String(parentTypeId));
+                const parentTypeName = parentTypeMeta ? (parentTypeMeta.val || '') : '';
+
                 const apiBase = this.getApiBase();
-                const response = await fetch(`${ apiBase }/edit_obj/${ parentId }?JSON`);
+                const response = await fetch(`${ apiBase }/object/${ parentTypeId }/?JSON_OBJ&t${ parentTypeId }=@${ parentId }`);
                 if (!response.ok) {
                     console.error('Failed to fetch parent info:', response.status);
                     return;
                 }
                 const data = await response.json();
-                if (data && data.obj) {
+                if (Array.isArray(data) && data.length > 0) {
+                    const item = data[0];
                     this.parentInfo = {
-                        id: data.obj.id,
-                        val: data.obj.val,
-                        typ: data.obj.typ,
-                        typ_name: data.obj.typ_name
+                        id: item.i,
+                        val: item.r ? (item.r[0] || '') : '',
+                        typ: parentTypeId,
+                        typ_name: parentTypeName
                     };
                     // Re-render if data is already loaded, so the title updates
                     if (this.columns.length > 0) {

--- a/js/integram-table/24-global-functions.js
+++ b/js/integram-table/24-global-functions.js
@@ -125,16 +125,21 @@ async function openCreateRecordForm(tableTypeId, parentId, fieldValues = {}) {
         let parentInfo = null;
         if (String(parentId) !== '1') {
             try {
-                const parentUrl = `${apiBase}/edit_obj/${parentId}?JSON`;
-                const parentResponse = await fetch(parentUrl);
-                if (parentResponse.ok) {
-                    const parentData = await parentResponse.json();
-                    if (parentData && parentData.obj && parentData.obj.val) {
-                        parentInfo = {
-                            id: parentData.obj.id,
-                            val: parentData.obj.val,
-                            typ_name: parentData.obj.typ_name
-                        };
+                // Get parent type ID from child table metadata (metadata.up = parent type ID for child tables)
+                const parentTypeId = metadata && metadata.up && String(metadata.up) !== '0' ? String(metadata.up) : null;
+                if (parentTypeId) {
+                    const parentUrl = `${apiBase}/object/${parentTypeId}/?JSON_OBJ&t${parentTypeId}=@${parentId}`;
+                    const parentResponse = await fetch(parentUrl);
+                    if (parentResponse.ok) {
+                        const parentData = await parentResponse.json();
+                        if (Array.isArray(parentData) && parentData.length > 0) {
+                            const item = parentData[0];
+                            parentInfo = {
+                                id: item.i,
+                                val: item.r ? (item.r[0] || '') : '',
+                                typ_name: ''
+                            };
+                        }
                     }
                 }
             } catch (parentError) {


### PR DESCRIPTION
## Summary

Replaces two usages of `edit_obj/{parentId}?JSON` with the `object/{typeId}/?JSON_OBJ` endpoint pattern (consistent with how record data is fetched elsewhere in the codebase).

**`loadParentInfo` (01-core.js):**
- Awaits `globalMetadataPromise` (already loading in parallel)
- Finds parent type ID via `childTypeMeta.up` from globalMetadata
- Gets type name from globalMetadata
- Fetches `object/{parentTypeId}/?JSON_OBJ&t{parentTypeId}=@{parentId}`

**`openCreateRecordForm` (24-global-functions.js):**
- Uses `metadata.up` as parent type ID (metadata already fetched above)
- Fetches `object/{parentTypeId}/?JSON_OBJ&t{parentTypeId}=@{parentId}`

Third usage (`openEditRecordForm`) is left unchanged — it uses `.reqs` from the edit_obj response.

## Test Plan

- [ ] Child table breadcrumb title renders: "Parent Type Name · Record Value: Current Table"
- [ ] Create record form shows "в: {parentValue}" subtitle when parentId is set
- [ ] Both work when parentId = 1 (root) — no fetch, no subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)