### PR TITLE
fix: auto-open record list after selecting table in any-ref editor (#1807)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -12835,20 +12835,28 @@ class IntegramTable{
                             const escaped = this.escapeHtml(String(tName));
                             return `<div class="inline-editor-reference-option form-any-ref-table-option" data-table-id="${ tId }" data-text="${ escaped }" tabindex="0">${ escaped }</div>`;
                         }).join('');
-                        // Table selected: load its records
+                        // Table selected: load its records (issue #1807)
                         dropdown.querySelectorAll('.form-any-ref-table-option').forEach(opt => {
-                            opt.addEventListener('click', async () => {
+                            opt.addEventListener('click', async (e) => {
+                                // Stop propagation so the document outside-click handler
+                                // does not close the dropdown when the option element is
+                                // removed from DOM during innerHTML replacement
+                                e.stopPropagation();
                                 const tableId = opt.dataset.tableId;
                                 wrapper._currentTableId = tableId;
                                 searchInput.value = '';
                                 dropdown.innerHTML = '<div class="inline-editor-reference-empty">Загрузка...</div>';
+                                dropdown.style.display = 'block';
                                 try {
                                     const records = await loadTableRecords(tableId);
                                     wrapper._currentRecords = records;
                                     wrapper._serverSearch = records.length >= 20;
                                     renderRecordOptions(records);
+                                    dropdown.style.display = 'block';
+                                    searchInput.focus();
                                 } catch (e) {
                                     dropdown.innerHTML = `<div class="inline-editor-reference-empty">Ошибка: ${ this.escapeHtml(e.message) }</div>`;
+                                    dropdown.style.display = 'block';
                                 }
                             });
                         });

--- a/js/integram-table/20-form-create.js
+++ b/js/integram-table/20-form-create.js
@@ -855,20 +855,28 @@
                             const escaped = this.escapeHtml(String(tName));
                             return `<div class="inline-editor-reference-option form-any-ref-table-option" data-table-id="${ tId }" data-text="${ escaped }" tabindex="0">${ escaped }</div>`;
                         }).join('');
-                        // Table selected: load its records
+                        // Table selected: load its records (issue #1807)
                         dropdown.querySelectorAll('.form-any-ref-table-option').forEach(opt => {
-                            opt.addEventListener('click', async () => {
+                            opt.addEventListener('click', async (e) => {
+                                // Stop propagation so the document outside-click handler
+                                // does not close the dropdown when the option element is
+                                // removed from DOM during innerHTML replacement
+                                e.stopPropagation();
                                 const tableId = opt.dataset.tableId;
                                 wrapper._currentTableId = tableId;
                                 searchInput.value = '';
                                 dropdown.innerHTML = '<div class="inline-editor-reference-empty">Загрузка...</div>';
+                                dropdown.style.display = 'block';
                                 try {
                                     const records = await loadTableRecords(tableId);
                                     wrapper._currentRecords = records;
                                     wrapper._serverSearch = records.length >= 20;
                                     renderRecordOptions(records);
+                                    dropdown.style.display = 'block';
+                                    searchInput.focus();
                                 } catch (e) {
                                     dropdown.innerHTML = `<div class="inline-editor-reference-empty">Ошибка: ${ this.escapeHtml(e.message) }</div>`;
+                                    dropdown.style.display = 'block';
                                 }
                             });
                         });


### PR DESCRIPTION
## Root cause

When the user clicked a table option in the table-picker dropdown, the `click` handler synchronously replaced `dropdown.innerHTML` with "Загрузка...", removing the clicked element from the DOM. The event then bubbled to the document-level outside-click handler, which saw `e.target` (now detached) as no longer contained in `wrapper` and called `dropdown.style.display = 'none'`. By the time the async `loadTableRecords` resolved and `renderRecordOptions` ran, the dropdown was already hidden.

## Fix

- `e.stopPropagation()` on the table option click to prevent the document handler from firing
- `dropdown.style.display = 'block'` explicitly set before and after the async load
- `searchInput.focus()` after records are rendered so the user can type immediately

## Test plan

- [ ] Open edit form → click table-picker button → table list appears
- [ ] Click a table name → "Загрузка..." shows, then record list appears **without any extra click**
- [ ] User can type in the search field immediately after table selection
- [ ] Clicking outside the editor closes the dropdown

Closes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)