### PR TITLE
fix: restore missing closing brace in drawForm() loop (issue #1912)

### DIFF
--- a/templates/iquiz.html
+++ b/templates/iquiz.html
@@ -620,6 +620,7 @@ function drawForm(){
         }
         else if(inputBox[iquiz.form[i].view])
             shownAndHidden(i,iquiz.form[i],f);
+    }
     for(j in dataItems.id)
         if(dataItems.id[j]===iquiz.type&&dataItems.req_id[j]!==''
                 &&f.hiddens.indexOf('id="h'+dataItems.req_id[j]+'"')===-1){


### PR DESCRIPTION
## Summary

- Fixes missing `}` closing brace for `for(i=0;...)` loop in `drawForm()`, introduced in PR #1911
- The for loop was converted from brace-less to brace-style, but the closing `}` was omitted
- As a result, `for(j in dataItems.id)` and all subsequent code were parsed inside the outer for loop, leaving `drawForm()` unclosed — causing **"Unexpected end of input"** JS syntax error that broke the entire page

## Root cause

In PR #1911, this original code (no braces):
```js
for(i=0;i<iquiz.form.length;i++)
    if(...) {...}
    else if(...) shownAndHidden(...)
for(j in dataItems.id) ...  // separate loop
```

Was changed to use braces `{` for the outer loop, but the closing `}` was missing, leaving `for(j in dataItems.id)` and everything after it inside the unclosed for loop.

## Fix

Added the missing `}` to properly close the `for(i=0;i<iquiz.form.length;i++)` loop before `for(j in dataItems.id)`.

Fixes #1912

🤖 Generated with [Claude Code](https://claude.com/claude-code)