### PR TITLE
fix: show sql-hint-3 only when interact is checked and ref=120 column exists

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T06:32:03.593Z for PR creation at branch issue-1883-e9da3e1b6a05 for issue https://github.com/ideav/crm/issues/1883

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T06:32:03.593Z for PR creation at branch issue-1883-e9da3e1b6a05 for issue https://github.com/ideav/crm/issues/1883

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -1205,7 +1205,11 @@ document.addEventListener('DOMContentLoaded', function() {
         steps: 3,
         onInit: function(api) {
             var interactCheck = document.getElementById('interact');
-            if (interactCheck) interactCheck.addEventListener('change', function() { api.advance(3); });
+            if (interactCheck) interactCheck.addEventListener('change', function() {
+                if (interactCheck.checked && document.querySelector('.col-title-wrapper[ref="120"]')) {
+                    api.advance(3);
+                }
+            });
         }
     });
 });


### PR DESCRIPTION
## Summary

Fixes #1883

- `.sql-hint-3` is now shown only when both conditions are met:
  1. The `#interact` checkbox is checked
  2. The report contains a column with `ref="120"` (Доступ -> Описание)

Previously the hint advanced to step 3 on any checkbox change event, regardless of the checkbox state or whether the required column was present.

## How to reproduce the issue

1. Open the SQL workspace
2. Check/uncheck the «Интерактивный» checkbox — hint-3 would show even without the Доступ → Описание column

## Fix

Modified `onInit` callback in `templates/sql.html` to guard `api.advance(3)` behind both conditions:
```js
if (interactCheck.checked && document.querySelector('.col-title-wrapper[ref="120"]')) {
    api.advance(3);
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)