### PR TITLE
feat: display parent record value in subordinate modal header

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11630,6 +11630,23 @@ class IntegramTable{
                 }
                 const metadata = this.metadataCache[arrId];
 
+                // Fetch parent record data to display in header (issue #1853)
+                const apiBase = this.getApiBase();
+                const parentTypeId = this.options.typeId;
+                const parentDataUrl = `${ apiBase }/object/${ parentTypeId }/${ parentRecordId }/?JSON_OBJ`;
+                let parentRecordValue = '';
+
+                try {
+                    const parentResponse = await fetch(parentDataUrl);
+                    const parentData = await parentResponse.json();
+                    if (parentData && parentData.obj && parentData.obj.val) {
+                        parentRecordValue = parentData.obj.val;
+                    }
+                } catch (error) {
+                    // If we can't fetch parent data, just continue without it
+                    console.warn('Could not fetch parent record data:', error);
+                }
+
                 // Create modal for subordinate table
                 const modalDepth = (window._integramModalDepth || 0) + 1;
                 window._integramModalDepth = modalDepth;
@@ -11646,10 +11663,11 @@ class IntegramTable{
                 modal.dataset.modalDepth = modalDepth;
 
                 const typeName = this.getMetadataName(metadata);
+                const headerTitle = parentRecordValue ? `${ this.escapeHtml(parentRecordValue) } / ${ typeName }` : typeName;
 
                 modal.innerHTML = `
                     <div class="edit-form-header">
-                        <h3>${ typeName }</h3>
+                        <h3>${ headerTitle }</h3>
                         <button class="edit-form-close subordinate-modal-close"><i class="pi pi-times"></i></button>
                     </div>
                     <div class="edit-form-body">

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -934,6 +934,23 @@
                 }
                 const metadata = this.metadataCache[arrId];
 
+                // Fetch parent record data to display in header (issue #1853)
+                const apiBase = this.getApiBase();
+                const parentTypeId = this.options.typeId;
+                const parentDataUrl = `${ apiBase }/object/${ parentTypeId }/${ parentRecordId }/?JSON_OBJ`;
+                let parentRecordValue = '';
+
+                try {
+                    const parentResponse = await fetch(parentDataUrl);
+                    const parentData = await parentResponse.json();
+                    if (parentData && parentData.obj && parentData.obj.val) {
+                        parentRecordValue = parentData.obj.val;
+                    }
+                } catch (error) {
+                    // If we can't fetch parent data, just continue without it
+                    console.warn('Could not fetch parent record data:', error);
+                }
+
                 // Create modal for subordinate table
                 const modalDepth = (window._integramModalDepth || 0) + 1;
                 window._integramModalDepth = modalDepth;
@@ -950,10 +967,11 @@
                 modal.dataset.modalDepth = modalDepth;
 
                 const typeName = this.getMetadataName(metadata);
+                const headerTitle = parentRecordValue ? `${ this.escapeHtml(parentRecordValue) } / ${ typeName }` : typeName;
 
                 modal.innerHTML = `
                     <div class="edit-form-header">
-                        <h3>${ typeName }</h3>
+                        <h3>${ headerTitle }</h3>
                         <button class="edit-form-close subordinate-modal-close"><i class="pi pi-times"></i></button>
                     </div>
                     <div class="edit-form-body">


### PR DESCRIPTION
## Issue
GitHub issue #1853: Subordinate modal header should display the parent record's value to provide context about which parent record the child records belong to.

## Solution
When opening a subordinate table from the main table, the modal header now displays:
- **Format**: `{parent_record_value} / {subordinate_table_name}`
- **Example**: If editing items under "Product A", the header shows "Product A / Items"

This makes it immediately clear which parent record is being edited and improves the user experience, especially when working with nested data.

## Implementation
- Fetch parent record data when opening subordinate modal
- Extract parent record's first column value from the API response
- Combine parent value with subordinate table name in the header
- Gracefully handle errors: if parent data can't be fetched, display table name only

## Error Handling
- If the parent API call fails, the modal still opens and displays just the table name
- No impact on the subordinate table functionality if parent data fetch fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)