### PR TITLE
Fix ReferenceError: newApi is not defined on dash pages

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
+# Updated: 2026-05-02T16:27:15.167Z

--- a/templates/main.html
+++ b/templates/main.html
@@ -256,6 +256,7 @@
             <div class="sidebar-resize-handle"></div>
         </aside>
 
+        <script src="/js/main.js"></script>
         <!-- Main Content Area -->
         <main class="app-content">
             <!-- File: a -->
@@ -271,7 +272,6 @@
     </script>
     <script src="/js/app.js"></script>
     <script src="/js/main-app.js"></script>
-    <script src="/js/main.js"></script>
     <script>
     function changePwd(){
         var oldPwd=document.getElementById('old-pwd').value,


### PR DESCRIPTION
## Root Cause

PR #2259 removed the duplicate `<script src="/js/main.js">` from `templates/dash.html`. That script appeared redundant because `main.html` already loads `main.js`. However, `main.html` loaded `main.js` **after** the `<!-- File: a -->` placeholder where `dash.html` content (including `<script src="/js/dash.js">`) is injected.

Since browser scripts execute in DOM order, `dash.js` ran before `main.js` was loaded, leaving `newApi` undefined.

```
templates/main.html layout (before this fix):
  ...
  <main>
    <!-- File: a -->  ← dash.html injected here, including <script src="/js/dash.js">
  </main>
  <script src="/js/app.js"></script>
  <script src="/js/main-app.js"></script>
  <script src="/js/main.js"></script>  ← newApi defined here, but too late!
```

## Fix

Move `<script src="/js/main.js">` to before the `<!-- File: a -->` placeholder in `templates/main.html`. This ensures `newApi` is defined before any page-specific script runs.

```
templates/main.html layout (after this fix):
  ...
  <script src="/js/main.js"></script>  ← newApi defined here ✓
  <main>
    <!-- File: a -->  ← dash.js runs, newApi already available ✓
  </main>
  <script src="/js/app.js"></script>
  <script src="/js/main-app.js"></script>
```

## How to verify

1. Open any dash page in the CRM
2. Open DevTools Console — the `Uncaught ReferenceError: newApi is not defined` error should be gone
3. The dashboard should load and function normally

Fixes #2264