### PR TITLE
Fix chart axes: columns as X-axis labels, rows as datasets

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
-# Updated: 2026-05-02T18:53:18.096Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
+# Updated: 2026-05-02T18:53:18.096Z

--- a/js/dash.js
+++ b/js/dash.js
@@ -1242,36 +1242,36 @@ function dashPanelGetRows(panelEl) {
 }
 
 function dashCollectPanelData(panelEl) {
-    var labels = [], datasets = [], cols = dashPanelGetColumns(panelEl);
-    panelEl.querySelectorAll('.f-item').forEach(function(tr) {
-        labels.push(tr.getAttribute('item-name') || '');
-    });
+    var datasets = [], cols = dashPanelGetColumns(panelEl);
+    var itemRows = Array.from(panelEl.querySelectorAll('.f-item'));
 
     if (cols.length === 0) {
-        // Single value column
-        var vals = [];
-        panelEl.querySelectorAll('.f-item').forEach(function(tr) {
+        // Single value column — one dataset, labels are row names
+        var labels = [], vals = [];
+        itemRows.forEach(function(tr) {
+            labels.push(tr.getAttribute('item-name') || '');
             var td = tr.querySelector('td.f-cell');
             vals.push(dashGetFloat(td ? td.textContent.trim() : '') || 0);
         });
         datasets.push({ label: '', data: vals });
-    } else {
-        cols.forEach(function(col, ci) {
-            var vals = [];
-            panelEl.querySelectorAll('.f-item').forEach(function(tr) {
-                var cells = Array.from(tr.querySelectorAll('td.f-cell'));
-                // Find cells matching this column
-                var matching = cells.filter(function(td) {
-                    return (td.dataset.rgCol || '') === col || (td.dataset.rgHead || '') === col;
-                });
-                var sum = 0;
-                matching.forEach(function(td) { sum += dashGetFloat(td.textContent.trim()) || 0; });
-                vals.push(matching.length ? sum : 0);
-            });
-            datasets.push({ label: col, data: vals });
-        });
+        return { labels: labels, datasets: datasets };
     }
-    return { labels: labels, datasets: datasets };
+
+    // Multiple columns: columns are X-axis labels, each row is a dataset
+    itemRows.forEach(function(tr) {
+        var rowName = tr.getAttribute('item-name') || '';
+        var vals = cols.map(function(col) {
+            var cells = Array.from(tr.querySelectorAll('td.f-cell'));
+            var matching = cells.filter(function(td) {
+                return (td.dataset.rgCol || '') === col || (td.dataset.rgHead || '') === col;
+            });
+            var sum = 0;
+            matching.forEach(function(td) { sum += dashGetFloat(td.textContent.trim()) || 0; });
+            return matching.length ? sum : 0;
+        });
+        datasets.push({ label: rowName, data: vals });
+    });
+    return { labels: cols, datasets: datasets };
 }
 
 var CHART_COLORS = [


### PR DESCRIPTION
## Problem

In `dashCollectPanelData` (js/dash.js), for panels with multiple columns (e.g. months across the top), the data was collected with:
- **labels** = row names (task types like "Кол-во задач в работе")
- **datasets** = one per column (month)

This meant the chart showed months in the legend and task-type names on the X-axis — the opposite of the table layout.

## Fix

For multi-column panels, transpose the mapping:
- **labels** = column names (months) → X-axis
- **datasets** = one per row item (task type) → legend series

Single-column panels are unchanged (labels = row names, one dataset of values).

## How to reproduce

Open a dashboard panel that has rows (e.g. task types) and date-period columns (months). Switch to line/bar/area chart view. Before this fix the chart showed task types on X-axis; after the fix it shows months on X-axis with task types as named series.

Fixes #2270