### PR TITLE
fix: IQUIZ name prefix doubling and drag reorder for page break (issue #1916)

### DIFF
--- a/templates/iquiz.html
+++ b/templates/iquiz.html
@@ -504,7 +504,7 @@ function selectQuiz(i){
         $('#deselect').remove();
         for(j in iquiz)
             $('.iq-save[name='+j+']').val(iquiz[j]);
-        $('#iquizName').val($('#'+i).find('span').html());
+        $('#iquizName').val($('#'+i).find('span').html().replace(/^IQUIZ\s+/,''));
         drawForm();
     }
     else
@@ -1293,19 +1293,16 @@ function setNull(t){
     $('#t'+t).val('');
 }
 function reOrderFields(){
-    var i=0,j;
-    $('.fld').each(function(){
-        if(iquiz.form[i].id!==this.id)
-            for(j in iquiz.form)
-                if(iquiz.form[j].id===this.id){
-                    $('#'+this.id+',#h'+this.id).attr('order',i);
-                    $('#'+iquiz.form[i].id+',#h'+iquiz.form[i].id).attr('order',j);
-                    [iquiz.form[i],iquiz.form[j]]=[iquiz.form[j],iquiz.form[i]];
-                    break;
-                }
-        i++;
+    var newForm=[];
+    $('#fields').children('[order]').each(function(){
+        var idx=parseInt($(this).attr('order'));
+        if(!isNaN(idx)&&iquiz.form[idx]!==undefined)
+            newForm.push(iquiz.form[idx]);
     });
+    if(newForm.length===iquiz.form.length)
+        iquiz.form=newForm;
     setEdited();
+    drawForm();
 }
 function addItem(t){
     var val=$('.set'+t+' input').val(),reforig=$('#t'+t).attr('reforig');


### PR DESCRIPTION
## Fixes

### 1. IQUIZ prefix accumulates on each save

**Root cause:** `selectQuiz()` populates `#iquizName` with the raw DB value (`"IQUIZ Задача"`). Then `saveIquiz()` prepends `"IQUIZ "` again on the next save → `"IQUIZ IQUIZ Задача"`.

**Fix:** Strip existing `"IQUIZ "` prefix when loading the name into `#iquizName`:
```js
$('#iquizName').val($('#'+i).find('span').html().replace(/^IQUIZ\s+/,''));
```

### 2. Dragging the page break separator doesn't save its position

**Root cause:** `reOrderFields()` only iterated `.fld` elements — page break dividers (`.page-break-divider`) were skipped, so dragging the separator updated the DOM visually but `iquiz.form` was not reordered.

**Fix:** Rewrite to iterate all `#fields` children with an `[order]` attribute, rebuild `iquiz.form` from DOM order, then call `drawForm()` to re-render with correct page assignments.

Closes #1916