### PR TITLE
Fix inline cell editor layout shift and input styling (issue #2240)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T10:39:50.991Z for PR creation at branch issue-2240-92ef9aebf5a9 for issue https://github.com/ideav/crm/issues/2240

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T10:39:50.991Z for PR creation at branch issue-2240-92ef9aebf5a9 for issue https://github.com/ideav/crm/issues/2240

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -2636,33 +2636,41 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
 .inline-editor {
     width: 100%;
     max-width: 100%;
-    padding: 6px 10px 6px 0;
-    /* border: 2px solid var(--md-primary); */
+    padding: 0;
+    border: none;
     border-radius: 4px;
     font-size: 0.875rem;
     font-family: inherit;
     color: var(--md-text-primary);
-    background: var(--md-surface);
-    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.15);
+    background: transparent;
+    box-shadow: none;
     transition: var(--md-transition);
     outline: none;
     box-sizing: border-box;
 }
 
 .inline-editor:focus {
-    border-color: var(--md-primary-dark);
-    box-shadow: 0 0 0 3px rgba(25, 118, 210, 0.25);
+    box-shadow: none;
 }
 
 /* Specific styles for different editor types */
 .inline-editor-number,
 .inline-editor-text {
-    min-height: 32px;
+    /* no min-height — keep row at its natural height */
+}
+
+/* Remove spinner arrows from number inputs */
+.inline-editor-number::-webkit-outer-spin-button,
+.inline-editor-number::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+.inline-editor-number {
+    -moz-appearance: textfield;
 }
 
 .inline-editor-date,
 .inline-editor-datetime {
-    min-height: 32px;
     cursor: pointer;
 }
 
@@ -2692,10 +2700,9 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     opacity: 1;
 }
 
-/* Visual feedback for inline editing active state */
+/* Visual feedback for inline editing active state — keep original padding to prevent layout shift (issue #2240) */
 td:has(.inline-editor) {
     background-color: rgba(25, 118, 210, 0.08) !important;
-    padding: 4px !important;
     overflow: hidden;
 }
 
@@ -2705,14 +2712,10 @@ td.cell-saving {
     transition: background-color 0.2s ease;
 }
 
-/* Ensure proper sizing in compact mode */
-.integram-table.compact td:has(.inline-editor) {
-    padding: 2px !important;
-}
+/* Compact mode: inline editor inherits cell padding, no override needed (issue #2240) */
 
 /* Inline select editor for GRANT and REPORT_COLUMN types (issue #601) */
 .inline-editor-select {
-    min-height: 32px;
     cursor: pointer;
     appearance: none;
     -webkit-appearance: none;


### PR DESCRIPTION
## Problem

When editing a cell inline, the row height increases and the layout shifts. Additionally, numeric input fields show browser spinner arrows, a blue border/shadow appears around the input, and there are minimum height constraints on inputs.

## Root Cause

1. `td:has(.inline-editor)` was overriding cell `padding` to `4px`, causing layout shift vs the normal `10px` padding
2. `.inline-editor-number`, `.inline-editor-text`, `.inline-editor-date`, `.inline-editor-datetime` had `min-height: 32px` forcing the row to grow
3. `.inline-editor` had `box-shadow` and `background` that made the input visually bulky
4. Number inputs had browser default spinner arrows

## Changes (`css/integram-table.css`)

- Removed `padding: 4px !important` override from `td:has(.inline-editor)` — cell keeps its original padding, no layout shift
- Removed `min-height` from all inline editor input types
- Set `.inline-editor` `border: none`, `box-shadow: none`, `background: transparent`, `padding: 0` — input blends into the highlighted cell
- Added `::-webkit-outer-spin-button` / `::-webkit-inner-spin-button` + `-moz-appearance: textfield` to hide number spinners
- Removed `min-height` from `.inline-editor-select`

## How to reproduce

Open any table with an editable numeric column and click a cell to edit it. Before the fix the row grows taller with a bordered/shadowed input; after the fix the row stays the same height and the input is borderless.


Fixes #2240