### PR TITLE
fix: suppress all date defaults in secondary form fields (issue #2205 v2)

### DIFF
--- a/experiments/test-issue-2205-form-date-first-only.js
+++ b/experiments/test-issue-2205-form-date-first-only.js
@@ -1,8 +1,9 @@
 /**
  * Test for issue #2205:
  * When opening a create form via .column-add-btn or .title-create-btn,
- * only the FIRST date/datetime field should be filled with the current date.
- * Other date fields must remain empty unless they have an explicit attrs default.
+ * ALL date/datetime fields in sortedFields (secondary fields) must remain
+ * empty by default unless they have an explicit attrs default.
+ * The main field is rendered separately and handled outside this loop.
  */
 
 function makeStub() {
@@ -17,6 +18,7 @@ function makeStub() {
     function resolveDefaultValue(rawAttrs, format, suppressDateFallback = false) {
         if (rawAttrs && rawAttrs.trim().length > 0) {
             // simplified stub: doesn't parse tokens
+            return '(explicit-default)';
         }
         if (!suppressDateFallback) {
             if (format === 'DATE') return formatDate(now);
@@ -29,74 +31,62 @@ function makeStub() {
 }
 
 function simulateFormFields(fields, isCreate, resolveDefaultValue) {
-    let firstDateFieldSeen = false;
     return fields.map(req => {
         const baseFormat = req.format;
         const storedValue = req.storedValue || '';
-        const isDateLike = baseFormat === 'DATE' || baseFormat === 'DATETIME';
-        const suppressDateFallback = isDateLike && firstDateFieldSeen;
-        if (isDateLike) firstDateFieldSeen = true;
-        return storedValue || (isCreate ? resolveDefaultValue(req.attrs || '', baseFormat, suppressDateFallback) : '');
+        // Issue #2205: always suppress date fallback for sortedFields in create mode
+        return storedValue || (isCreate ? resolveDefaultValue(req.attrs || '', baseFormat, true) : '');
     });
 }
 
 function runTests() {
-    const { resolveDefaultValue, now } = makeStub();
+    const { resolveDefaultValue } = makeStub();
 
     const fields = [
-        { id: '1', format: 'SHORT', attrs: '' },    // Text (title) — empty
-        { id: '2', format: 'DATE', attrs: '' },      // First DATE — should be filled
-        { id: '3', format: 'DATE', attrs: '' },      // Second DATE — should be empty
+        { id: '2', format: 'DATE', attrs: '' },      // DATE — should be empty
+        { id: '3', format: 'DATE', attrs: '' },      // DATE — should be empty
         { id: '4', format: 'DATETIME', attrs: '' },  // DATETIME — should be empty
         { id: '5', format: 'SHORT', attrs: '' },     // Text — empty
+        { id: '6', format: 'DATE', attrs: 'defaultValue=[TODAY]' }, // explicit attrs — gets value
     ];
 
     const values = simulateFormFields(fields, true, resolveDefaultValue);
     let pass = true;
 
     if (values[0] !== '') {
-        console.error('FAIL: Text field should be empty, got:', values[0]);
+        console.error('FAIL: First DATE field should be empty (secondary), got:', values[0]);
         pass = false;
     } else {
-        console.log('PASS: Text field is empty');
+        console.log('PASS: First DATE secondary field is empty');
     }
 
-    if (!values[1] || values[1] === '') {
-        console.error('FAIL: First DATE field should be filled, got:', values[1]);
-        pass = false;
-    } else {
-        console.log('PASS: First DATE field filled with:', values[1]);
-    }
-
-    if (values[2] !== '') {
-        console.error('FAIL: Second DATE field should be empty, got:', values[2]);
+    if (values[1] !== '') {
+        console.error('FAIL: Second DATE field should be empty, got:', values[1]);
         pass = false;
     } else {
         console.log('PASS: Second DATE field is empty');
     }
 
-    if (values[3] !== '') {
-        console.error('FAIL: DATETIME field should be empty, got:', values[3]);
+    if (values[2] !== '') {
+        console.error('FAIL: DATETIME field should be empty, got:', values[2]);
         pass = false;
     } else {
         console.log('PASS: DATETIME field is empty');
     }
 
-    if (values[4] !== '') {
-        console.error('FAIL: Second text field should be empty, got:', values[4]);
+    if (values[3] !== '') {
+        console.error('FAIL: Text field should be empty, got:', values[3]);
         pass = false;
     } else {
-        console.log('PASS: Second text field is empty');
+        console.log('PASS: Text field is empty');
     }
 
-    // Explicit attrs default should still work for non-first date fields
-    const fieldsWithDefault = [
-        { id: '1', format: 'DATE', attrs: '' },
-        { id: '2', format: 'DATE', attrs: 'defaultValue=[TODAY]' },
-    ];
-    // suppressDateFallback=true only blocks the "no attrs" fallback, not explicit tokens
-    // (in real code [TODAY] would resolve; stub doesn't parse tokens but flag passes correctly)
-    console.log('INFO: suppressDateFallback only blocks fallback, explicit attrs still processed in real code');
+    if (values[4] !== '(explicit-default)') {
+        console.error('FAIL: Field with explicit attrs default should be filled, got:', values[4]);
+        pass = false;
+    } else {
+        console.log('PASS: Field with explicit attrs default is filled:', values[4]);
+    }
 
     if (pass) {
         console.log('\nAll tests PASSED');

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11484,9 +11484,6 @@ class IntegramTable{
                 sortedFields.sort((a, b) => sortKey.get(a.id) - sortKey.get(b.id));
             }
 
-            // Issue #2205: only the first date/datetime field gets current date as default;
-            // subsequent date fields are suppressed unless they have an explicit attrs default.
-            let firstDateFieldSeen = false;
             sortedFields.forEach(req => {
                 const attrs = this.parseAttrs(req.attrs);
                 const fieldName = attrs.alias || req.val;
@@ -11496,11 +11493,10 @@ class IntegramTable{
                 const isRequired = attrs.required;
                 const isMulti = attrs.multi; // Issue #853
                 // Apply default value from attrs when creating a new record (issue #1498)
-                // Suppress date fallback for all date fields after the first one (issue #2205)
-                const isDateLike = baseFormat === 'DATE' || baseFormat === 'DATETIME';
-                const suppressDateFallback = isDateLike && firstDateFieldSeen;
-                if (isDateLike) firstDateFieldSeen = true;
-                const reqValue = storedValue || (isCreate ? this.resolveDefaultValue(req.attrs, baseFormat, suppressDateFallback) : '');
+                // Suppress date fallback for ALL sortedFields in create mode (issue #2205):
+                // the main field (first column) is rendered separately above and gets today's
+                // date there; secondary fields must not auto-fill dates unless attrs say so.
+                const reqValue = storedValue || (isCreate ? this.resolveDefaultValue(req.attrs, baseFormat, true) : '');
                 // Field is read-only when form is read-only and req does not have granted: "WRITE" (issue #1508)
                 const isReqReadOnly = formIsReadOnly && req.granted !== 'WRITE';
 

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -438,9 +438,6 @@
                 sortedFields.sort((a, b) => sortKey.get(a.id) - sortKey.get(b.id));
             }
 
-            // Issue #2205: only the first date/datetime field gets current date as default;
-            // subsequent date fields are suppressed unless they have an explicit attrs default.
-            let firstDateFieldSeen = false;
             sortedFields.forEach(req => {
                 const attrs = this.parseAttrs(req.attrs);
                 const fieldName = attrs.alias || req.val;
@@ -450,11 +447,10 @@
                 const isRequired = attrs.required;
                 const isMulti = attrs.multi; // Issue #853
                 // Apply default value from attrs when creating a new record (issue #1498)
-                // Suppress date fallback for all date fields after the first one (issue #2205)
-                const isDateLike = baseFormat === 'DATE' || baseFormat === 'DATETIME';
-                const suppressDateFallback = isDateLike && firstDateFieldSeen;
-                if (isDateLike) firstDateFieldSeen = true;
-                const reqValue = storedValue || (isCreate ? this.resolveDefaultValue(req.attrs, baseFormat, suppressDateFallback) : '');
+                // Suppress date fallback for ALL sortedFields in create mode (issue #2205):
+                // the main field (first column) is rendered separately above and gets today's
+                // date there; secondary fields must not auto-fill dates unless attrs say so.
+                const reqValue = storedValue || (isCreate ? this.resolveDefaultValue(req.attrs, baseFormat, true) : '');
                 // Field is read-only when form is read-only and req does not have granted: "WRITE" (issue #1508)
                 const isReqReadOnly = formIsReadOnly && req.granted !== 'WRITE';
 


### PR DESCRIPTION
## Summary

Previous fix (PR #2205) was incorrect: it allowed the first date field in `sortedFields` to be auto-filled, but all `sortedFields` are secondary fields — the main field (first table column) is rendered separately and already gets today's date there.

Correct fix: pass `suppressDateFallback = true` unconditionally for all `sortedFields` in create mode. Explicit `attrs` defaults (e.g. `defaultValue=[TODAY]`) still work as before.

## Verification

- `bash build.sh`
- `node --check js/integram-table.js`
- `node experiments/test-issue-2205-form-date-first-only.js`
- `node experiments/test-issue-2057-add-row-date-fill.js`

Fixes #2205