### PR TITLE
Fix dashboard report formula groups

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-28T17:47:38.715Z for PR creation at branch issue-2232-4e3da5ef3cdc for issue https://github.com/ideav/crm/issues/2232

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-28T17:47:38.715Z for PR creation at branch issue-2232-4e3da5ef3cdc for issue https://github.com/ideav/crm/issues/2232

--- a/experiments/test-issue-1879-dashboard-grouped-value.js
+++ b/experiments/test-issue-1879-dashboard-grouped-value.js
@@ -31,8 +31,8 @@ ${extractFunction('dashResolveValueCell')}
 
 dashItems['2263'] = { name: 'Выручка' };
 dashFormulas['2263'] = '[]';
-dashValues['Выручка:План'] = [{ date: '20260101', val: '340434754' }];
-dashValues['Выручка:Факт'] = [{ date: '20260101', val: '42' }];
+dashValues['выручка:план'] = [{ date: '20260101', val: '340434754' }];
+dashValues['выручка:факт'] = [{ date: '20260101', val: '42' }];
 
 const plan = dashResolveValueCell('2263', 'План');
 const fact = dashResolveValueCell('2263', 'Факт');

--- a/experiments/test-issue-2166-dashboard-panel-filter.js
+++ b/experiments/test-issue-2166-dashboard-panel-filter.js
@@ -36,7 +36,7 @@ let dashReportNames = {};
 let dashReportKeys = {};
 let dashFormulas = {};
 let dashAjaxes = 0;
-const repRegex = /^\\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)\\]$/;
+const repRegex = /^\\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)?\\]$/;
 
 function newApi(method, url, callback, vars, index) {
     calls.push({ method, url, callback, vars, index });
@@ -49,6 +49,16 @@ ${extractFunctionMaybe('dashReportKey')}
 ${extractFunctionMaybe('dashReportUrl')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
+${extractFunctionMaybe('dashParseReportFormula')}
+${extractFunctionMaybe('dashReportFieldName')}
+${extractFunctionMaybe('dashReportHasField')}
+${extractFunctionMaybe('dashReportSumField')}
+${extractFunctionMaybe('dashNormalizeGroupName')}
+${extractFunctionMaybe('dashSameGroupName')}
+${extractFunctionMaybe('dashCellRgColumn')}
+${extractFunctionMaybe('dashCellReportGroup')}
+${extractFunctionMaybe('dashCollectReportGroups')}
+${extractFunctionMaybe('dashResolveReportCellValue')}
 ${extractFunction('dashGetRepVals')}
 ${extractFunction('dashGetRepDone')}
 ${extractFunction('dashGetRep')}

--- a/experiments/test-issue-2232-dashboard-report-groups.js
+++ b/experiments/test-issue-2232-dashboard-report-groups.js
@@ -1,0 +1,153 @@
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('templates/dash.html', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function extractFunctionMaybe(name) {
+    return source.indexOf('function ' + name + '(') === -1 ? '' : extractFunction(name);
+}
+
+const code = `
+const repRegex = /^\\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)?\\]$/;
+let dashReports = {};
+let dashReportNames = {};
+let dashReportKeys = {};
+let dashFormulas = {};
+let rowsById = {};
+
+let document = {
+    getElementById(id) {
+        return rowsById[id] || null;
+    }
+};
+
+function makeCell(groupName, range) {
+    return {
+        innerHTML: '',
+        attrs: { range: range || '20260101-20261231', ready: '0' },
+        dataset: groupName ? { rgCol: groupName } : {},
+        getAttribute(name) { return this.attrs[name]; },
+        setAttribute(name, value) { this.attrs[name] = value; },
+        closest() { return null; }
+    };
+}
+
+function makeHeadCell(groupName, range) {
+    const cell = makeCell('', range);
+    cell.dataset = groupName ? { rgHead: groupName } : {};
+    return cell;
+}
+
+function setFormulaCase(formula, cells, reportRows) {
+    const reportKey = 'Подбор персонала и адаптация';
+    dashReports = {};
+    dashReportNames = {};
+    dashReportKeys = {};
+    dashFormulas = {};
+    rowsById = {};
+
+    dashReports[reportKey] = reportRows;
+    dashReportNames[reportKey] = 'Подбор персонала и адаптация';
+    dashReportKeys['row1'] = reportKey;
+    dashFormulas['row1'] = formula;
+    rowsById['row1'] = {
+        querySelectorAll() {
+            return cells;
+        }
+    };
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+${extractFunction('dashGetFloat')}
+${extractFunction('dashNormalizeVal')}
+${extractFunctionMaybe('dashParseReportFormula')}
+${extractFunctionMaybe('dashReportFieldName')}
+${extractFunctionMaybe('dashReportHasField')}
+${extractFunctionMaybe('dashReportSumField')}
+${extractFunctionMaybe('dashNormalizeGroupName')}
+${extractFunctionMaybe('dashSameGroupName')}
+${extractFunctionMaybe('dashCellRgColumn')}
+${extractFunctionMaybe('dashCellReportGroup')}
+${extractFunctionMaybe('dashCollectReportGroups')}
+${extractFunctionMaybe('dashResolveReportCellValue')}
+${extractFunction('dashGetRepVals')}
+
+let plan = makeCell('План');
+let fact = makeCell('Факт');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ]', [plan, fact], [
+    { Date: '20260101', 'Интервью с НМ.План': '10', 'Интервью с НМ.Факт': '7' }
+]);
+dashGetRepVals();
+assert(plan.innerHTML === '10', 'plain formula should fill План from field.План when plain field is absent');
+assert(fact.innerHTML === '7', 'plain formula should fill Факт from field.Факт when plain field is absent');
+
+plan = makeHeadCell('План');
+fact = makeHeadCell('Факт');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ]', [plan, fact], [
+    { Date: '20260101', 'Интервью с НМ.План': '11', 'Интервью с НМ.Факт': '9' }
+]);
+dashGetRepVals();
+assert(plan.innerHTML === '11', 'plain formula should fill rgHead План from field.План');
+assert(fact.innerHTML === '9', 'plain formula should fill rgHead Факт from field.Факт');
+
+plan = makeCell('План');
+fact = makeCell('Факт');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ]', [plan, fact], [
+    { Date: '20260101', 'Интервью с НМ': '5', 'Интервью с НМ.План': '10', 'Интервью с НМ.Факт': '7' }
+]);
+dashGetRepVals();
+assert(plan.innerHTML === '5', 'plain report field should be used for every group when it exists');
+assert(fact.innerHTML === '5', 'plain report field should override grouped fields for all groups');
+
+plan = makeCell('План');
+fact = makeCell('Факт');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ.План]', [plan, fact], [
+    { Date: '20260101', 'Интервью с НМ.План': '12', 'Интервью с НМ.Факт': '8' }
+]);
+dashGetRepVals();
+assert(plan.innerHTML === '12', 'explicit grouped formula should fill its matching group');
+assert(fact.innerHTML === '', 'explicit grouped formula should ignore other groups');
+assert(fact.getAttribute('ready') === '0', 'ignored group cell should stay unresolved');
+
+const single = makeCell('Любая группа');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ.План]', [single], [
+    { Date: '20260101', 'Интервью с НМ': '5', 'Интервью с НМ.План': '12' }
+]);
+dashGetRepVals();
+assert(single.innerHTML === '12', 'single group should prefer field.group over field');
+
+const singleFallback = makeCell('Любая группа');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ.План]', [singleFallback], [
+    { Date: '20260101', 'Интервью с НМ': '5' }
+]);
+dashGetRepVals();
+assert(singleFallback.innerHTML === '5', 'single group should fall back to plain field');
+
+const noGroup = makeCell('');
+setFormulaCase('[Подбор персонала и адаптация.Интервью с НМ.План]', [noGroup], [
+    { Date: '20260101', 'Интервью с НМ': '5' }
+]);
+dashGetRepVals();
+assert(noGroup.innerHTML === '5', 'ungrouped cells should use COALESCE(field.group, field)');
+`;
+
+vm.runInNewContext(code, { console });
+console.log('issue-2232 dashboard report group parsing: ok');

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -381,7 +381,7 @@ td:has(.dash-cell-input) {
 <script>
 (function() {
 
-const repRegex  = /^\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)\]$/
+const repRegex  = /^\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)(\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)?\]$/
     , itemRegex = /^\[([A-Za-яЁё][ A-Za-яЁё0-9\(\)-]*)\]$/
     , exprRegex = /(СУММА)\(\[(.*?)\]:\[(.*?)\]\)/g
     , itemIdRegex = /\[\d+\]/g;
@@ -558,6 +558,126 @@ function dashReportUrl(rep, fr, to, panelFilter) {
         , filter = dashNormalizePanelFilter(panelFilter);
     if (filter) url += '&' + filter;
     return url;
+}
+
+function dashParseReportFormula(formula) {
+    var rep = (formula || '').match(repRegex);
+    if (!rep) return null;
+    var field = rep[2].substr(1)
+        , group = rep[3] ? rep[3].substr(1) : '';
+    return {
+        report: rep[1],
+        field: field,
+        group: group,
+        fullField: group ? field + '.' + group : field
+    };
+}
+
+function dashReportFieldName(row, field) {
+    var k, fieldLower;
+    if (!row || !field) return null;
+    if (Object.prototype.hasOwnProperty.call(row, field)) return field;
+    fieldLower = String(field).toLowerCase();
+    for (k in row)
+        if (String(k).toLowerCase() === fieldLower) return k;
+    return null;
+}
+
+function dashReportHasField(reportRows, field) {
+    var i;
+    for (i in reportRows || [])
+        if (dashReportFieldName(reportRows[i], field) !== null) return true;
+    return false;
+}
+
+function dashReportSumField(reportRows, dateField, range, field) {
+    var i, row, fieldName, n, acc = 0;
+    for (i in reportRows || []) {
+        row = reportRows[i];
+        fieldName = dashReportFieldName(row, field);
+        if (fieldName === null) continue;
+        // If range[0] is empty (range="-"), include all data regardless of date (issue #1875)
+        if (!range[0] || (row[dateField] >= range[0] && row[dateField] <= range[1])) {
+            n = dashGetFloat(row[fieldName] || 0);
+            if (!isNaN(n)) acc += n;
+        }
+    }
+    return dashNormalizeVal(field, acc);
+}
+
+function dashNormalizeGroupName(groupName) {
+    return String(groupName || '').trim().toLowerCase();
+}
+
+function dashSameGroupName(a, b) {
+    return dashNormalizeGroupName(a) === dashNormalizeGroupName(b);
+}
+
+function dashCellRgColumn(td) {
+    if (td.dataset && td.dataset.rgCol) return td.dataset.rgCol;
+    var table = td.closest ? td.closest('table') : null;
+    if (!table) return null;
+    var subhead = table.querySelector('thead .f-subhead');
+    if (!subhead) return null;
+    var colIdx = Array.from(td.parentNode.cells).indexOf(td);
+    var ths = Array.from(subhead.querySelectorAll('th'));
+    var th = ths[colIdx];
+    return (th && th.getAttribute('data-rg-col')) || null;
+}
+
+function dashCellReportGroup(td) {
+    return dashCellRgColumn(td) || (td.dataset ? td.dataset.rgHead : '') || '';
+}
+
+function dashCollectReportGroups(cells) {
+    var groups = [], seen = {};
+    cells.forEach(function(cell) {
+        var group = dashCellReportGroup(cell)
+            , key = dashNormalizeGroupName(group);
+        if (key && !seen[key]) {
+            seen[key] = true;
+            groups.push(group);
+        }
+    });
+    return groups;
+}
+
+function dashResolveReportCellValue(reportRows, dateField, range, parsed, cellGroup, groups) {
+    var groupCount = groups ? groups.length : 0
+        , hasGroups = groupCount > 0
+        , groupedField;
+
+    if (!hasGroups) {
+        if (parsed.group && dashReportHasField(reportRows, parsed.fullField))
+            return dashReportSumField(reportRows, dateField, range, parsed.fullField);
+        if (dashReportHasField(reportRows, parsed.field))
+            return dashReportSumField(reportRows, dateField, range, parsed.field);
+        return undefined;
+    }
+
+    if (!parsed.group) {
+        if (dashReportHasField(reportRows, parsed.field))
+            return dashReportSumField(reportRows, dateField, range, parsed.field);
+        if (cellGroup) {
+            groupedField = parsed.field + '.' + cellGroup;
+            if (dashReportHasField(reportRows, groupedField))
+                return dashReportSumField(reportRows, dateField, range, groupedField);
+        }
+        return undefined;
+    }
+
+    if (groupCount === 1) {
+        if (dashReportHasField(reportRows, parsed.fullField))
+            return dashReportSumField(reportRows, dateField, range, parsed.fullField);
+        if (dashReportHasField(reportRows, parsed.field))
+            return dashReportSumField(reportRows, dateField, range, parsed.field);
+        return undefined;
+    }
+
+    if (!dashSameGroupName(cellGroup, parsed.group)) return undefined;
+    if (dashReportHasField(reportRows, parsed.fullField))
+        return dashReportSumField(reportRows, dateField, range, parsed.fullField);
+    return undefined;
 }
 
 function dashFetchMatrixValues() {
@@ -792,7 +912,7 @@ function dashCalcRGFormulas() {
 }
 
 function dashGetRepVals() {
-    var reportKey, reportRows, rep, i, j, repField, date;
+    var reportKey, reportRows, rep, i, parsed, date;
     for (reportKey in dashReports) {
         reportRows = dashReports[reportKey];
         if (!reportRows || !reportRows[0]) continue;
@@ -800,25 +920,30 @@ function dashGetRepVals() {
         for (i in reportRows[0]) { date = i; break; }
         rep = dashReportNames[reportKey] || reportKey;
         for (i in dashFormulas) {
+            parsed = dashParseReportFormula(dashFormulas[i]);
+            if (!parsed) continue;
             if (dashReportKeys[i]) {
                 if (dashReportKeys[i] !== reportKey) continue;
-            } else if (dashFormulas[i].indexOf('[' + rep + '.') !== 0) {
+            } else if (parsed.report !== rep) {
                 continue;
             }
-            if (dashFormulas[i].indexOf('[' + rep + '.') === 0) {
-                repField = dashFormulas[i].match(repRegex)[2].substr(1);
-                // Use getElementById to avoid invalid CSS selectors when IDs start with digits (issue #2074)
-                var iEl = document.getElementById(i);
-                (iEl ? iEl.querySelectorAll('.f-rg-cell') : []).forEach(function(el) {
-                    var val = 0, range = el.getAttribute('range').split('-');
-                    for (j in reportRows)
-                        // If range[0] is empty (range="-"), include all data regardless of date (issue #1875)
-                        if (!range[0] || (reportRows[j][date] >= range[0] && reportRows[j][date] <= range[1]))
-                            val += dashGetFloat(reportRows[j][repField]);
-                    el.innerHTML = dashNormalizeVal(i, val);
-                    el.setAttribute('ready', '1');
+            // Use getElementById to avoid invalid CSS selectors when IDs start with digits (issue #2074)
+            var iEl = document.getElementById(i);
+            var cells = iEl ? Array.from(iEl.querySelectorAll('.f-rg-cell[data-src="report"],.f-values[data-src="report"]')) : [];
+            if (!cells.length && iEl)
+                cells = Array.from(iEl.querySelectorAll('.f-rg-cell')).filter(function(cell) {
+                    return !cell.dataset || !cell.dataset.src || cell.dataset.src === 'report';
                 });
-            }
+            var groups = dashCollectReportGroups(cells);
+            cells.forEach(function(el) {
+                var range = String(el.getAttribute('range') || '-').split('-')
+                    , group = dashCellReportGroup(el)
+                    , val = dashResolveReportCellValue(reportRows, date, range, parsed, group, groups);
+                if (val !== undefined) {
+                    el.innerHTML = val;
+                    el.setAttribute('ready', '1');
+                }
+            });
         }
     }
 }
@@ -875,7 +1000,8 @@ function dashDrawPeriods() {
                                     }
                                     var cellExtra = s.extra
                                         + (valueItemId ? ' data-value-item-id="' + valueItemId + '"' : '')
-                                        + (rgHeadVal ? ' data-rg-head="' + rgHeadVal.replace(/"/g, '&quot;') + '"' : '');
+                                        + (rgHeadVal ? ' data-rg-head="' + rgHeadVal.replace(/"/g, '&quot;') + '"' : '')
+                                        + ' data-rg-col="' + colName.replace(/"/g, '&quot;') + '"';
                                     row.insertAdjacentHTML('beforeend',
                                         cellTpl.replace(':val:', v || '')
                                             .replace(':ready:', '1')


### PR DESCRIPTION
## Summary
Fixes #2232.

- Supports dashboard report formulas with an optional group suffix, for example `[Подбор персонала и адаптация.Интервью с НМ.План]`.
- Routes `[report.field]` into all dashboard groups when `field` exists, or into matching `field.<group>` report columns when only grouped report fields exist.
- Routes `[report.field.group]` into the matching group, with `COALESCE(field.group, field)` behavior for single-group or ungrouped cells.
- Leaves unmatched grouped cells unresolved instead of writing incorrect `NaN`/zero values.

## Reproduction
Before this change, a dashboard row formula like `[Подбор персонала и адаптация.Интервью с НМ]` could not populate RGcolumns such as `План` and `Факт` from report fields named `Интервью с НМ.План` and `Интервью с НМ.Факт`. A formula with the explicit suffix `[Подбор персонала и адаптация.Интервью с НМ.План]` was not parsed as a report formula at all.

## Tests
- `node experiments/test-issue-2232-dashboard-report-groups.js`
- `node experiments/test-issue-2166-dashboard-panel-filter.js`
- `node experiments/test-issue-1879-dashboard-grouped-value.js`
- `node experiments/test-issue-2148-dashboard-matrix.js`
- `node experiments/test-issue-2107-case-insensitive-dash.js`
- `node experiments/test_rg_columns_accumulation.js`
- dashboard inline script parse check with Node `new Function(...)`
- `git diff --check`
