### PR TITLE
feat: persist active dashboard tab in URL hash

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -758,12 +758,19 @@ function dashGetModel(json) {
         }
     }
 
-    // Activate first tab
-    var firstTab = model.querySelector('.dash-sheet-tab');
-    if (firstTab && !model.querySelector('.dash-sheet-tab.active')) {
-        firstTab.classList.add('active');
-        var firstSheet = model.querySelector('.f-sheet');
-        if (firstSheet) firstSheet.style.display = '';
+    // Activate tab: restore from URL hash or default to first tab (issue #1840)
+    if (!model.querySelector('.dash-sheet-tab.active')) {
+        var savedTab = null;
+        try {
+            var hashMatch = window.location.hash.match(/^#tab=(.+)/);
+            if (hashMatch) savedTab = model.querySelector('.dash-sheet-tab#' + CSS.escape(decodeURIComponent(hashMatch[1])));
+        } catch(e) {}
+        var targetTab = savedTab || model.querySelector('.dash-sheet-tab');
+        if (targetTab) {
+            targetTab.classList.add('active');
+            var targetSheet = document.getElementById('ds' + targetTab.id);
+            if (targetSheet) targetSheet.style.display = '';
+        }
     }
 }
 
@@ -834,6 +841,8 @@ window.dashSetActive = function(el) {
     el.classList.add('active');
     var sheet = document.getElementById('ds' + el.id);
     if (sheet) sheet.style.display = '';
+    // Persist active tab in URL hash so page refresh restores it (issue #1840)
+    try { history.replaceState(null, '', '#tab=' + encodeURIComponent(el.id)); } catch(e) {}
 };
 
 window.dashCopy2Buffer = function(text) {


### PR DESCRIPTION
## Summary
- Clicking a dashboard sheet tab now saves the tab ID to the URL hash (`#tab=<sheetID>`) via `history.replaceState`
- On page load/refresh, the saved tab is restored from the hash instead of defaulting to the first tab
- Uses `CSS.escape` for safe ID selection

Closes #1840

## Test plan
- [ ] Open a dashboard with multiple sheet tabs
- [ ] Click on a non-first tab — verify the URL updates to `#tab=<id>`
- [ ] Refresh the page — verify the same tab is active
- [ ] Clear the hash from URL and refresh — verify the first tab is shown (default behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)