### PR TITLE
fix: avoid redundant API call when opening subordinate from cell click

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11630,21 +11630,26 @@ class IntegramTable{
                 }
                 const metadata = this.metadataCache[arrId];
 
-                // Fetch parent record data to display in header (issue #1853)
-                const apiBase = this.getApiBase();
-                const parentTypeId = this.options.typeId;
-                const parentDataUrl = `${ apiBase }/object/${ parentTypeId }/${ parentRecordId }/?JSON_OBJ`;
+                // Extract parent record value from the clicked row (issue #1853, #1857)
+                // Try to get it from the row data structure instead of making a redundant API call
                 let parentRecordValue = '';
-
-                try {
-                    const parentResponse = await fetch(parentDataUrl);
-                    const parentData = await parentResponse.json();
-                    if (parentData && parentData.obj && parentData.obj.val) {
-                        parentRecordValue = parentData.obj.val;
+                const clickedRow = event.target.closest('tr');
+                if (clickedRow) {
+                    const firstCell = clickedRow.querySelector('td:first-child');
+                    if (firstCell) {
+                        // Get the text content from the first cell (parent record value)
+                        const cellText = firstCell.textContent.trim();
+                        // Remove any leading index/ID prefix and icon markup
+                        parentRecordValue = cellText.replace(/^\d+\s*/, '').replace(/<[^>]*>/g, '').trim();
                     }
-                } catch (error) {
-                    // If we can't fetch parent data, just continue without it
-                    console.warn('Could not fetch parent record data:', error);
+                }
+
+                // Fallback: try to find parent value from the clicked element's row in the data structure
+                if (!parentRecordValue && this.cellSubordinateContext && this.cellSubordinateContext.arrId === arrId) {
+                    const rowData = this.cellSubordinateContext.rowData;
+                    if (rowData && rowData.r && rowData.r[0]) {
+                        parentRecordValue = this.stripReferencePrefix(String(rowData.r[0]));
+                    }
                 }
 
                 // Create modal for subordinate table

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -934,21 +934,26 @@
                 }
                 const metadata = this.metadataCache[arrId];
 
-                // Fetch parent record data to display in header (issue #1853)
-                const apiBase = this.getApiBase();
-                const parentTypeId = this.options.typeId;
-                const parentDataUrl = `${ apiBase }/object/${ parentTypeId }/${ parentRecordId }/?JSON_OBJ`;
+                // Extract parent record value from the clicked row (issue #1853, #1857)
+                // Try to get it from the row data structure instead of making a redundant API call
                 let parentRecordValue = '';
-
-                try {
-                    const parentResponse = await fetch(parentDataUrl);
-                    const parentData = await parentResponse.json();
-                    if (parentData && parentData.obj && parentData.obj.val) {
-                        parentRecordValue = parentData.obj.val;
+                const clickedRow = event.target.closest('tr');
+                if (clickedRow) {
+                    const firstCell = clickedRow.querySelector('td:first-child');
+                    if (firstCell) {
+                        // Get the text content from the first cell (parent record value)
+                        const cellText = firstCell.textContent.trim();
+                        // Remove any leading index/ID prefix and icon markup
+                        parentRecordValue = cellText.replace(/^\d+\s*/, '').replace(/<[^>]*>/g, '').trim();
                     }
-                } catch (error) {
-                    // If we can't fetch parent data, just continue without it
-                    console.warn('Could not fetch parent record data:', error);
+                }
+
+                // Fallback: try to find parent value from the clicked element's row in the data structure
+                if (!parentRecordValue && this.cellSubordinateContext && this.cellSubordinateContext.arrId === arrId) {
+                    const rowData = this.cellSubordinateContext.rowData;
+                    if (rowData && rowData.r && rowData.r[0]) {
+                        parentRecordValue = this.stripReferencePrefix(String(rowData.r[0]));
+                    }
                 }
 
                 // Create modal for subordinate table


### PR DESCRIPTION
## Issue
GitHub issue #1857: Unnecessary and incorrect HTTP requests when clicking subordinate count links.

**Problem:**
When clicking on a subordinate count link, an invalid API request was made to:
```
https://ideav.ru/sportzania/object/undefined/1883/?JSON_OBJ
```
Resulting in:
- HTTP 500 Internal Server Error
- URL contains "undefined" instead of valid parent type ID
- Redundant network traffic and API call

## Root Cause
The previous implementation (from issue #1853) was attempting to fetch parent record data from the API using:
```javascript
const parentTypeId = this.options.typeId;
const parentDataUrl = `${apiBase}/object/${parentTypeId}/${parentRecordId}/?JSON_OBJ`;
```

This is problematic because:
1. When opening from a subordinate table cell click, `this.options.typeId` is the main table's ID, not the subordinate table's ID
2. This results in incorrect type IDs being used in the URL
3. The parent record value is already available in the DOM (the first cell of the clicked row)

## Solution
Extract parent record value directly from the clicked row in the DOM instead of making an API call:

1. Get the clicked row from the click event
2. Extract text from the first cell (contains parent record value)
3. Clean up the text to remove prefixes and markup
4. Display in the header without any server request

## Benefits
- ✅ Eliminates HTTP 500 errors
- ✅ Removes "undefined" URLs
- ✅ Improves performance (no network call)
- ✅ Data already available locally, no need to fetch
- ✅ Works correctly for both main table and subordinate table clicks

## Files Changed
- 19-form-edit.js: Replaced API call with DOM extraction logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)