### PR TITLE
fix: show sql-hint-2 only when first report column is Пользователь

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T06:11:04.841Z for PR creation at branch issue-1881-2c5d21566f24 for issue https://github.com/ideav/crm/issues/1881

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T06:11:04.841Z for PR creation at branch issue-1881-2c5d21566f24 for issue https://github.com/ideav/crm/issues/1881

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -858,7 +858,11 @@ function myApi(m,u,b,vars,index){ // Параметры: метод, адрес,
                     byId('warning').classList.remove('hidden');
                 }
                 $('#rbody').show();
-                if (window.sqlHintAdvance) window.sqlHintAdvance(2);
+                if (window.sqlHintAdvance) {
+                    var firstColWrapper = document.querySelector('.col-title-wrapper');
+                    var firstColAnchor = firstColWrapper && firstColWrapper.querySelector('a');
+                    if (firstColAnchor && firstColAnchor.title === 'Пользователь') window.sqlHintAdvance(2);
+                }
                 break;
 
         }


### PR DESCRIPTION
## Summary

Fixes #1881

Before this fix, `sql-hint-2` was shown whenever a report was loaded. Now it only appears if the first column of the report has the original name "Пользователь" (checked via the `<a title="...">` attribute in the `.col-title-wrapper` DOM element).

## How to verify

1. Open the SQL query builder workspace.
2. Run a report whose first column is **not** "Пользователь" — hint 2 should **not** appear.
3. Run a report whose first column **is** "Пользователь" — hint 2 should appear (if not previously dismissed).

## Change

`templates/sql.html` line 861: guard the `sqlHintAdvance(2)` call with a DOM check on the first `.col-title-wrapper > a[title="Пользователь"]`.

---
*This PR was created automatically by the AI issue solver*