### PR TITLE
fix: use contrastive text colors #000/#fff when brand-bg is on (issue #1903)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
+# Updated: 2026-04-17T14:39:37.092Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
-# Updated: 2026-04-17T14:39:37.092Z

--- a/templates/sportzania/main.html
+++ b/templates/sportzania/main.html
@@ -28,6 +28,16 @@
             background-color: transparent !important;
             backdrop-filter: blur(0px);
         }
+        /* High-contrast text when brand-bg is on — light theme */
+        body.brand-bg-on {
+            --text-primary: #000000;
+            --text-secondary: #000000;
+        }
+        /* High-contrast text when brand-bg is on — dark theme */
+        [data-theme="dark"] body.brand-bg-on {
+            --text-primary: #ffffff;
+            --text-secondary: #ffffff;
+        }
     </style>
     <script>
         // Font size control — global, stored in cookie integram-table-font-settings (issue #1626/#1628)


### PR DESCRIPTION
## Summary

Fixes #1903

When the background image (brand-bg) is enabled, the existing muted text colors (`#212529` / `#e9ecef`) lack contrast against the image. This PR overrides the CSS custom properties to use fully contrastive colors:

- **Light theme** with brand-bg on: `--text-primary` and `--text-secondary` → `#000000`
- **Dark theme** with brand-bg on: `--text-primary` and `--text-secondary` → `#ffffff`

### Implementation

Added two CSS rule blocks inside the existing `<style>` tag in `templates/sportzania/main.html`:

```css
/* High-contrast text when brand-bg is on — light theme */
body.brand-bg-on {
    --text-primary: #000000;
    --text-secondary: #000000;
}
/* High-contrast text when brand-bg is on — dark theme */
[data-theme="dark"] body.brand-bg-on {
    --text-primary: #ffffff;
    --text-secondary: #ffffff;
}
```

All existing components that use `var(--text-primary)` / `var(--text-secondary)` automatically inherit the high-contrast values when the background image is active.

## Test plan

- [ ] Enable brand background image via the opacity dropdown in the user menu
- [ ] Verify text in navbar and sidebar is pure black (`#000`) in light theme
- [ ] Switch to dark theme, enable brand-bg, verify text is pure white (`#fff`)
- [ ] Disable brand-bg, verify text colors revert to the original muted values

🤖 Generated with [Claude Code](https://claude.com/claude-code)