### PR TITLE
fix: cast record fields to String in any-ref editor (TypeError fix)

### DIFF
--- a/templates/edit_obj.html
+++ b/templates/edit_obj.html
@@ -382,19 +382,19 @@ $(document).ready(function() {
                 if (filterText && records.length < 20) {
                     var q = filterText.toLowerCase();
                     list = records.filter(function(r) {
-                        return (r.u || '').toLowerCase().indexOf(q) !== -1;
+                        return String(r.u || r.o || r.i || '').toLowerCase().indexOf(q) !== -1;
                     });
                 }
                 if (!list.length) {
                     $dropdown.append('<div class="list-group-item list-group-item-action text-muted small">Нет результатов</div>');
                 } else {
                     list.forEach(function(r) {
-                        var $opt = $('<a href="#" class="list-group-item list-group-item-action py-1 px-2 small"></a>').text(r.u || r.o || r.i);
+                        var $opt = $('<a href="#" class="list-group-item list-group-item-action py-1 px-2 small"></a>').text(String(r.u || r.o || r.i || ''));
                         $opt.on('click', function(e) {
                             e.preventDefault();
                             e.stopPropagation();
                             var selId = r.i;
-                            var selText = r.u || r.o || r.i;
+                            var selText = String(r.u || r.o || r.i || '');
                             $search.val(selText);
                             $sel.val(selId);
                             // Update hidden select option if needed


### PR DESCRIPTION
Fixes regression from #1812.

## Problem

```
Uncaught TypeError: (r.u || "").toLowerCase is not a function
```

`r.u` (display value from `object/{tableId}?JSON_OBJ`) can be a **number**, not a string. Calling `.toLowerCase()` on a number throws TypeError.

## Fix

Wrap all usages of `r.u || r.o || r.i` in `String(...)` before calling string methods or passing to `.text()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)