### PR TITLE
fix: any-ref editor — fix overlapping buttons, hide clear when empty (#1804)

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -2774,6 +2774,49 @@ td.cell-saving {
     color: var(--md-text-hint);
 }
 
+/* Issue #1804: "link to any record" editor — clear + table-picker buttons in flex row */
+.form-any-ref-editor .inline-editor-reference-header {
+    padding-right: 4px;
+}
+
+.form-any-ref-editor .inline-editor-reference-search {
+    padding-right: 8px;
+}
+
+.form-any-ref-editor .inline-editor-reference-clear {
+    position: static;
+    transform: none;
+    flex-shrink: 0;
+    margin: 0 2px;
+}
+
+.form-any-ref-editor .inline-editor-reference-clear:active {
+    transform: scale(0.9);
+}
+
+.form-any-ref-table-btn {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: transparent;
+    color: var(--md-text-secondary);
+    font-size: 1rem;
+    cursor: pointer;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    padding: 0;
+    margin-right: 2px;
+}
+
+.form-any-ref-table-btn:hover {
+    background: var(--md-hover);
+    color: var(--md-primary);
+}
+
 /* Issue #1384: dropdown is moved to document.body by JS (_attachFixedDropdown) so it
    escapes the table's overflow clipping. position/top/left/width are set via JS. */
 .inline-editor-reference-dropdown {

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -10748,7 +10748,7 @@ class IntegramTable{
                                            placeholder="Поиск..."
                                            autocomplete="off"
                                            value="${ this.escapeHtml(currentText) }">
-                                    <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
+                                    <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button" style="${ currentId ? '' : 'display:none;' }"><i class="pi pi-times"></i></button>
                                     <button class="form-any-ref-table-btn" title="Выбрать таблицу" aria-label="Выбрать таблицу" type="button"><i class="pi pi-table"></i></button>
                                 </div>
                                 <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${ req.id }-dropdown" style="display:none;">
@@ -12958,17 +12958,20 @@ class IntegramTable{
                         hiddenInput.value = option.dataset.id;
                         searchInput.value = option.dataset.text;
                         dropdown.style.display = 'none';
+                        // Issue #1804: show clear button when a value is selected
+                        if (clearButton) clearButton.style.display = '';
                         hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
                     }
                 });
 
-                // Clear button
+                // Clear button — hidden when no value (issue #1804)
                 if (clearButton) {
                     clearButton.addEventListener('click', (e) => {
                         e.preventDefault();
                         e.stopPropagation();
                         hiddenInput.value = '';
                         searchInput.value = '';
+                        clearButton.style.display = 'none';
                         if (wrapper._currentTableId) {
                             renderRecordOptions(wrapper._currentRecords || []);
                         }

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -480,7 +480,7 @@
                                            placeholder="Поиск..."
                                            autocomplete="off"
                                            value="${ this.escapeHtml(currentText) }">
-                                    <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button"><i class="pi pi-times"></i></button>
+                                    <button class="inline-editor-reference-clear form-ref-clear" title="Очистить значение" aria-label="Очистить значение" type="button" style="${ currentId ? '' : 'display:none;' }"><i class="pi pi-times"></i></button>
                                     <button class="form-any-ref-table-btn" title="Выбрать таблицу" aria-label="Выбрать таблицу" type="button"><i class="pi pi-table"></i></button>
                                 </div>
                                 <div class="inline-editor-reference-dropdown form-ref-dropdown" id="field-${ req.id }-dropdown" style="display:none;">

--- a/js/integram-table/20-form-create.js
+++ b/js/integram-table/20-form-create.js
@@ -978,17 +978,20 @@
                         hiddenInput.value = option.dataset.id;
                         searchInput.value = option.dataset.text;
                         dropdown.style.display = 'none';
+                        // Issue #1804: show clear button when a value is selected
+                        if (clearButton) clearButton.style.display = '';
                         hiddenInput.dispatchEvent(new Event('change', { bubbles: true }));
                     }
                 });
 
-                // Clear button
+                // Clear button — hidden when no value (issue #1804)
                 if (clearButton) {
                     clearButton.addEventListener('click', (e) => {
                         e.preventDefault();
                         e.stopPropagation();
                         hiddenInput.value = '';
                         searchInput.value = '';
+                        clearButton.style.display = 'none';
                         if (wrapper._currentTableId) {
                             renderRecordOptions(wrapper._currentRecords || []);
                         }


### PR DESCRIPTION
## Summary

Fixes the UI issues in the "link to any record" field editor introduced in #1803.

## Changes

**CSS (`css/integram-table.css`)**
- `.form-any-ref-editor .inline-editor-reference-clear` — override `position: static` so the clear button doesn't use absolute positioning and doesn't overlap the table-picker button; place it in the flex row
- `.form-any-ref-editor .inline-editor-reference-search` — reduce right padding (no longer needs room for an absolute button)
- `.form-any-ref-table-btn` — add styles: size 28×28, transparent bg with hover effect

**HTML (`js/integram-table/19-form-edit.js`)**
- Clear button rendered with `style="display:none;"` when field has no current value

**JS (`js/integram-table/20-form-create.js`)**
- After selecting a record → `clearButton.style.display = ''` (show)
- After clicking clear → `clearButton.style.display = 'none'` (hide)

## Test plan

- [ ] Open edit form with an any-record-link field that has **no value** → only table-picker button visible, no clear button
- [ ] Click table-picker → select table → select record → clear button appears, no overlap with table-picker
- [ ] Click clear → value reset, clear button disappears
- [ ] Open edit form with an any-record-link field that **has a value** → both buttons visible and not overlapping

Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)