### PR TITLE
fix: prevent duplicate values in dashboard table cells

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -441,7 +441,8 @@ function dashDrawPeriods() {
                                 headTpl.replace(':head:', p[i].r[0]).replace(':from:', fr).replace(':to:', to));
                             panel.querySelectorAll('.f-item').forEach(function(row) {
                                 var s = dashCellSrc(row.id, 'rg');
-                                if (dashFormulas[row.id]) {
+                                v = dashGetVal(row.getAttribute('item-name'), fr, to);
+                                if (v === undefined && dashFormulas[row.id]) {
                                     if (dashFormulas[row.id] === '[]')
                                         v = dashGetVal(row.getAttribute('item-name'), fr, to);
                                     else if (itemRegex.test(dashFormulas[row.id]))


### PR DESCRIPTION
## Summary
- Fixed bug where value "42" from "Кол-во закрытых задач" was duplicated across multiple cells in the dashboard table
- **Root cause**: In `dashDrawPeriods`, the `v` variable was only assigned inside `if (dashFormulas[row.id])`. Rows without formulas inherited the stale `v` from the previous row's iteration
- **Fix**: Each row now starts with `v = dashGetVal(row.getAttribute('item-name'), fr, to)` before checking formulas, so rows without formulas get their own value (or `undefined` → empty cell)

Closes #1837

## Test plan
- [ ] Open the dashboard with the "Операционные результаты" panel
- [ ] Verify "42" appears only in the "Кол-во закрытых задач" row for April
- [ ] Verify other rows without values show empty cells
- [ ] Verify rows with formulas still resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)