### PR TITLE
feat: add error response handling for API delete operations (#1863)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -15024,6 +15024,22 @@ class IntegramTable{
                     body: params.toString()
                 });
 
+                const responseText = await response.text();
+                let result;
+                try {
+                    result = JSON.parse(responseText);
+                } catch (e) {
+                    if (responseText.includes('error') || !response.ok) {
+                        throw new Error(responseText);
+                    }
+                    result = { success: true };
+                }
+
+                const serverError = this.getServerError(result);
+                if (serverError) {
+                    throw new Error(serverError);
+                }
+
                 if (!response.ok) {
                     throw new Error(`Ошибка удаления: ${ response.statusText }`);
                 }
@@ -16115,11 +16131,26 @@ class IntegramTable{
                     });
 
                     const text = await response.text();
+                    let result;
                     try {
-                        JSON.parse(text);
+                        result = JSON.parse(text);
                     } catch (parseErr) {
                         // Invalid JSON response - report as warning but don't stop
                         errors.push(`#${ record.id } : ${ record.value } : ${ text }`);
+                    }
+
+                    // Check for error key in the response
+                    if (result) {
+                        let serverError = null;
+                        if (Array.isArray(result)) {
+                            serverError = (result[0] && result[0].error) || null;
+                        } else {
+                            serverError = result.error || null;
+                        }
+
+                        if (serverError) {
+                            errors.push(`#${ record.id } : ${ record.value } : ${ serverError }`);
+                        }
                     }
                 } catch (err) {
                     errors.push(`#${ record.id } : ${ record.value } : ${ err.message }`);

--- a/js/integram-table/21-form-field-settings.js
+++ b/js/integram-table/21-form-field-settings.js
@@ -613,6 +613,22 @@
                     body: params.toString()
                 });
 
+                const responseText = await response.text();
+                let result;
+                try {
+                    result = JSON.parse(responseText);
+                } catch (e) {
+                    if (responseText.includes('error') || !response.ok) {
+                        throw new Error(responseText);
+                    }
+                    result = { success: true };
+                }
+
+                const serverError = this.getServerError(result);
+                if (serverError) {
+                    throw new Error(serverError);
+                }
+
                 if (!response.ok) {
                     throw new Error(`Ошибка удаления: ${ response.statusText }`);
                 }

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -126,11 +126,26 @@
                     });
 
                     const text = await response.text();
+                    let result;
                     try {
-                        JSON.parse(text);
+                        result = JSON.parse(text);
                     } catch (parseErr) {
                         // Invalid JSON response - report as warning but don't stop
                         errors.push(`#${ record.id } : ${ record.value } : ${ text }`);
+                    }
+
+                    // Check for error key in the response
+                    if (result) {
+                        let serverError = null;
+                        if (Array.isArray(result)) {
+                            serverError = (result[0] && result[0].error) || null;
+                        } else {
+                            serverError = result.error || null;
+                        }
+
+                        if (serverError) {
+                            errors.push(`#${ record.id } : ${ record.value } : ${ serverError }`);
+                        }
                     }
                 } catch (err) {
                     errors.push(`#${ record.id } : ${ record.value } : ${ err.message }`);


### PR DESCRIPTION
## Summary
- Parse JSON responses from API calls to detect error keys
- Check for error key in response object or array elements  
- Display error message to user if present
- Apply to both single record deletion and bulk delete operations

## Issue
When API returns an error response (e.g., 409 Conflict), the error may be in the response body with an `error` key, not just reflected in HTTP status code.

Example case from issue #1863:
```
Status: 409 Conflict
Response: [{ "error": "Нельзя удалить объект, на который существует ссылки (всего: 2)!" }]
```

## Changes
- Updated `deleteRecord()` in 21-form-field-settings.js to parse JSON and use getServerError()
- Updated bulk delete in 23-bulk-export.js to check for error keys in response
- Both changes use consistent error detection logic