### PR TITLE
fix: remove divider lines between checkboxes in table settings

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -1260,6 +1260,12 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     border-bottom: 1px solid var(--border-color, #f0f0f0);
 }
 
+.table-settings-item:has(input[type="checkbox"]) {
+    border-bottom: none;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
 .table-settings-item > label:first-child {
     font-weight: 600;
     margin-bottom: 5px;


### PR DESCRIPTION
Fixes #1748

Adds `.table-settings-item:has(input[type="checkbox"]) { border-bottom: none }` to `css/integram-table.css`. Section items (Отступы, Размер страницы, links) keep their border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)