### PR TITLE
fix: load more data when user is already at page bottom (issue #1889)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-17T06:59:58.062Z for PR creation at branch issue-1889-b6ede1e4758e for issue https://github.com/ideav/crm/issues/1889

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-17T06:59:58.062Z for PR creation at branch issue-1889-b6ede1e4758e for issue https://github.com/ideav/crm/issues/1889

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -6353,8 +6353,18 @@ class IntegramTable{
                 if (!tableWrapper || this.isLoading || !this.hasMore) return;
 
                 const rect = tableWrapper.getBoundingClientRect();
+                const scrollThreshold = 200;
+
                 // If table bottom is above viewport bottom (table fits on screen), load more
                 if (rect.bottom < window.innerHeight - 50) {
+                    this.loadData(true);  // Append mode
+                    return;
+                }
+
+                // Also load more if user is already at the bottom of the page and can't scroll further
+                // This handles the case where previous loads already scrolled user to the bottom (issue #1889)
+                const scrolledToBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - scrollThreshold;
+                if (scrolledToBottom) {
                     this.loadData(true);  // Append mode
                 }
             }, 100);  // Small delay to ensure DOM is updated

--- a/js/integram-table/09-scroll-layout.js
+++ b/js/integram-table/09-scroll-layout.js
@@ -56,8 +56,18 @@
                 if (!tableWrapper || this.isLoading || !this.hasMore) return;
 
                 const rect = tableWrapper.getBoundingClientRect();
+                const scrollThreshold = 200;
+
                 // If table bottom is above viewport bottom (table fits on screen), load more
                 if (rect.bottom < window.innerHeight - 50) {
+                    this.loadData(true);  // Append mode
+                    return;
+                }
+
+                // Also load more if user is already at the bottom of the page and can't scroll further
+                // This handles the case where previous loads already scrolled user to the bottom (issue #1889)
+                const scrolledToBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - scrollThreshold;
+                if (scrolledToBottom) {
                     this.loadData(true);  // Append mode
                 }
             }, 100);  // Small delay to ensure DOM is updated


### PR DESCRIPTION
## Fixes #1889

### Root cause

Infinite scroll works by listening to the `window` scroll event. After each data load, `checkAndLoadMore()` is called — it tries to load more data if the table fits entirely on the screen.

**The bug**: When the table grows large enough that it fills the screen, the user may already be at the very bottom of the page (e.g. after `checkAndLoadMore` auto-loaded the first batch). At that point:
- The table doesn't fit on screen → `checkAndLoadMore` does nothing
- The user is at the page bottom → no further scroll events fire
- Result: `hasMore=true` but no more data is loaded

### Fix

In `checkAndLoadMore()` (`js/integram-table/09-scroll-layout.js`), added a second condition: if the user is already scrolled to the bottom of the page (within 200px threshold), trigger another load even when the table extends beyond the viewport.

```js
// Also load more if user is already at the bottom of the page and can't scroll further
const scrolledToBottom = window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - scrollThreshold;
if (scrolledToBottom) {
    this.loadData(true);
}
```

### How to reproduce

1. Open a table with more than 40 records
2. Observe "Показано 40 из ?" in the counter — scroll doesn't load more
3. After the fix, the counter advances automatically as data loads

---
*This PR was created automatically by the AI issue solver*