### PR TITLE
feat: Ctrl+Enter triggers paste insert in #paste-data-textarea

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -2719,6 +2719,14 @@ class IntegramTable{
                 window[instanceName].previewPastedData(modal, closeModal);
             });
 
+            // Ctrl+Enter in textarea triggers "Вставить" (issue #1845)
+            modal.querySelector('#paste-data-textarea').addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                    e.preventDefault();
+                    modal.querySelector('#paste-data-insert-btn').click();
+                }
+            });
+
             // Focus textarea
             setTimeout(() => modal.querySelector('#paste-data-textarea').focus(), 50);
         }

--- a/js/integram-table/06-render-cell.js
+++ b/js/integram-table/06-render-cell.js
@@ -938,6 +938,14 @@
                 window[instanceName].previewPastedData(modal, closeModal);
             });
 
+            // Ctrl+Enter in textarea triggers "Вставить" (issue #1845)
+            modal.querySelector('#paste-data-textarea').addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+                    e.preventDefault();
+                    modal.querySelector('#paste-data-insert-btn').click();
+                }
+            });
+
             // Focus textarea
             setTimeout(() => modal.querySelector('#paste-data-textarea').focus(), 50);
         }


### PR DESCRIPTION
## Summary
- Added keydown listener on `#paste-data-textarea` that triggers the "Вставить" button click on Ctrl+Enter (or Cmd+Enter on Mac)

Closes #1845

## Test plan
- [ ] Open "Вставить данные из буфера" form
- [ ] Paste data into the textarea
- [ ] Press Ctrl+Enter — verify it triggers the insert action
- [ ] Verify normal Enter still adds newlines in the textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)