### PR TITLE
fix: use report/236801 when invite-user is empty (issue #2125)

### DIFF
--- a/js/cabinet.js
+++ b/js/cabinet.js
@@ -1824,7 +1824,8 @@ class CabinetController {
 
         try {
             const host = this.apiConfig.host;
-            const url = 'https://' + host + '/my/report/385?JSON_KV';
+            const reportId = user ? '385' : '236801';
+            const url = 'https://' + host + '/my/report/' + reportId + '?JSON_KV';
 
             const fd = new FormData();
             fd.append('confirmed', '1');


### PR DESCRIPTION
## Summary
- In `sendInvite()` in `js/cabinet.js`, the report endpoint now depends on whether `#invite-user` is empty
- Empty `#invite-user` → calls `report/236801`
- Non-empty `#invite-user` → calls `report/385` (existing behaviour)

## Test plan
- [ ] Open invite modal, leave user field empty, click submit → request goes to `/my/report/236801?JSON_KV`
- [ ] Open invite modal, fill in user field, click submit → request goes to `/my/report/385?JSON_KV`

Closes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)