### PR TITLE
fix: skip redundant confirmation when duplicating record with pre-modified field

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -10700,6 +10700,9 @@ class IntegramTable{
                 window._integramModalDepth = 0;
             }
             window._integramModalDepth++;
+
+            // Store original main value for duplicate check (issue #1851)
+            const originalMainValue = recordData && recordData.obj ? recordData.obj.val : '';
             const modalDepth = window._integramModalDepth;
             const baseZIndex = 1000 + (modalDepth * 10);
 
@@ -10813,7 +10816,7 @@ class IntegramTable{
                 ${ tabsHtml }
                 <div class="edit-form-body">
                     <div class="edit-form-tab-content active" data-tab-content="attributes">
-                        <form id="edit-form" class="edit-form" onsubmit="return false;" autocomplete="off">
+                        <form id="edit-form" class="edit-form" onsubmit="return false;" autocomplete="off" data-original-main-value="${ this.escapeHtml(originalMainValue) }">
                             ${ attributesHtml }
                         </form>
                     </div>
@@ -14863,17 +14866,22 @@ class IntegramTable{
 
             const formData = new FormData(form);
             const mainValue = formData.get('main');
+            const originalMainValue = form.getAttribute('data-original-main-value') || '';
 
             let newFirstColumnValue = mainValue;
 
             if (isUnique) {
-                // Prompt user to enter a new value for the first (unique) column
-                const prompted = await this.showDuplicateUniqueValueModal(mainValue);
-                if (prompted === null) {
-                    // User cancelled
-                    return;
+                // Skip confirmation if value has already been changed in the form (issue #1851)
+                if (mainValue === originalMainValue) {
+                    // Prompt user to enter a new value for the first (unique) column
+                    const prompted = await this.showDuplicateUniqueValueModal(mainValue);
+                    if (prompted === null) {
+                        // User cancelled
+                        return;
+                    }
+                    newFirstColumnValue = prompted;
                 }
-                newFirstColumnValue = prompted;
+                // If value was already changed, use the form value directly
             }
 
             const apiBase = this.getApiBase();

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -4,6 +4,9 @@
                 window._integramModalDepth = 0;
             }
             window._integramModalDepth++;
+
+            // Store original main value for duplicate check (issue #1851)
+            const originalMainValue = recordData && recordData.obj ? recordData.obj.val : '';
             const modalDepth = window._integramModalDepth;
             const baseZIndex = 1000 + (modalDepth * 10);
 
@@ -117,7 +120,7 @@
                 ${ tabsHtml }
                 <div class="edit-form-body">
                     <div class="edit-form-tab-content active" data-tab-content="attributes">
-                        <form id="edit-form" class="edit-form" onsubmit="return false;" autocomplete="off">
+                        <form id="edit-form" class="edit-form" onsubmit="return false;" autocomplete="off" data-original-main-value="${ this.escapeHtml(originalMainValue) }">
                             ${ attributesHtml }
                         </form>
                     </div>

--- a/js/integram-table/21-form-field-settings.js
+++ b/js/integram-table/21-form-field-settings.js
@@ -680,17 +680,22 @@
 
             const formData = new FormData(form);
             const mainValue = formData.get('main');
+            const originalMainValue = form.getAttribute('data-original-main-value') || '';
 
             let newFirstColumnValue = mainValue;
 
             if (isUnique) {
-                // Prompt user to enter a new value for the first (unique) column
-                const prompted = await this.showDuplicateUniqueValueModal(mainValue);
-                if (prompted === null) {
-                    // User cancelled
-                    return;
+                // Skip confirmation if value has already been changed in the form (issue #1851)
+                if (mainValue === originalMainValue) {
+                    // Prompt user to enter a new value for the first (unique) column
+                    const prompted = await this.showDuplicateUniqueValueModal(mainValue);
+                    if (prompted === null) {
+                        // User cancelled
+                        return;
+                    }
+                    newFirstColumnValue = prompted;
                 }
-                newFirstColumnValue = prompted;
+                // If value was already changed, use the form value directly
             }
 
             const apiBase = this.getApiBase();


### PR DESCRIPTION
## Issue
GitHub issue #1851: When duplicating a record with a unique first column, if the user has already modified the value in the form, the system still shows a redundant confirmation dialog asking them to enter a new value.

## Solution
The system now checks if the first column value has already been changed in the form before showing the confirmation dialog:
- **Original value = Current form value**: Show confirmation dialog (user hasn't modified the field)
- **Original value ≠ Current form value**: Skip confirmation and use the form value directly (user already made a change)

This removes unnecessary friction from the duplicate workflow while maintaining data integrity by still requesting a new unique value when needed.

## Changes
- Store original main value in form data attribute (`19-form-edit.js`)
- Compare current form value with original before showing confirmation (`21-form-field-settings.js`)
- Use the user's pre-modified value directly if it differs from the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)