### PR TITLE
fix: page break doesn't split fields in iquiz form (issue #1914)

### DIFF
--- a/templates/iquiz.html
+++ b/templates/iquiz.html
@@ -589,27 +589,26 @@ function shownAndHidden(i,fld,f){
 }
 function drawForm(){
     var i,j,k,f={flds:'',hiddens:''},currentPage=1;
-    // Определить количество страниц
+    // Определить количество страниц (количество разделителей + 1)
     var totalPages = 1;
-    for(i in iquiz.form)
-        if(iquiz.form[i].page && iquiz.form[i].page > totalPages)
-            totalPages = iquiz.form[i].page;
+    for(i=0;i<iquiz.form.length;i++)
+        if(iquiz.form[i].isPageBreak) totalPages++;
 
     for(i=0;i<iquiz.form.length;i++){
-        // Установить page для полей, у которых её нет
-        if(!iquiz.form[i].page)
-            iquiz.form[i].page = currentPage;
-        else if(iquiz.form[i].isPageBreak)
-            currentPage = iquiz.form[i].page;
-
-        // Отобразить разделитель страницы
+        // Пересчитываем page по позиции в массиве, чтобы разделитель всегда делил поля корректно
         if(iquiz.form[i].isPageBreak){
-            f.flds+='<div class="page-break-divider p-3 my-3 border-top border-bottom bg-light" style="text-align:center; color:#666; font-weight:bold;">'
+            currentPage++;
+            iquiz.form[i].page = currentPage;
+            // Отобразить разделитель страницы
+            f.flds+='<div class="page-break-divider p-3 my-3 border-top border-bottom bg-light" order="'+i+'" style="text-align:center; color:#666; font-weight:bold;">'
                 +'  📄 Страница ' + iquiz.form[i].page + ' из ' + totalPages
+                +'  <a onclick="moveFldUp(this)" class="ml-2" style="display:inline-block" title="Переместить разделитель вверх">↑</a>'
+                +'  <a onclick="moveFldDown(this)" class="ml-2" style="display:inline-block" title="Переместить разделитель вниз">↓</a>'
                 +'  <a onclick="deleteFld(this)" class="ml-2" style="display:inline-block" title="Удалить разделитель">'+ delSvg +'</a>'
                 +'</div>';
             continue;
         }
+        iquiz.form[i].page = currentPage;
 
         if(iquiz.form[i].id!==iquiz.form[i].type&&!reqExists(iquiz.form[i].id)&&iquizId){
             k=i--;
@@ -1317,6 +1316,20 @@ function addItem(t){
 function deleteFld(el){
     var i=$(el).closest('[order]').attr('order');
     intApi('POST','_d_del_req/'+iquiz.form[i].id+'?JSON','delFld','',i);
+}
+function moveFldUp(el){
+    var i=parseInt($(el).closest('[order]').attr('order'));
+    if(i<=0) return;
+    var tmp=iquiz.form[i]; iquiz.form[i]=iquiz.form[i-1]; iquiz.form[i-1]=tmp;
+    setEdited();
+    drawForm();
+}
+function moveFldDown(el){
+    var i=parseInt($(el).closest('[order]').attr('order'));
+    if(i>=iquiz.form.length-1) return;
+    var tmp=iquiz.form[i]; iquiz.form[i]=iquiz.form[i+1]; iquiz.form[i+1]=tmp;
+    setEdited();
+    drawForm();
 }
 var timer;
 function showMsg(i,err,mode,timeout){


### PR DESCRIPTION
## Problem

When a user added all their fields and then added a page break separator, all fields remained on page 1 and page 2 was empty. This happened because:

1. `drawForm()` only assigned `page` to fields that had no page yet — so existing fields with `page: 1` were never reassigned when the page break position changed
2. The page break divider had no `order` attribute, so `deleteFld()` didn't work on it
3. There was no way to reposition the page break between existing fields

## Fix

- **`drawForm()`** now always recalculates `page` by position in the array (each page break increments `currentPage`), so the separator correctly splits whichever fields fall before and after it
- **Page break divider** now has `order="i"` attribute so `deleteFld()` works correctly  
- **↑ / ↓ move buttons** added to the page break divider so users can reposition it between existing fields
- **`moveFldUp()` / `moveFldDown()`** functions added to support reordering

## How to test

1. Open iquiz configurator, add several fields
2. Click "Добавить разделитель страницы" — it appears at the bottom
3. Use ↑ to move the separator between existing fields
4. Save and open the public form — fields before the separator appear on page 1, fields after on page 2

Closes #1914