### PR TITLE
fix: add bottom padding to table so rows don't hide under scroll-counter (#1925)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-17T08:32:40.838Z for PR creation at branch issue-1781-74a4a8c627f8 for issue https://github.com/ideav/crm/issues/1781
 # Updated: 2026-04-17T14:26:33.012Z
 # Updated: 2026-04-17T14:54:18.848Z
+# Updated: 2026-04-18T14:22:10.398Z

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -29,6 +29,7 @@
     position: relative;
     /* margin: 20px 0; */
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    padding-bottom: 60px; /* Leave space for fixed .scroll-counter at bottom (issue #1925) */
 }
 
 #form-settings-btn {


### PR DESCRIPTION
## Problem

When scrolling to the bottom of the table, the last rows were hidden behind the fixed `.scroll-counter` element (positioned `bottom: 20px`), making them inaccessible.

## Fix

Added `padding-bottom: 60px` to `.integram-table-wrapper` in `css/integram-table.css`. This ensures there is always enough empty space below the last table row so users can scroll the content fully into view above the counter.

The value of 60px covers the scroll-counter height (~28px) plus its 20px bottom offset, with some extra margin.

## How to reproduce

1. Open a table with many rows
2. Scroll to the bottom
3. Before fix: the last row(s) were hidden under the scroll-counter
4. After fix: all rows are visible when scrolled to the bottom

Closes #1925