### PR TITLE
fix: handle null response in dashGetSrc

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -358,7 +358,7 @@ function dashGetRep(rep, fr, to) {
 }
 
 function dashGetSrc(json) {
-    for (var i in json) {
+    for (var i in json || []) {
         if (json[i].value.length > 0) {
             try {
                 dashValues[json[i].item] = JSON.parse('[' + json[i].value + ']');


### PR DESCRIPTION
## Summary

`report/Дэшборд.ЗначенияЗаПериод?JSON_KV` returns `null` when no values exist for the requested period. `for (var i in null)` throws — fixed with `json || []` to skip gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)