### PR TITLE
feat: OTP code input and login flow (issue #1955)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -716,69 +716,101 @@ class App {
         // OTP (one-time password to email)
         const otpBtn = document.getElementById('otp-btn');
         const otpMessage = document.getElementById('otp-message');
+        const otpCodeGroup = document.getElementById('otp-code-group');
+        const otpCodeInput = document.getElementById('otp-code-input');
+        const otpSubmitBtn = document.getElementById('otp-submit-btn');
+
+        function getSelectedDb() {
+            const dbSelect = document.getElementById('auth-db-select');
+            const customInput = document.getElementById('auth-db-custom');
+            let db = dbSelect ? dbSelect.value : 'my';
+            if (db === '__other__') {
+                db = customInput ? customInput.value.trim() : '';
+            }
+            return db;
+        }
+
+        function showOtpMessage(text, isError) {
+            if (!otpMessage) return;
+            otpMessage.style.display = '';
+            otpMessage.className = isError ? '' : 'success-message';
+            if (isError) {
+                otpMessage.style.background = 'var(--bg-secondary)';
+                otpMessage.style.color = 'var(--error-color, #ef4444)';
+            }
+            otpMessage.textContent = text;
+        }
+
+        // Step 1: send email → request OTP code
         if (otpBtn) {
             otpBtn.addEventListener('click', async () => {
                 const emailVal = loginEmailInput ? loginEmailInput.value.trim() : '';
-                if (!emailVal) {
-                    showToast('Введите email', 'error');
-                    return;
-                }
+                if (!emailVal) { showToast('Введите email', 'error'); return; }
                 const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-                if (!emailRe.test(emailVal)) {
-                    showToast('Введите корректный email', 'error');
-                    return;
-                }
-                const dbSelect = document.getElementById('auth-db-select');
-                const customInput = document.getElementById('auth-db-custom');
-                let selectedDb = dbSelect ? dbSelect.value : 'my';
-                if (selectedDb === '__other__') {
-                    selectedDb = customInput ? customInput.value.trim() : '';
-                    if (!selectedDb) {
-                        showToast('Введите имя базы данных', 'error');
-                        return;
-                    }
-                }
+                if (!emailRe.test(emailVal)) { showToast('Введите корректный email', 'error'); return; }
+                const selectedDb = getSelectedDb();
+                if (!selectedDb) { showToast('Введите имя базы данных', 'error'); return; }
                 otpBtn.disabled = true;
                 try {
                     const formData = new FormData();
                     formData.append('email', emailVal);
                     const response = await fetch(`${encodeURIComponent(selectedDb)}/otp`, {
                         method: 'POST',
+                        credentials: 'include',
                         body: formData
                     });
                     const text = await response.text();
                     let data = null;
                     try { data = JSON.parse(text); } catch (e) { data = null; }
-                    if (otpMessage) {
-                        otpMessage.style.display = '';
-                        if (data !== null) {
-                            const msg = (data.message || '').toUpperCase();
-                            const isError = msg.includes('WRONG') || msg.includes('ERROR');
-                            if (!isError) {
-                                otpMessage.className = 'success-message';
-                                otpMessage.textContent = data.details || data.message || text;
-                            } else {
-                                otpMessage.className = '';
-                                otpMessage.style.background = 'var(--bg-secondary)';
-                                otpMessage.style.color = 'var(--error-color, #ef4444)';
-                                otpMessage.textContent = Object.entries(data).map(([k, v]) => `${k}: ${v}`).join(', ');
-                            }
-                        } else {
-                            otpMessage.className = '';
-                            otpMessage.style.background = 'var(--bg-secondary)';
-                            otpMessage.style.color = 'var(--text-primary)';
-                            otpMessage.textContent = text;
-                        }
+                    const isError = !response.ok || (data && (data.msg || '').toUpperCase().includes('ERROR'));
+                    showOtpMessage(
+                        (data && (data.msg || data.message || data.details)) || text,
+                        isError
+                    );
+                    if (!isError && otpCodeGroup) {
+                        otpCodeGroup.style.display = '';
+                        if (otpCodeInput) otpCodeInput.focus();
                     }
                 } catch (err) {
-                    if (otpMessage) {
-                        otpMessage.style.display = '';
-                        otpMessage.className = '';
-                        otpMessage.style.color = 'var(--error-color, #ef4444)';
-                        otpMessage.textContent = err.message || 'Ошибка при отправке кода';
-                    }
+                    showOtpMessage(err.message || 'Ошибка при отправке кода', true);
                 } finally {
                     otpBtn.disabled = false;
+                }
+            });
+        }
+
+        // Step 2: submit OTP code → login
+        if (otpSubmitBtn) {
+            otpSubmitBtn.addEventListener('click', async () => {
+                const emailVal = loginEmailInput ? loginEmailInput.value.trim() : '';
+                const codeVal = otpCodeInput ? otpCodeInput.value.trim() : '';
+                if (!codeVal) { showToast('Введите код из письма', 'error'); return; }
+                const selectedDb = getSelectedDb();
+                if (!selectedDb) { showToast('Введите имя базы данных', 'error'); return; }
+                otpSubmitBtn.disabled = true;
+                try {
+                    const formData = new FormData();
+                    formData.append('email', emailVal);
+                    formData.append('otp', codeVal);
+                    const response = await fetch(`${encodeURIComponent(selectedDb)}/otp`, {
+                        method: 'POST',
+                        credentials: 'include',
+                        body: formData
+                    });
+                    const text = await response.text();
+                    let data = null;
+                    try { data = JSON.parse(text); } catch (e) { data = null; }
+                    if (data && data.token && (data.msg === '' || data.msg == null)) {
+                        CookieUtil.set('last_db', selectedDb, 365);
+                        window.location.href = window.location.origin + '/' + selectedDb;
+                    } else {
+                        const errText = (data && (data.msg || data.message)) || text || 'Неверный код';
+                        showOtpMessage(errText, true);
+                        otpSubmitBtn.disabled = false;
+                    }
+                } catch (err) {
+                    showOtpMessage(err.message || 'Ошибка при проверке кода', true);
+                    otpSubmitBtn.disabled = false;
                 }
             });
         }

--- a/start.html
+++ b/start.html
@@ -1490,6 +1490,13 @@ mark.search-highlight {
                     </div>
                 </form>
                 <div id="otp-message" style="display:none; margin-top:0.75rem; padding:0.5rem 0.75rem; border-radius:var(--radius-sm); font-size:0.9rem;"></div>
+                <div id="otp-code-group" class="database-field-group" style="display:none; margin-top:0.75rem;">
+                    <label for="otp-code-input" class="database-field-label">Код из письма</label>
+                    <div style="display:flex; gap:0.5rem; align-items:center;">
+                        <input type="text" id="otp-code-input" class="database-field-input" placeholder="Введите код" autocomplete="one-time-code">
+                        <button type="button" id="otp-submit-btn" class="btn-primary" style="width:auto; white-space:nowrap;">Войти по коду</button>
+                    </div>
+                </div>
                 <div id="reset-message" style="display:none; margin-top:0.75rem; padding:0.5rem 0.75rem; border-radius:var(--radius-sm); font-size:0.9rem;"></div>
                 <div style="text-align:center; margin-top:0.75rem;">
                     <a href="#" id="reset-link" style="font-size:0.85rem; color:var(--link-color); text-decoration:none;">Сбросить пароль</a>


### PR DESCRIPTION
Closes #1955

## Flow

1. User enters email, clicks **"Код на почту"** → `POST /{db}/otp` with `email` → on success shows **"Код из письма"** input + **"Войти по коду"** button
2. User enters code, clicks **"Войти по коду"** → `POST /{db}/otp` with `email` + `otp` → on success (`token` present, `msg` empty) navigates to `/{db}`

## Changes

- `start.html` — added `#otp-code-group` (hidden by default) with text input and submit button
- `js/app.js` — refactored OTP block:
  - Extracted `getSelectedDb()` and `showOtpMessage()` helpers
  - Step 1 handler shows code input on success
  - Step 2 handler sends email+otp, checks `data.token` + `data.msg === ''` to navigate

🤖 Generated with [Claude Code](https://claude.com/claude-code)