### PR TITLE
fix: advance sql-hint-3 when report loads with ref=120 column and interact is checked

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T06:49:30.782Z for PR creation at branch issue-1885-2619c426a3fc for issue https://github.com/ideav/crm/issues/1885

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T06:49:30.782Z for PR creation at branch issue-1885-2619c426a3fc for issue https://github.com/ideav/crm/issues/1885

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -862,6 +862,8 @@ function myApi(m,u,b,vars,index){ // Параметры: метод, адрес,
                     var firstColWrapper = document.querySelector('.col-title-wrapper');
                     var firstColAnchor = firstColWrapper && firstColWrapper.querySelector('a');
                     if (firstColAnchor && firstColAnchor.title === 'Пользователь') window.sqlHintAdvance(2);
+                    var interactCheck = document.getElementById('interact');
+                    if (interactCheck && interactCheck.checked && document.querySelector('.col-title-wrapper[ref="120"]')) window.sqlHintAdvance(3);
                 }
                 break;
 


### PR DESCRIPTION
## Summary

Fixes #1885

The \`ref=\"120\"\` attribute on \`.col-title-wrapper\` elements is only added to the DOM during report table construction (\`case 'select'\`), which runs before \`case 'ShowReport'\`. This means the hint-3 check in the \`change\` event handler for the «Интерактивный» checkbox would fail if the user checked it before the report was loaded.

**Root cause:** The DOM query \`document.querySelector('.col-title-wrapper[ref=\"120\"]')\` returns \`null\` until a report is loaded and its column structure is rendered.

**Fix:** Added an additional check inside \`case 'ShowReport'\` (after the report renders) that advances hint-3 if both conditions are met:
1. The «Интерактивный» checkbox is checked
2. A column with \`ref=\"120\"\` exists in the DOM

This handles the case where the user checks «Интерактивный» first, then loads a report containing the Доступ → Описание column.

## How to reproduce

1. Open SQL workspace
2. Check «Интерактивный» checkbox (hint-3 would NOT appear)
3. Request/load a report that includes a column with ref=120 (Доступ → Описание)
4. Before fix: hint-3 never appears; After fix: hint-3 appears after report loads

## Test plan

- [ ] Check «Интерактивный» before loading a report with ref=120 column → hint-3 should appear after report loads
- [ ] Load report with ref=120 column first, then check «Интерактивный» → hint-3 should appear (existing behavior preserved)
- [ ] Check «Интерактивный» when report has no ref=120 column → hint-3 should NOT appear (existing guard preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)