### PR TITLE
fix: resolve reference label for pre-filled cells in addNewRow (issue #2206)

### DIFF
--- a/experiments/test-issue-2206-ref-default-label.js
+++ b/experiments/test-issue-2206-ref-default-label.js
@@ -1,0 +1,69 @@
+/**
+ * Test for issue #2206:
+ * When addNewRow pre-fills a reference column with a bare ID (e.g. "447"),
+ * the label must be resolved asynchronously and the cell updated to "447:sportzania".
+ */
+
+function runTests() {
+    let pass = true;
+
+    // Simulate the resolution logic used in addNewRow
+    function resolveRefLabel(value, options) {
+        if (!value || String(value).indexOf(':') >= 0) return value; // already resolved
+        const match = options.find(([id]) => String(id) === String(value));
+        if (!match) return value;
+        return `${ match[0] }:${ match[1] }`;
+    }
+
+    const options = [
+        ['447', 'sportzania'],
+        ['448', 'another'],
+    ];
+
+    const bare = '447';
+    const resolved = resolveRefLabel(bare, options);
+    if (resolved !== '447:sportzania') {
+        console.error('FAIL: expected "447:sportzania", got:', resolved);
+        pass = false;
+    } else {
+        console.log('PASS: bare ID resolved to label:', resolved);
+    }
+
+    // Already resolved value should be unchanged
+    const alreadyResolved = '447:sportzania';
+    const unchanged = resolveRefLabel(alreadyResolved, options);
+    if (unchanged !== alreadyResolved) {
+        console.error('FAIL: already-resolved value was changed:', unchanged);
+        pass = false;
+    } else {
+        console.log('PASS: already-resolved value unchanged:', unchanged);
+    }
+
+    // Unknown ID — fallback to raw
+    const unknown = '999';
+    const fallback = resolveRefLabel(unknown, options);
+    if (fallback !== '999') {
+        console.error('FAIL: unknown ID should remain as-is, got:', fallback);
+        pass = false;
+    } else {
+        console.log('PASS: unknown ID kept as fallback:', fallback);
+    }
+
+    // Empty value — unchanged
+    const empty = resolveRefLabel('', options);
+    if (empty !== '') {
+        console.error('FAIL: empty value should remain empty, got:', empty);
+        pass = false;
+    } else {
+        console.log('PASS: empty value unchanged');
+    }
+
+    if (pass) {
+        console.log('\nAll tests PASSED');
+    } else {
+        console.error('\nSome tests FAILED');
+        process.exit(1);
+    }
+}
+
+runTests();

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -3261,6 +3261,50 @@ class IntegramTable{
             setTimeout(() => {
                 this.startNewRowEdit(newRowIndex);
             }, 50);
+
+            // Issue #2206: Async resolve display labels for reference columns pre-filled with bare IDs.
+            // resolveDefaultValue returns the raw ID token (e.g. "447") but renderCell expects
+            // "id:Label" format (e.g. "447:sportzania").  Fetch options, find the matching label,
+            // update in-memory data and patch the specific cell in the DOM — no full re-render
+            // needed so the first-column editor is not disrupted.
+            const _refCols = this.columns
+                .map((col, colIndex) => ({ col, colIndex, value: emptyRow[colIndex] }))
+                .filter(({ col, value }) => {
+                    if (!value || String(value).indexOf(':') >= 0) return false;
+                    return col.ref_id != null || (col.ref && col.ref !== 0);
+                });
+
+            if (_refCols.length > 0) {
+                const _parentId = this.options.parentId || 1;
+                (async () => {
+                    for (const { col, colIndex, value } of _refCols) {
+                        if (!this.pendingNewRow || this.pendingNewRow.rowIndex !== newRowIndex) break;
+                        try {
+                            const options = await this.fetchReferenceOptions(
+                                col.paramId || col.type, _parentId, '', {}, col.attrs || ''
+                            );
+                            const match = options.find(([id]) => String(id) === String(value));
+                            if (!match) continue;
+                            const resolved = `${ match[0] }:${ match[1] }`;
+                            // Update in-memory data so subsequent renders are correct
+                            if (this.data[newRowIndex]) this.data[newRowIndex][colIndex] = resolved;
+                            if (this.rawObjectData[newRowIndex]) this.rawObjectData[newRowIndex].r[colIndex] = resolved;
+                            emptyRow[colIndex] = resolved;
+                            // Patch the specific cell in the DOM to avoid disrupting the active editor
+                            const cell = this.container && this.container.querySelector(
+                                `td[data-col-id="${ col.id }"][data-row-index="${ newRowIndex }"]`
+                            );
+                            if (cell) {
+                                const orderedColIndex = cell.dataset.col !== undefined
+                                    ? parseInt(cell.dataset.col, 10) : colIndex;
+                                cell.outerHTML = this.renderCell(col, resolved, newRowIndex, orderedColIndex);
+                            }
+                        } catch (_e) {
+                            // silently ignore — raw ID is acceptable fallback
+                        }
+                    }
+                })();
+            }
         }
 
         /**

--- a/js/integram-table/07-inline-edit.js
+++ b/js/integram-table/07-inline-edit.js
@@ -51,6 +51,50 @@
             setTimeout(() => {
                 this.startNewRowEdit(newRowIndex);
             }, 50);
+
+            // Issue #2206: Async resolve display labels for reference columns pre-filled with bare IDs.
+            // resolveDefaultValue returns the raw ID token (e.g. "447") but renderCell expects
+            // "id:Label" format (e.g. "447:sportzania").  Fetch options, find the matching label,
+            // update in-memory data and patch the specific cell in the DOM — no full re-render
+            // needed so the first-column editor is not disrupted.
+            const _refCols = this.columns
+                .map((col, colIndex) => ({ col, colIndex, value: emptyRow[colIndex] }))
+                .filter(({ col, value }) => {
+                    if (!value || String(value).indexOf(':') >= 0) return false;
+                    return col.ref_id != null || (col.ref && col.ref !== 0);
+                });
+
+            if (_refCols.length > 0) {
+                const _parentId = this.options.parentId || 1;
+                (async () => {
+                    for (const { col, colIndex, value } of _refCols) {
+                        if (!this.pendingNewRow || this.pendingNewRow.rowIndex !== newRowIndex) break;
+                        try {
+                            const options = await this.fetchReferenceOptions(
+                                col.paramId || col.type, _parentId, '', {}, col.attrs || ''
+                            );
+                            const match = options.find(([id]) => String(id) === String(value));
+                            if (!match) continue;
+                            const resolved = `${ match[0] }:${ match[1] }`;
+                            // Update in-memory data so subsequent renders are correct
+                            if (this.data[newRowIndex]) this.data[newRowIndex][colIndex] = resolved;
+                            if (this.rawObjectData[newRowIndex]) this.rawObjectData[newRowIndex].r[colIndex] = resolved;
+                            emptyRow[colIndex] = resolved;
+                            // Patch the specific cell in the DOM to avoid disrupting the active editor
+                            const cell = this.container && this.container.querySelector(
+                                `td[data-col-id="${ col.id }"][data-row-index="${ newRowIndex }"]`
+                            );
+                            if (cell) {
+                                const orderedColIndex = cell.dataset.col !== undefined
+                                    ? parseInt(cell.dataset.col, 10) : colIndex;
+                                cell.outerHTML = this.renderCell(col, resolved, newRowIndex, orderedColIndex);
+                            }
+                        } catch (_e) {
+                            // silently ignore — raw ID is acceptable fallback
+                        }
+                    }
+                })();
+            }
         }
 
         /**


### PR DESCRIPTION
## Summary

- `resolveDefaultValue` returns the raw token from attrs (e.g. `447`), but `renderCell` expects `id:Label` format (`447:sportzania`) to display the label.
- After the initial table render in `addNewRow`, asynchronously call `fetchReferenceOptions` for each pre-filled reference column, find the matching label, update `this.data` / `rawObjectData` in memory, and patch the specific cell's `outerHTML` in the DOM.
- No full re-render is triggered so the first-column inline editor is not disrupted.

## Verification

- `bash build.sh`
- `node --check js/integram-table.js`
- `node experiments/test-issue-2206-ref-default-label.js`

Fixes #2206