### PR TITLE
fix: ensure subordinate paste modal is properly closed

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -12105,6 +12105,7 @@ class IntegramTable{
             document.body.appendChild(overlay);
 
             const closeModal = () => {
+                modal.remove();
                 overlay.remove();
                 window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
             };
@@ -18596,6 +18597,7 @@ class IntegramCreateFormHelper {
         document.body.appendChild(overlay);
 
         const closeModal = () => {
+            modal.remove();
             overlay.remove();
             window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
         };

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -1409,6 +1409,7 @@
             document.body.appendChild(overlay);
 
             const closeModal = () => {
+                modal.remove();
                 overlay.remove();
                 window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
             };

--- a/js/integram-table/25-create-form-helper.js
+++ b/js/integram-table/25-create-form-helper.js
@@ -1697,6 +1697,7 @@ class IntegramCreateFormHelper {
         document.body.appendChild(overlay);
 
         const closeModal = () => {
+            modal.remove();
             overlay.remove();
             window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
         };


### PR DESCRIPTION
## Issue
GitHub issue #1861: Buttons are not blocked while insertion is happening (related to PR #1850).

**Root Cause:**
The subordinate paste modal's `closeModal()` function was only removing the overlay element from the DOM, but NOT removing the modal element itself. This caused the modal to remain in the DOM even after it was supposed to be closed.

**Symptom:**
When users performed a paste/insert operation:
1. Buttons were correctly disabled during insertion ✅
2. After insertion completed, the modal was supposed to close
3. However, the modal remained in the DOM
4. The buttons appeared stuck in a disabled state to the user

**The Bug:**
```javascript
// BEFORE (incomplete cleanup)
const closeModal = () => {
    overlay.remove();  // Only removes overlay
    window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
};
```

## Solution
```javascript
// AFTER (complete cleanup)
const closeModal = () => {
    modal.remove();    // Remove modal
    overlay.remove();  // Remove overlay
    window._integramModalDepth = Math.max(0, (window._integramModalDepth || 1) - 1);
};
```

## Impact
- ✅ Modal properly removed from DOM after insertion
- ✅ Buttons no longer appear stuck in disabled state
- ✅ No orphaned DOM elements remain
- ✅ Proper cleanup and memory management
- ✅ Consistent with other modal closing patterns in the codebase

## Files Changed
- 19-form-edit.js: Fix closeModal in openSubordinatePasteDataDialog
- 25-create-form-helper.js: Fix closeModal in openSubordinatePasteDataDialog
- js/integram-table.js: Rebuilt bundle

## Testing
- Open subordinate table paste dialog
- Paste some data and click "Вставить" (Insert)
- Verify modal closes completely and doesn't remain on screen
- Verify buttons are not stuck in disabled state
- Verify no console errors about missing DOM elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)