### PR TITLE
fix: remove jQuery from main.js, add main.js to dash.html

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -28,17 +28,18 @@ var state = false;
 var navbar = document.getElementById("navbarSupportedContent");
 var rightBlock = document.getElementById("right_block");
 
-var navListItem=$('#navlist').html()
-    ,navList=$('#dropdown-list').html()
-    ,extraListItem=$('#dropdown-list').html()
-    ,extraListTemplate=$('#extralist').html();
+var navListItem = document.getElementById('navlist') ? document.getElementById('navlist').innerHTML : '';
+var navList = document.getElementById('dropdown-list') ? document.getElementById('dropdown-list').innerHTML : '';
+var extraListItem = document.getElementById('dropdown-list') ? document.getElementById('dropdown-list').innerHTML : '';
+var extraListTemplate = document.getElementById('extralist') ? document.getElementById('extralist').innerHTML : '';
+
 function resizeMutations(){
     var extraList='',listLength=byId('brand').offsetWidth; // The nav's length in pixels
     byId('navbar-list').innerHTML='';
     for(var i in menu){ // Add a menu item and calc the space left for the rest of items
         if(listLength+byId('right_block').offsetWidth+200<document.documentElement.clientWidth
                 || (i==menu.length-1 && extraList==='') // Do not shrink the lone last item
-                || document.documentElement.clientWidth<=562){ 
+                || document.documentElement.clientWidth<=562){
             byId('navbar-list').innerHTML+=navListItem.replace(/:href:/g,menu[i].href)
                                                     .replace(':name:',menu[i].name)
                                                     .replace(':id:',i);
@@ -51,11 +52,13 @@ function resizeMutations(){
     }
     if(extraList!=='') // Put the extra menu in, if any
         byId('navbar-list').innerHTML+=extraListTemplate.replace(extraListItem,extraList);
-    $('a[href$="'+document.location.pathname+'"]').addClass('nav-link-active');
-    if($('.nav-link-active').length===0&&action==='object')
-        $('a[href$="dict"]').addClass('nav-link-active');
-	if(action.length>0)
-		$('a[href*="'+action+'?"]').addClass('nav-link-active');
+    document.querySelectorAll('a[href$="'+document.location.pathname+'"]').forEach(function(el){
+        el.classList.add('nav-link-active');
+    });
+    if(document.querySelectorAll('.nav-link-active').length===0&&action==='object')
+        document.querySelectorAll('a[href$="dict"]').forEach(function(el){ el.classList.add('nav-link-active'); });
+    if(action.length>0)
+        document.querySelectorAll('a[href*="'+action+'?"]').forEach(function(el){ el.classList.add('nav-link-active'); });
 }
 // Put the burger's menu after the nav pane to see the proper dropdown list
 var observer = new MutationObserver((e) => {
@@ -87,83 +90,106 @@ var burgerClick = function(target) {
     //resizeMutations();
 }
 
+// Создать DOM-элемент из HTML-строки
+function htmlToElement(html) {
+    var tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.firstChild;
+}
+
 // Fill in the GJS repeating groups
-$('div[src-split]').each(function(){
-    if($(this).html().match(/({ *.+ *})/))
-        $(this).attr('src-data',$(this).html().match(/({ *.+ *})/)[1]);
+document.querySelectorAll('div[src-split]').forEach(function(el){
+    if(el.innerHTML.match(/({ *.+ *})/))
+        el.setAttribute('src-data', el.innerHTML.match(/({ *.+ *})/)[1]);
     else
-        $(this).removeAttr('src-split');
+        el.removeAttribute('src-split');
 });
-$('[src-report]').each(function(){
-    if($(this).attr('src-report')>0)
-        newApi('GET','report/'+$(this).attr('src-report')+'?JSON','gjsParseReport','',this);
+document.querySelectorAll('[src-report]').forEach(function(el){
+    if(el.getAttribute('src-report')>0)
+        newApi('GET','report/'+el.getAttribute('src-report')+'?JSON','gjsParseReport','',el);
 });
 function gjsParseReport(json,el){
     var i,j,html='';
     if(el.tagName==='SELECT'){
         for(i in json.data[0])
             html+='<option value="'+json.data[0][i]+'">'+json.data[1][i]+'</option>';
-        $(el).append(html);
+        el.insertAdjacentHTML('beforeend', html);
     }
     else{
         var tmpClass=getTmpClass();
-        var template=$(el).addClass(tmpClass).prop('outerHTML');
+        el.classList.add(tmpClass);
+        var template=el.outerHTML;
         for(i in json.data[0]){
             html=template;
             for(j in json.columns)
                 html=html.replace(new RegExp('\{ *'+json.columns[j].name+' *\}','gmi'),json.data[j][i]);
-            if(i>0)
-                $('.'+tmpClass+'[gjs-order='+(i-1)+']').after($(html).attr('gjs-order',i));
+            var newEl=htmlToElement(html);
+            newEl.setAttribute('gjs-order',i);
+            if(i>0){
+                var prev=document.querySelector('.'+tmpClass+'[gjs-order="'+(i-1)+'"]');
+                if(prev) prev.parentNode.insertBefore(newEl, prev.nextSibling);
+            }
             else
-                $(el).replaceWith($(html).attr('gjs-order',i));
+                el.parentNode.replaceChild(newEl, el);
         }
         gjsSeekSplit(tmpClass);
     }
 }
-$('[src-object]').each(function(){
-    if($(this).attr('src-object')>0)
-        newApi('GET','object/'+$(this).attr('src-object')+'?JSON','gjsParseObject','',this);
+document.querySelectorAll('[src-object]').forEach(function(el){
+    if(el.getAttribute('src-object')>0)
+        newApi('GET','object/'+el.getAttribute('src-object')+'?JSON','gjsParseObject','',el);
 });
 function gjsParseObject(json,el){
     var i,j,html='';
     if(el.tagName==='SELECT'){
         for(i in json.object)
             html+='<option value="'+json.object[i].id+'">'+json.object[i].val+'</option>';
-        $(el).append(html);
+        el.insertAdjacentHTML('beforeend', html);
     }
     else{
         var tmpClass=getTmpClass();
-        var template=$(el).addClass(tmpClass).prop('outerHTML');
+        el.classList.add(tmpClass);
+        var template=el.outerHTML;
         for(i in json.object){
             html=template.replace(new RegExp('\{ *'+json.type.val+' *\}','gmi'),json.object[i].val);
             for(j in json.req_type)
                 html=html.replace(new RegExp('\{ *'+json.req_type[j]+' *\}','gmi'),getObjReq(json,json.object[i].id,json.req_type[j]));
-            if(i>0)
-                $('.'+tmpClass+'[gjs-order='+(i-1)+']').after($(html).attr('gjs-order',i));
+            var newEl=htmlToElement(html);
+            newEl.setAttribute('gjs-order',i);
+            if(i>0){
+                var prev=document.querySelector('.'+tmpClass+'[gjs-order="'+(i-1)+'"]');
+                if(prev) prev.parentNode.insertBefore(newEl, prev.nextSibling);
+            }
             else
-                $(el).replaceWith($(html).attr('gjs-order',i));
+                el.parentNode.replaceChild(newEl, el);
         }
         gjsSeekSplit(tmpClass);
     }
 }
 function gjsSeekSplit(tmpClass){
-    $('.'+tmpClass).find('[src-split]').each(function(){
-        if($(this).attr('src-data').indexOf($(this).attr('src-split'))>0)
-            gjsSplit(this);
+    document.querySelectorAll('.'+tmpClass+' [src-split]').forEach(function(el){
+        if(el.getAttribute('src-data').indexOf(el.getAttribute('src-split'))>0)
+            gjsSplit(el);
     });
 }
 function gjsSplit(el) {
     var i,tmpClass=getTmpClass()
-        ,html,src=$(el).attr('src-data')
-        ,items=$(el).attr('src-data').split($(el).attr('src-split'));
-    $(el).removeAttr('src-data').removeAttr('src-split');
-    var template=$(el).addClass(tmpClass).prop('outerHTML');
+        ,html,src=el.getAttribute('src-data')
+        ,items=el.getAttribute('src-data').split(el.getAttribute('src-split'));
+    el.removeAttribute('src-data');
+    el.removeAttribute('src-split');
+    el.classList.add(tmpClass);
+    var template=el.outerHTML;
     for(i in items){
         html=template.replace(src,items[i]);
-        if(i>0)
-            $('.'+tmpClass+'[gjs-order='+(i-1)+']').after($(html).attr('gjs-order',i));
+        var newEl=htmlToElement(html);
+        newEl.setAttribute('gjs-order',i);
+        if(i>0){
+            var prev=document.querySelector('.'+tmpClass+'[gjs-order="'+(i-1)+'"]');
+            if(prev) prev.parentNode.insertBefore(newEl, prev.nextSibling);
+        }
         else
-            $(el).replaceWith($(html).attr('gjs-order',i));
+            el.parentNode.replaceChild(newEl, el);
     }
 }
 function postForm(url) {
@@ -197,4 +223,5 @@ function escapeHtml(str) {
                       .replace(/"/g, '&quot;')
                       .replace(/'/g, '&#039;');
 }
-$('#brand').html('<svg width="40" height="34" viewBox="0 0 40 34" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="34" fill="white" fill-opacity="0.01"></rect><g clip-path="url(#clip0_2328_26459)"><path d="M21.0983 12.4256L19.5194 14.1254L22.2153 17.0289L13.4346 26.3889L2.28812 22.7817V11.2779L13.4346 7.67068L15.452 9.87038L17.0454 8.19038L14.1005 5L0 9.56361V24.4959L14.1005 29.0595L25.3877 17.0289L21.0983 12.4256Z" fill="white"></path><path d="M15.4718 21.634L17.0489 19.9341L14.3548 17.0307L23.1356 7.67068L34.2802 11.2779V22.7817L23.1356 26.3889L21.1127 24.1838L19.5193 25.8656L22.4679 29.0595L36.5683 24.4977V9.56361L22.4679 5L11.1807 17.0307L15.4718 21.634Z" fill="white"></path></g><defs><clipPath id="clip0_2328_26459"><rect width="36.6316" height="24" fill="white" transform="translate(0 5)"></rect></clipPath></defs></svg>');
+var brandEl = document.getElementById('brand');
+if(brandEl) brandEl.innerHTML = '<svg width="40" height="34" viewBox="0 0 40 34" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="40" height="34" fill="white" fill-opacity="0.01"></rect><g clip-path="url(#clip0_2328_26459)"><path d="M21.0983 12.4256L19.5194 14.1254L22.2153 17.0289L13.4346 26.3889L2.28812 22.7817V11.2779L13.4346 7.67068L15.452 9.87038L17.0454 8.19038L14.1005 5L0 9.56361V24.4959L14.1005 29.0595L25.3877 17.0289L21.0983 12.4256Z" fill="white"></path><path d="M15.4718 21.634L17.0489 19.9341L14.3548 17.0307L23.1356 7.67068L34.2802 11.2779V22.7817L23.1356 26.3889L21.1127 24.1838L19.5193 25.8656L22.4679 29.0595L36.5683 24.4977V9.56361L22.4679 5L11.1807 17.0307L15.4718 21.634Z" fill="white"></path></g><defs><clipPath id="clip0_2328_26459"><rect width="36.6316" height="24" fill="white" transform="translate(0 5)"></rect></clipPath></defs></svg>';

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -73,6 +73,7 @@
     <div class="sheets"></div>
 </div>
 
+<script src="/js/main.js"></script>
 <script>
 (function() {
 


### PR DESCRIPTION
## Summary

Fixes two errors introduced after moving `newApi` to `js/main.js`:

- **`main.js:31 Uncaught ReferenceError: $ is not defined`** — `main.js` used jQuery (`$`) but `main.html` doesn't load jQuery. All jQuery calls replaced with vanilla JS equivalents.
- **`newApi is not defined` in dash.html** — `dash.html` didn't include `main.js`. Added `<script src="/js/main.js">` before the inline script block.

## Changes

**`js/main.js`** — jQuery → vanilla JS:
- `$().html()` → `innerHTML`
- `$().each()` → `querySelectorAll().forEach()`
- `$().addClass()` → `classList.add()`
- `$().attr()` / `removeAttr()` → `getAttribute` / `setAttribute` / `removeAttribute`
- `$().after()` / `$().replaceWith()` → `insertBefore` / `replaceChild`
- `$().append()` → `insertAdjacentHTML('beforeend', ...)`
- `$().find()` → descendant CSS selector
- Added `htmlToElement()` helper for HTML string → DOM node
- Added null guard on `#brand` element

**`templates/dash.html`** — added `<script src="/js/main.js">` so `newApi` is available.

## Test plan

- [ ] `main.html` loads without `$ is not defined` errors
- [ ] Navbar resize/menu highlighting still works
- [ ] `dash.html` loads without `newApi is not defined` errors
- [ ] GJS template attributes (`src-report`, `src-object`, `src-split`) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)