### PR TITLE
Hide password login controls after email code send

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252

--- a/experiments/test-issue-2248-start-otp-endpoints.js
+++ b/experiments/test-issue-2248-start-otp-endpoints.js
@@ -22,6 +22,14 @@ class FakeElement {
         this.listeners[type] = handler;
     }
 
+    removeAttribute(name) {
+        this[name] = false;
+    }
+
+    setAttribute(name, value) {
+        this[name] = value === '' ? true : value;
+    }
+
     focus() {
         this.focused = true;
     }
@@ -31,6 +39,10 @@ const elements = {
     'auth-db-select': new FakeElement('auth-db-select'),
     'auth-db-custom': new FakeElement('auth-db-custom'),
     'login-email': new FakeElement('login-email'),
+    'login-password': new FakeElement('login-password'),
+    'login-password-group': new FakeElement('login-password-group'),
+    'login-captcha-container': new FakeElement('login-captcha-container'),
+    'login-submit-btn': new FakeElement('login-submit-btn'),
     'otp-btn': new FakeElement('otp-btn'),
     'otp-message': new FakeElement('otp-message'),
     'otp-code-group': new FakeElement('otp-code-group'),
@@ -110,6 +122,11 @@ vm.runInContext(`${source}; this.App = App;`, context);
     assert.strictEqual(getCodeBody.get('u'), 'user@example.com');
     assert.strictEqual(getCodeBody.has('email'), false);
     assert.strictEqual(elements['otp-code-group'].style.display, '');
+    assert.strictEqual(elements['login-password-group'].style.display, 'none');
+    assert.strictEqual(elements['login-captcha-container'].style.display, 'none');
+    assert.strictEqual(elements['login-submit-btn'].style.display, 'none');
+    assert.strictEqual(elements['otp-btn'].style.display, 'none');
+    assert.strictEqual(elements['login-password'].required, false);
     assert.strictEqual(elements['otp-message'].textContent, 'Код отправлен на почту');
 
     await elements['otp-submit-btn'].listeners.click();

--- a/js/app.js
+++ b/js/app.js
@@ -691,6 +691,7 @@ class App {
             backToLoginLink.addEventListener('click', (e) => {
                 e.preventDefault();
                 exitResetMode();
+                exitOtpCodeMode();
             });
         }
 
@@ -755,6 +756,8 @@ class App {
         const otpCodeGroup = document.getElementById('otp-code-group');
         const otpCodeInput = document.getElementById('otp-code-input');
         const otpSubmitBtn = document.getElementById('otp-submit-btn');
+        const loginCaptchaContainer = document.getElementById('login-captcha-container');
+        const loginPasswordInput = document.getElementById('login-password');
 
         function getSelectedDb() {
             const dbSelect = document.getElementById('auth-db-select');
@@ -778,6 +781,26 @@ class App {
                 otpMessage.style.color = '';
             }
             otpMessage.textContent = text;
+        }
+
+        function enterOtpCodeMode() {
+            if (otpCodeGroup) otpCodeGroup.style.display = '';
+            if (loginPasswordGroup) loginPasswordGroup.style.display = 'none';
+            if (loginCaptchaContainer) loginCaptchaContainer.style.display = 'none';
+            if (loginSubmitBtn) loginSubmitBtn.style.display = 'none';
+            if (otpBtn) otpBtn.style.display = 'none';
+            if (loginPasswordInput) loginPasswordInput.removeAttribute('required');
+            if (otpCodeInput) otpCodeInput.focus();
+        }
+
+        function exitOtpCodeMode() {
+            if (otpCodeGroup) otpCodeGroup.style.display = 'none';
+            if (loginPasswordGroup) loginPasswordGroup.style.display = '';
+            if (loginCaptchaContainer) loginCaptchaContainer.style.display = '';
+            if (loginSubmitBtn) loginSubmitBtn.style.display = '';
+            if (otpBtn) otpBtn.style.display = '';
+            if (loginPasswordInput) loginPasswordInput.setAttribute('required', '');
+            if (otpMessage) otpMessage.style.display = 'none';
         }
 
         // Step 1: send email → request OTP code
@@ -809,10 +832,7 @@ class App {
                             ? 'Пользователь с таким email не найден'
                             : ((data && (data.error || data.message || data.details || data.msg)) || text || 'Ошибка при отправке кода'));
                     showOtpMessage(message, isError);
-                    if (!isError && otpCodeGroup) {
-                        otpCodeGroup.style.display = '';
-                        if (otpCodeInput) otpCodeInput.focus();
-                    }
+                    if (!isError) enterOtpCodeMode();
                 } catch (err) {
                     showOtpMessage(err.message || 'Ошибка при отправке кода', true);
                 } finally {


### PR DESCRIPTION
## Summary
- Hide the password field, SmartCaptcha, "Войти", and "Код на почту" controls after a login code is successfully sent by email.
- Keep only the email-code entry flow visible and remove the password required constraint while entering the code.
- Extend the existing OTP experiment test to verify the UI state after a successful getcode response.

## Reproduction
1. Open start.html and choose email-code login.
2. Enter a valid email and click "Код на почту".
3. Before this change, the password login controls and captcha remained visible next to the code entry field.

## Verification
- node experiments/test-issue-2248-start-otp-endpoints.js
- node --check js/app.js
- git diff --check

Fixes #2252