### PR TITLE
feat: add keyboard navigation and matching style for dash cell editor (issue #1892)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
-# Updated: 2026-04-17T09:02:16.845Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
+# Updated: 2026-04-17T09:02:16.845Z

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -196,19 +196,25 @@
     background-color: var(--bg-secondary, #f0f4ff);
     outline: 1px solid var(--border-color, #adb5bd);
 }
-/* Inline editor input */
+/* Inline editor input — styled to match integram-table .inline-editor */
 .dash-cell-input {
     width: 100%;
     min-width: 4rem;
-    border: 1px solid #86b7fe;
-    border-radius: 3px;
-    padding: 0.1rem 0.3rem;
-    font-size: inherit;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 10px;
+    font-size: 0.875rem;
+    font-family: inherit;
     text-align: right;
-    background: var(--input-bg, #fff);
-    color: var(--text-primary, #212529);
+    background: var(--md-surface, #fff);
+    color: var(--md-text-primary, #212529);
     outline: none;
-    box-shadow: 0 0 0 2px rgba(13,110,253,.15);
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.15);
+    box-sizing: border-box;
+    transition: box-shadow 0.15s ease;
+}
+.dash-cell-input:focus {
+    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.25);
 }
 /* Formula modal */
 #dash-formula-modal {
@@ -1221,10 +1227,46 @@ function dashStartInlineEdit(td) {
 
     input.addEventListener('blur', commit);
     input.addEventListener('keydown', function(e) {
-        if (e.key === 'Enter') { input.blur(); }
-        if (e.key === 'Escape') {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            input.blur();
+        } else if (e.key === 'Escape') {
             input.removeEventListener('blur', commit);
             td.textContent = currentVal;
+        } else if (e.key === 'Tab' || e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            input.removeEventListener('blur', commit);
+            commit();
+            var editableCells = Array.from(document.querySelectorAll('td.f-cell[data-src="rg"], td.f-cell[data-src="value"]'));
+            var idx = editableCells.indexOf(td);
+            var target = null;
+            if (e.key === 'Tab') {
+                target = e.shiftKey ? editableCells[idx - 1] : editableCells[idx + 1];
+            } else if (e.key === 'ArrowDown') {
+                // Find cell in same column, next row
+                var colIdx = Array.from(td.parentNode.cells).indexOf(td);
+                var nextRow = td.parentNode.nextElementSibling;
+                while (nextRow) {
+                    var candidate = nextRow.cells[colIdx];
+                    if (candidate && (candidate.dataset.src === 'rg' || candidate.dataset.src === 'value')) {
+                        target = candidate; break;
+                    }
+                    nextRow = nextRow.nextElementSibling;
+                }
+            } else if (e.key === 'ArrowUp') {
+                var colIdx = Array.from(td.parentNode.cells).indexOf(td);
+                var prevRow = td.parentNode.previousElementSibling;
+                while (prevRow) {
+                    var candidate = prevRow.cells[colIdx];
+                    if (candidate && (candidate.dataset.src === 'rg' || candidate.dataset.src === 'value')) {
+                        target = candidate; break;
+                    }
+                    prevRow = prevRow.previousElementSibling;
+                }
+            }
+            if (target) {
+                setTimeout(function() { dashStartInlineEdit(target); }, 0);
+            }
         }
     });
 }


### PR DESCRIPTION
Fixes #1892

## What changed

### Keyboard navigation in dashboard inline cell editor (`templates/dash.html`)

Added keyboard navigation to `dashStartInlineEdit` — the inline text editor for `data-src="rg"` and `data-src="value"` cells in the dashboard:

- **Tab** — commits current value and moves focus to the next editable cell
- **Shift+Tab** — commits current value and moves focus to the previous editable cell
- **ArrowDown** — commits current value and moves focus to the cell in the same column, next row
- **ArrowUp** — commits current value and moves focus to the cell in the same column, previous row
- **Enter** — commits current value (unchanged, now uses `e.preventDefault()`)
- **Escape** — cancels edit and restores original value (unchanged)

### Styling — `.dash-cell-input` updated to match `integram-table` `.inline-editor`

| Property | Before | After |
|---|---|---|
| `border` | `1px solid #86b7fe` | `none` |
| `border-radius` | `3px` | `4px` |
| `padding` | `0.1rem 0.3rem` | `6px 10px` |
| `font-size` | `inherit` | `0.875rem` |
| `box-shadow` | `0 0 0 2px rgba(13,110,253,.15)` | `0 0 0 3px rgba(25, 118, 210, 0.15)` |
| focus shadow | — | `0 0 0 3px rgba(25, 118, 210, 0.25)` |
| CSS variables | Bootstrap (`--input-bg`, `--text-primary`) | Material (`--md-surface`, `--md-text-primary`) |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)