### PR TITLE
Remove duplicate main.js load from templates/dash.html

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
+# Updated: 2026-05-02T15:24:05.163Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
-# Updated: 2026-05-02T15:24:05.163Z

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -33,5 +33,4 @@
 <!-- Readonly tooltip -->
 <div class="dash-readonly-tip" id="dash-readonly-tip">Только чтение</div>
 
-<script src="/js/main.js"></script>
 <script src="/js/dash.js"></script>


### PR DESCRIPTION
## Problem

`templates/dash.html` contained `<script src="/js/main.js"></script>`, but `dash.html` is always embedded inside `main.html` via the template engine (`<!-- File: a -->` placeholder). `main.html` already loads `/js/main.js` at line 274, so including it again in `dash.html` caused the script to execute twice on every dash page.

## Fix

Removed the redundant `<script src="/js/main.js"></script>` from `templates/dash.html` (line 36). The `dash.js` load that followed it is preserved.

## How to verify

1. Open any dash page in the CRM
2. In browser DevTools → Network tab → filter by `main.js`
3. Before fix: `main.js` appears twice in the network requests
4. After fix: `main.js` appears only once


Fixes #2258