### PR TITLE
fix: dash filter — no redundant get_record, partial sheet reload with FR_sheet, flex panel layout (issue #1770)

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -33,9 +33,16 @@
 /* Sheets and panels */
 #dash-model .f-sheet {
     padding: 0.75rem 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1rem;
+}
+.dash-filter-bar {
+    flex-basis: 100%;
 }
 .f-panel {
-    margin-bottom: 1.5rem;
+    margin-bottom: 0;
 }
 .f-panel .f-table-wrap {
     overflow-x: visible;
@@ -148,7 +155,7 @@ const repRegex  = /^\[([A-Za-яЁё][A-Za-яЁё0-9]*)(\.[A-Za-яЁё][A-Za-яЁ
     , exprRegex = /(СУММА)\(\[(.*?)\]:\[(.*?)\]\)/g
     , itemIdRegex = /\[\d+\]/g;
 
-let dashCurrentId = null, dashDateFr = null, dashDateTo = null, dashPeriodVal = 'Месяц';
+let dashCurrentId = null, dashRecordId = null, dashDateFr = null, dashDateTo = null, dashPeriodVal = 'Месяц';
 
 function dashToInputDate(s) {
     if (!s) return '';
@@ -557,6 +564,7 @@ function dashGetRecord(json) {
     document.title = json.val;
     var navCenter = document.querySelector('.navbar-center .navbar-workspace');
     if (navCenter) navCenter.textContent = json.val;
+    dashRecordId = json.id;
     dashSetStatus('Загрузка модели...');
     newApi('GET', 'report/Дэшборд?JSON_KV&FR_modelID=' + json.id + '&period=' + encodeURIComponent(dashPeriodVal), 'dashGetModel');
 }
@@ -667,10 +675,32 @@ window.dashDebug                  = dashDebug;
 window.dashUpdateTableWrapOverflow = dashUpdateTableWrapOverflow;
 
 window.dashApplyFilter = function(sheetEl) {
-    dashDateFr  = dashFromInputDate(sheetEl.querySelector('.dash-fr-input').value);
-    dashDateTo  = dashFromInputDate(sheetEl.querySelector('.dash-to-input').value);
+    dashDateFr    = dashFromInputDate(sheetEl.querySelector('.dash-fr-input').value);
+    dashDateTo    = dashFromInputDate(sheetEl.querySelector('.dash-to-input').value);
     dashPeriodVal = sheetEl.querySelector('.dash-period-sel').value;
-    window.dashLoad(dashCurrentId);
+
+    // Get active sheet name for FR_sheet filter
+    var model = document.getElementById('dash-model');
+    var activeTab = model.querySelector('.dash-sheet-tab.active');
+    var sheetName = activeTab ? activeTab.textContent.trim() : '';
+
+    // Partial reset: remove only this sheet's panels, keep tabs/other sheets intact
+    sheetEl.querySelectorAll('.f-panel').forEach(function(p) {
+        p.querySelectorAll('.f-item').forEach(function(row) {
+            delete dashFormulas[row.id];
+            delete dashItems[row.id];
+        });
+        delete dashModelData[p.id];
+        p.remove();
+    });
+    dashPeriodData = {}; dashPeriods = {}; dashValues = {}; dashReports = {}; dashAjaxes = 0;
+
+    // Re-fetch model for this sheet only — skip get_record, use cached dashRecordId
+    dashSetStatus('Загрузка данных...');
+    newApi('GET', 'report/Дэшборд?JSON_KV&FR_modelID=' + dashRecordId
+        + '&period=' + encodeURIComponent(dashPeriodVal)
+        + (sheetName ? '&FR_sheet=' + encodeURIComponent(sheetName) : ''),
+        'dashGetModel');
 };
 
 window.dashApplySearch = function(query, sheetEl) {


### PR DESCRIPTION
## Fixes for #1770 (depends on #1769)

Three corrections to the filter bar from PR #1769:

### Fix 1 — Don't re-fetch `get_record` on Применить

Previously `dashApplyFilter` called `dashLoad(dashCurrentId)` which always re-issued `GET get_record/{id}` just to get the dashboard record's internal ID.

**Fix:** Cache the record ID as `dashRecordId` when `dashGetRecord` first runs. `dashApplyFilter` now calls the `report/Дэшборд` model fetch directly using `dashRecordId` — no round-trip to `get_record`.

### Fix 3 — Stay on active tab, only reload current sheet

Previously the whole dashboard was wiped (`dashReset`) and rebuilt on every filter apply, losing the active tab state.

**Fix:** `dashApplyFilter` now does a **partial reset**:
- Removes only the panels of the currently active `.f-sheet` from DOM
- Deletes only those items' entries from `dashFormulas` / `dashItems` / `dashModelData`
- Resets shared data stores (`dashPeriodData`, `dashValues`, `dashReports`, `dashAjaxes`)
- Fetches model with `&FR_sheet=<active tab name>` — only the current sheet's rows are returned and rendered
- Other tabs and their panels remain intact; the active tab stays active

### Fix 2 — Panels flow side-by-side

`.f-sheet` is now `display: flex; flex-wrap: wrap; align-items: flex-start; gap: 1rem` so panels arrange horizontally and only wrap to the next row when there isn't enough room for the next panel. `.dash-filter-bar` gets `flex-basis: 100%` so it always occupies its own row above the panels.

## How to verify

1. Open dashboard → click a non-first tab → change dates → Применить → stays on same tab, only that tab reloads ✓
2. Other tabs still show their previous data ✓
3. Network tab: no `get_record` request on Применить ✓
4. Panels on a sheet with multiple panels appear side-by-side if screen width allows ✓

Fixes #1770

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)