### PR TITLE
feat: show appropriate progress message when errors occur during bulk delete (#1869)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -16170,7 +16170,7 @@ class IntegramTable{
                 
                 // Show blocking errors first (red alert)
                 if (errors.length > 0) {
-                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
                         <strong>Ошибки (блокирующие):</strong><br>
                         ${ errors.map(e => {
                             // Parse error format: "#recordId : recordValue : errorMessage"
@@ -16200,8 +16200,12 @@ class IntegramTable{
                 errorsDiv.innerHTML = html;
             }
 
-            // Update progress text
-            progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            // Update progress text based on errors
+            if (errors.length > 0) {
+                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
+            } else {
+                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            }
 
             // Auto-close progress after 1.5s if no errors, else add close button
             if (errors.length === 0 && warnings.length === 0) {

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -165,7 +165,7 @@
                 
                 // Show blocking errors first (red alert)
                 if (errors.length > 0) {
-                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
                         <strong>Ошибки (блокирующие):</strong><br>
                         ${ errors.map(e => {
                             // Parse error format: "#recordId : recordValue : errorMessage"
@@ -195,8 +195,12 @@
                 errorsDiv.innerHTML = html;
             }
 
-            // Update progress text
-            progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            // Update progress text based on errors
+            if (errors.length > 0) {
+                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
+            } else {
+                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            }
 
             // Auto-close progress after 1.5s if no errors, else add close button
             if (errors.length === 0 && warnings.length === 0) {


### PR DESCRIPTION
## Summary
Show accurate progress messages that reflect whether bulk deletion completed successfully or encountered blocking errors.

## Problem
When bulk deletion encountered blocking errors (like "cannot delete due to references"), the progress text still showed "Удаление завершено:" (Deletion completed), which confused users because the operation didn't actually complete successfully.

## Solution
- Show "Удаление завершено с ошибками:" (Completed with errors) when blocking errors occur
- Show "Удаление завершено:" (Completed) only when deletion fully succeeded with no errors
- Enhance error alert styling:
  - Increased border width (2px) and color for more visibility
  - Explicit red background (#f8d7da)
  - Added border radius for modern appearance
  - Added padding for better spacing

## Changes
- Updated progress text logic in 23-bulk-export.js to check for errors
- Enhanced error alert styling with inline CSS for prominence
- Users now clearly see when deletion completed with errors vs. successfully