### PR TITLE
Handle dashboard report style columns

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T07:57:29.057Z for PR creation at branch issue-2360-a0caa1bfef56 for issue https://github.com/ideav/crm/issues/2360

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T07:57:29.057Z for PR creation at branch issue-2360-a0caa1bfef56 for issue https://github.com/ideav/crm/issues/2360

--- a/experiments/test-issue-2300-dashboard-viz-report-source.js
+++ b/experiments/test-issue-2300-dashboard-viz-report-source.js
@@ -42,6 +42,7 @@ ${extractFunction('dashNormalizeReportJson')}
 ${extractFunction('dashReportColumnByField')}
 ${extractFunction('dashReportColumnIsNumeric')}
 ${extractFunction('dashReportColumnNameHasIdSuffix')}
+${extractFunction('dashReportColumnIsStyle')}
 ${extractFunction('dashReportColumnIsMeasure')}
 ${extractFunction('dashReportColumnIsDimension')}
 ${extractFunction('dashReportDefaultColumn')}

--- a/experiments/test-issue-2304-dashboard-panel-filter.js
+++ b/experiments/test-issue-2304-dashboard-panel-filter.js
@@ -33,6 +33,7 @@ ${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashReportRowValue')}
 ${extractFunction('dashReportColumnIsNumeric')}
+${extractFunction('dashReportColumnIsStyle')}
 ${extractFunction('dashPanelDateValue')}
 ${extractFunction('dashPanelMonthValue')}
 ${extractFunction('dashPanelFilterValueKey')}
@@ -51,12 +52,14 @@ const columns = [
     { id: 'amount', name: 'Сумма', format: 'NUMBER' },
     { id: 'deadline', name: 'Срок', format: 'DATE' },
     { id: 'month', name: 'Месяц', format: 'DATE' },
-    { id: 'period', name: 'Период', format: 'SHORT' }
+    { id: 'period', name: 'Период', format: 'SHORT' },
+    { id: 'clientStyle', name: 'Клиент.style', format: 'SHORT' },
+    { id: 'rowStyle', name: 'style', format: 'SHORT' }
 ];
 const rows = [
-    { 'Клиент': 'Альфа', 'Сумма': '10', 'Срок': '2026-01-10', 'Месяц': '2026-01', 'Период': '2026-01' },
-    { 'Клиент': 'Бета', 'Сумма': '15', 'Срок': '2026-01-15', 'Месяц': '2026-01', 'Период': '2026-01' },
-    { 'Клиент': 'Альфа', 'Сумма': '25,5', 'Срок': '2026-02-05', 'Месяц': '2026-02', 'Период': '2026-02' }
+    { 'Клиент': 'Альфа', 'Сумма': '10', 'Срок': '2026-01-10', 'Месяц': '2026-01', 'Период': '2026-01', 'Клиент.style': 'color: red', 'style': 'font-weight: bold' },
+    { 'Клиент': 'Бета', 'Сумма': '15', 'Срок': '2026-01-15', 'Месяц': '2026-01', 'Период': '2026-01', 'Клиент.style': 'color: blue', 'style': 'font-weight: normal' },
+    { 'Клиент': 'Альфа', 'Сумма': '25,5', 'Срок': '2026-02-05', 'Месяц': '2026-02', 'Период': '2026-02', 'Клиент.style': 'color: green', 'style': 'font-style: italic' }
 ];
 
 const fields = dashBuildReportFilterFields(columns, rows);
@@ -75,6 +78,8 @@ assert.strictEqual(byField['Месяц'].kind, 'month');
 assert.deepStrictEqual(byField['Месяц'].options.map(function(option) { return option.value; }), ['2026-01', '2026-02']);
 assert.strictEqual(byField['Период'].kind, 'month');
 assert.deepStrictEqual(byField['Период'].options.map(function(option) { return option.value; }), ['2026-01', '2026-02']);
+assert.strictEqual(byField['Клиент.style'], undefined, 'targeted style columns should not be offered as report filters');
+assert.strictEqual(byField['style'], undefined, 'plain style columns should not be offered as report filters');
 
 let filtered = dashFilterReportRowsForPanel(rows, {
     'report:Клиент': { source: 'report', field: 'Клиент', kind: 'values', selected: ['Альфа'] },

--- a/experiments/test-issue-2330-dashboard-report-table.js
+++ b/experiments/test-issue-2330-dashboard-report-table.js
@@ -38,12 +38,16 @@ ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeReportJson')}
 ${extractFunction('dashReportColumnIsNumeric')}
 ${extractFunction('dashReportColumnNameHasIdSuffix')}
+${extractFunction('dashReportColumnIsStyle')}
+${extractFunction('dashReportStyleTargetName')}
 ${extractFunction('dashReportColumnIsMeasure')}
 ${extractFunction('dashReportColumnIsVisible')}
 ${extractFunction('dashReportVisibleColumns')}
 ${extractFunction('dashReportRowValue')}
 ${extractFunction('dashPanelGetVizReportData')}
 ${extractFunction('dashReportValueText')}
+${extractFunction('dashReportColumnStyleKey')}
+${extractFunction('dashReportRowCellStyles')}
 ${extractFunction('dashReportColumnIsHtml')}
 ${extractFunction('dashReportColumnAlign')}
 ${extractFunction('dashReportHasTotals')}

--- a/experiments/test-issue-2334-dashboard-report-display.js
+++ b/experiments/test-issue-2334-dashboard-report-display.js
@@ -57,11 +57,15 @@ ${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashReportColumnIsNumeric')}
 ${extractFunction('dashReportColumnNameHasIdSuffix')}
+${extractFunction('dashReportColumnIsStyle')}
+${extractFunction('dashReportStyleTargetName')}
 ${extractFunction('dashReportColumnIsVisible')}
 ${extractFunction('dashReportVisibleColumns')}
 ${extractFunction('dashReportColumnAlign')}
 ${extractFunction('dashReportHasTotals')}
 ${extractFunction('dashReportValueText')}
+${extractFunction('dashReportColumnStyleKey')}
+${extractFunction('dashReportRowCellStyles')}
 ${extractFunction('dashReportColumnIsHtml')}
 ${extractFunction('dashReportRowValue')}
 ${extractFunction('dashReportTableCellHtml')}

--- a/experiments/test-issue-2350-dashboard-report-table.js
+++ b/experiments/test-issue-2350-dashboard-report-table.js
@@ -33,9 +33,13 @@ ${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashReportColumnIsNumeric')}
 ${extractFunction('dashReportColumnNameHasIdSuffix')}
+${extractFunction('dashReportColumnIsStyle')}
+${extractFunction('dashReportStyleTargetName')}
 ${extractFunction('dashReportColumnIsVisible')}
 ${extractFunction('dashReportVisibleColumns')}
 ${extractFunction('dashReportValueText')}
+${extractFunction('dashReportColumnStyleKey')}
+${extractFunction('dashReportRowCellStyles')}
 ${extractFunction('dashReportColumnIsHtml')}
 ${extractFunction('dashReportColumnAlign')}
 ${extractFunction('dashReportHasTotals')}

--- a/experiments/test-issue-2360-dashboard-report-style-columns.js
+++ b/experiments/test-issue-2360-dashboard-report-style-columns.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// Issue #2360: dashboard report tables should hide service style columns
+// and apply their per-row CSS values to the intended visible cells.
+
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function maybeExtractFunction(name) {
+    return source.includes('function ' + name + '(') ? extractFunction(name) : '';
+}
+
+const code = `
+function dashFilterReportRowsForPanel(rows) { return rows || []; }
+
+${extractFunction('dashAttr')}
+${extractFunction('dashEscapeHtml')}
+${extractFunction('dashNormalizeNumberText')}
+${extractFunction('dashGetFloat')}
+${extractFunction('dashReportColumnIsNumeric')}
+${extractFunction('dashReportColumnNameHasIdSuffix')}
+${maybeExtractFunction('dashReportColumnIsStyle')}
+${extractFunction('dashReportColumnIsVisible')}
+${extractFunction('dashReportVisibleColumns')}
+${extractFunction('dashReportValueText')}
+${extractFunction('dashReportColumnIsHtml')}
+${extractFunction('dashReportColumnAlign')}
+${extractFunction('dashReportHasTotals')}
+${extractFunction('dashReportRowValue')}
+${maybeExtractFunction('dashReportStyleTargetName')}
+${maybeExtractFunction('dashReportColumnStyleKey')}
+${maybeExtractFunction('dashReportRowCellStyles')}
+${extractFunction('dashReportTableCellHtml')}
+${extractFunction('dashRenderReportTableHtml')}
+`;
+
+const ctx = {};
+vm.createContext(ctx);
+vm.runInContext(code, ctx);
+
+const report = {
+    columns: [
+        { id: 'name', format: 'CHARS', name: 'Name' },
+        { id: 'amount', format: 'NUMBER', name: 'Amount Total' },
+        { id: 'amountStyle', format: 'CHARS', name: 'Amount Total.style' },
+        { id: 'status', format: 'CHARS', name: 'Status' },
+        { id: 'rowStyle', format: 'CHARS', name: 'style' },
+        { id: 'note', format: 'CHARS', name: 'Note' },
+        { id: 'missingStyle', format: 'CHARS', name: 'Missing Column.style' }
+    ],
+    rows: [
+        {
+            'Name': 'Contract',
+            'Amount Total': '125',
+            'Amount Total.style': 'background-color: #bfe3db; color: black',
+            'Status': 'Ready',
+            'style': 'font-weight: bold',
+            'Note': 'Fallback target',
+            'Missing Column.style': 'text-decoration: underline'
+        }
+    ]
+};
+
+const html = ctx.dashRenderReportTableHtml(report, {});
+
+assert(!/<th[^>]*>Amount Total\.style<\/th>/.test(html), '.style column header is hidden');
+assert(!/<th[^>]*>style<\/th>/.test(html), 'plain style column header is hidden');
+assert(!/<th[^>]*>Missing Column\.style<\/th>/.test(html), 'unmatched .style column header is hidden');
+assert(!/>background-color: #bfe3db; color: black<\//.test(html), 'targeted style value is not rendered as cell text');
+assert(!/>font-weight: bold<\//.test(html), 'plain style value is not rendered as cell text');
+
+assert(
+    /<td[^>]*data-column-id="amount"[^>]*style="background-color: #bfe3db; color: black"[^>]*>125<\/td>/.test(html),
+    '.style value is applied to the matching visible column, including names with spaces'
+);
+assert(
+    /<td[^>]*data-column-id="status"[^>]*style="font-weight: bold"[^>]*>Ready<\/td>/.test(html),
+    'plain style column applies to the previous visible cell'
+);
+assert(
+    /<td[^>]*data-column-id="note"[^>]*style="text-decoration: underline"[^>]*>Fallback target<\/td>/.test(html),
+    'unmatched .style column applies to the previous visible cell'
+);
+
+console.log('issue-2360 dashboard report style columns: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -557,15 +557,29 @@ function dashReportColumnNameHasIdSuffix(column) {
     return /(^|[\s_-])(id|ид)$/i.test(name) || /(ID|ИД)$/.test(name);
 }
 
+function dashReportColumnIsStyle(column) {
+    var name = String((column && column.name) || '')
+        , lower = name.toLowerCase();
+    return lower === 'style' || lower.slice(-6) === '.style';
+}
+
+function dashReportStyleTargetName(column) {
+    var name = String((column && column.name) || '')
+        , lower = name.toLowerCase();
+    if (lower === 'style') return '';
+    return lower.slice(-6) === '.style' ? name.slice(0, -6) : '';
+}
+
 function dashReportColumnIsMeasure(column) {
     if (!dashReportColumnIsNumeric(column)) return false;
+    if (dashReportColumnIsStyle(column)) return false;
     if (column && column.ref) return false;
     if (dashReportColumnNameHasIdSuffix(column)) return false;
     return true;
 }
 
 function dashReportColumnIsVisible(column) {
-    return !!column && !dashReportColumnNameHasIdSuffix(column);
+    return !!column && !dashReportColumnNameHasIdSuffix(column) && !dashReportColumnIsStyle(column);
 }
 
 function dashReportVisibleColumns(columns) {
@@ -573,7 +587,7 @@ function dashReportVisibleColumns(columns) {
 }
 
 function dashReportColumnIsDimension(column) {
-    return !!column && !dashReportColumnIsMeasure(column);
+    return !!column && !dashReportColumnIsStyle(column) && !dashReportColumnIsMeasure(column);
 }
 
 function dashReportDefaultColumn(columns, preferredField, predicate) {
@@ -591,6 +605,43 @@ function dashReportRowValue(row, column) {
 
 function dashReportValueText(value) {
     return value === undefined || value === null ? '' : String(value);
+}
+
+function dashReportColumnStyleKey(column) {
+    var id = column && column.id;
+    return String(id !== undefined && id !== null && id !== '' ? id : (column && column.name) || '');
+}
+
+function dashReportRowCellStyles(row, allColumns, visibleColumns) {
+    var styles = {}
+        , visibleByName = {}
+        , previousVisibleColumn = null;
+
+    (visibleColumns || []).forEach(function(column) {
+        var name = String((column && column.name) || '');
+        if (!visibleByName[name]) visibleByName[name] = column;
+    });
+
+    (allColumns || []).forEach(function(column) {
+        var styleText, targetName, targetColumn, key;
+        if (!dashReportColumnIsStyle(column)) {
+            if (dashReportColumnIsVisible(column)) previousVisibleColumn = column;
+            return;
+        }
+
+        styleText = dashReportValueText(dashReportRowValue(row, column)).trim();
+        if (!styleText) return;
+
+        targetName = dashReportStyleTargetName(column);
+        targetColumn = targetName ? visibleByName[targetName] : null;
+        if (!targetColumn) targetColumn = previousVisibleColumn;
+        if (!targetColumn) return;
+
+        key = dashReportColumnStyleKey(targetColumn);
+        styles[key] = styles[key] ? styles[key] + '; ' + styleText : styleText;
+    });
+
+    return styles;
 }
 
 function dashReportColumnIsHtml(column) {
@@ -613,23 +664,27 @@ function dashReportHasTotals(report) {
     });
 }
 
-function dashReportTableCellHtml(tagName, column, value, extraClass) {
+function dashReportTableCellHtml(tagName, column, value, extraClass, styleText) {
     var format = String((column && column.format) || '').toUpperCase()
         , align = dashReportColumnAlign(column)
         , classes = ['dash-report-cell', 'dash-report-cell--' + align]
         , text = dashReportValueText(value)
-        , content = (tagName === 'td' && dashReportColumnIsHtml(column)) ? text : dashEscapeHtml(text);
+        , content = (tagName === 'td' && dashReportColumnIsHtml(column)) ? text : dashEscapeHtml(text)
+        , inlineStyle = tagName === 'td' ? dashReportValueText(styleText).trim() : '';
     if (extraClass) classes.push(extraClass);
     return '<' + tagName
         + ' class="' + classes.join(' ') + '"'
         + ' data-format="' + dashAttr(format) + '"'
-        + ' data-column-id="' + dashAttr(column ? column.id : '') + '">'
+        + ' data-column-id="' + dashAttr(column ? column.id : '') + '"'
+        + (inlineStyle ? ' style="' + dashAttr(inlineStyle) + '"' : '')
+        + '>'
         + content
         + '</' + tagName + '>';
 }
 
 function dashRenderReportTableHtml(report, filters) {
-    var columns = dashReportVisibleColumns(report ? report.columns || [] : [])
+    var allColumns = report ? report.columns || [] : []
+        , columns = dashReportVisibleColumns(allColumns)
         , rows = dashFilterReportRowsForPanel(report ? report.rows || [] : [], filters || {})
         , html = '<table class="table table-sm table-bordered w-auto dash-report-table" data-dash-report-table="1"><thead>'
         , hasTotals = dashReportHasTotals({ columns: columns });
@@ -643,9 +698,10 @@ function dashRenderReportTableHtml(report, filters) {
     html += '</tr></thead><tbody>';
 
     rows.forEach(function(row) {
+        var rowStyles = dashReportRowCellStyles(row, allColumns, columns);
         html += '<tr class="dash-report-row">';
         columns.forEach(function(column) {
-            html += dashReportTableCellHtml('td', column, dashReportRowValue(row, column), '');
+            html += dashReportTableCellHtml('td', column, dashReportRowValue(row, column), '', rowStyles[dashReportColumnStyleKey(column)]);
         });
         if (!columns.length)
             html += '<td></td>';
@@ -765,6 +821,8 @@ function dashPanelAddFilterOption(field, rawValue) {
 function dashBuildReportFilterFields(columns, rows) {
     var fields = [];
     (columns || []).forEach(function(column) {
+        if (dashReportColumnIsStyle(column)) return;
+
         var values = (rows || []).map(function(row) { return dashReportRowValue(row, column); })
             , kindInfo = dashPanelFilterFieldKind(column, values)
             , field = {


### PR DESCRIPTION
Fixes #2360

## Summary
- Treat dashboard report columns named `style` or ending with `.style` as service style columns.
- Hide those columns from rendered report tables and report filter fields.
- Apply each row's style value to the matching visible column for `name.style`, including names with spaces; if the target column is missing or the service column is plain `style`, apply it to the previous visible cell.
- Add regression coverage for targeted styles, fallback styles, and related dashboard report helpers.

## Reproduce
1. Render a dashboard report table with columns like `Amount Total`, `Amount Total.style`, `Status`, `style`, `Note`, and `Missing Column.style`.
2. Before this change, service style columns appeared as headers/cells and their CSS strings were rendered as table text.
3. After this change, service columns are omitted, `Amount Total.style` styles the `Amount Total` cell, and plain or unmatched style columns style the previous visible cell.

## Tests
- `node --check js/dash.js`
- `node experiments/test-issue-2300-dashboard-viz-report-source.js`
- `node experiments/test-issue-2304-dashboard-panel-filter.js`
- `node experiments/test-issue-2330-dashboard-report-table.js`
- `node experiments/test-issue-2334-dashboard-report-display.js`
- `node experiments/test-issue-2350-dashboard-report-table.js`
- `node experiments/test-issue-2360-dashboard-report-style-columns.js`
- `git diff --check`
