### PR TITLE
Fix column layout shift when inline editing (issue #2244)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-29T11:41:39.689Z for PR creation at branch issue-2244-2d06b6184c17 for issue https://github.com/ideav/crm/issues/2244

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-29T11:41:39.689Z for PR creation at branch issue-2244-2d06b6184c17 for issue https://github.com/ideav/crm/issues/2244

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -2636,6 +2636,7 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
 .inline-editor {
     width: 100%;
     max-width: 100%;
+    min-width: 0; /* prevent input's intrinsic size from expanding the column (issue #2244) */
     padding: 0;
     border: none;
     border-radius: 4px;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -3375,6 +3375,9 @@ class IntegramTable{
             // Highlight required fields in the row (issue #807)
             this.highlightNewRowRequiredCells(cell);
 
+            // Freeze column widths before inserting editor to prevent layout shift (issue #2244)
+            this._freezeColumnWidths();
+
             // Use pre-filled default value from addNewRow (issue #1500)
             const colDataIndex = this.columns.findIndex(c => c.id === colId);
             const defaultValue = (this.data[rowIndex] && colDataIndex !== -1)
@@ -3724,6 +3727,9 @@ class IntegramTable{
 
             // Get current value from the cell
             const currentValue = this.extractCellValue(cell);
+
+            // Freeze column widths before inserting editor to prevent layout shift (issue #2244)
+            this._freezeColumnWidths();
 
             // Store reference to current editing cell
             this.currentEditingCell = {
@@ -5715,6 +5721,8 @@ class IntegramTable{
             if (this.currentEditingCell.fixedDropdown && this.currentEditingCell.fixedDropdown.parentNode) {
                 this.currentEditingCell.fixedDropdown.parentNode.removeChild(this.currentEditingCell.fixedDropdown);
             }
+            // Unfreeze column widths now that the editor is removed (issue #2244)
+            this._unfreezeColumnWidths();
             this.currentEditingCell = null;
 
             // Navigate to the pending cell immediately, without waiting for the save (issue #1431)
@@ -5912,6 +5920,8 @@ class IntegramTable{
                 if (this.currentEditingCell.outsideClickHandler) {
                     document.removeEventListener('click', this.currentEditingCell.outsideClickHandler);
                 }
+                // Unfreeze column widths (issue #2244)
+                this._unfreezeColumnWidths();
                 this.currentEditingCell = null;
 
                 this.showToast('Запись создана', 'success');
@@ -6193,6 +6203,9 @@ class IntegramTable{
                 this.currentEditingCell.fixedDropdown.parentNode.removeChild(this.currentEditingCell.fixedDropdown);
             }
 
+            // Unfreeze column widths now that the editor is removed (issue #2244)
+            this._unfreezeColumnWidths();
+
             this.currentEditingCell = null;
 
             // Navigate to pending cell if set (issue #518)
@@ -6201,6 +6214,43 @@ class IntegramTable{
                 this.pendingCellClick = null;
                 this.navigateToCell(targetCell);
             }
+        }
+
+        /**
+         * Snapshot all th widths and lock them as inline styles so the table layout
+         * does not shift when an inline editor replaces cell content (issue #2244).
+         * Only locks headers that don't already have an explicit width stored in
+         * this.columnWidths, so manually-resized columns are unaffected.
+         */
+        _freezeColumnWidths() {
+            if (!this.container) return;
+            const table = this.container.querySelector('.integram-table');
+            if (!table) return;
+            const headers = table.querySelectorAll('thead th');
+            this._frozenHeaders = [];
+            headers.forEach(th => {
+                const colId = th.dataset.columnId;
+                // Skip headers that already have an explicit pixel width (manually resized)
+                if (colId && this.columnWidths[colId]) return;
+                const w = th.offsetWidth;
+                if (w > 0) {
+                    th.style.width = w + 'px';
+                    th.style.minWidth = w + 'px';
+                    this._frozenHeaders.push(th);
+                }
+            });
+        }
+
+        /**
+         * Remove the inline width styles added by _freezeColumnWidths (issue #2244).
+         */
+        _unfreezeColumnWidths() {
+            if (!this._frozenHeaders) return;
+            this._frozenHeaders.forEach(th => {
+                th.style.width = '';
+                th.style.minWidth = '';
+            });
+            this._frozenHeaders = null;
         }
 
         /**
@@ -6228,6 +6278,8 @@ class IntegramTable{
                 if (this.currentEditingCell.fixedDropdown && this.currentEditingCell.fixedDropdown.parentNode) {
                     this.currentEditingCell.fixedDropdown.parentNode.removeChild(this.currentEditingCell.fixedDropdown);
                 }
+                // Unfreeze column widths (issue #2244)
+                this._unfreezeColumnWidths();
                 this.currentEditingCell = null;
             }
 

--- a/js/integram-table/07-inline-edit.js
+++ b/js/integram-table/07-inline-edit.js
@@ -200,6 +200,9 @@
             // Highlight required fields in the row (issue #807)
             this.highlightNewRowRequiredCells(cell);
 
+            // Freeze column widths before inserting editor to prevent layout shift (issue #2244)
+            this._freezeColumnWidths();
+
             // Use pre-filled default value from addNewRow (issue #1500)
             const colDataIndex = this.columns.findIndex(c => c.id === colId);
             const defaultValue = (this.data[rowIndex] && colDataIndex !== -1)
@@ -549,6 +552,9 @@
 
             // Get current value from the cell
             const currentValue = this.extractCellValue(cell);
+
+            // Freeze column widths before inserting editor to prevent layout shift (issue #2244)
+            this._freezeColumnWidths();
 
             // Store reference to current editing cell
             this.currentEditingCell = {
@@ -2540,6 +2546,8 @@
             if (this.currentEditingCell.fixedDropdown && this.currentEditingCell.fixedDropdown.parentNode) {
                 this.currentEditingCell.fixedDropdown.parentNode.removeChild(this.currentEditingCell.fixedDropdown);
             }
+            // Unfreeze column widths now that the editor is removed (issue #2244)
+            this._unfreezeColumnWidths();
             this.currentEditingCell = null;
 
             // Navigate to the pending cell immediately, without waiting for the save (issue #1431)
@@ -2737,6 +2745,8 @@
                 if (this.currentEditingCell.outsideClickHandler) {
                     document.removeEventListener('click', this.currentEditingCell.outsideClickHandler);
                 }
+                // Unfreeze column widths (issue #2244)
+                this._unfreezeColumnWidths();
                 this.currentEditingCell = null;
 
                 this.showToast('Запись создана', 'success');
@@ -3018,6 +3028,9 @@
                 this.currentEditingCell.fixedDropdown.parentNode.removeChild(this.currentEditingCell.fixedDropdown);
             }
 
+            // Unfreeze column widths now that the editor is removed (issue #2244)
+            this._unfreezeColumnWidths();
+
             this.currentEditingCell = null;
 
             // Navigate to pending cell if set (issue #518)
@@ -3026,6 +3039,43 @@
                 this.pendingCellClick = null;
                 this.navigateToCell(targetCell);
             }
+        }
+
+        /**
+         * Snapshot all th widths and lock them as inline styles so the table layout
+         * does not shift when an inline editor replaces cell content (issue #2244).
+         * Only locks headers that don't already have an explicit width stored in
+         * this.columnWidths, so manually-resized columns are unaffected.
+         */
+        _freezeColumnWidths() {
+            if (!this.container) return;
+            const table = this.container.querySelector('.integram-table');
+            if (!table) return;
+            const headers = table.querySelectorAll('thead th');
+            this._frozenHeaders = [];
+            headers.forEach(th => {
+                const colId = th.dataset.columnId;
+                // Skip headers that already have an explicit pixel width (manually resized)
+                if (colId && this.columnWidths[colId]) return;
+                const w = th.offsetWidth;
+                if (w > 0) {
+                    th.style.width = w + 'px';
+                    th.style.minWidth = w + 'px';
+                    this._frozenHeaders.push(th);
+                }
+            });
+        }
+
+        /**
+         * Remove the inline width styles added by _freezeColumnWidths (issue #2244).
+         */
+        _unfreezeColumnWidths() {
+            if (!this._frozenHeaders) return;
+            this._frozenHeaders.forEach(th => {
+                th.style.width = '';
+                th.style.minWidth = '';
+            });
+            this._frozenHeaders = null;
         }
 
         /**
@@ -3053,6 +3103,8 @@
                 if (this.currentEditingCell.fixedDropdown && this.currentEditingCell.fixedDropdown.parentNode) {
                     this.currentEditingCell.fixedDropdown.parentNode.removeChild(this.currentEditingCell.fixedDropdown);
                 }
+                // Unfreeze column widths (issue #2244)
+                this._unfreezeColumnWidths();
                 this.currentEditingCell = null;
             }
 


### PR DESCRIPTION
## Problem

Despite PR #2241 fixing the row-height shift, the **column widths still shift** when editing a cell inline. The \"Формула\" column disappears and adjacent columns become wider while an editor is active (see issue screenshots).

## Root Cause

PR #2241 removed the `padding` override that caused row-height growth, but the underlying cause of column reflow was not addressed:

- The table uses `table-layout: auto` (browser default), so column widths are determined by content
- When an `<input>` or `<textarea>` is inserted into a cell, the browser recalculates all column widths based on the new content
- HTML input elements have an intrinsic minimum size that can push columns wider, overriding the auto-computed widths from before editing

## Fix

**JS (`js/integram-table/07-inline-edit.js`)**:

- `_freezeColumnWidths()`: called just before the inline editor is inserted. Reads the current rendered `offsetWidth` of each `th` and locks it via inline `style.width` / `style.minWidth`. Only freezes headers that don't already have a manually-saved width in `this.columnWidths`, so user-resized columns are unaffected.
- `_unfreezeColumnWidths()`: called when editing ends (save, cancel, or new-row cancel). Removes the temporary inline styles so the table returns to auto-layout.
- Called from `startInlineEdit`, `startNewRowFirstColumnEdit`, `saveInlineEdit`, `cancelInlineEdit`, `saveNewRowFirstColumn`, and `cancelNewRow`.

**CSS (`css/integram-table.css`)**:

- Added `min-width: 0` to `.inline-editor` as a CSS-level guard against the input's intrinsic size expanding the column width.

## How to reproduce

1. Open a table with multiple columns (e.g. Панель Операционные показатели: Строка)
2. Note the column widths before editing
3. Click a cell to edit it — columns should no longer shift

## Testing

The freeze/unfreeze cycle is symmetric: every edit path (regular save, cancel, Tab navigation, new row) now correctly unfreezes on exit.

Fixes #2244