### PR TITLE
fix: use r.r[0] as display value in any-ref editor (#1814)

### DIFF
--- a/templates/edit_obj.html
+++ b/templates/edit_obj.html
@@ -382,19 +382,20 @@ $(document).ready(function() {
                 if (filterText && records.length < 20) {
                     var q = filterText.toLowerCase();
                     list = records.filter(function(r) {
-                        return String(r.u || r.o || r.i || '').toLowerCase().indexOf(q) !== -1;
+                        var dispText = (r.r && r.r[0] != null) ? String(r.r[0]) : String(r.i || ''); return dispText.toLowerCase().indexOf(q) !== -1;
                     });
                 }
                 if (!list.length) {
                     $dropdown.append('<div class="list-group-item list-group-item-action text-muted small">Нет результатов</div>');
                 } else {
                     list.forEach(function(r) {
-                        var $opt = $('<a href="#" class="list-group-item list-group-item-action py-1 px-2 small"></a>').text(String(r.u || r.o || r.i || ''));
+                        var recDisp = (r.r && r.r[0] != null) ? String(r.r[0]) : String(r.i || '');
+                        var $opt = $('<a href="#" class="list-group-item list-group-item-action py-1 px-2 small"></a>').text(recDisp);
                         $opt.on('click', function(e) {
                             e.preventDefault();
                             e.stopPropagation();
                             var selId = r.i;
-                            var selText = String(r.u || r.o || r.i || '');
+                            var selText = (r.r && r.r[0] != null) ? String(r.r[0]) : String(r.i || '');
                             $search.val(selText);
                             $sel.val(selId);
                             // Update hidden select option if needed


### PR DESCRIPTION
Closes #1814

## Problem

Records in the any-ref dropdown showed `1` instead of their actual names.

## Root cause

`r.u` in the `object/{tableId}?JSON_OBJ` response is the **parent record ID** (not the display name). The actual display value is `r.r[0]` — the first field of the record's data array. This is the same pattern used in `07-inline-edit.js:1329`.

## Fix

Replace `r.u || r.o || r.i` with `(r.r && r.r[0] != null) ? String(r.r[0]) : String(r.i)` in all three places: filter, option text, and selected text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)