### PR TITLE
feat: add ID-based include/exclude filter types for REF columns (#1819)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -160,6 +160,8 @@ class IntegramTable{
             this.filterTypes['REF'] = [
                 { symbol: '=', name: 'равно', format: 'FR_{ T }={ X }' },
                 { symbol: '(,)', name: 'в списке', format: 'FR_{ T }={ X }' },
+                { symbol: '@', name: 'по ID: включая', format: 'FR_{ T }=@{ X }' },
+                { symbol: '!@', name: 'по ID: исключая', format: 'FR_{ T }=!@{ X }' },
                 { symbol: '~', name: 'содержит', format: 'FR_{ T }=%{ X }%' },
                 { symbol: '^', name: 'начинается с...', format: 'FR_{ T }={ X }%' },
                 { symbol: '!', name: 'не содержит', format: 'FR_{ T }=!%{ X }%' },
@@ -167,7 +169,8 @@ class IntegramTable{
                 { symbol: '!%', name: 'пустое', format: 'FR_{ T }=!%' }
             ];
             // Text-based filter types for REF columns - these use text input instead of dropdown (issue #799)
-            this.refTextFilterTypes = new Set(['~', '^', '!']);
+            // '@' and '!@' also use text input - user types IDs directly (issue #1819)
+            this.refTextFilterTypes = new Set(['~', '^', '!', '@', '!@']);
 
             this.init();
         }
@@ -1169,7 +1172,15 @@ class IntegramTable{
 
             if (!filterDef) return;
 
-            if (type === '...') {
+            if (type === '@' || type === '!@') {
+                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819)
+                const ids = value.split(',').map(v => v.trim()).filter(v => /^\d+$/.test(v));
+                if (ids.length === 0) return;
+                const formatted = ids.length === 1
+                    ? `${type}${ids[0]}`
+                    : `${type}(${ids.join(',')})`;
+                params.append(`FR_${ colId }`, formatted);
+            } else if (type === '...') {
                 const values = value.split(',').map(v => v.trim());
                 if (values.length >= 2) {
                     params.append(`FR_${ colId }`, values[0]);
@@ -3411,6 +3422,14 @@ class IntegramTable{
                         const col = this.columns.find(c => c.id === colId);
                         const fmt = col ? (col.format || 'SHORT') : 'SHORT';
                         this.filters[colId] = { type: this.getDefaultFilterType(fmt), value: '' };
+                    }
+                    // Validate input for ID-based filter types (issue #1819): only digits and commas
+                    const filterType = this.filters[colId] && this.filters[colId].type;
+                    if (filterType === '@' || filterType === '!@') {
+                        const sanitized = input.value.replace(/[^\d,\s]/g, '');
+                        if (sanitized !== input.value) {
+                            input.value = sanitized;
+                        }
                     }
                     this.filters[colId].value = input.value;
                     // Clear displayValue: user is now entering their own filter, not the resolved label (issue #551)
@@ -9035,6 +9054,22 @@ class IntegramTable{
             }
             if (rawValue === '!%') {
                 return { type: '!%', value: '' };
+            }
+
+            // Check for ID-based exclusion filter: !@{id} or !@(id1,id2,...) (issue #1819)
+            const refExclIdMatch = rawValue.match(/^!@(\d+)$/);
+            if (refExclIdMatch) {
+                return { type: '!@', value: refExclIdMatch[1] };
+            }
+            const refExclListMatch = rawValue.match(/^!@\((.+)\)$/);
+            if (refExclListMatch) {
+                return { type: '!@', value: refExclListMatch[1] };
+            }
+
+            // Check for ID-based including-list filter: @(id1,id2,...) (issue #1819)
+            const refInclListMatch = rawValue.match(/^@\((.+)\)$/);
+            if (refInclListMatch) {
+                return { type: '@', value: refInclListMatch[1] };
             }
 
             // Check for ID-based filter: @{id} means filter by record ID, not by text value (issue #551)

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -143,6 +143,8 @@
             this.filterTypes['REF'] = [
                 { symbol: '=', name: 'равно', format: 'FR_{ T }={ X }' },
                 { symbol: '(,)', name: 'в списке', format: 'FR_{ T }={ X }' },
+                { symbol: '@', name: 'по ID: включая', format: 'FR_{ T }=@{ X }' },
+                { symbol: '!@', name: 'по ID: исключая', format: 'FR_{ T }=!@{ X }' },
                 { symbol: '~', name: 'содержит', format: 'FR_{ T }=%{ X }%' },
                 { symbol: '^', name: 'начинается с...', format: 'FR_{ T }={ X }%' },
                 { symbol: '!', name: 'не содержит', format: 'FR_{ T }=!%{ X }%' },
@@ -150,7 +152,8 @@
                 { symbol: '!%', name: 'пустое', format: 'FR_{ T }=!%' }
             ];
             // Text-based filter types for REF columns - these use text input instead of dropdown (issue #799)
-            this.refTextFilterTypes = new Set(['~', '^', '!']);
+            // '@' and '!@' also use text input - user types IDs directly (issue #1819)
+            this.refTextFilterTypes = new Set(['~', '^', '!', '@', '!@']);
 
             this.init();
         }

--- a/js/integram-table/03-filters-core.js
+++ b/js/integram-table/03-filters-core.js
@@ -14,7 +14,15 @@
 
             if (!filterDef) return;
 
-            if (type === '...') {
+            if (type === '@' || type === '!@') {
+                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819)
+                const ids = value.split(',').map(v => v.trim()).filter(v => /^\d+$/.test(v));
+                if (ids.length === 0) return;
+                const formatted = ids.length === 1
+                    ? `${type}${ids[0]}`
+                    : `${type}(${ids.join(',')})`;
+                params.append(`FR_${ colId }`, formatted);
+            } else if (type === '...') {
                 const values = value.split(',').map(v => v.trim());
                 if (values.length >= 2) {
                     params.append(`FR_${ colId }`, values[0]);

--- a/js/integram-table/07-inline-edit.js
+++ b/js/integram-table/07-inline-edit.js
@@ -245,6 +245,14 @@
                         const fmt = col ? (col.format || 'SHORT') : 'SHORT';
                         this.filters[colId] = { type: this.getDefaultFilterType(fmt), value: '' };
                     }
+                    // Validate input for ID-based filter types (issue #1819): only digits and commas
+                    const filterType = this.filters[colId] && this.filters[colId].type;
+                    if (filterType === '@' || filterType === '!@') {
+                        const sanitized = input.value.replace(/[^\d,\s]/g, '');
+                        if (sanitized !== input.value) {
+                            input.value = sanitized;
+                        }
+                    }
                     this.filters[colId].value = input.value;
                     // Clear displayValue: user is now entering their own filter, not the resolved label (issue #551)
                     delete this.filters[colId].displayValue;

--- a/js/integram-table/14-url-config.js
+++ b/js/integram-table/14-url-config.js
@@ -379,6 +379,22 @@
                 return { type: '!%', value: '' };
             }
 
+            // Check for ID-based exclusion filter: !@{id} or !@(id1,id2,...) (issue #1819)
+            const refExclIdMatch = rawValue.match(/^!@(\d+)$/);
+            if (refExclIdMatch) {
+                return { type: '!@', value: refExclIdMatch[1] };
+            }
+            const refExclListMatch = rawValue.match(/^!@\((.+)\)$/);
+            if (refExclListMatch) {
+                return { type: '!@', value: refExclListMatch[1] };
+            }
+
+            // Check for ID-based including-list filter: @(id1,id2,...) (issue #1819)
+            const refInclListMatch = rawValue.match(/^@\((.+)\)$/);
+            if (refInclListMatch) {
+                return { type: '@', value: refInclListMatch[1] };
+            }
+
             // Check for ID-based filter: @{id} means filter by record ID, not by text value (issue #551)
             // Example: FR_4547=@6753 means filter column 4547 by record ID 6753
             const refIdMatch = rawValue.match(/^@(\d+)$/);


### PR DESCRIPTION
## Summary

Adds two new filter types for reference/lookup ("списочные") fields in the table filter row:

| Symbol | Name | Example value | API parameter |
|--------|------|--------------|---------------|
| `@` | по ID: включая | `777` or `111, 222, 333` | `FR_N=@777` / `FR_N=@(111,222,333)` |
| `!@` | по ID: исключая | `777` or `111, 222, 333` | `FR_N=!@777` / `FR_N=!@(111,222,333)` |

## Implementation

- **`01-core.js`** — add `@` and `!@` entries to `filterTypes['REF']`; add both to `refTextFilterTypes` so a text input renders (not a value-picker dropdown)
- **`03-filters-core.js`** — handle `@`/`!@` in `applyFilter`: split input on commas, keep only valid integers, format as `@id` (single) or `@(id1,id2)` (list); `!@` prefixes with `!`
- **`07-inline-edit.js`** — sanitize input for `@`/`!@` filter types: strip characters other than digits, commas, spaces
- **`14-url-config.js`** — parse `!@id`, `!@(id1,id2,...)` and `@(id1,id2,...)` URL patterns back into the correct filter type on page load
- **`js/integram-table.js`** — rebuilt bundle

## Test plan

- [ ] Open a table that has a reference column
- [ ] Click the filter icon (`=`) on the ref column — menu should include `@` (по ID: включая) and `!@` (по ID: исключая)
- [ ] Select `@`, type `777` → URL gets `FR_N=@777`, matching rows appear
- [ ] Select `@`, type `111, 222, 333` → URL gets `FR_N=@(111,222,333)`
- [ ] Select `!@`, type `777` → URL gets `FR_N=!@777`
- [ ] Select `!@`, type `111, 222` → URL gets `FR_N=!@(111,222)`
- [ ] Try typing letters in the `@`/`!@` filter input — they should be silently rejected
- [ ] Reload the page with a `FR_N=!@(111,222)` URL param — filter should restore correctly with `!@` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)