### PR TITLE
fix: opaque sidebar background on mobile when brand-bg is on (issue #1918)

### DIFF
--- a/templates/sportzania/main.html
+++ b/templates/sportzania/main.html
@@ -29,6 +29,12 @@
             background-color: transparent !important;
             backdrop-filter: blur(0px);
         }
+        /* On mobile the sidebar is a fixed overlay — keep it opaque */
+        @media (max-width: 900px) {
+            body.brand-bg-on .app-sidebar {
+                background-color: var(--bg-primary) !important;
+            }
+        }
         /* High-contrast text when brand-bg is on — light theme */
         body.brand-bg-on {
             --text-primary: #000000;


### PR DESCRIPTION
## Problem

On mobile, the sidebar menu had a transparent background when the brand background image was enabled (`brand-bg-on` class). Since the mobile sidebar is a fixed overlay (`position: fixed; z-index: 200`), this made the page content visible through the menu, making it unreadable.

## Root cause

`main.html` has a rule:
```css
body.brand-bg-on .app-sidebar {
    background-color: transparent !important;
}
```
This is intentional on desktop (sidebar blends into the brand background), but on mobile the sidebar slides in as a full overlay and needs a solid background.

## Fix

Added a `@media (max-width: 900px)` override that restores `var(--bg-primary)` on the sidebar, matching the 900px mobile breakpoint already used throughout `main-app.css`.

Closes #1918