### PR TITLE
fix: render multi-select editor for :MULTI: ref fields in subordinate create form (issue #1772)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11866,12 +11866,42 @@ class IntegramTable{
                 const fieldName = attrs.alias || req.val;
                 const baseFormat = this.normalizeFormat(req.type);
                 const isRequired = attrs.required;
+                const isMulti = attrs.multi;
 
                 formHtml += `<div class="form-group">`;
                 formHtml += `<label for="sub-field-${ req.id }">${ fieldName }${ isRequired ? ' <span class="required">*</span>' : '' }</label>`;
 
-                // Reference field (searchable dropdown with clear/add buttons - same as inline table editor)
-                if (req.ref_id) {
+                // Multi-select reference field (issue #1772)
+                if (req.ref_id && isMulti) {
+                    formHtml += `
+                        <div class="form-reference-editor form-multi-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.orig || req.ref_id }" data-multi="1" data-current-value="">
+                            <div class="inline-editor-reference form-ref-editor-box inline-editor-multi-reference">
+                                <div class="multi-ref-tags-container form-multi-ref-tags-container">
+                                    <span class="multi-ref-tags-placeholder">Загрузка...</span>
+                                </div>
+                                <div class="inline-editor-reference-header">
+                                    <input type="text"
+                                           class="inline-editor-reference-search form-ref-search"
+                                           id="sub-field-${ req.id }-search"
+                                           placeholder="Добавить..."
+                                           autocomplete="off">
+                                    <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button"><i class="pi pi-plus"></i></button>
+                                </div>
+                                <div class="inline-editor-reference-dropdown form-ref-dropdown" id="sub-field-${ req.id }-dropdown" style="display:none;">
+                                    <div class="inline-editor-reference-empty">Загрузка...</div>
+                                </div>
+                            </div>
+                            <input type="hidden"
+                                   class="form-ref-value form-multi-ref-value"
+                                   id="sub-field-${ req.id }"
+                                   name="t${ req.id }"
+                                   value=""
+                                   data-ref-id="${ req.id }">
+                        </div>
+                    `;
+                }
+                // Single-select reference field
+                else if (req.ref_id) {
                     formHtml += `
                         <div class="form-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.orig || req.ref_id }">
                             <div class="inline-editor-reference form-ref-editor-box">

--- a/js/integram-table/20-form-create.js
+++ b/js/integram-table/20-form-create.js
@@ -92,12 +92,42 @@
                 const fieldName = attrs.alias || req.val;
                 const baseFormat = this.normalizeFormat(req.type);
                 const isRequired = attrs.required;
+                const isMulti = attrs.multi;
 
                 formHtml += `<div class="form-group">`;
                 formHtml += `<label for="sub-field-${ req.id }">${ fieldName }${ isRequired ? ' <span class="required">*</span>' : '' }</label>`;
 
-                // Reference field (searchable dropdown with clear/add buttons - same as inline table editor)
-                if (req.ref_id) {
+                // Multi-select reference field (issue #1772)
+                if (req.ref_id && isMulti) {
+                    formHtml += `
+                        <div class="form-reference-editor form-multi-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.orig || req.ref_id }" data-multi="1" data-current-value="">
+                            <div class="inline-editor-reference form-ref-editor-box inline-editor-multi-reference">
+                                <div class="multi-ref-tags-container form-multi-ref-tags-container">
+                                    <span class="multi-ref-tags-placeholder">Загрузка...</span>
+                                </div>
+                                <div class="inline-editor-reference-header">
+                                    <input type="text"
+                                           class="inline-editor-reference-search form-ref-search"
+                                           id="sub-field-${ req.id }-search"
+                                           placeholder="Добавить..."
+                                           autocomplete="off">
+                                    <button class="inline-editor-reference-add form-ref-add" style="display: none;" title="Создать запись" aria-label="Создать запись" type="button"><i class="pi pi-plus"></i></button>
+                                </div>
+                                <div class="inline-editor-reference-dropdown form-ref-dropdown" id="sub-field-${ req.id }-dropdown" style="display:none;">
+                                    <div class="inline-editor-reference-empty">Загрузка...</div>
+                                </div>
+                            </div>
+                            <input type="hidden"
+                                   class="form-ref-value form-multi-ref-value"
+                                   id="sub-field-${ req.id }"
+                                   name="t${ req.id }"
+                                   value=""
+                                   data-ref-id="${ req.id }">
+                        </div>
+                    `;
+                }
+                // Single-select reference field
+                else if (req.ref_id) {
                     formHtml += `
                         <div class="form-reference-editor" data-ref-id="${ req.id }" data-required="${ isRequired }" data-ref-type-id="${ req.orig || req.ref_id }">
                             <div class="inline-editor-reference form-ref-editor-box">


### PR DESCRIPTION
## Problem

On the subordinate record create form (`.subordinate-modal`, opened via `.subordinate-add-btn`), reference fields with `:MULTI:` in their `attrs` were rendered as regular single-select dropdowns instead of multi-select tag editors.

## Root Cause

`renderSubordinateCreateForm()` in `20-form-create.js` iterated `regularFields` and checked only `req.ref_id` to decide whether to render a reference editor — it never checked `attrs.multi`. The `isMulti` variable was not read at all.

Meanwhile, `loadReferenceOptions()` (also in `20-form-create.js`) already had the correct logic:
```js
if (wrapper.dataset.multi === '1') {
    this.initFormMultiReferenceEditor(wrapper, ...);
    continue;
}
```
…but the wrapper never had `data-multi="1"` because the HTML was always generated without it.

## Fix

In the `regularFields.forEach` loop:
1. Extract `const isMulti = attrs.multi;` (attrs is already parsed from `req.attrs`)
2. Add a new branch `if (req.ref_id && isMulti)` that renders the full multi-reference editor HTML — identical in structure to `25-create-form-helper.js` — with `data-multi="1"`, `.inline-editor-multi-reference`, `.form-multi-ref-tags-container`, and `.form-multi-ref-value`
3. The existing `if (req.ref_id)` becomes `else if (req.ref_id)` for single-select

`loadReferenceOptions()` then detects `data-multi="1"` and calls `initFormMultiReferenceEditor()` as intended — no further changes required.

## How to verify

1. Open a subordinate table that has a column with `:MULTI:` in attrs (e.g. "Колонка группы" from the issue example)
2. Click the add button to open the create form
3. The multi-select field now shows a tags-based editor with search and add-item functionality ✓
4. Single-select reference fields are unchanged ✓

Fixes #1772

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)