### PR TITLE
feat: add 'Свободная ссылка' (id=1) to add-column-modal base types (#1821)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -7416,7 +7416,8 @@ class IntegramTable{
                 { id: 11, name: 'Логическое значение (Да / Нет)' },
                 { id: 12, name: 'Многострочный текст' },
                 { id: 4, name: 'Дата и время' },
-                { id: 10, name: 'Файл' }
+                { id: 10, name: 'Файл' },
+                { id: 1, name: 'Свободная ссылка' }
             ];
 
             // Create modal overlay (issue #567: make the form a modal)

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -744,7 +744,8 @@
                 { id: 11, name: 'Логическое значение (Да / Нет)' },
                 { id: 12, name: 'Многострочный текст' },
                 { id: 4, name: 'Дата и время' },
-                { id: 10, name: 'Файл' }
+                { id: 10, name: 'Файл' },
+                { id: 1, name: 'Свободная ссылка' }
             ];
 
             // Create modal overlay (issue #567: make the form a modal)


### PR DESCRIPTION
## Summary
- Adds **Свободная ссылка** (type id=1) as the last option in the base type dropdown of the Add Column modal
- Placed at the end of the `baseTypes` array in `showAddColumnForm()`, as specified in the issue

Closes #1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)