### PR TITLE
Fix dashboard duplicate report rows

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-28T20:31:40.940Z for PR creation at branch issue-2235-a38ba3802247 for issue https://github.com/ideav/crm/issues/2235

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-28T20:31:40.940Z for PR creation at branch issue-2235-a38ba3802247 for issue https://github.com/ideav/crm/issues/2235

--- a/experiments/test-issue-2235-dashboard-duplicate-report-rows.js
+++ b/experiments/test-issue-2235-dashboard-duplicate-report-rows.js
@@ -1,0 +1,133 @@
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('templates/dash.html', 'utf8');
+
+if (!source.includes('dashIsDuplicateModelRow(previousItem, json[i])')) {
+    throw new Error('dashGetModel should detect consecutive duplicate rows while parsing the model');
+}
+if (!source.includes('dashRememberReportSource(itemTargetId')) {
+    throw new Error('dashGetModel should register duplicate report formulas on the visible row');
+}
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function extractFunctionMaybe(name) {
+    const marker = 'function ' + name + '(';
+    return source.indexOf(marker) === -1 ? '' : extractFunction(name);
+}
+
+const code = `
+const repRegex = /^\\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)?\\]$/;
+let dashReports = {};
+let dashReportNames = {};
+let dashReportKeys = {};
+let dashReportSources = {};
+let dashFormulas = {};
+let rowsById = {};
+
+let document = {
+    getElementById(id) {
+        return rowsById[id] || null;
+    }
+};
+
+function makeCell(groupName, range) {
+    return {
+        innerHTML: '',
+        attrs: { range: range || '20260101-20261231', ready: '0' },
+        dataset: groupName ? { rgCol: groupName } : {},
+        getAttribute(name) { return this.attrs[name]; },
+        setAttribute(name, value) { this.attrs[name] = value; },
+        closest() { return null; }
+    };
+}
+
+function makeRow(cells) {
+    return {
+        querySelectorAll() {
+            return cells;
+        }
+    };
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+${extractFunction('dashGetFloat')}
+${extractFunction('dashNormalizeVal')}
+${extractFunctionMaybe('dashNormalizePanelFilter')}
+${extractFunctionMaybe('dashReportKey')}
+${extractFunctionMaybe('dashParseReportFormula')}
+${extractFunctionMaybe('dashReportFieldName')}
+${extractFunctionMaybe('dashReportHasField')}
+${extractFunctionMaybe('dashReportSumField')}
+${extractFunctionMaybe('dashNormalizeGroupName')}
+${extractFunctionMaybe('dashSameGroupName')}
+${extractFunctionMaybe('dashCellRgColumn')}
+${extractFunctionMaybe('dashCellReportGroup')}
+${extractFunctionMaybe('dashCollectReportGroups')}
+${extractFunctionMaybe('dashIsDuplicateModelRow')}
+${extractFunctionMaybe('dashReportGroupMatches')}
+${extractFunctionMaybe('dashResolveReportCellValue')}
+${extractFunction('dashGetRepVals')}
+
+assert(typeof dashIsDuplicateModelRow === 'function',
+    'dash model parser should expose duplicate-row detection');
+assert(dashIsDuplicateModelRow(
+    { panelID: '1035', itemID: 'row1', item: 'Закрыто из взятых в работу', level: '2' },
+    { panelID: '1035', itemID: 'row2', item: 'Закрыто из взятых в работу', level: '2' }
+), 'same-name consecutive rows in the same panel and level should merge into the previous row');
+assert(!dashIsDuplicateModelRow(
+    { panelID: '1035', itemID: 'row1', item: 'Закрыто из взятых в работу', level: '2' },
+    { panelID: '1035', itemID: 'row3', item: 'Средний TTS', level: '2' }
+), 'different row names should remain separate');
+
+const row1Plan = makeCell('Подбор персонала и адаптация');
+const row1Strategy = makeCell('Стратегия');
+const row2Plan = makeCell('Подбор персонала и адаптация');
+const row2Strategy = makeCell('Стратегия');
+
+rowsById.row1 = makeRow([row1Plan, row1Strategy]);
+rowsById.row2 = makeRow([row2Plan, row2Strategy]);
+
+const reportA = dashReportKey('Подбор персонала и адаптация', '');
+const reportB = dashReportKey('Стратегия', '');
+
+dashReportNames[reportA] = 'Подбор персонала и адаптация';
+dashReportNames[reportB] = 'Стратегия';
+dashReportKeys.row1 = reportA;
+dashReportKeys.row2 = reportB;
+dashFormulas.row1 = '[Подбор персонала и адаптация.Закрыто]';
+dashFormulas.row2 = '[Стратегия.Закрыто]';
+dashReportSources.row1 = [
+    { formula: dashFormulas.row1, reportKey: reportA },
+    { formula: dashFormulas.row2, reportKey: reportB }
+];
+dashReports[reportA] = [{ Date: '20260101', 'Закрыто': '3' }];
+dashReports[reportB] = [{ Date: '20260101', 'Закрыто': '4' }];
+
+dashGetRepVals();
+
+assert(row1Plan.innerHTML === '3',
+    'first duplicate formula should fill the matching group on the visible row');
+assert(row1Strategy.innerHTML === '4',
+    'second duplicate formula should fill the next matching group on the visible row');
+`;
+
+vm.runInNewContext(code, { console });
+console.log('issue-2235 dashboard duplicate report rows: ok');

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -448,7 +448,7 @@ const sheetTabTpl = '<li class="nav-item"><a id=":id:" class="nav-link dash-shee
         + ':name:'
     , cellTpl     = '<td range=":from:-:to:" ready=":ready:" class="f-cell :classes:" align="right" title=":title:" data-src=":src:" data-item-id=":item-id:":extra:>:val:';
 
-let dashModelData = {}, dashPeriodData = {}, dashPeriods = {}, dashValues = {}, dashFormulas = {}, dashItems = {}, dashReports = {}, dashReportNames = {}, dashReportKeys = {}, dashAjaxes = 0;
+let dashModelData = {}, dashPeriodData = {}, dashPeriods = {}, dashValues = {}, dashFormulas = {}, dashItems = {}, dashReports = {}, dashReportNames = {}, dashReportKeys = {}, dashReportSources = {}, dashAjaxes = 0;
 let dashValueItemIds = {}; // item name -> valueItemID from ЗначенияЗаПериод
 let dashMatrixValues = [], dashMatrixValuesRequested = false, dashRgSourceIds = {};
 
@@ -611,6 +611,33 @@ function dashNormalizeGroupName(groupName) {
 
 function dashSameGroupName(a, b) {
     return dashNormalizeGroupName(a) === dashNormalizeGroupName(b);
+}
+
+function dashIsDuplicateModelRow(previousRow, row) {
+    if (!previousRow || !row || !row.itemID) return false;
+    if (String(previousRow.panelID || '') !== String(row.panelID || '')) return false;
+    if (String(previousRow.itemID || '') === String(row.itemID || '')) return false;
+    return String(previousRow.item || '') === String(row.item || '')
+        && String(previousRow.level || 1) === String(row.level || 1);
+}
+
+function dashRememberReportSource(rowId, formula, reportKey) {
+    var i, sources, parsed;
+    if (!rowId || !formula) return;
+    parsed = dashParseReportFormula(formula);
+    if (!parsed) return;
+    sources = dashReportSources[rowId] || (dashReportSources[rowId] = []);
+    for (i = 0; i < sources.length; i++) {
+        if (sources[i].formula === formula && sources[i].reportKey === reportKey) return;
+    }
+    sources.push({ formula: formula, reportKey: reportKey });
+}
+
+function dashReportGroupMatches(groups, reportName) {
+    var i;
+    for (i = 0; i < (groups || []).length; i++)
+        if (dashSameGroupName(groups[i], reportName)) return true;
+    return false;
 }
 
 function dashCellRgColumn(td) {
@@ -912,38 +939,51 @@ function dashCalcRGFormulas() {
 }
 
 function dashGetRepVals() {
-    var reportKey, reportRows, rep, i, parsed, date;
+    var reportKey, reportRows, rep, i, parsed, date, rowIds = {}, sources, source, sourceIdx
+        , reportSources = (typeof dashReportSources !== 'undefined') ? dashReportSources : {};
     for (reportKey in dashReports) {
         reportRows = dashReports[reportKey];
         if (!reportRows || !reportRows[0]) continue;
         date = '';
         for (i in reportRows[0]) { date = i; break; }
         rep = dashReportNames[reportKey] || reportKey;
-        for (i in dashFormulas) {
-            parsed = dashParseReportFormula(dashFormulas[i]);
-            if (!parsed) continue;
-            if (dashReportKeys[i]) {
-                if (dashReportKeys[i] !== reportKey) continue;
-            } else if (parsed.report !== rep) {
-                continue;
-            }
-            // Use getElementById to avoid invalid CSS selectors when IDs start with digits (issue #2074)
-            var iEl = document.getElementById(i);
-            var cells = iEl ? Array.from(iEl.querySelectorAll('.f-rg-cell[data-src="report"],.f-values[data-src="report"]')) : [];
-            if (!cells.length && iEl)
-                cells = Array.from(iEl.querySelectorAll('.f-rg-cell')).filter(function(cell) {
-                    return !cell.dataset || !cell.dataset.src || cell.dataset.src === 'report';
-                });
-            var groups = dashCollectReportGroups(cells);
-            cells.forEach(function(el) {
-                var range = String(el.getAttribute('range') || '-').split('-')
-                    , group = dashCellReportGroup(el)
-                    , val = dashResolveReportCellValue(reportRows, date, range, parsed, group, groups);
-                if (val !== undefined) {
-                    el.innerHTML = val;
-                    el.setAttribute('ready', '1');
+        rowIds = {};
+        for (i in dashFormulas) rowIds[i] = true;
+        for (i in reportSources) rowIds[i] = true;
+        for (i in rowIds) {
+            sources = (reportSources[i] && reportSources[i].length)
+                ? reportSources[i]
+                : [{ formula: dashFormulas[i], reportKey: dashReportKeys[i] }];
+            for (sourceIdx = 0; sourceIdx < sources.length; sourceIdx++) {
+                source = sources[sourceIdx] || {};
+                parsed = dashParseReportFormula(source.formula || dashFormulas[i]);
+                if (!parsed) continue;
+                if (source.reportKey || dashReportKeys[i]) {
+                    if ((source.reportKey || dashReportKeys[i]) !== reportKey) continue;
+                } else if (parsed.report !== rep) {
+                    continue;
                 }
-            });
+                // Use getElementById to avoid invalid CSS selectors when IDs start with digits (issue #2074)
+                var iEl = document.getElementById(i);
+                var cells = iEl ? Array.from(iEl.querySelectorAll('.f-rg-cell[data-src="report"],.f-values[data-src="report"]')) : [];
+                if (!cells.length && iEl)
+                    cells = Array.from(iEl.querySelectorAll('.f-rg-cell')).filter(function(cell) {
+                        return !cell.dataset || !cell.dataset.src || cell.dataset.src === 'report';
+                    });
+                var groups = dashCollectReportGroups(cells)
+                    , restrictToReportGroup = sources.length > 1 && !parsed.group && dashReportGroupMatches(groups, parsed.report);
+                cells.forEach(function(el) {
+                    var range = String(el.getAttribute('range') || '-').split('-')
+                        , group = dashCellReportGroup(el)
+                        , val;
+                    if (restrictToReportGroup && !dashSameGroupName(group, parsed.report)) return;
+                    val = dashResolveReportCellValue(reportRows, date, range, parsed, group, groups);
+                    if (val !== undefined) {
+                        el.innerHTML = val;
+                        el.setAttribute('ready', '1');
+                    }
+                });
+            }
         }
     }
 }
@@ -1337,7 +1377,7 @@ function dashGetModel(json) {
         dashSetStatus('Дэшборд не найден');
         return;
     }
-    var i, j, rep, fr, to;
+    var i, j, rep, fr, to, lastVisibleItemByPanel = {};
     dashSetStatus('Загрузка данных...');
 
     for (i in json) {
@@ -1376,6 +1416,10 @@ function dashGetModel(json) {
     var model = document.getElementById('dash-model');
 
     for (i in json) {
+        var panelKey = 'fp' + json[i].panelID
+            , previousItem = lastVisibleItemByPanel[panelKey]
+            , isDuplicateRow = dashIsDuplicateModelRow(previousItem, json[i])
+            , itemTargetId = isDuplicateRow ? previousItem.itemID : json[i].itemID;
         // Add sheet tab
         if (!document.getElementById(json[i].sheetID)) {
             model.querySelector('.sheet-tabs').insertAdjacentHTML('beforeend',
@@ -1385,43 +1429,55 @@ function dashGetModel(json) {
             dashInitFilterBar(document.getElementById('ds' + json[i].sheetID));
         }
         // Add panel to sheet (prefix 'fp' to avoid ID collision with item rows)
-        if (!document.getElementById('fp' + json[i].panelID)) {
+        if (!document.getElementById(panelKey)) {
             document.getElementById('ds' + json[i].sheetID).insertAdjacentHTML('beforeend',
-                panelTpl.replace(/:id:/g, 'fp' + json[i].panelID)
+                panelTpl.replace(/:id:/g, panelKey)
                     .replace(':head:', json[i].itemsHead || json[i].panel)
                     .replace(':period:', json[i].period)
                     .replace(':name:', json[i].panel));
-            dashModelData['fp' + json[i].panelID] = { items: {}, rgs: {}, noDates: json[i].NoDates };
+            dashModelData[panelKey] = { items: {}, rgs: {}, noDates: json[i].NoDates };
         }
         if (json[i].NoDates !== undefined)
-            dashModelData['fp' + json[i].panelID].noDates = json[i].NoDates;
+            dashModelData[panelKey].noDates = json[i].NoDates;
         // Add item row
-        if (json[i].itemID && !document.getElementById(json[i].itemID)) {
-            document.getElementById('fp' + json[i].panelID).querySelector('table tbody').insertAdjacentHTML('beforeend',
+        if (json[i].itemID && !isDuplicateRow && !document.getElementById(json[i].itemID)) {
+            document.getElementById(panelKey).querySelector('table tbody').insertAdjacentHTML('beforeend',
                 itemTpl.replace(/:id:/g, json[i].itemID)
                     .replace(':pl:', Math.max(0, (json[i].level || 1) - 1))
                     .replace(/:name:/g, json[i].item));
         }
+        if (json[i].itemID && !isDuplicateRow) {
+            lastVisibleItemByPanel[panelKey] = {
+                panelID: json[i].panelID,
+                itemID: json[i].itemID,
+                item: json[i].item,
+                level: json[i].level || 1
+            };
+        }
         // Remember RG metadata; accumulate column names across rows (each row may carry one column)
-        if (!dashModelData['fp' + json[i].panelID].rgs[json[i].RG])
-            dashModelData['fp' + json[i].panelID].rgs[json[i].RG] = { type: json[i].RGtype, head: json[i].rgHead, src: json[i].RGsourceID, columns: json[i].RGcolumns || '', rgFormulas: json[i].RGformulas || '' };
+        if (!dashModelData[panelKey].rgs[json[i].RG])
+            dashModelData[panelKey].rgs[json[i].RG] = { type: json[i].RGtype, head: json[i].rgHead, src: json[i].RGsourceID, columns: json[i].RGcolumns || '', rgFormulas: json[i].RGformulas || '' };
         else if (json[i].RGcolumns) {
-            var existingCols = dashModelData['fp' + json[i].panelID].rgs[json[i].RG].columns
+            var existingCols = dashModelData[panelKey].rgs[json[i].RG].columns
                 .split(',').map(function(c) { return c.trim(); }).filter(Boolean);
             json[i].RGcolumns.split(',').map(function(c) { return c.trim(); }).filter(Boolean).forEach(function(col) {
                 if (existingCols.indexOf(col) === -1) existingCols.push(col);
             });
-            dashModelData['fp' + json[i].panelID].rgs[json[i].RG].columns = existingCols.join(',');
+            dashModelData[panelKey].rgs[json[i].RG].columns = existingCols.join(',');
         }
         // Predefined values
         if (json[i].value.length > 0)
-            dashValues[json[i].itemID] = dashNormalizeVal(json[i].itemID, json[i].value);
+            dashValues[itemTargetId] = dashNormalizeVal(itemTargetId, json[i].value);
         // Formulas
         if (json[i].formulas.length > 0) {
-            dashFormulas[json[i].itemID] = json[i].formulas;
-            if (rep = json[i].formulas.match(repRegex)) {
+            rep = json[i].formulas.match(repRegex);
+            if (!dashFormulas[itemTargetId] || (rep && dashFormulas[itemTargetId] === '[]'))
+                dashFormulas[itemTargetId] = json[i].formulas;
+            if (rep) {
                 var reportKey = dashReportKey(rep[1], json[i].panelFilter);
-                dashReportKeys[json[i].itemID] = reportKey;
+                if (!dashReportKeys[itemTargetId])
+                    dashReportKeys[itemTargetId] = reportKey;
+                dashRememberReportSource(itemTargetId, json[i].formulas, reportKey);
                 dashReportNames[reportKey] = rep[1];
                 if (!dashReports[reportKey])
                     dashGetRep(rep[1], fr, to, json[i].panelFilter);
@@ -1447,7 +1503,7 @@ function dashGetModel(json) {
 
 function dashReset() {
     dashModelData = {}; dashPeriodData = {}; dashPeriods = {}; dashValues = {};
-    dashFormulas = {}; dashItems = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashAjaxes = 0; dashValueItemIds = {};
+    dashFormulas = {}; dashItems = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashReportSources = {}; dashAjaxes = 0; dashValueItemIds = {};
     dashMatrixValues = []; dashMatrixValuesRequested = false; dashRgSourceIds = {};
     var model = document.getElementById('dash-model');
     model.querySelector('.sheet-tabs').innerHTML = '';
@@ -1483,7 +1539,7 @@ window.dashApplyFilter = function(sheetEl) {
         delete dashModelData[p.id];
         p.remove();
     });
-    dashPeriodData = {}; dashPeriods = {}; dashValues = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashAjaxes = 0; dashValueItemIds = {}; dashRgSourceIds = {};
+    dashPeriodData = {}; dashPeriods = {}; dashValues = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashReportSources = {}; dashAjaxes = 0; dashValueItemIds = {}; dashRgSourceIds = {};
 
     // Re-fetch model for this sheet only — skip get_record, use cached dashRecordId
     dashSetStatus('Загрузка данных...');


### PR DESCRIPTION
## Summary
Fixes #2235.

- Treats consecutive dashboard model rows with the same row name, panel, and level as one visible row.
- Registers report formulas from duplicate rows as additional sources for the previous visible row.
- Routes duplicate report formulas into matching RG group columns when the report name matches the group name, so each group can be populated from its own query.
- Keeps existing grouped report formula behavior for single-source rows and explicit `[report.field.group]` formulas.

## Reproduction
Before this change, duplicating a dashboard row such as `Закрыто из взятых в работу` with formulas `[Подбор персонала и адаптация.Закрыто]` and `[Стратегия.Закрыто]` produced separate rendered rows or reused only one report source for the visible row. The first plain report field could also fill every group cell, preventing the second query from filling its group.

## Tests
- `node experiments/test-issue-2235-dashboard-duplicate-report-rows.js`
- `node experiments/test-issue-2232-dashboard-report-groups.js`
- `node experiments/test-issue-2166-dashboard-panel-filter.js`
- `node experiments/test-issue-1879-dashboard-grouped-value.js`
- `node experiments/test-issue-2148-dashboard-matrix.js`
- `node experiments/test-issue-2107-case-insensitive-dash.js`
- `node experiments/test_rg_columns_accumulation.js`
- dashboard inline script parse check with Node `new Function(...)`
- `git diff --check`
