### PR TITLE
refactor: replace edit_obj with object/?JSON_OBJ in edit/create record forms

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -293,22 +293,28 @@ class IntegramTable{
                     return;
                 }
 
-                // Wait for global metadata to determine parent type
+                // Find parent type by searching globalMetadata for a type that has
+                // arr_id === tableTypeId in its reqs (child table types have up=0 in metadata,
+                // so metadata.up is not useful for finding the parent type)
                 await this.globalMetadataPromise;
 
                 if (!Array.isArray(this.globalMetadata)) {
                     return;
                 }
 
-                // Find the child table type in global metadata to get parent type ID
-                const childTypeMeta = this.globalMetadata.find(m => String(m.id) === String(tableTypeId));
-                if (!childTypeMeta || !childTypeMeta.up || String(childTypeMeta.up) === '0') {
-                    return;
+                let parentTypeId = null;
+                let parentTypeName = '';
+                for (const typeMeta of this.globalMetadata) {
+                    if (typeMeta.reqs && typeMeta.reqs.some(req => String(req.arr_id) === String(tableTypeId))) {
+                        parentTypeId = String(typeMeta.id);
+                        parentTypeName = typeMeta.val || '';
+                        break;
+                    }
                 }
 
-                const parentTypeId = childTypeMeta.up;
-                const parentTypeMeta = this.globalMetadata.find(m => String(m.id) === String(parentTypeId));
-                const parentTypeName = parentTypeMeta ? (parentTypeMeta.val || '') : '';
+                if (!parentTypeId) {
+                    return;
+                }
 
                 const apiBase = this.getApiBase();
                 const response = await fetch(`${ apiBase }/object/${ parentTypeId }/?JSON_OBJ&t${ parentTypeId }=@${ parentId }`);
@@ -15489,8 +15495,19 @@ async function openCreateRecordForm(tableTypeId, parentId, fieldValues = {}) {
         let parentInfo = null;
         if (String(parentId) !== '1') {
             try {
-                // Get parent type ID from child table metadata (metadata.up = parent type ID for child tables)
-                const parentTypeId = metadata && metadata.up && String(metadata.up) !== '0' ? String(metadata.up) : null;
+                // Find parent type by searching globalMetadata for a type that has
+                // arr_id === tableTypeId in its reqs (metadata.up is 0 for all table types)
+                let parentTypeId = null;
+                const globalMetadata = window._integramTableInstances &&
+                    window._integramTableInstances.find(inst => inst && inst.globalMetadata);
+                const allMeta = globalMetadata ? globalMetadata.globalMetadata : null;
+                if (Array.isArray(allMeta)) {
+                    const parentMeta = allMeta.find(t => t.reqs &&
+                        t.reqs.some(req => String(req.arr_id) === String(tableTypeId)));
+                    if (parentMeta) {
+                        parentTypeId = String(parentMeta.id);
+                    }
+                }
                 if (parentTypeId) {
                     const parentUrl = `${apiBase}/object/${parentTypeId}/?JSON_OBJ&t${parentTypeId}=@${parentId}`;
                     const parentResponse = await fetch(parentUrl);

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -276,22 +276,28 @@
                     return;
                 }
 
-                // Wait for global metadata to determine parent type
+                // Find parent type by searching globalMetadata for a type that has
+                // arr_id === tableTypeId in its reqs (child table types have up=0 in metadata,
+                // so metadata.up is not useful for finding the parent type)
                 await this.globalMetadataPromise;
 
                 if (!Array.isArray(this.globalMetadata)) {
                     return;
                 }
 
-                // Find the child table type in global metadata to get parent type ID
-                const childTypeMeta = this.globalMetadata.find(m => String(m.id) === String(tableTypeId));
-                if (!childTypeMeta || !childTypeMeta.up || String(childTypeMeta.up) === '0') {
-                    return;
+                let parentTypeId = null;
+                let parentTypeName = '';
+                for (const typeMeta of this.globalMetadata) {
+                    if (typeMeta.reqs && typeMeta.reqs.some(req => String(req.arr_id) === String(tableTypeId))) {
+                        parentTypeId = String(typeMeta.id);
+                        parentTypeName = typeMeta.val || '';
+                        break;
+                    }
                 }
 
-                const parentTypeId = childTypeMeta.up;
-                const parentTypeMeta = this.globalMetadata.find(m => String(m.id) === String(parentTypeId));
-                const parentTypeName = parentTypeMeta ? (parentTypeMeta.val || '') : '';
+                if (!parentTypeId) {
+                    return;
+                }
 
                 const apiBase = this.getApiBase();
                 const response = await fetch(`${ apiBase }/object/${ parentTypeId }/?JSON_OBJ&t${ parentTypeId }=@${ parentId }`);

--- a/js/integram-table/24-global-functions.js
+++ b/js/integram-table/24-global-functions.js
@@ -125,8 +125,19 @@ async function openCreateRecordForm(tableTypeId, parentId, fieldValues = {}) {
         let parentInfo = null;
         if (String(parentId) !== '1') {
             try {
-                // Get parent type ID from child table metadata (metadata.up = parent type ID for child tables)
-                const parentTypeId = metadata && metadata.up && String(metadata.up) !== '0' ? String(metadata.up) : null;
+                // Find parent type by searching globalMetadata for a type that has
+                // arr_id === tableTypeId in its reqs (metadata.up is 0 for all table types)
+                let parentTypeId = null;
+                const globalMetadata = window._integramTableInstances &&
+                    window._integramTableInstances.find(inst => inst && inst.globalMetadata);
+                const allMeta = globalMetadata ? globalMetadata.globalMetadata : null;
+                if (Array.isArray(allMeta)) {
+                    const parentMeta = allMeta.find(t => t.reqs &&
+                        t.reqs.some(req => String(req.arr_id) === String(tableTypeId)));
+                    if (parentMeta) {
+                        parentTypeId = String(parentMeta.id);
+                    }
+                }
                 if (parentTypeId) {
                     const parentUrl = `${apiBase}/object/${parentTypeId}/?JSON_OBJ&t${parentTypeId}=@${parentId}`;
                     const parentResponse = await fetch(parentUrl);


### PR DESCRIPTION
## Summary

Replaces remaining `edit_obj` API calls with `object/{typeId}/?JSON_OBJ` (same pattern as `fetchRecordData` in `16-state.js`).

**`openEditRecordForm` (25-create-form-helper.js):**
- Fetches `object/{typeId}/?JSON_OBJ&FR_{typeId}=@{recordId}`
- Converts `{i, u, o, r}` → `{obj, reqs}` format expected by `renderEditFormModalStandalone`
- Handles GRANT/REPORT_COLUMN `"id:value"` parsing, arr_id subordinate table counts

**`loadParentInfo` + `openCreateRecordForm`:**
- Parent type can't be found via `metadata.up` (all table types have `up=0`)
- Instead searches `globalMetadata` for a type with `arr_id === tableTypeId` in its reqs

## Test Plan

- [ ] Edit form opens with pre-filled values (text, numbers, dates)
- [ ] Reference field dropdowns show current value
- [ ] Subordinate table tabs show correct record counts
- [ ] Child table breadcrumb title shows "Parent Type · Record: Table"
- [ ] Create record form shows "в: {parentValue}" subtitle

🤖 Generated with [Claude Code](https://claude.com/claude-code)