### PR TITLE
refactor: move newApi to js/main.js

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,29 @@
+// Функция для отправки асинхронного запроса по https api с обработкой его результата
+function newApi(m,u,b,vars,index){ // Параметры: метод, адрес, действие - ветка switch, параметры, ID целевого элемента
+    vars=vars||''; // По умолчанию список параметров пуст
+    var json,obj=new XMLHttpRequest(); // Объявляем переменную под JSON и API по HTTPS
+    obj.open(m,'/'+db+'/'+u,true); // Открываем асинхронное соединение заданным методом по нужному адресу
+    if(m=='POST') // Если это POST запрос, то передаем заданные параметры
+        if(typeof vars=='object')
+            vars.append('_xsrf',xsrf);
+        else{
+            obj.setRequestHeader('Content-Type','application/x-www-form-urlencoded');
+            vars='_xsrf='+xsrf+'&'+vars; // добавляем токен xsrf, необходимый для POST-запроса
+        }
+    obj.onload=function(e){ // Когда запрос вернет результат - сработает эта функция
+        try{ // в this.responseText лежит ответ от сервера
+            json=JSON.parse(this.responseText); // Пытаемся разобрать ответ как JSON
+        }
+        catch(e){ // Если произошла ошибка при разборе JSON
+            changeMsg('alert-danger', this.responseText); // Выводим ошибку
+        }
+        obj.abort(); // Закрываем соединение
+        if(typeof window[b]==='function') // Вызываем функцию-исполнитель переданного действия (callback)
+            window[b](json,index);
+    };
+    obj.send(vars); // отправили запрос и теперь будем ждать ответ, а пока - выходим
+}
+
 var state = false;
 var navbar = document.getElementById("navbarSupportedContent");
 var rightBlock = document.getElementById("right_block");

--- a/templates/main.html
+++ b/templates/main.html
@@ -189,6 +189,7 @@
     </script>
     <script src="/js/app.js"></script>
     <script src="/js/main-app.js"></script>
+    <script src="/js/main.js"></script>
     <script>
     function changePwd(){
         var oldPwd=document.getElementById('old-pwd').value,
@@ -272,31 +273,6 @@
         function cookieAccept() {
             localStorage.setItem('cookie_consent', '1');
             document.getElementById('cookie-consent').style.display = 'none';
-        }
-        // Функция для отправки асинхронного запроса по https api с обработкой его результата
-        function newApi(m,u,b,vars,index){ // Параметры: метод, адрес, действие - ветка switch, параметры, ID целевого элемента
-            vars=vars||''; // По умолчанию список параметров пуст
-            var json,obj=new XMLHttpRequest(); // Объявляем переменную под JSON и API по HTTPS
-            obj.open(m,'/'+db+'/'+u,true); // Открываем асинхронное соединение заданным методом по нужному адресу
-            if(m=='POST') // Если это POST запрос, то передаем заданные параметры
-                if(typeof vars=='object')
-                    vars.append('_xsrf',xsrf);
-                else{
-                    obj.setRequestHeader('Content-Type','application/x-www-form-urlencoded');
-                    vars='_xsrf='+xsrf+'&'+vars; // добавляем токен xsrf, необходимый для POST-запроса
-                }
-            obj.onload=function(e){ // Когда запрос вернет результат - сработает эта функция
-                try{ // в this.responseText лежит ответ от сервера
-                    json=JSON.parse(this.responseText); // Пытаемся разобрать ответ как JSON
-                }
-                catch(e){ // Если произошла ошибка при разборе JSON
-                    changeMsg('alert-danger', this.responseText); // Выводим ошибку
-                }
-                obj.abort(); // Закрываем соединение
-                if(typeof window[b]==='function') // Вызываем функцию-исполнитель переданного действия (callback)
-                    window[b](json,index);
-            };
-            obj.send(vars); // отправили запрос и теперь будем ждать ответ, а пока - выходим
         }
     </script>
     <script>


### PR DESCRIPTION
## Summary

- `newApi` was defined inline in `templates/main.html` but used across 11+ files (templates and `js/main.js` itself)
- Moved the function to `js/main.js` where it is centrally available
- `templates/main.html` now loads `<script src="/js/main.js">` instead of defining `newApi` inline

## Test plan

- [ ] Verify app loads correctly (navbar, menus work)
- [ ] Verify any page using `newApi` calls (`object.html`, `sql.html`, `dict.html`, `edit_obj.html`, `form.html`) still functions correctly
- [ ] Verify GJS template rendering (`[src-report]`, `[src-object]` attributes) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)