### PR TITLE
feat: show yellow warning toast for server 'warning' responses

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -1762,6 +1762,12 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     border-left: 4px solid #2196f3;
 }
 
+.integram-toast-warning {
+    background: #fff8e1;
+    color: #f57f17;
+    border-left: 4px solid #ffc107;
+}
+
 /* Searchable select (dropdown with search) */
 .searchable-select-wrapper {
     position: relative;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -5074,6 +5074,7 @@ class IntegramTable{
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Update cell display with comma-separated text of selected items
                 const displayText = (selectedItems || []).map(s => s.text).join(', ');
@@ -5200,6 +5201,7 @@ class IntegramTable{
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Save confirmed — remove the saving highlight
                 cell.classList.remove('cell-saving');
@@ -5535,6 +5537,7 @@ class IntegramTable{
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Extract created record ID and value from response
                 // According to the issue: "её id приходит в ключе obj JSON в ответ на запрос _m_new"
@@ -5701,6 +5704,11 @@ class IntegramTable{
                     throw new Error(serverError);
                 }
 
+                // Check for warning (singular) - show yellow toast (issue #1847)
+                if (result.warning) {
+                    this.showToast(result.warning, 'warning');
+                }
+
                 // Check for warnings (plural) - show modal but continue with save (issue #610)
                 // These are informational warnings that don't block the save
                 if (result.warnings) {
@@ -5789,6 +5797,7 @@ class IntegramTable{
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Extract created record ID from response
                 // According to the issue: "её id приходит в ключе obj JSON"
@@ -12711,6 +12720,7 @@ class IntegramTable{
                     if (serverError) {
                         throw new Error(serverError);
                     }
+                    if (result.warning) this.showToast(result.warning, 'warning');
 
                     closeModal();
                     this.showToast('Запись создана', 'success');
@@ -14108,6 +14118,7 @@ class IntegramTable{
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 const createdId = result.obj || result.id || result.i;
                 const createdValue = result.val || mainValue;
@@ -17775,6 +17786,7 @@ class IntegramCreateFormHelper {
             if (serverError) {
                 throw new Error(serverError);
             }
+            if (result.warning) this.showToast(result.warning, 'warning');
 
             // Success - close modal
             this.showToast('Запись создана', 'success');
@@ -18851,6 +18863,7 @@ class IntegramCreateFormHelper {
             if (serverError) {
                 throw new Error(serverError);
             }
+            if (result.warning) this.showToast(result.warning, 'warning');
 
             // Success - close modal
             this.showToast('Изменения сохранены', 'success');

--- a/js/integram-table/07-inline-edit.js
+++ b/js/integram-table/07-inline-edit.js
@@ -1888,6 +1888,7 @@
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Update cell display with comma-separated text of selected items
                 const displayText = (selectedItems || []).map(s => s.text).join(', ');
@@ -2014,6 +2015,7 @@
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Save confirmed — remove the saving highlight
                 cell.classList.remove('cell-saving');
@@ -2349,6 +2351,7 @@
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Extract created record ID and value from response
                 // According to the issue: "её id приходит в ключе obj JSON в ответ на запрос _m_new"
@@ -2515,6 +2518,11 @@
                     throw new Error(serverError);
                 }
 
+                // Check for warning (singular) - show yellow toast (issue #1847)
+                if (result.warning) {
+                    this.showToast(result.warning, 'warning');
+                }
+
                 // Check for warnings (plural) - show modal but continue with save (issue #610)
                 // These are informational warnings that don't block the save
                 if (result.warnings) {
@@ -2603,6 +2611,7 @@
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 // Extract created record ID from response
                 // According to the issue: "её id приходит в ключе obj JSON"

--- a/js/integram-table/20-form-create.js
+++ b/js/integram-table/20-form-create.js
@@ -318,6 +318,7 @@
                     if (serverError) {
                         throw new Error(serverError);
                     }
+                    if (result.warning) this.showToast(result.warning, 'warning');
 
                     closeModal();
                     this.showToast('Запись создана', 'success');
@@ -1715,6 +1716,7 @@
                 if (serverError) {
                     throw new Error(serverError);
                 }
+                if (result.warning) this.showToast(result.warning, 'warning');
 
                 const createdId = result.obj || result.id || result.i;
                 const createdValue = result.val || mainValue;

--- a/js/integram-table/25-create-form-helper.js
+++ b/js/integram-table/25-create-form-helper.js
@@ -1134,6 +1134,7 @@ class IntegramCreateFormHelper {
             if (serverError) {
                 throw new Error(serverError);
             }
+            if (result.warning) this.showToast(result.warning, 'warning');
 
             // Success - close modal
             this.showToast('Запись создана', 'success');
@@ -2210,6 +2211,7 @@ class IntegramCreateFormHelper {
             if (serverError) {
                 throw new Error(serverError);
             }
+            if (result.warning) this.showToast(result.warning, 'warning');
 
             // Success - close modal
             this.showToast('Изменения сохранены', 'success');


### PR DESCRIPTION
## Summary
- Added `.integram-toast-warning` CSS class (yellow background, amber border)
- Added `result.warning` checks after all `getServerError` calls across:
  - `07-inline-edit.js` — inline cell save, multiselect save, reference save, new record creation (5 locations)
  - `20-form-create.js` — subordinate create form, main create form (2 locations)
  - `25-create-form-helper.js` — create and edit save (2 locations)
- `21-form-field-settings.js` already handled `warning` via `showWarningModal`
- When server responds with `{"warning": "Запись уже существует"}`, a yellow toast is shown

Closes #1847

## Test plan
- [ ] Trigger a save that returns a `warning` field in the response
- [ ] Verify yellow toast appears with the warning message
- [ ] Verify normal saves without warnings still work as before
- [ ] Verify error responses still show red error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)