### PR TITLE
fix: validate record type before loading dashboard model

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -376,6 +376,10 @@ function dashGetRecord(json) {
         dashSetStatus('Дэшборд не найден');
         return;
     }
+    if (json.type !== 'Дэшборд') {
+        dashSetStatus('Объект не является дэшбордом');
+        return;
+    }
     var titleEl = document.getElementById('dash-title');
     if (titleEl) titleEl.textContent = json.val;
     dashSetStatus('Загрузка модели...');


### PR DESCRIPTION
## Summary

- `dashGetRecord` now checks `json.type === 'Дэшборд'` before calling `report/Дэшборд`
- If the record is not a dashboard, shows `'Объект не является дэшбордом'` and stops

## Example `get_record` response
\`\`\`json
{"id": "1161", "val": "Дэшборд", "up": "1", "obj": "1137", "type": "Дэшборд", "base": "3"}
\`\`\`

## Test plan
- [ ] Valid dashboard id → title set, model loads
- [ ] Wrong type id → status message shown, no model request

🤖 Generated with [Claude Code](https://claude.com/claude-code)