### PR TITLE
feat: render HTML links in error messages instead of displaying HTML code (#1867)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -16172,7 +16172,20 @@ class IntegramTable{
                 if (errors.length > 0) {
                     html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
                         <strong>Ошибки (блокирующие):</strong><br>
-                        ${ errors.map(e => this.escapeHtml(e)).join('<br>') }
+                        ${ errors.map(e => {
+                            // Parse error format: "#recordId : recordValue : errorMessage"
+                            const parts = e.split(' : ');
+                            if (parts.length >= 3) {
+                                const recordId = this.escapeHtml(parts[0]);
+                                const recordValue = this.escapeHtml(parts[1]);
+                                // Join remaining parts in case error message contains " : "
+                                const errorMsg = parts.slice(2).join(' : ');
+                                // Sanitize the error message to allow safe HTML (links) but prevent XSS
+                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
+                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
+                            }
+                            return this.escapeHtml(e);
+                        }).join('<br>') }
                     </div>`;
                 }
                 

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -167,7 +167,20 @@
                 if (errors.length > 0) {
                     html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
                         <strong>Ошибки (блокирующие):</strong><br>
-                        ${ errors.map(e => this.escapeHtml(e)).join('<br>') }
+                        ${ errors.map(e => {
+                            // Parse error format: "#recordId : recordValue : errorMessage"
+                            const parts = e.split(' : ');
+                            if (parts.length >= 3) {
+                                const recordId = this.escapeHtml(parts[0]);
+                                const recordValue = this.escapeHtml(parts[1]);
+                                // Join remaining parts in case error message contains " : "
+                                const errorMsg = parts.slice(2).join(' : ');
+                                // Sanitize the error message to allow safe HTML (links) but prevent XSS
+                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
+                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
+                            }
+                            return this.escapeHtml(e);
+                        }).join('<br>') }
                     </div>`;
                 }
                 


### PR DESCRIPTION
## Summary
Error messages from the API can contain HTML links that should be rendered as clickable anchors, not displayed as HTML code.

## Problem
When an API error response contained HTML links like:
```
"Этот реквизит используется в <a href=\"/ru2/object/22/?F_28=366\">отчетах</a>"
```

The HTML was being escaped, and users saw:
```
&lt;a href=...&gt;отчетах&lt;/a&gt;
```

Instead of seeing a clickable link.

## Solution
- Parse error string to separate record ID/value from the error message
- Escape record ID and value (safe, from user data)
- Sanitize error message using `sanitizeInlineMessageHtml()` to:
  - Preserve safe HTML links with valid URLs
  - Prevent XSS attacks by validating URLs (http://, https://, or /)
  - Escape other potentially dangerous HTML
  - Add `target="_blank" rel="noopener noreferrer"` to links

## Changes
- Updated bulk delete error display in 23-bulk-export.js
- Uses existing `sanitizeInlineMessageHtml()` utility method for safety
- Toast error display already had this functionality, now bulk delete matches