### PR TITLE
feat: add OTP login button to start.html (issue #1951)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -713,6 +713,76 @@ class App {
             });
         }
 
+        // OTP (one-time password to email)
+        const otpBtn = document.getElementById('otp-btn');
+        const otpMessage = document.getElementById('otp-message');
+        if (otpBtn) {
+            otpBtn.addEventListener('click', async () => {
+                const emailVal = loginEmailInput ? loginEmailInput.value.trim() : '';
+                if (!emailVal) {
+                    showToast('Введите email', 'error');
+                    return;
+                }
+                const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                if (!emailRe.test(emailVal)) {
+                    showToast('Введите корректный email', 'error');
+                    return;
+                }
+                const dbSelect = document.getElementById('auth-db-select');
+                const customInput = document.getElementById('auth-db-custom');
+                let selectedDb = dbSelect ? dbSelect.value : 'my';
+                if (selectedDb === '__other__') {
+                    selectedDb = customInput ? customInput.value.trim() : '';
+                    if (!selectedDb) {
+                        showToast('Введите имя базы данных', 'error');
+                        return;
+                    }
+                }
+                otpBtn.disabled = true;
+                try {
+                    const formData = new FormData();
+                    formData.append('email', emailVal);
+                    const response = await fetch(`${encodeURIComponent(selectedDb)}/otp`, {
+                        method: 'POST',
+                        body: formData
+                    });
+                    const text = await response.text();
+                    let data = null;
+                    try { data = JSON.parse(text); } catch (e) { data = null; }
+                    if (otpMessage) {
+                        otpMessage.style.display = '';
+                        if (data !== null) {
+                            const msg = (data.message || '').toUpperCase();
+                            const isError = msg.includes('WRONG') || msg.includes('ERROR');
+                            if (!isError) {
+                                otpMessage.className = 'success-message';
+                                otpMessage.textContent = data.details || data.message || text;
+                            } else {
+                                otpMessage.className = '';
+                                otpMessage.style.background = 'var(--bg-secondary)';
+                                otpMessage.style.color = 'var(--error-color, #ef4444)';
+                                otpMessage.textContent = Object.entries(data).map(([k, v]) => `${k}: ${v}`).join(', ');
+                            }
+                        } else {
+                            otpMessage.className = '';
+                            otpMessage.style.background = 'var(--bg-secondary)';
+                            otpMessage.style.color = 'var(--text-primary)';
+                            otpMessage.textContent = text;
+                        }
+                    }
+                } catch (err) {
+                    if (otpMessage) {
+                        otpMessage.style.display = '';
+                        otpMessage.className = '';
+                        otpMessage.style.color = 'var(--error-color, #ef4444)';
+                        otpMessage.textContent = err.message || 'Ошибка при отправке кода';
+                    }
+                } finally {
+                    otpBtn.disabled = false;
+                }
+            });
+        }
+
         // Register form
         const registerForm = document.getElementById('register-form');
         if (registerForm) {

--- a/start.html
+++ b/start.html
@@ -1483,9 +1483,13 @@ mark.search-highlight {
                     </div>
                     <div id="reset-hint" style="display:none; font-size:0.85rem; color:var(--text-secondary); margin-bottom:0.5rem;">Введите имя пользователя или email, мы попробуем найти вашу учетную запись и пришлем новый пароль на вашу почту</div>
                     <br />
-                    <button type="submit" id="login-submit-btn" class="btn-primary">Войти</button>
-                    <button type="button" id="reset-submit-btn" class="btn-primary" style="display:none;">Сбросить пароль</button>
+                    <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
+                        <button type="submit" id="login-submit-btn" class="btn-primary">Войти</button>
+                        <button type="button" id="otp-btn" class="btn-secondary" title="Получить одноразовый пароль на зарегистрированную почту">Код на почту</button>
+                        <button type="button" id="reset-submit-btn" class="btn-primary" style="display:none;">Сбросить пароль</button>
+                    </div>
                 </form>
+                <div id="otp-message" style="display:none; margin-top:0.75rem; padding:0.5rem 0.75rem; border-radius:var(--radius-sm); font-size:0.9rem;"></div>
                 <div id="reset-message" style="display:none; margin-top:0.75rem; padding:0.5rem 0.75rem; border-radius:var(--radius-sm); font-size:0.9rem;"></div>
                 <div style="text-align:center; margin-top:0.75rem;">
                     <a href="#" id="reset-link" style="font-size:0.85rem; color:var(--link-color); text-decoration:none;">Сбросить пароль</a>


### PR DESCRIPTION
Closes #1951

## Summary

- Added **"Код на почту"** button next to "Войти" in the login form with `title="Получить одноразовый пароль на зарегистрированную почту"`
- Email validation before sending: checks non-empty and `x@x.x` format, shows toast on error
- On click: `POST /{db}/otp` with `email` parameter via `FormData`
- Response displayed in a dedicated `#otp-message` div below the form (success/error styling)
- Button disabled while request is in flight to prevent double-submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)