### PR TITLE
feat: distinguish blocking errors from warnings in bulk delete (#1865)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -16084,6 +16084,7 @@ class IntegramTable{
             const total = records.length;
             let completed = 0;
             const errors = [];
+            const warnings = [];
 
             // Create progress modal
             const progressId = `bulk-delete-progress-${ Date.now() }`;
@@ -16136,7 +16137,7 @@ class IntegramTable{
                         result = JSON.parse(text);
                     } catch (parseErr) {
                         // Invalid JSON response - report as warning but don't stop
-                        errors.push(`#${ record.id } : ${ record.value } : ${ text }`);
+                        warnings.push(`#${ record.id } : ${ record.value } : ${ text }`);
                     }
 
                     // Check for error key in the response
@@ -16162,20 +16163,35 @@ class IntegramTable{
 
             await Promise.all(deletePromises);
 
-            // Show errors if any
-            if (errors.length > 0) {
+            // Show errors and warnings if any
+            if (errors.length > 0 || warnings.length > 0) {
                 errorsDiv.style.display = 'block';
-                errorsDiv.innerHTML = `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
-                    <strong>Предупреждения:</strong><br>
-                    ${ errors.map(e => this.escapeHtml(e)).join('<br>') }
-                </div>`;
+                let html = '';
+                
+                // Show blocking errors first (red alert)
+                if (errors.length > 0) {
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Ошибки (блокирующие):</strong><br>
+                        ${ errors.map(e => this.escapeHtml(e)).join('<br>') }
+                    </div>`;
+                }
+                
+                // Show warnings after errors (yellow alert)
+                if (warnings.length > 0) {
+                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Предупреждения:</strong><br>
+                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
+                    </div>`;
+                }
+                
+                errorsDiv.innerHTML = html;
             }
 
             // Update progress text
             progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
 
             // Auto-close progress after 1.5s if no errors, else add close button
-            if (errors.length === 0) {
+            if (errors.length === 0 && warnings.length === 0) {
                 setTimeout(() => {
                     progressOverlay.remove();
                 }, 1500);

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -79,6 +79,7 @@
             const total = records.length;
             let completed = 0;
             const errors = [];
+            const warnings = [];
 
             // Create progress modal
             const progressId = `bulk-delete-progress-${ Date.now() }`;
@@ -131,7 +132,7 @@
                         result = JSON.parse(text);
                     } catch (parseErr) {
                         // Invalid JSON response - report as warning but don't stop
-                        errors.push(`#${ record.id } : ${ record.value } : ${ text }`);
+                        warnings.push(`#${ record.id } : ${ record.value } : ${ text }`);
                     }
 
                     // Check for error key in the response
@@ -157,20 +158,35 @@
 
             await Promise.all(deletePromises);
 
-            // Show errors if any
-            if (errors.length > 0) {
+            // Show errors and warnings if any
+            if (errors.length > 0 || warnings.length > 0) {
                 errorsDiv.style.display = 'block';
-                errorsDiv.innerHTML = `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
-                    <strong>Предупреждения:</strong><br>
-                    ${ errors.map(e => this.escapeHtml(e)).join('<br>') }
-                </div>`;
+                let html = '';
+                
+                // Show blocking errors first (red alert)
+                if (errors.length > 0) {
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Ошибки (блокирующие):</strong><br>
+                        ${ errors.map(e => this.escapeHtml(e)).join('<br>') }
+                    </div>`;
+                }
+                
+                // Show warnings after errors (yellow alert)
+                if (warnings.length > 0) {
+                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Предупреждения:</strong><br>
+                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
+                    </div>`;
+                }
+                
+                errorsDiv.innerHTML = html;
             }
 
             // Update progress text
             progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
 
             // Auto-close progress after 1.5s if no errors, else add close button
-            if (errors.length === 0) {
+            if (errors.length === 0 && warnings.length === 0) {
                 setTimeout(() => {
                     progressOverlay.remove();
                 }, 1500);


### PR DESCRIPTION
## Summary
Separate blocking errors from non-blocking warnings in bulk delete operation to display them with appropriate severity levels.

## Problem
When bulk deleting records, both blocking errors (like "cannot delete due to references") and non-blocking warnings (like JSON parse errors) were displayed as "Предупреждения:" (warnings) in yellow alerts. This confused users because blocking errors were presented as warnings.

## Solution
- Create separate arrays for `errors` (blocking) and `warnings` (non-blocking)
- JSON parse errors → warnings (yellow alert, non-blocking)
- Server errors (409 Conflict, etc.) → errors (red alert, blocking)
- Display errors and warnings separately with distinct styling
- Auto-close only when there are no errors or warnings

## Changes
- Updated 23-bulk-export.js to track error severity
- Errors display with "alert-danger" (red) styling
- Warnings display with "alert-warning" (yellow) styling
- Both sections are shown in the progress modal when present