### PR TITLE
fix: improve range='-' handling in dashboard formulas (issue #1877)

### DIFF
--- a/templates/dash.html
+++ b/templates/dash.html
@@ -342,8 +342,17 @@ function dashCalcCells() {
             if (refs) {
                 refs = [...new Set(refs.map(function(s) { return s.replace(/[\[\]]/g, ''); }))];
                 for (i in refs) {
-                    document.querySelectorAll('#' + refs[i] + ' .f-rg-cell[range="' + el.getAttribute('range') + '"],' +
-                        '#' + refs[i] + ' .f-col-cell[range="' + el.getAttribute('range') + '"]').forEach(function(rc) {
+                    // Try exact range match first; if not found and range="-", accept any range (issue #1877)
+                    var rangeVal = el.getAttribute('range');
+                    var selector = '#' + refs[i] + ' .f-rg-cell[range="' + rangeVal + '"],' +
+                        '#' + refs[i] + ' .f-col-cell[range="' + rangeVal + '"]';
+                    var cells = document.querySelectorAll(selector);
+                    if (cells.length === 0 && rangeVal === '-') {
+                        // If no exact match and looking for "-", accept any range
+                        cells = document.querySelectorAll('#' + refs[i] + ' .f-rg-cell,' +
+                            '#' + refs[i] + ' .f-col-cell');
+                    }
+                    cells.forEach(function(rc) {
                         if (rc.getAttribute('ready') === '1')
                             f = f.replace(new RegExp('\\[' + refs[i] + '\\]'), rc.innerHTML || 0);
                     });
@@ -376,7 +385,8 @@ function dashGetRepVals() {
                 document.querySelectorAll('#' + i + ' .f-rg-cell').forEach(function(el) {
                     var val = 0, range = el.getAttribute('range').split('-');
                     for (j in dashReports[rep])
-                        if (dashReports[rep][j][date] >= range[0] && dashReports[rep][j][date] <= range[1])
+                        // If range[0] is empty (range="-"), include all data regardless of date (issue #1875)
+                        if (!range[0] || (dashReports[rep][j][date] >= range[0] && dashReports[rep][j][date] <= range[1]))
                             val += dashGetFloat(dashReports[rep][j][repField]);
                     el.innerHTML = dashNormalizeVal(i, val);
                     el.setAttribute('ready', '1');


### PR DESCRIPTION
## Описание
Исправлена ошибка в обработке формул дэшборда, когда cells с range="-" (без фильтра по дате) не могли получить данные из cells с конкретными диапазонами дат.

## Проблема
- PR #1876 не сработал полностью, потому что формулы не могли найти referenced cells
- Формула cell с range="-" ищет referenced cells с точным совпадением range
- Если referenced cells имеют range="20260101-20260131", а formula ищет range="-", поиск не находит ничего
- Это приводит к пустым "План" и "Факт" колонкам

## Решение
**Два исправления:**

1. **dashGetRepVals()** - теперь включает все данные когда range="-" 
   - Добавлена проверка `!range[0]` перед сравнением дат
   - Если диапазон пуст (range="-"), данные включаются без фильтра по дате

2. **dashCalcCells()** - fallback для поиска referenced cells
   - При поиске cells для range="-" сначала ищет точное совпадение
   - Если ничего не найдено и range="-", принимает любой range от referenced cells
   - Это позволяет формулам с range="-" получить данные из cells с конкретными датами

## Результат
Столбцы с range="-" (без фильтра по дате) теперь корректно агрегируют и показывают данные.

## Закрывает
Closes #1877, fixes #1875