### PR TITLE
Version dashboard assets for panel filter modal close fix

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-04T08:22:58.635Z for PR creation at branch issue-2364-eaa6efb5d23e for issue https://github.com/ideav/crm/issues/2364

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-04T08:22:58.635Z for PR creation at branch issue-2364-eaa6efb5d23e for issue https://github.com/ideav/crm/issues/2364

--- a/experiments/test-issue-2364-dashboard-asset-version.js
+++ b/experiments/test-issue-2364-dashboard-asset-version.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const fs = require('fs');
+const assert = require('assert');
+
+const template = fs.readFileSync('templates/dash.html', 'utf8');
+
+assert(
+    /<link\b[^>]*href="\/css\/dash\.css\?\{_global_\.version\}"[^>]*>/m.test(template),
+    'dashboard stylesheet must include {_global_.version} so deployed browsers refresh dash.css'
+);
+
+assert(
+    /<script\b[^>]*src="\/js\/dash\.js\?\{_global_\.version\}"[^>]*><\/script>/m.test(template),
+    'dashboard script must include {_global_.version} so deployed browsers refresh dash.js close handlers'
+);
+
+console.log('issue-2364 dashboard assets are versioned: ok');

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -1,4 +1,4 @@
-<link rel="stylesheet" href="/css/dash.css">
+<link rel="stylesheet" href="/css/dash.css?{_global_.version}">
 
 <div id="dash-model" class="f-model m-2">
     <ul class="nav nav-tabs sheet-tabs"></ul>
@@ -59,4 +59,4 @@
     </div>
 </div>
 
-<script src="/js/dash.js"></script>
+<script src="/js/dash.js?{_global_.version}"></script>


### PR DESCRIPTION
Fixes #2364

## Summary
- Add `{_global_.version}` cache-busting to `templates/dash.html` for `/css/dash.css` and `/js/dash.js`.
- Add a regression experiment that fails when dashboard assets are loaded without the version query.
- This ensures deployed browsers fetch the `dash.js` build that contains the PR #2321 Escape/backdrop modal close handlers.

## Verification
- `node --check js/dash.js`
- `node experiments/test-issue-2364-dashboard-asset-version.js`
- `node experiments/test-issue-2317-dashboard-panel-filter-close.js`
- `node experiments/test-issue-2304-dashboard-panel-filter.js`
- `node experiments/test-issue-2312-dashboard-panel-filter-bulk.js`
- `git diff --check`
- Playwright local browser check: loaded `templates/dash.html`, confirmed versioned `dash.css`/`dash.js` requests, and verified Escape/backdrop close behavior still works.

No screenshots: visual layout did not change.
