### PR TITLE
fix: close sticky dash-head gap against navbar (issue #1766)

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -64,9 +64,15 @@
 /* Sticky table header */
 .dash-head {
     position: sticky;
-    top: 0;
+    top: -12px;
     z-index: 1;
     background: var(--bg-secondary, #f8f9fa);
+}
+@media (max-width: 900px) {
+    .dash-head { top: -1rem; }
+}
+@media (max-width: 600px) {
+    .dash-head { top: -0.75rem; }
 }
 /* Item rows */
 .dash-item:hover {


### PR DESCRIPTION
## Problem

After PR #1765, the dashboard table header (`.dash-head`) sticks but with a visible gap between it and the navigation menu when scrolling.

## Root Cause

`.app-content` is the scroll container with `padding: 12px`. For `position: sticky`, `top: 0` means the element sticks when its top edge reaches the **content-box** top of the scroll container — which is 12px below the visible edge (the padding). This leaves a 12px gap between the stuck header and the navbar.

## Fix

Set `top` on `.dash-head` to the negative of the scroll container's `padding-top`, so the sticky position compensates for the padding and the header appears flush against the top of the visible area:

- Default: `top: -12px` (matches `.app-content { padding: 12px }`)
- `@media (max-width: 900px)`: `top: -1rem` (matches `padding: 1rem`)
- `@media (max-width: 600px)`: `top: -0.75rem` (matches `padding: 0.75rem`)

## How to verify

1. Open a dashboard page (`/dash/ID`)
2. Scroll down — the table section header sticks with **no visible gap** between it and the navbar ✓
3. Sidebar still stays fixed ✓

Fixes #1766

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)