### PR TITLE
Fix chart showing all zeros for report-type dashboard panels

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-30T20:34:52.114Z for PR creation at branch issue-2252-ec4b755f35e8 for issue https://github.com/ideav/crm/issues/2252
 # Updated: 2026-05-02T16:27:15.167Z
+# Updated: 2026-05-02T19:05:58.832Z

--- a/experiments/test-issue-2272-chart-data-zeros.js
+++ b/experiments/test-issue-2272-chart-data-zeros.js
@@ -1,0 +1,228 @@
+// Test for issue #2272: chart data shows all zeros for report-type (f-col-cell) panels
+// Root cause: dashCollectPanelData matched cells by data-rg-col/data-rg-head attributes,
+// but f-col-cell cells (report source) didn't have these attributes, so all values were 0.
+// Fix: add data-rg-col attribute when building f-col-cell cells in dashDrawPeriods.
+
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error('FAIL: ' + message);
+    console.log('PASS: ' + message);
+}
+
+// Minimal DOM simulation for dashCollectPanelData
+function makeCell(rgCol, value) {
+    return {
+        tagName: 'TD',
+        className: 'f-cell f-col-cell',
+        dataset: rgCol ? { rgCol: rgCol } : {},
+        textContent: String(value),
+        querySelectorAll(selector) { return []; }
+    };
+}
+
+function makeHeadTh(text, rgCol) {
+    return {
+        tagName: 'TH',
+        getAttribute(name) {
+            if (name === 'data-rg-col') return rgCol || null;
+            return null;
+        },
+        textContent: text
+    };
+}
+
+function makeItemRow(name, cells) {
+    return {
+        getAttribute(name) { return name === 'item-name' ? name : null; },
+        querySelectorAll(selector) {
+            if (selector === 'td.f-cell') return cells;
+            return [];
+        },
+        _name: name
+    };
+}
+
+// Override getAttribute for item rows to return name
+function makeItemRowNamed(name, cells) {
+    return {
+        getAttribute(attr) { return attr === 'item-name' ? name : null; },
+        querySelectorAll(selector) {
+            if (selector === 'td.f-cell') return cells;
+            return [];
+        }
+    };
+}
+
+function makePanelEl(headThs, subheadThs, itemRows) {
+    return {
+        querySelector(selector) {
+            if (selector === 'thead .f-subhead') {
+                return subheadThs ? {
+                    querySelectorAll(s) {
+                        if (s === 'th') return subheadThs;
+                        return [];
+                    }
+                } : null;
+            }
+            if (selector === 'thead .f-head') {
+                return {
+                    querySelectorAll(s) {
+                        if (s === 'th') return headThs;
+                        return [];
+                    }
+                };
+            }
+            return null;
+        },
+        querySelectorAll(selector) {
+            if (selector === '.f-item') return itemRows;
+            return [];
+        }
+    };
+}
+
+// Extract functions from dash.js
+const code = `
+${extractFunction('dashNormalizeNumberText')}
+${extractFunction('dashGetFloat')}
+${extractFunction('dashPanelGetColumns')}
+${extractFunction('dashPanelGetRows')}
+${extractFunction('dashCollectPanelData')}
+`;
+
+const ctx = { console, window: {} };
+vm.createContext(ctx);
+vm.runInContext(code, ctx);
+
+const { dashCollectPanelData, dashPanelGetColumns } = ctx;
+
+// ---- Test 1: f-col-cell cells WITH data-rg-col (the fix applied) ----
+// Panel with columns "Завершена", "В работе", "Отложена"
+// Each row has cells with data-rg-col matching the column name
+{
+    const headThs = [
+        makeHeadTh(''),          // spacer at idx 0
+        makeHeadTh('Завершена'),
+        makeHeadTh('В работе'),
+        makeHeadTh('Отложена'),
+    ];
+
+    const row1Cells = [
+        makeCell('Завершена', '41'),
+        makeCell('В работе', '6'),
+        makeCell('Отложена', '0'),
+    ];
+
+    const panelEl = makePanelEl(headThs, null, [
+        makeItemRowNamed('Тип задачи 1', row1Cells)
+    ]);
+
+    const data = dashCollectPanelData(panelEl);
+
+    assert(data.labels.length === 3, 'labels should have 3 columns');
+    assert(data.labels[0] === 'Завершена', 'first label should be Завершена');
+    assert(data.labels[1] === 'В работе', 'second label should be В работе');
+    assert(data.labels[2] === 'Отложена', 'third label should be Отложена');
+    assert(data.datasets.length === 1, 'should have 1 dataset (one row)');
+    assert(data.datasets[0].data[0] === 41, 'Завершена value should be 41');
+    assert(data.datasets[0].data[1] === 6, 'В работе value should be 6');
+    assert(data.datasets[0].data[2] === 0, 'Отложена value should be 0');
+}
+
+// ---- Test 2: Multiple rows ----
+{
+    const headThs = [
+        makeHeadTh(''),
+        makeHeadTh('Завершена'),
+        makeHeadTh('В работе'),
+    ];
+
+    const row1Cells = [
+        makeCell('Завершена', '113'),
+        makeCell('В работе', '2'),
+    ];
+    const row2Cells = [
+        makeCell('Завершена', '162'),
+        makeCell('В работе', '4'),
+    ];
+
+    const panelEl = makePanelEl(headThs, null, [
+        makeItemRowNamed('Тип 1', row1Cells),
+        makeItemRowNamed('Тип 2', row2Cells),
+    ]);
+
+    const data = dashCollectPanelData(panelEl);
+
+    assert(data.datasets.length === 2, 'should have 2 datasets (two rows)');
+    assert(data.datasets[0].data[0] === 113, 'row1 Завершена should be 113');
+    assert(data.datasets[0].data[1] === 2, 'row1 В работе should be 2');
+    assert(data.datasets[1].data[0] === 162, 'row2 Завершена should be 162');
+    assert(data.datasets[1].data[1] === 4, 'row2 В работе should be 4');
+}
+
+// ---- Test 3: Cells WITHOUT data-rg-col (old broken behavior) — all zeros ----
+{
+    const headThs = [
+        makeHeadTh(''),
+        makeHeadTh('Завершена'),
+        makeHeadTh('В работе'),
+    ];
+
+    // Cells with no data-rg-col (simulates old f-col-cell without the fix)
+    const row1CellsNoCols = [
+        makeCell(null, '41'),   // no data-rg-col
+        makeCell(null, '6'),    // no data-rg-col
+    ];
+
+    const panelEl = makePanelEl(headThs, null, [
+        makeItemRowNamed('Тип 1', row1CellsNoCols)
+    ]);
+
+    const data = dashCollectPanelData(panelEl);
+
+    // Without data-rg-col, all values should be 0 (old broken behavior)
+    assert(data.datasets[0].data[0] === 0, 'without data-rg-col, value should be 0 (old broken behavior verified)');
+    assert(data.datasets[0].data[1] === 0, 'without data-rg-col, value should be 0 (old broken behavior verified)');
+}
+
+// ---- Test 4: Single column (no cols case) ----
+{
+    const headThs = [makeHeadTh('')]; // only spacer, no extra columns
+
+    const singleCell = { tagName: 'TD', className: 'f-cell', dataset: {}, textContent: '42', querySelectorAll() { return []; } };
+
+    const singleRow = {
+        getAttribute(attr) { return attr === 'item-name' ? 'Показатель' : null; },
+        querySelector(selector) { return selector === 'td.f-cell' ? singleCell : null; },
+        querySelectorAll(selector) { return selector === 'td.f-cell' ? [singleCell] : []; }
+    };
+
+    const panelEl = makePanelEl(headThs, null, [singleRow]);
+
+    const data = dashCollectPanelData(panelEl);
+
+    assert(data.labels.length === 1, 'single-col: labels should have 1 item (row name)');
+    assert(data.datasets.length === 1, 'single-col: should have 1 dataset');
+    assert(data.datasets[0].data[0] === 42, 'single-col: value should be 42');
+}
+
+console.log('\nAll tests passed!');

--- a/js/dash.js
+++ b/js/dash.js
@@ -877,6 +877,7 @@ function dashDrawPeriods() {
                                             v = dashGetColVal(itemName, col);
                                             if (v || dashFormulas[row.id] === '[]') ready = 1;
                                         }
+                                        extra += ' data-rg-col="' + dashAttr(col) + '"';
                                         row.insertAdjacentHTML('beforeend',
                                             cellTpl.replace(':val:', dashNormalizeVal(row.id, v || ''))
                                                 .replace(':ready:', ready)


### PR DESCRIPTION
## Problem

When a dashboard panel uses a report as its data source (the `default` case in `dashDrawPeriods`), switching to chart view showed all values as **zero**.

### Root cause

`dashCollectPanelData` matches each cell to its column by checking `data-rg-col` and `data-rg-head` attributes. However, `f-col-cell` cells (built from report-source data) were created **without** these attributes — only `f-rg-cell` cells (RG-type columns) had them. Since no cell matched any column, every value resolved to 0.

### Fix

Add `data-rg-col` when inserting `f-col-cell` nodes in `dashDrawPeriods` (`js/dash.js`, line ~880). This applies to both the plain report path and the matrix path, so column matching works correctly in charts for all panel types.

### How to reproduce

Open a dashboard panel whose data comes from a report with multiple columns (e.g. task statuses: "Завершена", "В работе", "Отложена"). Switch to line/bar/area chart. Before the fix all bars/lines are at 0; after the fix they show correct values.

### Test

`experiments/test-issue-2272-chart-data-zeros.js` — verifies that:
1. Cells with `data-rg-col` produce correct values in chart data
2. Multiple rows each get their correct dataset values
3. Cells without `data-rg-col` (old behavior) return 0 — confirming the bug and the fix

Fixes #2272