### PR TITLE
style: restyle subordinate paste button as icon to match adjacent icons

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11803,7 +11803,9 @@ class IntegramTable{
                     </div>
                     <div class="subordinate-table-actions">
                         <button type="button" class="subordinate-copy-buffer-btn" title="Копировать в буфер"><i class="pi pi-copy"></i></button>
-                        <button type="button" class="subordinate-paste-buffer-btn" title="Вставить из буфера"><i class="pi pi-clipboard"></i></button>
+                        <a href="#" class="subordinate-paste-buffer-btn" title="Вставить из буфера" onclick="event.preventDefault(); event.stopPropagation();">
+                            <i class="pi pi-clipboard"></i>
+                        </a>
                         <a href="${subordinateTableUrl}" class="subordinate-table-link" title="Открыть в таблице" target="_blank">
                             <i class="pi pi-table"></i>
                         </a>
@@ -18400,7 +18402,9 @@ class IntegramCreateFormHelper {
                 </button>
                 <div class="subordinate-table-actions">
                     <button type="button" class="subordinate-copy-buffer-btn" title="Копировать в буфер"><i class="pi pi-copy"></i></button>
-                    <button type="button" class="subordinate-paste-buffer-btn" title="Вставить из буфера"><i class="pi pi-clipboard"></i></button>
+                    <a href="#" class="subordinate-paste-buffer-btn" title="Вставить из буфера" onclick="event.preventDefault(); event.stopPropagation();">
+                        <i class="pi pi-clipboard"></i>
+                    </a>
                     <a href="${subordinateTableUrl}" class="subordinate-table-link" title="Открыть в таблице" target="_blank">
                         <i class="pi pi-table"></i>
                     </a>

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -1107,7 +1107,9 @@
                     </div>
                     <div class="subordinate-table-actions">
                         <button type="button" class="subordinate-copy-buffer-btn" title="Копировать в буфер"><i class="pi pi-copy"></i></button>
-                        <button type="button" class="subordinate-paste-buffer-btn" title="Вставить из буфера"><i class="pi pi-clipboard"></i></button>
+                        <a href="#" class="subordinate-paste-buffer-btn" title="Вставить из буфера" onclick="event.preventDefault(); event.stopPropagation();">
+                            <i class="pi pi-clipboard"></i>
+                        </a>
                         <a href="${subordinateTableUrl}" class="subordinate-table-link" title="Открыть в таблице" target="_blank">
                             <i class="pi pi-table"></i>
                         </a>

--- a/js/integram-table/25-create-form-helper.js
+++ b/js/integram-table/25-create-form-helper.js
@@ -1503,7 +1503,9 @@ class IntegramCreateFormHelper {
                 </button>
                 <div class="subordinate-table-actions">
                     <button type="button" class="subordinate-copy-buffer-btn" title="Копировать в буфер"><i class="pi pi-copy"></i></button>
-                    <button type="button" class="subordinate-paste-buffer-btn" title="Вставить из буфера"><i class="pi pi-clipboard"></i></button>
+                    <a href="#" class="subordinate-paste-buffer-btn" title="Вставить из буфера" onclick="event.preventDefault(); event.stopPropagation();">
+                        <i class="pi pi-clipboard"></i>
+                    </a>
                     <a href="${subordinateTableUrl}" class="subordinate-table-link" title="Открыть в таблице" target="_blank">
                         <i class="pi pi-table"></i>
                     </a>


### PR DESCRIPTION
## Issue
GitHub issue #1859: UI/UX improvements for subordinate table paste button styling and form layout.

**Part 1 - Icon Styling (Addressed in this PR):**
The `.subordinate-paste-buffer-btn` element needs to be restyled as an icon rather than a button, matching the appearance of adjacent icons in the interface (copy icon and table link).

**Part 2 - Form Layout:**
The paste insertion form to include preview functionality and all paste-related features (future enhancement).

## Solution for Part 1

Changed the subordinate paste button from a styled `<button>` element to an `<a>` anchor tag to match the visual style of adjacent icons.

### Before:
```html
<button type="button" class="subordinate-paste-buffer-btn" title="Вставить из буфера">
    <i class="pi pi-clipboard"></i>
</button>
```

### After:
```html
<a href="#" class="subordinate-paste-buffer-btn" title="Вставить из буфера" onclick="event.preventDefault(); event.stopPropagation();">
    <i class="pi pi-clipboard"></i>
</a>
```

## Benefits
- ✅ Unified icon-only interface for subordinate table actions
- ✅ Visual consistency with adjacent icons (copy button, table link)
- ✅ Better UX - all actions appear as icon buttons/links
- ✅ Maintains all functionality (click handlers work unchanged)
- ✅ Follows established pattern with `subordinate-table-link`

## Visual Result
The subordinate table actions bar now has a consistent icon-only appearance:
- 📋 Copy icon (button)
- 📋 Paste icon (link - matching adjacent icons)
- 📊 Table icon (link)

All three actions now have a unified, streamlined look without the button styling on the paste icon.

## Files Changed
- 19-form-edit.js: Paste button styling
- 25-create-form-helper.js: Paste button styling
- js/integram-table.js: Rebuilt bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)