### PR TITLE
fix: expose dash callback functions to window for newApi

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -482,6 +482,12 @@ function dashReset() {
     model.querySelector('.sheets').innerHTML = '';
 }
 
+window.dashGetRecord  = dashGetRecord;
+window.dashGetModel   = dashGetModel;
+window.dashGetSrc     = dashGetSrc;
+window.dashGetPeriods = dashGetPeriods;
+window.dashGetRepDone = dashGetRepDone;
+
 window.dashLoad = function(dashId) {
     dashReset();
     dashSetStatus('Загрузка дэшборда...');


### PR DESCRIPTION
## Summary

`newApi` calls callbacks via `window[b]`, but all dash functions were scoped inside an IIFE and not accessible on `window`.

Exposes: `dashGetRecord`, `dashGetModel`, `dashGetSrc`, `dashGetPeriods`, `dashGetRepDone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)