### PR TITLE
fix: keep Войти and Код на почту buttons on one line (issue #1953)

### DIFF
--- a/start.html
+++ b/start.html
@@ -1483,10 +1483,10 @@ mark.search-highlight {
                     </div>
                     <div id="reset-hint" style="display:none; font-size:0.85rem; color:var(--text-secondary); margin-bottom:0.5rem;">Введите имя пользователя или email, мы попробуем найти вашу учетную запись и пришлем новый пароль на вашу почту</div>
                     <br />
-                    <div style="display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap;">
-                        <button type="submit" id="login-submit-btn" class="btn-primary">Войти</button>
+                    <div style="display:flex; gap:0.5rem; align-items:center;">
+                        <button type="submit" id="login-submit-btn" class="btn-primary" style="width:auto;">Войти</button>
                         <button type="button" id="otp-btn" class="btn-secondary" title="Получить одноразовый пароль на зарегистрированную почту">Код на почту</button>
-                        <button type="button" id="reset-submit-btn" class="btn-primary" style="display:none;">Сбросить пароль</button>
+                        <button type="button" id="reset-submit-btn" class="btn-primary" style="display:none; width:auto;">Сбросить пароль</button>
                     </div>
                 </form>
                 <div id="otp-message" style="display:none; margin-top:0.75rem; padding:0.5rem 0.75rem; border-radius:var(--radius-sm); font-size:0.9rem;"></div>


### PR DESCRIPTION
Closes #1953

## Root cause

`.auth-card .btn-primary` sets `width: 100%`, so both buttons occupied full width and ended up on separate lines even inside a flex row.

## Fix

- Removed `flex-wrap: wrap` from the wrapper div
- Added `width: auto` inline style to `.btn-primary` buttons inside the row, overriding the auth-card rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)