### PR TITLE
Fix TypeError: Cannot read properties of undefined (reading 'pivotUI')

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
-# Updated: 2026-05-02T16:41:10.972Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
+# Updated: 2026-05-02T16:41:10.972Z

--- a/js/dash.js
+++ b/js/dash.js
@@ -1289,7 +1289,7 @@ function dashEnsureChartJs(cb) {
 }
 
 function dashEnsurePivotJs(cb) {
-    if (window.$.pivotUI) { cb(); return; }
+    if (window.jQuery && window.jQuery.fn && window.jQuery.fn.pivotUI) { cb(); return; }
     // Load pivottable.js CSS
     if (!document.getElementById('pivottable-css')) {
         var lnk = document.createElement('link');


### PR DESCRIPTION
## Summary

Fixes the `Uncaught TypeError: Cannot read properties of undefined (reading 'pivotUI')` crash reported in #2266.

## Root Cause

In `dashEnsurePivotJs` (dash.js:1292), the early-return guard was:

```js
if (window.$.pivotUI) { cb(); return; }
```

`window.$` can be `undefined` when jQuery has not yet loaded, causing the property access to throw. This is exactly the crash stack reported:

```
dash.js:1291 Uncaught TypeError: Cannot read properties of undefined (reading 'pivotUI')
    at dashEnsurePivotJs (dash.js:1291:18)
    at dashRenderPivot (dash.js:1395:9)
    at dashRenderChart (dash.js:1331:9)
```

## Fix

Use the same safe guard that `dashRenderPivot` already uses:

```js
if (window.jQuery && window.jQuery.fn && window.jQuery.fn.pivotUI) { cb(); return; }
```

This checks that jQuery exists before accessing its properties, preventing the crash.

## How to Reproduce / Verify

1. Open a dashboard page that has a panel with a pivot table visualization configured.
2. Before the fix: clicking the pivot view icon throws the TypeError in the console.
3. After the fix: the pivot table renders correctly without errors.

Fixes #2266