### PR TITLE
fix: remove divider between Шрифт and Бренд-фон menu items

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
-# Updated: 2026-04-17T14:42:41.346Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
+# Updated: 2026-04-17T14:42:41.346Z

--- a/templates/sportzania/main.html
+++ b/templates/sportzania/main.html
@@ -219,7 +219,6 @@
                             <button type="button" class="navbar-font-size-btn" data-size="larger" onclick="setPageFontSize('larger')" title="Шрифт больше" style="font-size:17px;">А</button>
                         </div>
                     </div>
-                    <div class="user-menu-divider"></div>
                     <div class="user-menu-item user-menu-font-size-row" title="Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url">
                         <i class="user-menu-icon pi pi-image" title="Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url"></i>
                         <span title="Фоновый рисунок можно изменить в меню Файлы - в main.html: background-image: url">Бренд-фон</span>


### PR DESCRIPTION
## Summary
- Removes the `<div class="user-menu-divider"></div>` separator between the "Шрифт" (Font size) and "Бренд-фон" (Brand background) items in the user dropdown menu in `templates/sportzania/main.html`

## How to verify
Open the user dropdown menu and confirm no divider line appears between the Font size controls and the Brand background selector.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)


Fixes #1905