### PR TITLE
fix: guard against undefined value in dashGetSrc

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -359,7 +359,7 @@ function dashGetRep(rep, fr, to) {
 
 function dashGetSrc(json) {
     for (var i in json) {
-        if (json[i].value.length > 0) {
+        if (json[i].value && json[i].value.length > 0) {
             try {
                 dashValues[json[i].item] = JSON.parse('[' + json[i].value + ']');
             } catch (e) {


### PR DESCRIPTION
`json[i].value` can be undefined — added null check before `.length`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)