### PR TITLE
fix: use getElementById for numeric IDs in dashGetModel

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -445,7 +445,7 @@ function dashGetModel(json) {
         }
         // Add item row
         if (json[i].itemID && !document.getElementById(json[i].itemID)) {
-            document.querySelector('#' + json[i].panelID + ' table tbody').insertAdjacentHTML('beforeend',
+            document.getElementById(json[i].panelID).querySelector('table tbody').insertAdjacentHTML('beforeend',
                 itemTpl.replace(/:id:/g, json[i].itemID)
                     .replace(':pl:', json[i].level - 1)
                     .replace(/:name:/g, json[i].item));


### PR DESCRIPTION
## Summary

`querySelector('#1035 table tbody')` throws `SyntaxError` when the ID starts with a digit — CSS selectors don't allow it. Replaced with `getElementById(panelID).querySelector('table tbody')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)