### PR TITLE
fix: update subordinate record count when closing modal

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11585,6 +11585,9 @@ class IntegramTable{
             event.preventDefault();
             event.stopPropagation();
 
+            // Remember the clicked cell so we can update its count on close (issue #1839)
+            const clickedCountCell = event.target.closest('td');
+
             try {
                 // Fetch metadata for subordinate table (use cache to avoid redundant requests)
                 if (!this.metadataCache[arrId]) {
@@ -11645,6 +11648,12 @@ class IntegramTable{
 
                 // Close handler
                 const closeModal = () => {
+                    // Update subordinate record count in the parent cell (issue #1839)
+                    if (clickedCountCell) {
+                        const newCount = container.querySelectorAll('table tbody tr').length || 0;
+                        const countLink = clickedCountCell.querySelector('.subordinate-count-link');
+                        if (countLink) countLink.textContent = `(${ newCount })`;
+                    }
                     modal.remove();
                     overlay.remove();
                     window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -921,6 +921,9 @@
             event.preventDefault();
             event.stopPropagation();
 
+            // Remember the clicked cell so we can update its count on close (issue #1839)
+            const clickedCountCell = event.target.closest('td');
+
             try {
                 // Fetch metadata for subordinate table (use cache to avoid redundant requests)
                 if (!this.metadataCache[arrId]) {
@@ -981,6 +984,12 @@
 
                 // Close handler
                 const closeModal = () => {
+                    // Update subordinate record count in the parent cell (issue #1839)
+                    if (clickedCountCell) {
+                        const newCount = container.querySelectorAll('table tbody tr').length || 0;
+                        const countLink = clickedCountCell.querySelector('.subordinate-count-link');
+                        if (countLink) countLink.textContent = `(${ newCount })`;
+                    }
                     modal.remove();
                     overlay.remove();
                     window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);


### PR DESCRIPTION
## Summary
- When closing a subordinate table modal opened from a cell click, the parent cell's count `(N)` now updates to reflect the current number of rows
- Saves a reference to the clicked cell, then on close counts `table tbody tr` rows in the modal container and updates the `.subordinate-count-link` text

Closes #1839

## Test plan
- [ ] Click on a subordinate count cell (e.g. showing `(0)`) to open the subordinate table modal
- [ ] Create one or more records in the subordinate table
- [ ] Close the modal — verify the count updates (e.g. `(0)` → `(1)`)
- [ ] Delete a record, close — verify count decreases
- [ ] Verify nested subordinate tables still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)