### PR TITLE
Handle Enter for start OTP code login

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-30T20:33:09.118Z for PR creation at branch issue-2250-b117778f360c for issue https://github.com/ideav/crm/issues/2250

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-30T20:33:09.118Z for PR creation at branch issue-2250-b117778f360c for issue https://github.com/ideav/crm/issues/2250

--- a/experiments/test-issue-2248-start-otp-endpoints.js
+++ b/experiments/test-issue-2248-start-otp-endpoints.js
@@ -112,7 +112,12 @@ vm.runInContext(`${source}; this.App = App;`, context);
     assert.strictEqual(elements['otp-code-group'].style.display, '');
     assert.strictEqual(elements['otp-message'].textContent, 'Код отправлен на почту');
 
-    await elements['otp-submit-btn'].listeners.click();
+    await elements['otp-code-input'].listeners.keydown({
+        key: 'Enter',
+        preventDefault() {
+            this.defaultPrevented = true;
+        }
+    });
     assert.strictEqual(fetchCalls[1].url, 'demo/checkcode?JSON');
     assert.strictEqual(fetchCalls[1].options.method, 'POST');
     assert.strictEqual(fetchCalls[1].options.credentials, 'include');

--- a/js/app.js
+++ b/js/app.js
@@ -821,41 +821,52 @@ class App {
             });
         }
 
+        async function submitOtpCode() {
+            const emailVal = loginEmailInput ? loginEmailInput.value.trim() : '';
+            const codeVal = otpCodeInput ? otpCodeInput.value.trim() : '';
+            if (!codeVal) { showToast('Введите код из письма', 'error'); return; }
+            const selectedDb = getSelectedDb();
+            if (!selectedDb) { showToast('Введите имя базы данных', 'error'); return; }
+            if (otpSubmitBtn) otpSubmitBtn.disabled = true;
+            try {
+                const formData = new URLSearchParams();
+                formData.append('u', emailVal);
+                formData.append('c', codeVal);
+                const response = await fetch(`${encodeURIComponent(selectedDb)}/checkcode?JSON`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    credentials: 'include',
+                    body: formData.toString()
+                });
+                const text = await response.text();
+                let data = null;
+                try { data = JSON.parse(text); } catch (e) { data = null; }
+                if (response.ok && data && data.token) {
+                    CookieUtil.set('idb_' + selectedDb, data.token, 30);
+                    CookieUtil.set('last_db', selectedDb, 365);
+                    window.location.href = window.location.origin + '/' + selectedDb;
+                } else {
+                    const errText = (data && (data.error || data.msg || data.message)) || text || 'Неверный код';
+                    showOtpMessage(errText, true);
+                    if (otpSubmitBtn) otpSubmitBtn.disabled = false;
+                }
+            } catch (err) {
+                showOtpMessage(err.message || 'Ошибка при проверке кода', true);
+                if (otpSubmitBtn) otpSubmitBtn.disabled = false;
+            }
+        }
+
         // Step 2: submit OTP code → login
         if (otpSubmitBtn) {
-            otpSubmitBtn.addEventListener('click', async () => {
-                const emailVal = loginEmailInput ? loginEmailInput.value.trim() : '';
-                const codeVal = otpCodeInput ? otpCodeInput.value.trim() : '';
-                if (!codeVal) { showToast('Введите код из письма', 'error'); return; }
-                const selectedDb = getSelectedDb();
-                if (!selectedDb) { showToast('Введите имя базы данных', 'error'); return; }
-                otpSubmitBtn.disabled = true;
-                try {
-                    const formData = new URLSearchParams();
-                    formData.append('u', emailVal);
-                    formData.append('c', codeVal);
-                    const response = await fetch(`${encodeURIComponent(selectedDb)}/checkcode?JSON`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                        credentials: 'include',
-                        body: formData.toString()
-                    });
-                    const text = await response.text();
-                    let data = null;
-                    try { data = JSON.parse(text); } catch (e) { data = null; }
-                    if (response.ok && data && data.token) {
-                        CookieUtil.set('idb_' + selectedDb, data.token, 30);
-                        CookieUtil.set('last_db', selectedDb, 365);
-                        window.location.href = window.location.origin + '/' + selectedDb;
-                    } else {
-                        const errText = (data && (data.error || data.msg || data.message)) || text || 'Неверный код';
-                        showOtpMessage(errText, true);
-                        otpSubmitBtn.disabled = false;
-                    }
-                } catch (err) {
-                    showOtpMessage(err.message || 'Ошибка при проверке кода', true);
-                    otpSubmitBtn.disabled = false;
+            otpSubmitBtn.addEventListener('click', submitOtpCode);
+        }
+        if (otpCodeInput) {
+            otpCodeInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    return submitOtpCode();
                 }
+                return undefined;
             });
         }
 


### PR DESCRIPTION
## Summary
- Reuse the OTP code submission logic for both the "Войти по коду" button and Enter in the code input.
- Keep the existing OTP endpoint behavior unchanged while preventing the browser default Enter action.
- Extend the existing OTP endpoint experiment to verify Enter submits the code and completes login.

Fixes #2250

## Reproduce
1. Open `start.html` and request an email login code.
2. Type the received code into the code input.
3. Press Enter.

Before this change, Enter did not trigger the code login action. After this change, Enter submits the same request as clicking "Войти по коду".

## Tests
- `node experiments/test-issue-2248-start-otp-endpoints.js`
- `git diff --check`
