### PR TITLE
fix: restore position:relative on .app-sidebar to fix sidebar resize (#1816)

### DIFF
--- a/css/main-app.css
+++ b/css/main-app.css
@@ -180,6 +180,7 @@
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    position: relative;
 }
 
 [data-theme="dark"] .app-sidebar {


### PR DESCRIPTION
## Root Cause

Commit 8e89cae (`fix: make app-content a real scroll container`, issue #1764) removed `position: sticky` from `.app-sidebar`. Without any non-static position, `.app-sidebar` is no longer the **containing block** for `.sidebar-resize-handle { position: absolute; right: 0 }`.

The handle ends up positioned relative to a distant ancestor element, making it invisible/unreachable at the sidebar edge — dragging no longer works.

## Fix

Add `position: relative` to `.app-sidebar` in `css/main-app.css`. This restores the correct containing block for the absolutely-positioned resize handle without reintroducing `position: sticky` (which was causing the scroll issues fixed in #1764).

## Test plan

- [ ] Open the CRM, hover over the right edge of the left sidebar — the resize cursor (`ew-resize`) should appear
- [ ] Drag the sidebar edge left/right — width should change smoothly
- [ ] Reload the page — saved width should persist (cookie)
- [ ] Collapse the sidebar — resize handle should be hidden
- [ ] Verify that the scrolling fix from #1764 (app-content scroll container) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)