### PR TITLE
feat: use _d_alias API for renaming free link columns

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -7104,10 +7104,13 @@ class IntegramTable{
                 try {
                     // 0. Rename column (issue #1018, extended to first column in issue #1026)
                     // For ref columns the name field is a hyperlink (not editable), so the input won't exist (issue #1435)
+                    // For free link columns (type=1) use _d_alias instead of _d_save (issue #1835)
                     const nameInput = colEditModal.querySelector(`#col-edit-name-${instanceName}`);
                     const newName = nameInput ? nameInput.value.trim() : '';
                     if (newName && newName !== currentName) {
-                        const result = await this.renameColumn(col.orig || col.id, newName, col.type);
+                        const result = isFreeLink
+                            ? await this.setColumnAlias(col.orig || col.id, newName)
+                            : await this.renameColumn(col.orig || col.id, newName, col.type);
                         if (!result.success) {
                             showStatus('Ошибка переименования: ' + result.error, true);
                             saveBtn.disabled = false;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -7109,7 +7109,7 @@ class IntegramTable{
                     const newName = nameInput ? nameInput.value.trim() : '';
                     if (newName && newName !== currentName) {
                         const result = isFreeLink
-                            ? await this.setColumnAlias(col.orig || col.id, newName)
+                            ? await this.setColumnAlias(col.id, newName)
                             : await this.renameColumn(col.orig || col.id, newName, col.type);
                         if (!result.success) {
                             showStatus('Ошибка переименования: ' + result.error, true);

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -432,10 +432,13 @@
                 try {
                     // 0. Rename column (issue #1018, extended to first column in issue #1026)
                     // For ref columns the name field is a hyperlink (not editable), so the input won't exist (issue #1435)
+                    // For free link columns (type=1) use _d_alias instead of _d_save (issue #1835)
                     const nameInput = colEditModal.querySelector(`#col-edit-name-${instanceName}`);
                     const newName = nameInput ? nameInput.value.trim() : '';
                     if (newName && newName !== currentName) {
-                        const result = await this.renameColumn(col.orig || col.id, newName, col.type);
+                        const result = isFreeLink
+                            ? await this.setColumnAlias(col.orig || col.id, newName)
+                            : await this.renameColumn(col.orig || col.id, newName, col.type);
                         if (!result.success) {
                             showStatus('Ошибка переименования: ' + result.error, true);
                             saveBtn.disabled = false;

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -437,7 +437,7 @@
                     const newName = nameInput ? nameInput.value.trim() : '';
                     if (newName && newName !== currentName) {
                         const result = isFreeLink
-                            ? await this.setColumnAlias(col.orig || col.id, newName)
+                            ? await this.setColumnAlias(col.id, newName)
                             : await this.renameColumn(col.orig || col.id, newName, col.type);
                         if (!result.success) {
                             showStatus('Ошибка переименования: ' + result.error, true);


### PR DESCRIPTION
## Summary
- When saving a "Свободная ссылка" (type:`1`) column, the rename now calls `_d_alias/{id}?JSON` with `val=newName` instead of `_d_save`
- All other column types continue using the existing `_d_save` endpoint

Closes #1835

## Test plan
- [ ] Open column edit form for a "Свободная ссылка" column
- [ ] Change the name and click Save
- [ ] Verify the rename is persisted via `_d_alias` (check Network tab)
- [ ] Verify renaming regular columns still uses `_d_save`

🤖 Generated with [Claude Code](https://claude.com/claude-code)