### PR TITLE
Fix start page email code login

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-30T19:46:56.218Z for PR creation at branch issue-2248-385f04115e34 for issue https://github.com/ideav/crm/issues/2248

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-30T19:46:56.218Z for PR creation at branch issue-2248-385f04115e34 for issue https://github.com/ideav/crm/issues/2248

--- a/experiments/test-issue-2248-start-otp-endpoints.js
+++ b/experiments/test-issue-2248-start-otp-endpoints.js
@@ -1,0 +1,132 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+class FakeElement {
+    constructor(id) {
+        this.id = id;
+        this.value = '';
+        this.style = {};
+        this.dataset = {};
+        this.disabled = false;
+        this.textContent = '';
+        this.className = '';
+        this.listeners = {};
+        this.classList = {
+            add: () => {},
+            remove: () => {}
+        };
+    }
+
+    addEventListener(type, handler) {
+        this.listeners[type] = handler;
+    }
+
+    focus() {
+        this.focused = true;
+    }
+}
+
+const elements = {
+    'auth-db-select': new FakeElement('auth-db-select'),
+    'auth-db-custom': new FakeElement('auth-db-custom'),
+    'login-email': new FakeElement('login-email'),
+    'otp-btn': new FakeElement('otp-btn'),
+    'otp-message': new FakeElement('otp-message'),
+    'otp-code-group': new FakeElement('otp-code-group'),
+    'otp-code-input': new FakeElement('otp-code-input'),
+    'otp-submit-btn': new FakeElement('otp-submit-btn')
+};
+elements['auth-db-select'].value = 'demo';
+elements['login-email'].value = 'user@example.com';
+elements['otp-code-input'].value = 'ABCD';
+
+const fetchCalls = [];
+const cookieWrites = [];
+const documentStub = {
+    documentElement: { setAttribute: () => {} },
+    getElementById: id => elements[id] || null,
+    querySelectorAll: () => [],
+    addEventListener: () => {}
+};
+Object.defineProperty(documentStub, 'cookie', {
+    get() {
+        return '';
+    },
+    set(value) {
+        cookieWrites.push(value);
+    }
+});
+
+const responses = [
+    { ok: true, body: '{"msg":"ok"}' },
+    { ok: true, body: '{"token":"tok123","_xsrf":"xsrf123"}' }
+];
+
+const context = {
+    console,
+    document: documentStub,
+    window: {
+        location: {
+            hostname: 'app.test',
+            origin: 'https://app.test',
+            href: ''
+        }
+    },
+    localStorage: {
+        getItem: () => null,
+        setItem: () => {}
+    },
+    URLSearchParams,
+    FormData,
+    setTimeout: () => {},
+    fetch: async (url, options) => {
+        fetchCalls.push({ url, options });
+        const response = responses.shift();
+        return {
+            ok: response.ok,
+            async text() {
+                return response.body;
+            }
+        };
+    }
+};
+context.window.document = documentStub;
+
+vm.createContext(context);
+const source = fs.readFileSync('js/app.js', 'utf8');
+vm.runInContext(`${source}; this.App = App;`, context);
+
+(async () => {
+    const app = new context.App();
+    await app.init();
+
+    await elements['otp-btn'].listeners.click();
+    assert.strictEqual(fetchCalls[0].url, 'demo/getcode?JSON');
+    assert.strictEqual(fetchCalls[0].options.method, 'POST');
+    assert.strictEqual(fetchCalls[0].options.credentials, 'include');
+    assert.strictEqual(fetchCalls[0].options.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    const getCodeBody = new URLSearchParams(fetchCalls[0].options.body);
+    assert.strictEqual(getCodeBody.get('u'), 'user@example.com');
+    assert.strictEqual(getCodeBody.has('email'), false);
+    assert.strictEqual(elements['otp-code-group'].style.display, '');
+    assert.strictEqual(elements['otp-message'].textContent, 'Код отправлен на почту');
+
+    await elements['otp-submit-btn'].listeners.click();
+    assert.strictEqual(fetchCalls[1].url, 'demo/checkcode?JSON');
+    assert.strictEqual(fetchCalls[1].options.method, 'POST');
+    assert.strictEqual(fetchCalls[1].options.credentials, 'include');
+    assert.strictEqual(fetchCalls[1].options.headers['Content-Type'], 'application/x-www-form-urlencoded');
+    const checkCodeBody = new URLSearchParams(fetchCalls[1].options.body);
+    assert.strictEqual(checkCodeBody.get('u'), 'user@example.com');
+    assert.strictEqual(checkCodeBody.get('c'), 'ABCD');
+    assert.strictEqual(checkCodeBody.has('email'), false);
+    assert.strictEqual(checkCodeBody.has('otp'), false);
+    assert(cookieWrites.some(value => value.startsWith('idb_demo=tok123')), 'OTP login should persist returned token in idb_<db> cookie');
+    assert.strictEqual(context.window.location.href, 'https://app.test/demo');
+
+    console.log('issue-2248 start OTP endpoint test passed');
+})().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/js/app.js
+++ b/js/app.js
@@ -773,6 +773,9 @@ class App {
             if (isError) {
                 otpMessage.style.background = 'var(--bg-secondary)';
                 otpMessage.style.color = 'var(--error-color, #ef4444)';
+            } else {
+                otpMessage.style.background = '';
+                otpMessage.style.color = '';
             }
             otpMessage.textContent = text;
         }
@@ -788,21 +791,24 @@ class App {
                 if (!selectedDb) { showToast('Введите имя базы данных', 'error'); return; }
                 otpBtn.disabled = true;
                 try {
-                    const formData = new FormData();
-                    formData.append('email', emailVal);
-                    const response = await fetch(`${encodeURIComponent(selectedDb)}/otp`, {
+                    const formData = new URLSearchParams();
+                    formData.append('u', emailVal);
+                    const response = await fetch(`${encodeURIComponent(selectedDb)}/getcode?JSON`, {
                         method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                         credentials: 'include',
-                        body: formData
+                        body: formData.toString()
                     });
                     const text = await response.text();
                     let data = null;
                     try { data = JSON.parse(text); } catch (e) { data = null; }
-                    const isError = !response.ok || (data && (data.msg || '').toUpperCase().includes('ERROR'));
-                    showOtpMessage(
-                        (data && (data.msg || data.message || data.details)) || text,
-                        isError
-                    );
+                    const isError = !response.ok || !data || !!data.error || data.msg !== 'ok';
+                    const message = data && data.msg === 'ok'
+                        ? 'Код отправлен на почту'
+                        : (data && data.msg === 'new'
+                            ? 'Пользователь с таким email не найден'
+                            : ((data && (data.error || data.message || data.details || data.msg)) || text || 'Ошибка при отправке кода'));
+                    showOtpMessage(message, isError);
                     if (!isError && otpCodeGroup) {
                         otpCodeGroup.style.display = '';
                         if (otpCodeInput) otpCodeInput.focus();
@@ -825,22 +831,24 @@ class App {
                 if (!selectedDb) { showToast('Введите имя базы данных', 'error'); return; }
                 otpSubmitBtn.disabled = true;
                 try {
-                    const formData = new FormData();
-                    formData.append('email', emailVal);
-                    formData.append('otp', codeVal);
-                    const response = await fetch(`${encodeURIComponent(selectedDb)}/otp`, {
+                    const formData = new URLSearchParams();
+                    formData.append('u', emailVal);
+                    formData.append('c', codeVal);
+                    const response = await fetch(`${encodeURIComponent(selectedDb)}/checkcode?JSON`, {
                         method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                         credentials: 'include',
-                        body: formData
+                        body: formData.toString()
                     });
                     const text = await response.text();
                     let data = null;
                     try { data = JSON.parse(text); } catch (e) { data = null; }
-                    if (data && data.token && (data.msg === '' || data.msg == null)) {
+                    if (response.ok && data && data.token) {
+                        CookieUtil.set('idb_' + selectedDb, data.token, 30);
                         CookieUtil.set('last_db', selectedDb, 365);
                         window.location.href = window.location.origin + '/' + selectedDb;
                     } else {
-                        const errText = (data && (data.msg || data.message)) || text || 'Неверный код';
+                        const errText = (data && (data.error || data.msg || data.message)) || text || 'Неверный код';
                         showOtpMessage(errText, true);
                         otpSubmitBtn.disabled = false;
                     }


### PR DESCRIPTION
Fixes #2248

## Summary
- Updated the start-page email code flow to use the existing `index.php` actions: `getcode?JSON` for sending the code and `checkcode?JSON` for validating it.
- Switched the OTP requests to the backend's expected `u` and `c` form fields.
- Persisted the returned token into `idb_<db>` before redirecting after successful code login.

## Reproduction
Before this change, the start page posted OTP requests to `/{db}/otp` with `email`/`otp`, but that endpoint is not implemented in `index.php`.

## Tests
- `node experiments/test-issue-2248-start-otp-endpoints.js`
- `node experiments/test-issue-1976-register-endpoint.js`
- `node experiments/test-issue-1965-logout.js`
- `node experiments/test-issue-781-token-validation-on-selection.js`
- `php -l index.php`
- `git diff --check`