### PR TITLE
fix: templates/sportzania/main.html — исправить ошибку и добавить title

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
+# Updated: 2026-04-17T14:26:33.012Z

--- a/templates/sportzania/main.html
+++ b/templates/sportzania/main.html
@@ -81,10 +81,10 @@
                 var opacity = parseFloat(value);
                 if (opacity > 0 && opacity <= 0.9) {
                     document.documentElement.style.setProperty('--brand-bg-opacity', opacity);
-                    document.body.classList.add('brand-bg-on');
+                    if (document.body) document.body.classList.add('brand-bg-on');
                 } else {
                     document.documentElement.style.removeProperty('--brand-bg-opacity');
-                    document.body.classList.remove('brand-bg-on');
+                    if (document.body) document.body.classList.remove('brand-bg-on');
                 }
             }
 
@@ -220,10 +220,10 @@
                         </div>
                     </div>
                     <div class="user-menu-divider"></div>
-                    <div class="user-menu-item user-menu-font-size-row" title="Бренд-фон">
-                        <i class="user-menu-icon pi pi-image"></i>
-                        <span>Бренд-фон</span>
-                        <select id="brand-bg-select" onchange="setBrandBg(this.value)" style="margin-left:auto;border:1px solid var(--border-color);border-radius:4px;padding:2px 4px;background:var(--input-bg,var(--bg-secondary));color:var(--text-primary);font-size:0.85rem;cursor:pointer;">
+                    <div class="user-menu-item user-menu-font-size-row" title="Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url">
+                        <i class="user-menu-icon pi pi-image" title="Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url"></i>
+                        <span title="Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url">Бренд-фон</span>
+                        <select id="brand-bg-select" onchange="setBrandBg(this.value)" title="Выберите прозрачность фонового рисунка для вашего удобства" style="margin-left:auto;border:1px solid var(--border-color);border-radius:4px;padding:2px 4px;background:var(--input-bg,var(--bg-secondary));color:var(--text-primary);font-size:0.85rem;cursor:pointer;">
                             <option value="0">—</option>
                             <option value="0.1">10%</option>
                             <option value="0.2">20%</option>


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot read properties of null (reading 'classList')` in `applyBrandBg` — the function was called before `DOMContentLoaded` when `document.body` is still `null`; added `if (document.body)` guard
- Added `title` attribute to the brand-bg menu item container, icon, and span: _"Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url"_
- Added `title` attribute to `#brand-bg-select`: _"Выберите прозрачность фонового рисунка для вашего удобства"_

## How to reproduce issue 1

Open browser DevTools console on any page using `main.html`. The error appeared on load because `applyBrandBg` is invoked immediately (before DOM is ready) and `document.body` is `null` at that point.

## Fix verification

The guard `if (document.body) document.body.classList...` prevents the TypeError while keeping the same behavior once the body is available.

Fixes #1901