### PR TITLE
feat: replace brand-bg buttons with opacity dropdown, make navbar/sidebar transparent (issue #1899)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
+# Updated: 2026-04-17T13:33:41.442Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
-# Updated: 2026-04-17T13:33:41.442Z

--- a/templates/sportzania/main.html
+++ b/templates/sportzania/main.html
@@ -12,8 +12,7 @@
             font-size: .82rem;
         }
         /* Brand background */
-        body.brand-bg-brighter::before,
-        body.brand-bg-dimmer::before {
+        body.brand-bg-on::before {
             content: '';
             position: fixed;
             inset: 0;
@@ -23,9 +22,14 @@
             background-repeat: no-repeat;
             pointer-events: none;
             z-index: 0;
+            opacity: var(--brand-bg-opacity, 0.3);
         }
-        body.brand-bg-brighter::before { opacity: 0.28; }
-        body.brand-bg-dimmer::before   { opacity: 0.15; }
+        /* Make navbar and sidebar transparent when brand-bg is on */
+        body.brand-bg-on .navbar,
+        body.brand-bg-on .app-sidebar {
+            background-color: transparent !important;
+            backdrop-filter: blur(0px);
+        }
     </style>
     <script>
         // Font size control — global, stored in cookie integram-table-font-settings (issue #1626/#1628)
@@ -71,35 +75,41 @@
         })();
     </script>
     <script>
-        // Brand background — stored in cookie (issue #1897)
+        // Brand background opacity — stored in cookie (issue #1897, #1899)
         (function() {
             var BG_COOKIE = 'sportzania-brand-bg';
-            var BG_CLASSES = { brighter: 'brand-bg-brighter', dimmer: 'brand-bg-dimmer' };
 
             function applyBrandBg(value) {
-                document.body.classList.remove('brand-bg-brighter', 'brand-bg-dimmer');
-                if (BG_CLASSES[value]) document.body.classList.add(BG_CLASSES[value]);
+                var opacity = parseFloat(value);
+                if (opacity > 0 && opacity <= 0.9) {
+                    document.documentElement.style.setProperty('--brand-bg-opacity', opacity);
+                    document.body.classList.add('brand-bg-on');
+                } else {
+                    document.documentElement.style.removeProperty('--brand-bg-opacity');
+                    document.body.classList.remove('brand-bg-on');
+                }
             }
 
             function loadBrandBg() {
                 var match = document.cookie.match(new RegExp('(?:^|; )' + BG_COOKIE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-                return match ? decodeURIComponent(match[1]) : 'off';
+                return match ? decodeURIComponent(match[1]) : '0';
             }
+
+            // Apply immediately before DOM renders
+            applyBrandBg(loadBrandBg());
 
             window.setBrandBg = function(value) {
                 document.cookie = BG_COOKIE + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000';
                 applyBrandBg(value);
-                document.querySelectorAll('.brand-bg-btn').forEach(function(btn) {
-                    btn.classList.toggle('active', btn.dataset.bg === value);
-                });
+                var sel = document.getElementById('brand-bg-select');
+                if (sel) sel.value = value;
             };
 
             document.addEventListener('DOMContentLoaded', function() {
                 var current = loadBrandBg();
                 applyBrandBg(current);
-                document.querySelectorAll('.brand-bg-btn').forEach(function(btn) {
-                    btn.classList.toggle('active', btn.dataset.bg === current);
-                });
+                var sel = document.getElementById('brand-bg-select');
+                if (sel) sel.value = current;
             });
         })();
     </script>
@@ -215,11 +225,18 @@
                     <div class="user-menu-item user-menu-font-size-row" title="Бренд-фон">
                         <i class="user-menu-icon pi pi-image"></i>
                         <span>Бренд-фон</span>
-                        <div class="navbar-font-size-group">
-                            <button type="button" class="navbar-font-size-btn brand-bg-btn" data-bg="off" onclick="setBrandBg('off')" title="Без фона" style="font-size:11px;">—</button>
-                            <button type="button" class="navbar-font-size-btn brand-bg-btn" data-bg="brighter" onclick="setBrandBg('brighter')" title="Ярче" style="font-size:14px;">◑</button>
-                            <button type="button" class="navbar-font-size-btn brand-bg-btn" data-bg="dimmer" onclick="setBrandBg('dimmer')" title="Бледнее" style="font-size:14px;">◔</button>
-                        </div>
+                        <select id="brand-bg-select" onchange="setBrandBg(this.value)" style="margin-left:auto;border:1px solid var(--border-color);border-radius:4px;padding:2px 4px;background:var(--input-bg,var(--bg-secondary));color:var(--text-primary);font-size:0.85rem;cursor:pointer;">
+                            <option value="0">—</option>
+                            <option value="0.1">10%</option>
+                            <option value="0.2">20%</option>
+                            <option value="0.3">30%</option>
+                            <option value="0.4">40%</option>
+                            <option value="0.5">50%</option>
+                            <option value="0.6">60%</option>
+                            <option value="0.7">70%</option>
+                            <option value="0.8">80%</option>
+                            <option value="0.9">90%</option>
+                        </select>
                     </div>
                     <div class="user-menu-divider"></div>
                     <button id="change-password-btn" class="user-menu-item" type="button" onclick="document.querySelector('.cp-form').style.display='block';document.querySelectorAll('.ch-toggle').forEach(function(el){el.style.display='flex';});document.querySelectorAll('.wait-toggle').forEach(function(el){el.style.display='none';});">


### PR DESCRIPTION
## Summary

- Replaces the 3-button brand background control (off/ярче/бледнее) with a `<select>` dropdown offering background opacity from **10% to 90% in 10% steps** (plus "—" for off)
- When brand background is active, **`.navbar` and `.app-sidebar` become transparent** so the brand image shows through both panels
- Uses CSS custom property `--brand-bg-opacity` driven by the selected value, applied via a single `.brand-bg-on` class
- Opacity is applied immediately on script parse (before DOM render) to prevent flash on reload
- Selection is persisted in cookie `sportzania-brand-bg`

## How to reproduce / verify

1. Open the sportzania app
2. Click the user avatar menu (top right)
3. Find the **Бренд-фон** row — it now shows a dropdown instead of 3 buttons
4. Select any opacity (10%–90%) — branded background appears at chosen opacity
5. Verify that navbar (top bar) and sidebar (left menu) are transparent, revealing the background image
6. Select "—" — background is removed, navbar/sidebar return to their normal colors
7. Reload — selected opacity is preserved

## Files changed

- `templates/sportzania/main.html` — CSS rules for transparent navbar/sidebar, JS opacity logic, dropdown UI

Closes #1899

🤖 Generated with [Claude Code](https://claude.com/claude-code)