### PR TITLE
Fix dashboard local panelFilter handling

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T06:14:51.357Z for PR creation at branch issue-2352-a271d77c863d for issue https://github.com/ideav/crm/issues/2352

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T06:14:51.357Z for PR creation at branch issue-2352-a271d77c863d for issue https://github.com/ideav/crm/issues/2352

--- a/experiments/test-issue-2352-dashboard-local-panel-filter.js
+++ b/experiments/test-issue-2352-dashboard-local-panel-filter.js
@@ -1,0 +1,194 @@
+'use strict';
+
+// Issue #2352: panelFilter values like "Field:Value" must not be sent to
+// report URLs. They are panel-local filters applied to the loaded report rows.
+
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+const urlCtx = {};
+vm.createContext(urlCtx);
+vm.runInContext(`
+${extractFunction('dashNormalizePanelFilter')}
+${extractFunction('dashReportKey')}
+${extractFunction('dashReportUrl')}
+${extractFunction('dashVizReportKey')}
+${extractFunction('dashVizReportUrl')}
+`, urlCtx);
+
+assert.strictEqual(
+    urlCtx.dashReportUrl('Документы', '01.01.2026', '31.12.2026', 'Тип документаID:158844'),
+    'report/Документы?JSON_KV&FR_Date=01.01.2026&TO_Date=31.12.2026',
+    'colon panelFilter must not be appended to formula report requests'
+);
+assert.strictEqual(
+    urlCtx.dashVizReportUrl('158891', '01.01.2026', '31.12.2026', 'Тип документаID:158844'),
+    'report/158891?JSON&FR_Date=01.01.2026&TO_Date=31.12.2026',
+    'colon panelFilter must not be appended to panel report requests'
+);
+assert.strictEqual(
+    urlCtx.dashVizReportUrl('158891', '01.01.2026', '31.12.2026', 'FR_dept=IN(2889)'),
+    'report/158891?JSON&FR_Date=01.01.2026&TO_Date=31.12.2026&FR_dept=IN(2889)',
+    'equals panelFilter must still be appended to panel report requests'
+);
+assert.strictEqual(
+    urlCtx.dashVizReportUrl('158891', '01.01.2026', '31.12.2026', '?FR_dept=IN(2889)&Тип%20документаID:158844'),
+    'report/158891?JSON&FR_Date=01.01.2026&TO_Date=31.12.2026&FR_dept=IN(2889)',
+    'mixed panelFilter values must append only server-side query parts'
+);
+assert.strictEqual(
+    urlCtx.dashReportKey('Документы', 'Тип документаID:158844'),
+    urlCtx.dashReportKey('Документы', ''),
+    'local-only filters must share the same server report cache key'
+);
+assert.notStrictEqual(
+    urlCtx.dashReportKey('Документы', 'FR_dept=IN(2889)'),
+    urlCtx.dashReportKey('Документы', ''),
+    'server filters must remain part of the report cache key'
+);
+
+const localCtx = { require };
+vm.createContext(localCtx);
+vm.runInContext(`
+let dashModelData = {};
+let dashPanelFilters = {};
+
+${extractFunction('dashNormalizeNumberText')}
+${extractFunction('dashGetFloat')}
+${extractFunction('dashPanelDateValue')}
+${extractFunction('dashPanelMonthValue')}
+${extractFunction('dashPanelFilterValueKey')}
+${extractFunction('dashPanelFilterIsActive')}
+${extractFunction('dashPanelReportRowPassesFilter')}
+${extractFunction('dashFilterReportRowsForPanel')}
+${extractFunction('dashPanelFilterPartIsLocal')}
+${extractFunction('dashPanelFilterParts')}
+${extractFunction('dashDecodePanelFilterPart')}
+${extractFunction('dashPanelLocalFilterState')}
+${extractFunction('dashMergePanelFilterState')}
+${extractFunction('dashPanelFiltersFor')}
+
+const assert = require('assert');
+
+const rows = [
+    { 'Документ': 'Акт', 'Тип документаID': '158844', 'Статус': 'Опубликовано' },
+    { 'Документ': 'Протокол', 'Тип документаID': '158835', 'Статус': 'Опубликовано' },
+    { 'Документ': 'Новость', 'Тип документаID': '158844', 'Статус': 'Черновик' }
+];
+
+const localFilters = dashPanelLocalFilterState('Тип документаID:158844&Статус:Опубликовано');
+assert.deepStrictEqual(
+    dashFilterReportRowsForPanel(rows, localFilters).map(function(row) { return row['Документ']; }),
+    ['Акт'],
+    'local panelFilter values must filter report rows by matching field values'
+);
+
+dashModelData.fp1 = { panelFilters: dashPanelLocalFilterState('Тип документаID:158844') };
+dashPanelFilters.fp1 = {
+    'report:Статус': { source: 'report', field: 'Статус', kind: 'values', valueType: 'text', selected: ['Опубликовано'] }
+};
+
+assert.deepStrictEqual(
+    dashFilterReportRowsForPanel(rows, dashPanelFiltersFor({ id: 'fp1' })).map(function(row) { return row['Документ']; }),
+    ['Акт'],
+    'configured local filters and interactive panel filters must be combined'
+);
+`, localCtx);
+
+const formulaCtx = { require };
+vm.createContext(formulaCtx);
+vm.runInContext(`
+const repRegex = /^\\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)(\\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)?\\]$/;
+let dashReports = {};
+let dashReportNames = {};
+let dashReportKeys = {};
+let dashReportSources = {};
+let dashFormulas = {};
+let dashModelData = {};
+let dashPanelFilters = {};
+
+${extractFunction('dashNormalizeNumberText')}
+${extractFunction('dashGetFloat')}
+${extractFunction('dashNormalizeVal')}
+${extractFunction('dashPanelDateValue')}
+${extractFunction('dashPanelMonthValue')}
+${extractFunction('dashPanelFilterValueKey')}
+${extractFunction('dashPanelFilterIsActive')}
+${extractFunction('dashPanelReportRowPassesFilter')}
+${extractFunction('dashFilterReportRowsForPanel')}
+${extractFunction('dashPanelFilterPartIsLocal')}
+${extractFunction('dashPanelFilterParts')}
+${extractFunction('dashDecodePanelFilterPart')}
+${extractFunction('dashPanelLocalFilterState')}
+${extractFunction('dashMergePanelFilterState')}
+${extractFunction('dashPanelFiltersFor')}
+${extractFunction('dashNormalizePanelFilter')}
+${extractFunction('dashReportKey')}
+${extractFunction('dashParseReportFormula')}
+${extractFunction('dashReportFieldName')}
+${extractFunction('dashReportHasField')}
+${extractFunction('dashReportSumField')}
+${extractFunction('dashNormalizeGroupName')}
+${extractFunction('dashSameGroupName')}
+${extractFunction('dashReportGroupMatches')}
+${extractFunction('dashCellRgColumn')}
+${extractFunction('dashCellReportGroup')}
+${extractFunction('dashCollectReportGroups')}
+${extractFunction('dashResolveReportCellValue')}
+${extractFunction('dashGetRepVals')}
+
+const assert = require('assert');
+
+const panel = { id: 'fp1' };
+const cell = {
+    innerHTML: '',
+    attrs: { range: '20260101-20261231' },
+    dataset: {},
+    getAttribute(name) { return this.attrs[name]; },
+    setAttribute(name, value) { this.attrs[name] = value; },
+    closest(selector) { return selector === '.f-panel' ? panel : null; }
+};
+const row = {
+    querySelectorAll(selector) {
+        return selector === '.f-rg-cell[data-src="report"],.f-values[data-src="report"]' ? [cell] : [];
+    }
+};
+const document = {
+    getElementById(id) {
+        return id === 'item1' ? row : null;
+    }
+};
+
+const reportKey = dashReportKey('Документы', 'Тип документаID:158844');
+dashModelData.fp1 = { panelFilters: dashPanelLocalFilterState('Тип документаID:158844') };
+dashReportNames[reportKey] = 'Документы';
+dashReportKeys.item1 = reportKey;
+dashFormulas.item1 = '[Документы.Количество]';
+dashReports[reportKey] = [
+    { Date: '20260101', 'Количество': '5', 'Тип документаID': '158844' },
+    { Date: '20260101', 'Количество': '9', 'Тип документаID': '158835' }
+];
+
+dashGetRepVals();
+assert.strictEqual(cell.innerHTML, '5', 'formula report cells must use locally filtered report rows');
+`, formulaCtx);
+
+console.log('issue-2352 dashboard local panelFilter: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -336,8 +336,84 @@ function dashHasRows(json) {
     return false;
 }
 
+function dashPanelFilterPartIsLocal(part) {
+    return part.indexOf('=') === -1 && part.indexOf(':') > 0;
+}
+
+function dashPanelFilterParts(panelFilter) {
+    var result = { server: [], local: [] }
+        , filter = String(panelFilter || '').trim().replace(/^[?&]+/, '');
+    if (!filter) return result;
+    filter.split('&').forEach(function(part) {
+        part = String(part || '').trim().replace(/^[?&]+/, '');
+        if (!part) return;
+        if (dashPanelFilterPartIsLocal(part))
+            result.local.push(part);
+        else
+            result.server.push(part);
+    });
+    return result;
+}
+
+function dashDecodePanelFilterPart(part) {
+    var text = String(part || '').replace(/\+/g, ' ');
+    try {
+        return decodeURIComponent(text);
+    } catch (e) {
+        return text;
+    }
+}
+
 function dashNormalizePanelFilter(panelFilter) {
-    return String(panelFilter || '').trim().replace(/^[?&]+/, '');
+    var filter = String(panelFilter || '').trim().replace(/^[?&]+/, '');
+    if (!filter) return '';
+    return filter.split('&').map(function(part) {
+        return String(part || '').trim().replace(/^[?&]+/, '');
+    }).filter(function(part) {
+        return part && !(part.indexOf('=') === -1 && part.indexOf(':') > 0);
+    }).join('&');
+}
+
+function dashPanelLocalFilterState(panelFilter) {
+    var filters = {};
+    dashPanelFilterParts(panelFilter).local.forEach(function(part) {
+        var idx = part.indexOf(':')
+            , field = dashDecodePanelFilterPart(part.slice(0, idx)).trim()
+            , value = dashDecodePanelFilterPart(part.slice(idx + 1)).trim()
+            , key, filterValue;
+        if (!field) return;
+        key = 'panelFilter:' + field;
+        filterValue = dashPanelFilterValueKey(value, 'values', 'text');
+        if (!filters[key])
+            filters[key] = { source: 'report', field: field, kind: 'values', valueType: 'text', selected: [] };
+        if (filters[key].selected.indexOf(filterValue) === -1)
+            filters[key].selected.push(filterValue);
+    });
+    return filters;
+}
+
+function dashMergePanelFilterState(target, incoming) {
+    target = target || {};
+    Object.keys(incoming || {}).forEach(function(key) {
+        var src = incoming[key]
+            , dst = target[key];
+        if (!dst) {
+            target[key] = Object.assign({}, src, {
+                selected: Array.isArray(src.selected) ? src.selected.slice() : src.selected
+            });
+            return;
+        }
+        if (Array.isArray(src.selected) && Array.isArray(dst.selected)) {
+            src.selected.forEach(function(value) {
+                if (dst.selected.indexOf(value) === -1) dst.selected.push(value);
+            });
+        } else {
+            target[key] = Object.assign({}, src, {
+                selected: Array.isArray(src.selected) ? src.selected.slice() : src.selected
+            });
+        }
+    });
+    return target;
 }
 
 function dashReportKey(rep, panelFilter) {
@@ -1303,7 +1379,9 @@ function dashGetRepVals() {
                     var range = String(el.getAttribute('range') || '-').split('-')
                         , group = dashCellReportGroup(el)
                         , panel = el.closest ? el.closest('.f-panel') : null
-                        , panelFilters = panel && dashPanelFilters[panel.id] ? dashPanelFilters[panel.id] : {}
+                        , panelFilters = (typeof dashPanelFiltersFor === 'function')
+                            ? dashPanelFiltersFor(panel)
+                            : (panel && typeof dashPanelFilters !== 'undefined' && dashPanelFilters[panel.id] ? dashPanelFilters[panel.id] : {})
                         , filteredReportRows = dashFilterReportRowsForPanel(reportRows, panelFilters)
                         , val;
                     if (restrictToReportGroup && !dashSameGroupName(group, parsed.report)) return;
@@ -1787,7 +1865,9 @@ function dashGetModel(json) {
             , isDuplicateRow = dashIsDuplicateModelRow(previousItem, json[i])
             , itemTargetId = isDuplicateRow ? previousItem.itemID : json[i].itemID
             , vizReportId = dashResolvePanelVizReportId(json[i])
-            , panelNotes = json[i].panelNotes === null || json[i].panelNotes === undefined ? '' : String(json[i].panelNotes);
+            , panelNotes = json[i].panelNotes === null || json[i].panelNotes === undefined ? '' : String(json[i].panelNotes)
+            , panelFilter = json[i].panelFilter || ''
+            , panelFilters = dashPanelLocalFilterState(panelFilter);
         // Add sheet tab
         if (!document.getElementById(json[i].sheetID)) {
             model.querySelector('.sheet-tabs').insertAdjacentHTML('beforeend',
@@ -1814,12 +1894,15 @@ function dashGetModel(json) {
                 settings: panelSettings,
                 panelID: json[i].panelID,
                 notes: '',
-                panelFilter: json[i].panelFilter || '',
+                panelFilter: panelFilter,
+                panelFilters: panelFilters,
                 vizReportId: vizReportId,
-                vizReportKey: vizReportId ? dashGetVizReport(vizReportId, fr, to, json[i].panelFilter) : ''
+                vizReportKey: vizReportId ? dashGetVizReport(vizReportId, fr, to, panelFilter) : ''
             };
             dashApplyVizSize(document.getElementById(panelKey), 'table', {});
             dashPanelApplySettings(panelKey, panelSettings, false);
+        } else if (dashModelData[panelKey]) {
+            dashModelData[panelKey].panelFilters = dashMergePanelFilterState(dashModelData[panelKey].panelFilters, panelFilters);
         }
         if (panelNotes.trim() && dashModelData[panelKey] && !dashModelData[panelKey].notes) {
             dashModelData[panelKey].notes = panelNotes;
@@ -1827,7 +1910,7 @@ function dashGetModel(json) {
         }
         if (vizReportId && dashModelData[panelKey] && !dashModelData[panelKey].vizReportId) {
             dashModelData[panelKey].vizReportId = vizReportId;
-            dashModelData[panelKey].vizReportKey = dashGetVizReport(vizReportId, fr, to, json[i].panelFilter);
+            dashModelData[panelKey].vizReportKey = dashGetVizReport(vizReportId, fr, to, panelFilter);
         }
         if (json[i].NoDates !== undefined)
             dashModelData[panelKey].noDates = json[i].NoDates;
@@ -1867,13 +1950,13 @@ function dashGetModel(json) {
             if (!dashFormulas[itemTargetId] || (rep && dashFormulas[itemTargetId] === '[]'))
                 dashFormulas[itemTargetId] = json[i].formulas;
             if (rep) {
-                var reportKey = dashReportKey(rep[1], json[i].panelFilter);
+                var reportKey = dashReportKey(rep[1], panelFilter);
                 if (!dashReportKeys[itemTargetId])
                     dashReportKeys[itemTargetId] = reportKey;
                 dashRememberReportSource(itemTargetId, json[i].formulas, reportKey);
                 dashReportNames[reportKey] = rep[1];
                 if (!dashReports[reportKey])
-                    dashGetRep(rep[1], fr, to, json[i].panelFilter);
+                    dashGetRep(rep[1], fr, to, panelFilter);
             }
         }
     }
@@ -3762,7 +3845,13 @@ function dashRefreshPanelMaxWidths() {
 var dashPanelFilterModalCtx = null;
 
 function dashPanelFiltersFor(panelEl) {
-    return panelEl && dashPanelFilters[panelEl.id] ? dashPanelFilters[panelEl.id] : {};
+    var modelStore = (typeof dashModelData !== 'undefined') ? dashModelData : {}
+        , filterStore = (typeof dashPanelFilters !== 'undefined') ? dashPanelFilters : {}
+        , modelFilters = panelEl && modelStore[panelEl.id] ? modelStore[panelEl.id].panelFilters : null
+        , userFilters = panelEl && filterStore[panelEl.id] ? filterStore[panelEl.id] : null;
+    if (!modelFilters) return userFilters || {};
+    if (!userFilters) return modelFilters || {};
+    return dashMergePanelFilterState(dashMergePanelFilterState({}, modelFilters), userFilters);
 }
 
 function dashPanelFilterModalIsOpen() {


### PR DESCRIPTION
## Problem

`report/Дэшборд` can return two different kinds of `panelFilter` values:

- `FR_dept=IN(2889)` should be sent to the report request as server-side query parameters.
- `Тип документаID:158844` should not be sent to the request; it should filter the loaded panel rows locally.

Colon-style filters were being appended to formula and panel report URLs, so report-backed panels could not reuse one report source for multiple locally filtered panels.

## Fix

- Split `panelFilter` into server query parts and colon-style local filter parts.
- Keep equals-style filters in formula/report request URLs and cache keys.
- Store colon-style filters on dashboard panel model data and merge them with interactive panel filters for report tables, charts, and formula-backed report cells.

## Reproduce

1. Return a dashboard row with `panelQuery: "158891"` and `panelFilter: "Тип документаID:158844"`.
2. Before the fix, the panel report request appended `&Тип документаID:158844`.
3. After the fix, the request is made without that colon filter, and report rows are filtered locally by `Тип документаID = 158844`.

## Tests

- `node experiments/test-issue-2352-dashboard-local-panel-filter.js`
- `node experiments/test-issue-2300-dashboard-viz-report-source.js`
- `node experiments/test-issue-2304-dashboard-panel-filter.js`
- `node experiments/test-issue-2312-dashboard-panel-filter-bulk.js`
- `node experiments/test-issue-2330-dashboard-report-table.js`
- `node experiments/test-issue-2350-dashboard-report-table.js`
- `node --check js/dash.js`
- `git diff --check`

Fixes #2352