### PR TITLE
Fix pivot table crash: load jQuery before pivot.min.js

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
+# Updated: 2026-05-02T18:29:27.954Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
-# Updated: 2026-05-02T18:29:27.954Z

--- a/js/dash.js
+++ b/js/dash.js
@@ -1298,10 +1298,21 @@ function dashEnsurePivotJs(cb) {
         lnk.href = 'https://cdn.jsdelivr.net/npm/pivottable@2/dist/pivot.min.css';
         document.head.appendChild(lnk);
     }
-    var s = document.createElement('script');
-    s.src = 'https://cdn.jsdelivr.net/npm/pivottable@2/dist/pivot.min.js';
-    s.onload = cb;
-    document.head.appendChild(s);
+    function loadPivot() {
+        var s = document.createElement('script');
+        s.src = 'https://cdn.jsdelivr.net/npm/pivottable@2/dist/pivot.min.js';
+        s.onload = cb;
+        document.head.appendChild(s);
+    }
+    // pivot.min.js requires jQuery — load it first if not present
+    if (!window.jQuery) {
+        var jq = document.createElement('script');
+        jq.src = 'https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js';
+        jq.onload = loadPivot;
+        document.head.appendChild(jq);
+    } else {
+        loadPivot();
+    }
 }
 
 function dashRenderChart(panelEl, vizType, fieldMap) {


### PR DESCRIPTION
## Root Cause

`pivot.min.js` (compiled from `pivot.coffee`) requires jQuery to be present on the page. The dashboard template (`templates/dash.html`) does not include jQuery, so when a user switches a panel to the **Сводная таблица (pivot)** view for the first time, `dashEnsurePivotJs` would load `pivot.min.js` without jQuery being available, producing:

```
pivot.coffee:8 Uncaught ReferenceError: jQuery is not defined
```

This was a follow-on error that also triggered:

```
dash.js:1291 Uncaught TypeError: Cannot read properties of undefined (reading 'pivotUI')
```

(reported in #2266).

## Fix

`dashEnsurePivotJs` in `js/dash.js` now checks whether `window.jQuery` exists before loading `pivot.min.js`. If jQuery is absent, it first loads jQuery 3.x from CDN, then chains the `pivot.min.js` load in the `onload` callback. If jQuery is already present (e.g., on pages that include it via another template), it loads `pivot.min.js` directly as before.

## How to verify

1. Open a dashboard as admin.
2. Hover over a panel → click the chart settings icon.
3. Enable **Сводная таблица**, mark as default, save.
4. Panel renders the pivot table with no console errors.

Fixes #2268