### PR TITLE
fix: proper tab and table styles in dash.html

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -1,36 +1,5 @@
 <style>
-.dash-head {
-    position: sticky;
-    top: 49px;
-    z-index: 1;
-}
-.dash-sheet-tab {
-    display: ;
-}
-.dash-first-cell {
-    position: relative;
-}
-.dash-item:hover {
-    background-color: var(--bg-secondary, #fafafa);
-}
-.dash-first-cell .show-id {
-    display: none;
-}
-.dash-first-cell:hover .show-id {
-    display: block;
-}
-.show-id:hover {
-    color: #000000;
-}
-.show-id {
-    position: absolute;
-    right: 0.5rem;
-    color: lightgray;
-    cursor: pointer;
-}
-.dash-err {
-    background-color: #ffeeee;
-}
+/* Toolbar */
 .dash-toolbar {
     display: flex;
     align-items: center;
@@ -51,15 +20,98 @@
     color: var(--text-secondary, #6c757d);
     margin-left: auto;
 }
+/* Sheet tabs */
 #dash-model .sheet-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    list-style: none;
+    margin: 0;
     padding: 0 0.5rem;
     border-bottom: 1px solid var(--border-color, #dee2e6);
 }
+.dash-sheet-tab {
+    display: block;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    color: var(--text-primary, #495057);
+    text-decoration: none;
+    border: 1px solid transparent;
+    border-radius: 4px 4px 0 0;
+    margin-bottom: -1px;
+    white-space: nowrap;
+}
+.dash-sheet-tab:hover {
+    color: var(--text-primary, #212529);
+    border-color: var(--border-color, #dee2e6) var(--border-color, #dee2e6) transparent;
+    text-decoration: none;
+}
+.dash-sheet-tab.active {
+    color: var(--text-primary, #212529);
+    background-color: var(--bg-primary, #fff);
+    border-color: var(--border-color, #dee2e6) var(--border-color, #dee2e6) var(--bg-primary, #fff);
+    font-weight: 500;
+}
+/* Sheets and panels */
 #dash-model .f-sheet {
-    padding: 0.5rem;
+    padding: 0.75rem 0.5rem;
 }
 .f-panel {
-    margin-bottom: 1rem;
+    margin-bottom: 1.5rem;
+    overflow-x: auto;
+}
+.f-panel h4 {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: var(--text-primary, #212529);
+}
+.f-panel table {
+    border-collapse: collapse;
+    font-size: 0.875rem;
+    white-space: nowrap;
+}
+.f-panel th, .f-panel td {
+    padding: 0.3rem 0.6rem;
+    border: 1px solid var(--border-color, #dee2e6);
+    vertical-align: middle;
+}
+.f-panel th {
+    background: var(--bg-secondary, #f8f9fa);
+    font-weight: 600;
+    text-align: center;
+}
+/* Sticky table header */
+.dash-head {
+    position: sticky;
+    top: 49px;
+    z-index: 1;
+    background: var(--bg-secondary, #f8f9fa);
+}
+/* Item rows */
+.dash-item:hover {
+    background-color: var(--bg-secondary, #fafafa);
+}
+.dash-first-cell {
+    position: relative;
+}
+.dash-first-cell .show-id {
+    display: none;
+}
+.dash-first-cell:hover .show-id {
+    display: block;
+}
+.show-id {
+    position: absolute;
+    right: 0.5rem;
+    color: lightgray;
+    cursor: pointer;
+}
+.show-id:hover {
+    color: #000;
+}
+/* Errors */
+.dash-err {
+    background-color: #ffeeee;
 }
 </style>
 


### PR DESCRIPTION
## Problem

Sheet tabs were showing as vertical bullet list — `.dash-sheet-tab { display: ; }` was broken, and `.sheet-tabs` had no flex layout so Bootstrap's nav-tabs styles weren't being applied.

## Changes

- `.sheet-tabs` — `display: flex; list-style: none` for horizontal tabs
- `.dash-sheet-tab` — explicit block display, tab border styling, active/hover states
- Table and panel styles to match model.html reference look
- Removed broken empty `display:` declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)