### PR TITLE
templates/dash.html Сделай прозрачный фон у шапки таблиц и их левой колонки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
+# Updated: 2026-04-17T14:54:18.848Z

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -54,12 +54,12 @@
     position: sticky;
     left: 0;
     z-index: 2;
-    background: var(--bg-primary, #fff);
+    background: transparent;
     border-right: 2px solid var(--border-color, #dee2e6);
 }
 .f-panel th:first-child {
     z-index: 3;
-    background: var(--bg-secondary, #f8f9fa);
+    background: transparent;
 }
 .f-panel h4 {
     font-size: 1rem;
@@ -78,7 +78,7 @@
     vertical-align: middle;
 }
 .f-panel th {
-    background: var(--bg-secondary, #f8f9fa);
+    background: transparent;
     font-weight: 600;
     text-align: center;
 }
@@ -133,7 +133,7 @@
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--bg-secondary, #f8f9fa);
+    background: transparent;
 }
 /* Corner cell: sticky both vertically and horizontally */
 .dash-head th:first-child {
@@ -141,7 +141,7 @@
 }
 /* Sub-header row for RGcolumns (column group names) */
 .f-subhead th {
-    background: var(--bg-secondary, #f8f9fa);
+    background: transparent;
     font-weight: 500;
     text-align: center;
     font-size: 0.8em;


### PR DESCRIPTION
## Summary

Fixes #1907

- Changed `background` to `transparent` for `.f-panel th`, `.f-panel th:first-child`, `.f-panel td:first-child`, `.dash-head th`, and `.f-subhead th` in `templates/dash.html`
- Table headers (top row) and the sticky left column now have transparent backgrounds instead of the solid `--bg-secondary` (`#f8f9fa`) color

## How to reproduce

Open the dashboard page and observe the table headers and left column had a light gray (`#f8f9fa`) background. After the fix they inherit the background from their container (transparent).

---
*This PR was created automatically by the AI issue solver*