### PR TITLE
fix: include all data when range filter is '-' (no date) in dashboard (issue #1875)

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -376,7 +376,8 @@ function dashGetRepVals() {
                 document.querySelectorAll('#' + i + ' .f-rg-cell').forEach(function(el) {
                     var val = 0, range = el.getAttribute('range').split('-');
                     for (j in dashReports[rep])
-                        if (dashReports[rep][j][date] >= range[0] && dashReports[rep][j][date] <= range[1])
+                        // If range[0] is empty (range="-"), include all data regardless of date
+                        if (!range[0] || (dashReports[rep][j][date] >= range[0] && dashReports[rep][j][date] <= range[1]))
                             val += dashGetFloat(dashReports[rep][j][repField]);
                     el.innerHTML = dashNormalizeVal(i, val);
                     el.setAttribute('ready', '1');


### PR DESCRIPTION
## Описание
Исправлена ошибка, при которой данные не отображались в колонках дэшборда, когда фильтр по дате был отключен (range="-").

## Проблема
- Столбцы "План" и "Факт" показывали пустые значения, хотя данные существовали
- При `range="-"` (без фильтра по дате), код выполнял сравнение с пустыми строками:
  ```javascript
  if (dashReports[rep][j][date] >= "" && dashReports[rep][j][date] <= "")
  ```
  Это сравнение всегда было ложным, поэтому данные не добавлялись

## Решение
- Добавлена проверка `!range[0]` перед сравнением дат
- Если первый элемент диапазона пуст (range="-"), включаются все данные независимо от даты
- Используется тот же подход, что и в функции `dashGetVal` (строка 279)

## Закрывает
Closes #1875