### PR TITLE
fix: report filter — FR-only request must not populate TO defaults; Enter submits form (issue #1763)

### DIFF
--- a/index.php
+++ b/index.php
@@ -2162,9 +2162,12 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
     			foreach($GLOBALS["STORED_REPS"][$id]["types"] as $key => $typ){ # Col => Type
         			trace(" Replace the report params with the gotten ones from REQUEST: $key => $typ");
     			    # Fill in the array of conditions for Construct_WHERE()
+    			    $frFromRequest = false; $toFromRequest = false;
     			    if(isset($GLOBALS["STORED_REPS"][$id][REP_COL_NAME][$key])){
         			    $str = str_replace(" ", "_", $GLOBALS["STORED_REPS"][$id][REP_COL_NAME][$key]);
 						$t = $GLOBALS["STORED_REPS"][$id]["columns"][$key];
+    			        $frFromRequest = (isset($_REQUEST["FR_$str"]) && strlen($_REQUEST["FR_$str"])) || (isset($_REQUEST["FR_$t"]) && strlen($_REQUEST["FR_$t"]));
+    			        $toFromRequest = (isset($_REQUEST["TO_$str"]) && strlen($_REQUEST["TO_$str"])) || (isset($_REQUEST["TO_$t"]) && strlen($_REQUEST["TO_$t"]));
     			        if(isset($_REQUEST["FR_$str"]) && strlen($_REQUEST["FR_$str"]))
                 				$GLOBALS["CONDS"][$key]["FR"] = $_REQUEST["FR_$str"];
     			        elseif(isset($_REQUEST["FR_$t"]) && strlen($_REQUEST["FR_$t"]))
@@ -2174,9 +2177,10 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
     			        elseif(isset($_REQUEST["TO_$t"]) && strlen($_REQUEST["TO_$t"]))
                 				$GLOBALS["CONDS"][$key]["TO"] = $_REQUEST["TO_$t"];
     			    }
-    				if(!isset($GLOBALS["CONDS"][$key]["FR"]) && isset($GLOBALS["STORED_REPS"][$id][REP_COL_FROM][$key]))
+    				# Apply stored defaults only if the request did not explicitly set the opposite side for this column
+    				if(!isset($GLOBALS["CONDS"][$key]["FR"]) && !$toFromRequest && isset($GLOBALS["STORED_REPS"][$id][REP_COL_FROM][$key]))
                             $GLOBALS["CONDS"][$key]["FR"] = $GLOBALS["STORED_REPS"][$id][REP_COL_FROM][$key];
-    				if(!isset($GLOBALS["CONDS"][$key]["TO"]) && isset($GLOBALS["STORED_REPS"][$id][REP_COL_TO][$key]))
+    				if(!isset($GLOBALS["CONDS"][$key]["TO"]) && !$frFromRequest && isset($GLOBALS["STORED_REPS"][$id][REP_COL_TO][$key]))
                             $GLOBALS["CONDS"][$key]["TO"] = $GLOBALS["STORED_REPS"][$id][REP_COL_TO][$key];
     			}
             $i = 0;

--- a/templates/report.html
+++ b/templates/report.html
@@ -25,6 +25,7 @@
 <body style="font-family:Verdana,Tahoma,sans-serif;font-size:13px;line-height:normal;padding:2px;background-color:var(--bg-primary,#fff);color:var(--text-primary,#212529)">
 <FORM method="post" id="report" action="/{_global_.z}/report/{_global_.id}">
 <input type="hidden" name="_xsrf" value="{_global_.xsrf}">
+<input type="submit" style="display:none">
     <TABLE>
 	<TR>
 		<TD>&nbsp;<a href="/{_global_.z}"><i class="pi pi-home" style="font-size: 1.25rem;"></i></a>&nbsp;


### PR DESCRIPTION
## Problems

Two bugs in the report filter (`report.html` + `index.php`):

### 1. FR-only request populates TO filters from stored defaults

When a request contains only `FR_*` params (e.g. `FR_sheet`, `FR_periodFrom`, `FR_periodTo`), the backend correctly sets `CONDS[col]["FR"]` from the request, but then unconditionally falls through to the stored-default fallback and sets `CONDS[col]["TO"]` from `REP_COL_TO` — even though the caller never sent any `TO_*` param.

**Root cause:** the stored-default fallback checked only `!isset(CONDS[col]["TO"])`, which is always true when the request contains no `TO_*` param.

**Fix (`index.php`):** Track `$frFromRequest` and `$toFromRequest` per column (inside the existing foreach). Skip the stored `REP_COL_TO` default when `$frFromRequest` is true, and skip the stored `REP_COL_FROM` default when `$toFromRequest` is true. No-filter-in-request case is unchanged (both defaults still apply).

### 2. Enter key in filter input does not submit the form

The `#report` form had no `<input type="submit">` or `<button type="submit">` — only an `<a onclick="byId('report').submit()">` link. Browsers only fire the native Enter-to-submit when the form contains at least one submit button.

**Fix (`report.html`):** Add `<input type="submit" style="display:none">` inside `#report`. The button is invisible; Enter now submits the form natively.

## How to verify

1. Send request with `FR_sheet=...&FR_periodFrom=...&FR_periodTo=...` — only FR values appear in the rendered filter, TO inputs stay empty ✓
2. Open a report, show the filter row, type a value, press **Enter** — form submits without needing DevTools ✓

Fixes #1763

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)