### PR TITLE
Add query column analysis and selected-first sorting to migration workspace

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T11:40:43.946Z for PR creation at branch issue-2243-bdecda71789e for issue https://github.com/ideav/crm/issues/2243

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T11:40:43.946Z for PR creation at branch issue-2243-bdecda71789e for issue https://github.com/ideav/crm/issues/2243

--- a/experiments/test-issue-2243-query-column-analysis.js
+++ b/experiments/test-issue-2243-query-column-analysis.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Test the query column parsing logic from issue #2243
+// API: object/28/?F_U={query_id}&JSON_OBJ&LIMIT=1000
+// r[0] format: "ID:Name" where ID is table/column id from metadata
+// Skip "0:..." (computed fields)
+
+const sampleColumns = [
+    { i: 7638, r: ["0:Вычисляемое", "Месяц", "CONCAT(SUBSTRING(СтартРаботы, 1, 6), '01')", "", "", "", "", "", "", "", "", "", "", ""] },
+    { i: 7628, r: ["8150:Вакансия актуальная -> Старт работы", "Старт работы", "СтартРаботы", "", "", "", "", "", "X", "", "", "", "", ""] },
+    { i: 157709, r: ["8153:Вакансия актуальная -> Выход", "Выход", "Выход", "", "", "", "", "", "X", "", "", "", "", ""] },
+    { i: 157713, r: ["7931:Тип найма", "Тип найма", "", "", "", "", "", "", "X", "", "", "", "", ""] },
+    { i: 157715, r: ["7931:Тип найма", "Тип наймаID", "ТипНаймаID", "", "", "", "85:abn_ID", "", "X", "", "", "", "", ""] },
+    { i: 157718, r: ["0:Вычисляемое", "TTS ОШ.Факт", "COALESCE(...)", "", "", "77:AVG", "", "", "", "", "", "", "", ""] },
+    { i: 157842, r: ["8143:Вакансия актуальная -> План", "Закрыто.План", "План", "", "", "73:SUM", "", "", "", "", "", "", "", ""] }
+];
+
+const catalogTables = [
+    { id: '7931', name: 'Тип найма' },
+    { id: '8150', name: 'Вакансия актуальная' },
+    { id: '8143', name: 'Вакансия актуальная' },
+    { id: '8152', name: 'Вакансия актуальная' },
+    { id: '8153', name: 'Вакансия актуальная' }
+];
+
+function mapById(items) {
+    const map = new Map();
+    (items || []).forEach(function(item) {
+        const id = String(item.id || '').trim();
+        if (id) map.set(id, item);
+    });
+    return map;
+}
+
+function parseQueryColumns(columns, tableById, selectedTables) {
+    let addedTables = 0;
+    for (const col of columns) {
+        const r0 = col.r && col.r[0] ? String(col.r[0]) : '';
+        const colon = r0.indexOf(':');
+        if (colon < 1) continue;
+        const rawId = r0.slice(0, colon).trim();
+        if (!rawId || rawId === '0' || !/^\d+$/.test(rawId)) continue;
+        if (selectedTables.has(rawId)) continue;
+        const known = tableById.get(rawId);
+        const name = known ? (known.name || rawId) : (r0.slice(colon + 1).trim() || rawId);
+        selectedTables.set(rawId, { id: rawId, name: name, exportData: false, filter: '' });
+        addedTables += 1;
+    }
+    return addedTables;
+}
+
+const tableById = mapById(catalogTables);
+const selectedTables = new Map();
+
+const added = parseQueryColumns(sampleColumns, tableById, selectedTables);
+
+console.log('Added tables:', added);
+console.log('Selected tables:', Array.from(selectedTables.entries()).map(([id, t]) => `${id}: ${t.name}`));
+
+// Assertions
+const ids = Array.from(selectedTables.keys());
+console.assert(!ids.includes('0'), 'Should not include computed (id=0)');
+console.assert(ids.includes('8150'), 'Should include 8150');
+console.assert(ids.includes('8153'), 'Should include 8153');
+console.assert(ids.includes('7931'), 'Should include 7931 (only once even though referenced twice)');
+console.assert(ids.includes('8143'), 'Should include 8143');
+console.assert(ids.length === 4, 'Should have 4 unique table ids: ' + ids.join(', '));
+
+// Test selected-first sorting
+const catalog = [
+    { id: '100', name: 'Alpha' },
+    { id: '7931', name: 'Тип найма' },
+    { id: '200', name: 'Beta' },
+    { id: '8150', name: 'Вакансия актуальная' }
+];
+
+const sorted = catalog.slice().sort((a, b) => {
+    const aSelected = selectedTables.has(a.id) ? 0 : 1;
+    const bSelected = selectedTables.has(b.id) ? 0 : 1;
+    return aSelected - bSelected;
+});
+
+const sortedIds = sorted.map(t => t.id);
+console.log('Sorted (selected first):', sortedIds);
+console.assert(sortedIds.indexOf('7931') < sortedIds.indexOf('100'), 'Selected 7931 should come before non-selected 100');
+console.assert(sortedIds.indexOf('8150') < sortedIds.indexOf('200'), 'Selected 8150 should come before non-selected 200');
+
+console.log('\nAll assertions passed!');

--- a/js/migr.js
+++ b/js/migr.js
@@ -260,6 +260,7 @@
                 '      <div class="migr-subtitle">JSON-пакет сущностей, запросов, рабочих мест и файлов</div>',
                 '    </div>',
                 '    <div class="migr-actions">',
+                '      <button type="button" class="migr-btn migr-btn-secondary" data-action="scan-queries" title="Найти таблицы и колонки, используемые в выбранных запросах"><i class="pi pi-sitemap"></i><span>Анализ запросов</span></button>',
                 '      <button type="button" class="migr-btn migr-btn-secondary" data-action="scan-files" title="Найти зависимости в выбранных файлах"><i class="pi pi-search"></i><span>Найти связи</span></button>',
                 '      <button type="button" class="migr-btn migr-btn-secondary" data-action="save-settings" title="Сохранить конфигурацию"><i class="pi pi-save"></i><span>Сохранить</span></button>',
                 '      <button type="button" class="migr-btn migr-btn-primary" data-action="export-package" title="Сформировать JSON"><i class="pi pi-download"></i><span>Экспорт</span></button>',
@@ -368,6 +369,8 @@
                 this.newSettings();
             } else if (action === 'save-settings') {
                 await this.saveSettings();
+            } else if (action === 'scan-queries') {
+                await this.scanSelectedQueries();
             } else if (action === 'scan-files') {
                 await this.scanSelectedFiles();
             } else if (action === 'export-package') {
@@ -614,8 +617,12 @@
             const count = this.container.querySelector('#migr-tables-count');
             if (!list) return;
 
-            const items = this.catalog.tables.filter(function(item) {
+            const items = this.catalog.tables.filter((item) => {
                 return !search || normalizeSearch(item.name + ' ' + item.id).indexOf(search) > -1;
+            }).slice().sort((a, b) => {
+                const aSelected = this.state.selectedTables.has(a.id) ? 0 : 1;
+                const bSelected = this.state.selectedTables.has(b.id) ? 0 : 1;
+                return aSelected - bSelected;
             });
             if (count) count.textContent = String(this.state.selectedTables.size) + ' / ' + String(this.catalog.tables.length);
 
@@ -654,8 +661,12 @@
             const count = this.container.querySelector('#migr-queries-count');
             if (!list) return;
 
-            const items = this.catalog.queries.filter(function(item) {
+            const items = this.catalog.queries.filter((item) => {
                 return !search || normalizeSearch(item.name + ' ' + item.id).indexOf(search) > -1;
+            }).slice().sort((a, b) => {
+                const aSelected = this.state.selectedQueries.has(a.id) ? 0 : 1;
+                const bSelected = this.state.selectedQueries.has(b.id) ? 0 : 1;
+                return aSelected - bSelected;
             });
             if (count) count.textContent = String(this.state.selectedQueries.size) + ' / ' + String(this.catalog.queries.length);
 
@@ -879,6 +890,56 @@
             }
         }
 
+        async scanSelectedQueries() {
+            const queries = Array.from(this.state.selectedQueries.values());
+            if (!queries.length) {
+                this.showToast('Выберите запросы для анализа', 'error');
+                return;
+            }
+
+            this.setBusy(true);
+            let addedTables = 0;
+            try {
+                const tableById = mapById(this.catalog.tables);
+                for (const query of queries) {
+                    let columns;
+                    try {
+                        columns = await this.fetchJson('object/28?F_U=' + encodeURIComponent(query.id) + '&JSON_OBJ&LIMIT=1000');
+                    } catch (e) {
+                        console.warn('[migr] query columns fetch failed for', query.id, e);
+                        continue;
+                    }
+                    if (!Array.isArray(columns)) continue;
+                    for (const col of columns) {
+                        const r0 = col.r && col.r[0] ? String(col.r[0]) : '';
+                        const colon = r0.indexOf(':');
+                        if (colon < 1) continue;
+                        const rawId = r0.slice(0, colon).trim();
+                        if (!rawId || rawId === '0' || !/^\d+$/.test(rawId)) continue;
+                        if (this.state.selectedTables.has(rawId)) continue;
+                        const known = tableById.get(rawId);
+                        const name = known ? (known.name || rawId) : (r0.slice(colon + 1).trim() || rawId);
+                        this.state.selectedTables.set(rawId, {
+                            id: rawId,
+                            name: name,
+                            exportData: false,
+                            filter: ''
+                        });
+                        addedTables += 1;
+                    }
+                }
+                this.renderTables();
+                this.renderSelectedTables();
+                this.showToast('Добавлено таблиц из запросов: ' + addedTables, 'success');
+                this.setStatus('Анализ запросов завершён');
+            } catch (e) {
+                console.error('[migr] query scan failed:', e);
+                this.showToast('Не удалось проанализировать запросы', 'error');
+            } finally {
+                this.setBusy(false);
+            }
+        }
+
         async scanSelectedFiles() {
             const files = Array.from(this.state.selectedFiles.values());
             if (!files.length) {
@@ -1037,12 +1098,18 @@
                 id: query.id,
                 name: query.name,
                 record: null,
+                columns: null,
                 report: null
             };
             try {
                 entry.record = await this.fetchJson('object/' + QUERY_TABLE_ID + '/' + encodeURIComponent(query.id) + '?JSON_OBJ');
             } catch (e) {
                 entry.recordError = e.message;
+            }
+            try {
+                entry.columns = await this.fetchJson('object/28?F_U=' + encodeURIComponent(query.id) + '&JSON_OBJ&LIMIT=1000');
+            } catch (e) {
+                entry.columnsError = e.message;
             }
             try {
                 entry.report = await this.fetchJson('report/' + encodeURIComponent(query.id) + '?JSON');


### PR DESCRIPTION
## Summary

- Selected tables and queries now appear at the top of their respective lists (selected-first sort)
- Added **Анализ запросов** button that fetches query columns via `object/28?F_U={id}&JSON_OBJ&LIMIT=1000`, parses `r[0]` entries (format `ID:Name`), skips computed fields (`0:...`), and adds the referenced table IDs to the migration selection
- Export package now includes query columns data (`columns` field) alongside `record` and `report`

## How to Reproduce

1. Open `/{db}/migr`
2. Select one or more queries in the Запросы panel
3. Click **Анализ запросов** — the tables referenced by those query columns are added to the Таблицы selection
4. Selected tables/queries appear at the top of their lists

## Verification

- `node --check js/migr.js` — syntax OK
- `node experiments/test-issue-2243-query-column-analysis.js` — all assertions pass: correct parsing of `r[0]`, deduplication, skip of `id=0` computed fields, selected-first sort

Fixes #2243