### PR TITLE
Fix dashboard numeric parsing with copied separators

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T10:25:54.748Z for PR creation at branch issue-2238-ae7350472f5d for issue https://github.com/ideav/crm/issues/2238

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T10:25:54.748Z for PR creation at branch issue-2238-ae7350472f5d for issue https://github.com/ideav/crm/issues/2238

--- a/experiments/test-issue-1879-dashboard-grouped-value.js
+++ b/experiments/test-issue-1879-dashboard-grouped-value.js
@@ -24,6 +24,7 @@ let dashValues = Object.create(null);
 let dashItems = Object.create(null);
 let dashFormulas = Object.create(null);
 function dashTrace() {}
+${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
 ${extractFunction('dashGetVal')}

--- a/experiments/test-issue-2148-dashboard-matrix.js
+++ b/experiments/test-issue-2148-dashboard-matrix.js
@@ -37,6 +37,7 @@ const code = `
 let dashMatrixValues = [];
 function dashTrace() {}
 
+${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
 ${extractFunction('dashNormalizeMatrixKey')}

--- a/experiments/test-issue-2166-dashboard-panel-filter.js
+++ b/experiments/test-issue-2166-dashboard-panel-filter.js
@@ -47,6 +47,7 @@ function dashDrawPeriods() {}
 ${extractFunctionMaybe('dashNormalizePanelFilter')}
 ${extractFunctionMaybe('dashReportKey')}
 ${extractFunctionMaybe('dashReportUrl')}
+${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
 ${extractFunctionMaybe('dashParseReportFormula')}

--- a/experiments/test-issue-2232-dashboard-report-groups.js
+++ b/experiments/test-issue-2232-dashboard-report-groups.js
@@ -76,6 +76,7 @@ function assert(condition, message) {
     if (!condition) throw new Error(message);
 }
 
+${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
 ${extractFunctionMaybe('dashParseReportFormula')}

--- a/experiments/test-issue-2235-dashboard-duplicate-report-rows.js
+++ b/experiments/test-issue-2235-dashboard-duplicate-report-rows.js
@@ -68,6 +68,7 @@ function assert(condition, message) {
     if (!condition) throw new Error(message);
 }
 
+${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
 ${extractFunctionMaybe('dashNormalizePanelFilter')}

--- a/experiments/test-issue-2238-dashboard-number-normalization.js
+++ b/experiments/test-issue-2238-dashboard-number-normalization.js
@@ -1,0 +1,119 @@
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('templates/dash.html', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function extractFunctionMaybe(name) {
+    const marker = 'function ' + name + '(';
+    return source.indexOf(marker) === -1 ? '' : extractFunction(name);
+}
+
+const code = `
+let dashValues = {};
+let document = {};
+
+function assertEqual(actual, expected, message) {
+    if (actual !== expected) {
+        throw new Error(message + ': expected ' + expected + ', got ' + actual);
+    }
+}
+
+function assertNear(actual, expected, message) {
+    if (Math.abs(actual - expected) > 0.000001) {
+        throw new Error(message + ': expected ' + expected + ', got ' + actual);
+    }
+}
+
+${extractFunctionMaybe('dashNormalizeNumberText')}
+${extractFunction('dashGetFloat')}
+${extractFunctionMaybe('dashNumberForFormula')}
+${extractFunctionMaybe('dashCellText')}
+${extractFunction('dashNormalizeVal')}
+${extractFunction('dashReportFieldName')}
+${extractFunction('dashReportSumField')}
+${extractFunction('dashGetVal')}
+${extractFunction('dashCalcLineTotals')}
+
+const nbsp = '\\u00a0';
+const narrowNbsp = '\\u202f';
+
+assertNear(dashGetFloat('2,061,818'), 2061818, 'comma thousands must parse as an integer');
+assertNear(dashGetFloat('2' + nbsp + '061' + nbsp + '818'), 2061818, 'NBSP thousands must parse as an integer');
+assertNear(dashGetFloat('2' + narrowNbsp + '061' + narrowNbsp + '818'), 2061818, 'narrow NBSP thousands must parse as an integer');
+assertNear(dashGetFloat('2' + nbsp + '061' + nbsp + '818.88'), 2061818.88, 'dot decimals with NBSP thousands must parse');
+assertNear(dashGetFloat('2' + nbsp + '061' + nbsp + '818,88'), 2061818.88, 'comma decimals with NBSP thousands must parse');
+assertNear(dashGetFloat('2.061.818'), 2061818, 'dot thousands must parse as an integer');
+assertNear(dashGetFloat('2.061.818,88'), 2061818.88, 'dot thousands with comma decimals must parse');
+assertNear(dashGetFloat('-201' + nbsp + '754'), -201754, 'negative values with NBSP thousands must parse');
+assertNear(dashGetFloat('0.123'), 0.123, 'small decimal values must stay decimals');
+assertNear(dashGetFloat('1234,567'), 1234.567, 'single separators after four integer digits must stay decimals');
+
+assertEqual(dashNumberForFormula('2,061,818'), '2061818',
+    'formula operands must be rewritten as calculation-safe numbers');
+assertEqual(dashNumberForFormula('2' + nbsp + '061' + nbsp + '818,88'), '2061818.88',
+    'formula operands must handle decimal commas and NBSP thousands');
+
+assertEqual(dashNormalizeVal('', '2' + nbsp + '061' + nbsp + '818,88'), '2061818.88',
+    'display normalization must keep a calculation-safe numeric string');
+assertEqual(dashNormalizeVal('', [{ val: '2,061,818' }]), '2061818',
+    'object value normalization must handle comma thousands');
+
+dashValues.revenue = [
+    { date: '20260101', val: '2,061,818' },
+    { date: '20260102', val: '2' + nbsp + '061' + nbsp + '818,88' },
+    { date: '20260103', val: '-201' + nbsp + '754' }
+];
+assertEqual(dashGetVal('Revenue', '20260101', '20260131'), '3921882.88',
+    'period values must sum normalized numbers');
+
+const reportRows = [
+    { Date: '20260101', Amount: '4' + nbsp + '268' + nbsp + '116' },
+    { Date: '20260102', Amount: '2,061,818.88' },
+    { Date: '20260103', Amount: '-201' + nbsp + '754' }
+];
+assertEqual(dashReportSumField(reportRows, 'Date', ['20260101', '20260131'], 'Amount'), '6128180.88',
+    'report values must sum normalized numbers');
+
+let lineTotal;
+const row = {
+    querySelectorAll(selector) {
+        if (selector !== '.f-rg-cell') return [];
+        return [
+            { innerHTML: '2,061,818' },
+            { innerHTML: '2' + nbsp + '061' + nbsp + '818,88' },
+            { innerHTML: '-201' + nbsp + '754' }
+        ];
+    }
+};
+lineTotal = {
+    innerHTML: '',
+    title: '',
+    closest() { return row; }
+};
+document = {
+    querySelectorAll(selector) {
+        return selector === '#dash-model .f-line-sum' ? [lineTotal] : [];
+    }
+};
+dashCalcLineTotals();
+assertEqual(String(lineTotal.innerHTML), '3921882.88',
+    'line totals must sum normalized cell text');
+`;
+
+vm.runInNewContext(code, { console });
+console.log('issue-2238 dashboard number normalization: ok');

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -468,15 +468,68 @@ function dashSetStatus(msg) {
     if (el) el.textContent = msg;
 }
 
+function dashNormalizeNumberText(v) {
+    if (v === null || v === undefined) return '';
+    var raw = String(v).trim()
+        , s, sign = '', lastComma, lastDot, lastSep, hasMixedSeparators
+        , parts, groupedThousands, whole, fraction;
+    if (!raw) return '';
+    raw = raw.replace(/[\u2212\u2012\u2013\u2014]/g, '-');
+    if (!/^[+-]?[\d\s\u00a0\u202f.,]+%?$/.test(raw)) return '';
+    s = raw.replace(/%$/, '').replace(/[\s\u00a0\u202f]/g, '');
+    if (s.charAt(0) === '+' || s.charAt(0) === '-') {
+        sign = s.charAt(0);
+        s = s.slice(1);
+    }
+    s = s.replace(/[^0-9.,]/g, '');
+    if (!/[0-9]/.test(s)) return '';
+
+    lastComma = s.lastIndexOf(',');
+    lastDot = s.lastIndexOf('.');
+    lastSep = Math.max(lastComma, lastDot);
+    if (lastSep !== -1) {
+        hasMixedSeparators = lastComma !== -1 && lastDot !== -1;
+        if (hasMixedSeparators) {
+            whole = s.slice(0, lastSep).replace(/[.,]/g, '') || '0';
+            fraction = s.slice(lastSep + 1).replace(/[.,]/g, '');
+            return sign + whole + (fraction ? '.' + fraction : '');
+        }
+
+        parts = s.split(s.charAt(lastSep));
+        groupedThousands = parts.length > 1
+            && parts.slice(1).every(function(part) { return part.length === 3; })
+            && parts[0].length > 0
+            && parts[0].length <= 3
+            && parts[0] !== '0';
+        if (!groupedThousands) {
+            whole = parts.slice(0, -1).join('').replace(/[.,]/g, '') || '0';
+            fraction = parts[parts.length - 1].replace(/[.,]/g, '');
+            return sign + whole + (fraction ? '.' + fraction : '');
+        }
+        s = parts.join('');
+    }
+    return sign + s;
+}
+
 function dashGetFloat(v) {
-    return parseFloat(String(v).replace(/ /g, '').replace(/,/g, '.'));
+    return parseFloat(dashNormalizeNumberText(v));
+}
+
+function dashNumberForFormula(v) {
+    var n = dashNormalizeNumberText(v);
+    return n === '' ? '0' : n;
+}
+
+function dashCellText(el) {
+    return el && el.textContent !== undefined ? el.textContent : (el ? el.innerHTML : '');
 }
 
 function dashNormalizeVal(item, val) {
-    var v = val || '';
+    var v = val || '', n;
     if (typeof val === 'object' && val !== null)
         v = val[0].val;
-    return String(v).replace(/ /g, '').replace(/,/g, '.');
+    n = dashNormalizeNumberText(v);
+    return n === '' ? String(v) : n;
 }
 
 function dashNormalizeMatrixKey(v) {
@@ -774,7 +827,7 @@ function dashCalcLineTotals() {
         var valids = false, v = 0;
         el.title = 'Сумма значений строки';
         el.closest('tr').querySelectorAll('.f-rg-cell').forEach(function(cell) {
-            var n = parseFloat(cell.innerHTML);
+            var n = dashGetFloat(dashCellText(cell));
             if (!isNaN(n)) { valids = true; v += n; }
         });
         if (valids) el.innerHTML = v;
@@ -836,12 +889,12 @@ function dashCalcCells() {
                     });
                     cells.forEach(function(rc) {
                         if (rc.getAttribute('ready') === '1')
-                            f = f.replace(new RegExp('\\[' + refs[i] + '\\]'), rc.innerHTML || 0);
+                            f = f.replace(new RegExp('\\[' + refs[i] + '\\]'), dashNumberForFormula(dashCellText(rc)));
                     });
                     // Use getElementById to avoid invalid CSS selectors when IDs start with digits (issue #2074)
                     (refEl ? refEl.querySelectorAll('.f-values') : []).forEach(function(fv) {
                         if (fv.getAttribute('ready') === '1')
-                            f = f.replace(new RegExp('\\[' + refs[i] + '\\]'), fv.innerHTML || 0);
+                            f = f.replace(new RegExp('\\[' + refs[i] + '\\]'), dashNumberForFormula(dashCellText(fv)));
                     });
                 }
                 refs = f.match(itemIdRegex);
@@ -900,7 +953,7 @@ function dashCalcRGFormulas() {
                     if (targetIdx < 0 || targetIdx >= cells.length) return '0';
                     var tc = cells[targetIdx];
                     if (!tc || tc.getAttribute('ready') !== '1') { allReady = false; return match; }
-                    return tc.textContent.trim() || '0';
+                    return dashNumberForFormula(dashCellText(tc));
                 }
                 // Named ref: find column index by name
                 var colIdx = colNameMap[ref.trim()];
@@ -910,7 +963,7 @@ function dashCalcRGFormulas() {
                 }
                 var tc = cells[colIdx];
                 if (!tc || tc.getAttribute('ready') !== '1') { allReady = false; return match; }
-                return tc.textContent.trim() || '0';
+                return dashNumberForFormula(dashCellText(tc));
             });
 
             if (!allReady) return; // wait for deps


### PR DESCRIPTION
Fixes #2238

## Summary
- Normalize dashboard numeric text before calculations, including spaces, NBSP/narrow NBSP, comma thousands, dot thousands, and comma/dot decimals.
- Route report/value sums, line totals, item formulas, and RG formulas through the shared normalization path.
- Add a focused issue 2238 experiment and update existing dashboard extraction tests for the new helper.

## Reproduction
Before the fix, `dashGetFloat("2,061,818")` parsed as `2.061`, and NBSP-separated values parsed only up to the first group. The new experiment covers those cases plus decimal comma/dot inputs and negative values.

## Verification
- `node experiments/test-issue-2238-dashboard-number-normalization.js`
- `node experiments/test-issue-1879-dashboard-grouped-value.js`
- `node experiments/test-issue-2232-dashboard-report-groups.js`
- `node experiments/test-issue-2235-dashboard-duplicate-report-rows.js`
- `node experiments/test-issue-2166-dashboard-panel-filter.js`
- `node experiments/test-issue-2148-dashboard-matrix.js`
- `node experiments/test_rgformulas.js`
- `node experiments/test-issue-2107-case-insensitive-dash.js`
- `git diff --check`
