### PR TITLE
fix: restore full opacity on scroll-counter hover (follow-up #1923)

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -840,6 +840,10 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     opacity: 0.7;
 }
 
+.scroll-counter.rows-beneath:hover {
+    opacity: 1;
+}
+
 .total-count-unknown {
     cursor: pointer;
     color: var(--md-primary);


### PR DESCRIPTION
Follow-up to #1923.

When table rows are beneath the `.scroll-counter` it fades to `opacity: 0.7`. On hover the element should return to fully opaque so the user can read the count.

```css
.scroll-counter.rows-beneath:hover {
    opacity: 1;
}
```

The existing `transition: opacity 0.2s ease` on `.scroll-counter` makes the fade-in/out smooth with no extra changes needed.