### PR TITLE
fix: skip _d_null request for first column in table settings (issue #1873)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -7169,20 +7169,23 @@ class IntegramTable{
                         }
                     }
 
-                    // 2. Required flag
-                    const newRequired = colEditModal.querySelector(`#col-edit-required-${instanceName}`).checked;
-                    if (newRequired !== isRequired) {
-                        const result = await this.setColumnRequired(col.id);
-                        if (!result.success) {
-                            showStatus('Ошибка изменения обязательности: ' + result.error, true);
-                            saveBtn.disabled = false;
-                            return;
-                        }
-                        // Update attrs
-                        if (newRequired) {
-                            col.attrs = (col.attrs || '') + ':!NULL:';
-                        } else {
-                            col.attrs = (col.attrs || '').replace(/:!NULL:/g, '');
+                    // 2. Required flag (skip for first column - issue #1873)
+                    // First column is always required and cannot have _d_null sent to server
+                    if (!isFirstColumn) {
+                        const newRequired = colEditModal.querySelector(`#col-edit-required-${instanceName}`).checked;
+                        if (newRequired !== isRequired) {
+                            const result = await this.setColumnRequired(col.id);
+                            if (!result.success) {
+                                showStatus('Ошибка изменения обязательности: ' + result.error, true);
+                                saveBtn.disabled = false;
+                                return;
+                            }
+                            // Update attrs
+                            if (newRequired) {
+                                col.attrs = (col.attrs || '') + ':!NULL:';
+                            } else {
+                                col.attrs = (col.attrs || '').replace(/:!NULL:/g, '');
+                            }
                         }
                     }
 

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -465,20 +465,23 @@
                         }
                     }
 
-                    // 2. Required flag
-                    const newRequired = colEditModal.querySelector(`#col-edit-required-${instanceName}`).checked;
-                    if (newRequired !== isRequired) {
-                        const result = await this.setColumnRequired(col.id);
-                        if (!result.success) {
-                            showStatus('Ошибка изменения обязательности: ' + result.error, true);
-                            saveBtn.disabled = false;
-                            return;
-                        }
-                        // Update attrs
-                        if (newRequired) {
-                            col.attrs = (col.attrs || '') + ':!NULL:';
-                        } else {
-                            col.attrs = (col.attrs || '').replace(/:!NULL:/g, '');
+                    // 2. Required flag (skip for first column - issue #1873)
+                    // First column is always required and cannot have _d_null sent to server
+                    if (!isFirstColumn) {
+                        const newRequired = colEditModal.querySelector(`#col-edit-required-${instanceName}`).checked;
+                        if (newRequired !== isRequired) {
+                            const result = await this.setColumnRequired(col.id);
+                            if (!result.success) {
+                                showStatus('Ошибка изменения обязательности: ' + result.error, true);
+                                saveBtn.disabled = false;
+                                return;
+                            }
+                            // Update attrs
+                            if (newRequired) {
+                                col.attrs = (col.attrs || '') + ':!NULL:';
+                            } else {
+                                col.attrs = (col.attrs || '').replace(/:!NULL:/g, '');
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Описание
Исправлена ошибка, когда при редактировании настроек таблицы отправлялась ненужная строка _d_null для первой колонки.

## Проблема
- При попытке изменить обязательность (required flag) для первой колонки отправляется неправильный запрос на /_d_null/{colId}
- Это приводит к ошибке: "Неверный реквизит 453"
- Первая колонка всегда должна быть обязательной и не может быть пустой

## Решение
- Добавлена проверка isFirstColumn перед вызовом setColumnRequired()
- Для первой колонки такой запрос не отправляется (как и для других операций, требующих корректности данных)

## Закрывает
Closes #1873