### PR TITLE
fix: make .scroll-counter semi-transparent when table rows are beneath it (issue #1922)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
 # Updated: 2026-04-17T14:54:18.848Z
+# Updated: 2026-04-18T13:46:46.436Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
 # Updated: 2026-04-17T14:54:18.848Z
-# Updated: 2026-04-18T13:46:46.436Z

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -832,6 +832,12 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     font-family: inherit;
     z-index: 100;
     letter-spacing: 0.25px;
+    transition: opacity 0.2s ease;
+}
+
+/* Make semi-transparent when table rows are beneath it (issue #1922) */
+.scroll-counter.rows-beneath {
+    opacity: 0.7;
 }
 
 .total-count-unknown {

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -6457,6 +6457,18 @@ class IntegramTable{
 
             if (!tableWrapper || !scrollCounter) return;
 
+            const updateScrollCounterOpacity = () => {
+                // Make scroll-counter semi-transparent when table rows are beneath it (issue #1922)
+                const tbody = this.container.querySelector('.integram-table tbody');
+                if (!tbody) return;
+                const counterRect = scrollCounter.getBoundingClientRect();
+                const tbodyRect = tbody.getBoundingClientRect();
+                // Rows are beneath the counter if tbody bottom is below counter top
+                // and tbody top is above counter bottom (overlap in vertical axis)
+                const overlaps = tbodyRect.bottom > counterRect.top && tbodyRect.top < counterRect.bottom;
+                scrollCounter.classList.toggle('rows-beneath', overlaps);
+            };
+
             const updateScrollCounterPosition = () => {
                 // Use .app-content left edge instead of tableWrapper, so the counter stays
                 // at a fixed viewport position when the table scrolls horizontally (issue #1010).
@@ -6464,6 +6476,7 @@ class IntegramTable{
                 const anchorEl = appContent || tableWrapper;
                 const rect = anchorEl.getBoundingClientRect();
                 scrollCounter.style.left = (rect.left + 20) + 'px';
+                updateScrollCounterOpacity();
             };
 
             // Remove existing listeners if any

--- a/js/integram-table/09-scroll-layout.js
+++ b/js/integram-table/09-scroll-layout.js
@@ -160,6 +160,18 @@
 
             if (!tableWrapper || !scrollCounter) return;
 
+            const updateScrollCounterOpacity = () => {
+                // Make scroll-counter semi-transparent when table rows are beneath it (issue #1922)
+                const tbody = this.container.querySelector('.integram-table tbody');
+                if (!tbody) return;
+                const counterRect = scrollCounter.getBoundingClientRect();
+                const tbodyRect = tbody.getBoundingClientRect();
+                // Rows are beneath the counter if tbody bottom is below counter top
+                // and tbody top is above counter bottom (overlap in vertical axis)
+                const overlaps = tbodyRect.bottom > counterRect.top && tbodyRect.top < counterRect.bottom;
+                scrollCounter.classList.toggle('rows-beneath', overlaps);
+            };
+
             const updateScrollCounterPosition = () => {
                 // Use .app-content left edge instead of tableWrapper, so the counter stays
                 // at a fixed viewport position when the table scrolls horizontally (issue #1010).
@@ -167,6 +179,7 @@
                 const anchorEl = appContent || tableWrapper;
                 const rect = anchorEl.getBoundingClientRect();
                 scrollCounter.style.left = (rect.left + 20) + 'px';
+                updateScrollCounterOpacity();
             };
 
             // Remove existing listeners if any


### PR DESCRIPTION
## Problem

The `.scroll-counter` element (fixed-position, bottom-left) overlaps table rows, making it impossible to read the data underneath.

## Solution

- Added `updateScrollCounterOpacity()` in `09-scroll-layout.js` that checks whether the table `<tbody>` overlaps with the scroll counter in the viewport
- Toggles the CSS class `.rows-beneath` on the counter when overlap is detected
- Added CSS rule `.scroll-counter.rows-beneath { opacity: 0.7; }` with a smooth `transition: opacity 0.2s ease`
- The check runs on every scroll and resize event (same listeners as the position update)

## Files changed

- `js/integram-table/09-scroll-layout.js` — added opacity check logic
- `css/integram-table.css` — added `.rows-beneath` rule and `transition`
- `js/integram-table.js` — regenerated via `build.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes #1922