### PR TITLE
fix: match .any-record-link color to .ref-value-link styling

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T06:56:40.743Z for PR creation at branch issue-1887-d152c913f4b5 for issue https://github.com/ideav/crm/issues/1887

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T06:56:40.743Z for PR creation at branch issue-1887-d152c913f4b5 for issue https://github.com/ideav/crm/issues/1887

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -3157,6 +3157,18 @@ td:has(.inline-editor-reference) {
     text-decoration: underline;
 }
 
+/* Any-record links — match ref-value-link styling (issue #1887) */
+.any-record-link {
+    color: var(--md-primary);
+    text-decoration: none;
+    transition: var(--md-transition);
+}
+
+.any-record-link:hover {
+    color: var(--md-primary-dark);
+    text-decoration: underline;
+}
+
 /* Hyperlinks in text cells (issue #947) */
 .cell-hyperlink {
     color: var(--md-primary);


### PR DESCRIPTION
## Problem

`.any-record-link` elements displayed with bright blue browser-default color (from `a:-webkit-any-link { color: -webkit-link; }`), inconsistent with `.ref-value-link` which uses Material Design primary color.

## Solution

Added `.any-record-link` and `.any-record-link:hover` CSS rules in `css/integram-table.css` mirroring the existing `.ref-value-link` styles:
- `color: var(--md-primary)` instead of browser default blue
- `text-decoration: none` with hover underline
- `transition: var(--md-transition)`

## Changes

- `css/integram-table.css`: added 12 lines after `.ref-value-link` block

Closes #1887