### PR TITLE
fix: remove dash-toolbar from dash.html

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -1,19 +1,4 @@
 <style>
-/* Toolbar */
-.dash-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    background: var(--bg-secondary, #f9f9f9);
-    border-bottom: 1px solid var(--border-color, #dee2e6);
-    flex-wrap: wrap;
-}
-.dash-status {
-    font-size: 0.8rem;
-    color: var(--text-secondary, #6c757d);
-    margin-left: auto;
-}
 /* Sheet tabs */
 #dash-model .sheet-tabs {
     display: flex;
@@ -109,9 +94,6 @@
 }
 </style>
 
-<div class="dash-toolbar">
-    <span class="dash-status" id="dash-status"></span>
-</div>
 
 <div id="dash-model" class="f-model m-2">
     <ul class="nav nav-tabs sheet-tabs"></ul>


### PR DESCRIPTION
Removes the `.dash-toolbar` block (status span) entirely — not needed after dashboard loads. `dashSetStatus` becomes a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)