### PR TITLE
js/integram-table.js: fix subordinate modal infinite scroll

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T06:49:55.936Z for PR creation at branch issue-2370-3cdae4825ada for issue https://github.com/ideav/crm/issues/2370

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T06:49:55.936Z for PR creation at branch issue-2370-3cdae4825ada for issue https://github.com/ideav/crm/issues/2370

--- a/experiments/test-issue-2370-subordinate-modal-scroll.js
+++ b/experiments/test-issue-2370-subordinate-modal-scroll.js
@@ -1,0 +1,119 @@
+/**
+ * Issue #2370 regression coverage.
+ *
+ * Subordinate tables shown inside an expanded edit form use the same
+ * .edit-form-body scroll area as .subordinate-modal, but the modal itself does
+ * not always have the .subordinate-modal class. Infinite scroll must attach to
+ * the nearest edit form body and must ignore inactive subordinate tabs so row
+ * ordering by drag-and-drop stays tied to the active visible table.
+ *
+ * Run with: node experiments/test-issue-2370-subordinate-modal-scroll.js
+ */
+
+const assert = require('assert');
+
+const IntegramTable = require('../js/integram-table.js');
+
+class ClassList {
+    constructor(classes = []) {
+        this.classes = new Set(classes);
+    }
+
+    contains(name) {
+        return this.classes.has(name);
+    }
+
+    add(name) {
+        this.classes.add(name);
+    }
+
+    remove(name) {
+        this.classes.delete(name);
+    }
+}
+
+function makeScrollBody() {
+    return {
+        scrollHeight: 1000,
+        scrollTop: 750,
+        clientHeight: 200,
+        listeners: [],
+        addEventListener(type, listener) {
+            if (type === 'scroll') this.listeners.push(listener);
+        },
+        removeEventListener(type, listener) {
+            if (type === 'scroll') {
+                this.listeners = this.listeners.filter(existing => existing !== listener);
+            }
+        },
+        dispatchScroll() {
+            this.listeners.forEach(listener => listener());
+        }
+    };
+}
+
+function makeModal(scrollBody) {
+    return {
+        classList: new ClassList(['edit-form-modal', 'expanded']),
+        querySelector(selector) {
+            return selector === '.edit-form-body' ? scrollBody : null;
+        }
+    };
+}
+
+function makeTabContent(active) {
+    return {
+        classList: new ClassList(active ? ['edit-form-tab-content', 'active'] : ['edit-form-tab-content'])
+    };
+}
+
+function makeContainer(modal, tabContent) {
+    return {
+        _subordinateIsLoading: false,
+        _subordinateHasMore: true,
+        closest(selector) {
+            if (selector === '.edit-form-modal') return modal;
+            if (selector === '.edit-form-modal.subordinate-modal') return null;
+            if (selector === '.edit-form-tab-content') return tabContent;
+            return null;
+        }
+    };
+}
+
+(async function run() {
+    const originalSetTimeout = global.setTimeout;
+    global.setTimeout = (fn) => {
+        fn();
+        return 0;
+    };
+
+    try {
+        const scrollBody = makeScrollBody();
+        const modal = makeModal(scrollBody);
+        const activeTab = makeTabContent(true);
+        const hiddenTab = makeTabContent(false);
+        const activeContainer = makeContainer(modal, activeTab);
+        const hiddenContainer = makeContainer(modal, hiddenTab);
+
+        const loadCalls = [];
+        const table = Object.create(IntegramTable.prototype);
+        table.loadMoreSubordinateRows = async (container) => {
+            loadCalls.push(container);
+        };
+
+        table.attachSubordinateScrollListener(activeContainer);
+        assert.strictEqual(scrollBody.listeners.length, 1, 'active subordinate tab should attach one scroll listener');
+        assert.deepStrictEqual(loadCalls, [activeContainer], 'active tab should auto-load when already near the bottom');
+
+        table.attachSubordinateScrollListener(hiddenContainer);
+        assert.strictEqual(scrollBody.listeners.length, 2, 'another tab can keep its own listener without replacing the active tab listener');
+        assert.deepStrictEqual(loadCalls, [activeContainer], 'inactive tab must not auto-load while hidden');
+
+        scrollBody.dispatchScroll();
+        assert.deepStrictEqual(loadCalls, [activeContainer, activeContainer], 'scrolling should load only the active visible subordinate table');
+
+        console.log('PASS issue-2370 subordinate modal infinite scroll');
+    } finally {
+        global.setTimeout = originalSetTimeout;
+    }
+})();

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -11949,6 +11949,8 @@ class IntegramTable{
                         if (!targetContent.dataset.loaded) {
                             await this.loadSubordinateTable(targetContent, arrId, parentRecordId, reqId);
                             targetContent.dataset.loaded = 'true';
+                        } else {
+                            this.attachSubordinateScrollListener(targetContent);
                         }
                     }
 
@@ -11989,15 +11991,15 @@ class IntegramTable{
                 const hasMore = rows.length > pageSize;
                 const firstPageRows = hasMore ? rows.slice(0, pageSize) : rows;
 
-                // Render the subordinate table with first page data
-                this.renderSubordinateTable(container, metadata, firstPageRows, arrId, parentRecordId);
-
                 // Store pagination state on container for infinite scroll (issue #1640)
                 container._subordinateHasMore = hasMore;
                 container._subordinateLoadedCount = firstPageRows.length;
                 container._subordinateIsLoading = false;
                 container._subordinateArrIdForScroll = arrId;
                 container._subordinateParentRecordIdForScroll = parentRecordId;
+
+                // Render the subordinate table with first page data
+                this.renderSubordinateTable(container, metadata, firstPageRows, arrId, parentRecordId);
 
                 // Attach infinite scroll listener to the modal's scrollable body (issue #1640)
                 this.attachSubordinateScrollListener(container);
@@ -12012,19 +12014,38 @@ class IntegramTable{
          * Attach scroll listener to the subordinate modal's .edit-form-body for infinite scroll (issue #1640).
          * Loads next page when user scrolls near the bottom. Shows Ajax spinner while loading.
          */
+        getSubordinateScrollElement(container) {
+            const modal = container && typeof container.closest === 'function'
+                ? container.closest('.edit-form-modal')
+                : null;
+            if (!modal || typeof modal.querySelector !== 'function') return null;
+            return modal.querySelector('.edit-form-body');
+        }
+
+        isSubordinateContainerActive(container) {
+            const tabContent = container && typeof container.closest === 'function'
+                ? container.closest('.edit-form-tab-content')
+                : null;
+
+            // Cell-opened .subordinate-modal tables are not inside tab content.
+            if (!tabContent) return true;
+            if (!tabContent.classList || typeof tabContent.classList.contains !== 'function') return true;
+            return tabContent.classList.contains('active');
+        }
+
         attachSubordinateScrollListener(container) {
-            // Find the scrollable modal body
-            const modal = container.closest('.edit-form-modal.subordinate-modal');
-            if (!modal) return;
-            const scrollEl = modal.querySelector('.edit-form-body');
+            const scrollEl = this.getSubordinateScrollElement(container);
             if (!scrollEl) return;
 
-            // Remove previous listener if re-attached (e.g. after re-render)
-            if (scrollEl._subordinateScrollListener) {
-                scrollEl.removeEventListener('scroll', scrollEl._subordinateScrollListener);
+            // Remove this container's previous listener if re-attached (e.g. after re-render).
+            // The same .edit-form-body can host several subordinate tabs, so listeners are
+            // tracked per container instead of replacing a shared scrollEl listener.
+            if (container._subordinateScrollElement && container._subordinateScrollListener) {
+                container._subordinateScrollElement.removeEventListener('scroll', container._subordinateScrollListener);
             }
 
             const scrollListener = () => {
+                if (!this.isSubordinateContainerActive(container)) return;
                 if (container._subordinateIsLoading || !container._subordinateHasMore) return;
 
                 const threshold = 200;
@@ -12034,7 +12055,8 @@ class IntegramTable{
                 }
             };
 
-            scrollEl._subordinateScrollListener = scrollListener;
+            container._subordinateScrollElement = scrollEl;
+            container._subordinateScrollListener = scrollListener;
             scrollEl.addEventListener('scroll', scrollListener);
 
             // Check immediately in case the first page already fits the screen (issue #1640)
@@ -12801,11 +12823,14 @@ class IntegramTable{
                 const hasMore = rows.length > pageSize;
                 const firstPageRows = hasMore ? rows.slice(0, pageSize) : rows;
 
-                this.renderSubordinateTable(container, metadata_new, firstPageRows, arrId, parentRecordId);
-
                 container._subordinateHasMore = hasMore;
                 container._subordinateLoadedCount = firstPageRows.length;
                 container._subordinateIsLoading = false;
+                container._subordinateArrIdForScroll = arrId;
+                container._subordinateParentRecordIdForScroll = parentRecordId;
+
+                this.renderSubordinateTable(container, metadata_new, firstPageRows, arrId, parentRecordId);
+                this.attachSubordinateScrollListener(container);
 
                 this.showToast(`Вставлено ${successCount} записей${errorCount > 0 ? `, ошибок: ${errorCount}` : ''}`, successCount > 0 ? 'success' : 'error');
             } catch (error) {
@@ -13205,7 +13230,6 @@ class IntegramTable{
                 this.showToast(`Ошибка: ${ error.message }`, 'error');
             }
         }
-
         renderSubordinateCreateForm(metadata, arrId, parentRecordId) {
             // Track modal depth for z-index stacking
             if (!window._integramModalDepth) {

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -693,6 +693,8 @@
                         if (!targetContent.dataset.loaded) {
                             await this.loadSubordinateTable(targetContent, arrId, parentRecordId, reqId);
                             targetContent.dataset.loaded = 'true';
+                        } else {
+                            this.attachSubordinateScrollListener(targetContent);
                         }
                     }
 
@@ -733,15 +735,15 @@
                 const hasMore = rows.length > pageSize;
                 const firstPageRows = hasMore ? rows.slice(0, pageSize) : rows;
 
-                // Render the subordinate table with first page data
-                this.renderSubordinateTable(container, metadata, firstPageRows, arrId, parentRecordId);
-
                 // Store pagination state on container for infinite scroll (issue #1640)
                 container._subordinateHasMore = hasMore;
                 container._subordinateLoadedCount = firstPageRows.length;
                 container._subordinateIsLoading = false;
                 container._subordinateArrIdForScroll = arrId;
                 container._subordinateParentRecordIdForScroll = parentRecordId;
+
+                // Render the subordinate table with first page data
+                this.renderSubordinateTable(container, metadata, firstPageRows, arrId, parentRecordId);
 
                 // Attach infinite scroll listener to the modal's scrollable body (issue #1640)
                 this.attachSubordinateScrollListener(container);
@@ -756,19 +758,38 @@
          * Attach scroll listener to the subordinate modal's .edit-form-body for infinite scroll (issue #1640).
          * Loads next page when user scrolls near the bottom. Shows Ajax spinner while loading.
          */
+        getSubordinateScrollElement(container) {
+            const modal = container && typeof container.closest === 'function'
+                ? container.closest('.edit-form-modal')
+                : null;
+            if (!modal || typeof modal.querySelector !== 'function') return null;
+            return modal.querySelector('.edit-form-body');
+        }
+
+        isSubordinateContainerActive(container) {
+            const tabContent = container && typeof container.closest === 'function'
+                ? container.closest('.edit-form-tab-content')
+                : null;
+
+            // Cell-opened .subordinate-modal tables are not inside tab content.
+            if (!tabContent) return true;
+            if (!tabContent.classList || typeof tabContent.classList.contains !== 'function') return true;
+            return tabContent.classList.contains('active');
+        }
+
         attachSubordinateScrollListener(container) {
-            // Find the scrollable modal body
-            const modal = container.closest('.edit-form-modal.subordinate-modal');
-            if (!modal) return;
-            const scrollEl = modal.querySelector('.edit-form-body');
+            const scrollEl = this.getSubordinateScrollElement(container);
             if (!scrollEl) return;
 
-            // Remove previous listener if re-attached (e.g. after re-render)
-            if (scrollEl._subordinateScrollListener) {
-                scrollEl.removeEventListener('scroll', scrollEl._subordinateScrollListener);
+            // Remove this container's previous listener if re-attached (e.g. after re-render).
+            // The same .edit-form-body can host several subordinate tabs, so listeners are
+            // tracked per container instead of replacing a shared scrollEl listener.
+            if (container._subordinateScrollElement && container._subordinateScrollListener) {
+                container._subordinateScrollElement.removeEventListener('scroll', container._subordinateScrollListener);
             }
 
             const scrollListener = () => {
+                if (!this.isSubordinateContainerActive(container)) return;
                 if (container._subordinateIsLoading || !container._subordinateHasMore) return;
 
                 const threshold = 200;
@@ -778,7 +799,8 @@
                 }
             };
 
-            scrollEl._subordinateScrollListener = scrollListener;
+            container._subordinateScrollElement = scrollEl;
+            container._subordinateScrollListener = scrollListener;
             scrollEl.addEventListener('scroll', scrollListener);
 
             // Check immediately in case the first page already fits the screen (issue #1640)
@@ -1545,11 +1567,14 @@
                 const hasMore = rows.length > pageSize;
                 const firstPageRows = hasMore ? rows.slice(0, pageSize) : rows;
 
-                this.renderSubordinateTable(container, metadata_new, firstPageRows, arrId, parentRecordId);
-
                 container._subordinateHasMore = hasMore;
                 container._subordinateLoadedCount = firstPageRows.length;
                 container._subordinateIsLoading = false;
+                container._subordinateArrIdForScroll = arrId;
+                container._subordinateParentRecordIdForScroll = parentRecordId;
+
+                this.renderSubordinateTable(container, metadata_new, firstPageRows, arrId, parentRecordId);
+                this.attachSubordinateScrollListener(container);
 
                 this.showToast(`Вставлено ${successCount} записей${errorCount > 0 ? `, ошибок: ${errorCount}` : ''}`, successCount > 0 ? 'success' : 'error');
             } catch (error) {
@@ -1949,4 +1974,3 @@
                 this.showToast(`Ошибка: ${ error.message }`, 'error');
             }
         }
-


### PR DESCRIPTION
## Problem
Subordinate-table pagination state was initialized, but the scroll listener only attached when the nearest modal matched `.edit-form-modal.subordinate-modal`. Subordinate tables shown as tabs in an expanded edit form share the same `.edit-form-body` scroll area without always having the `.subordinate-modal` class, so scrolling the table did not fetch the next page.

The table also supports row ordering via drag-and-drop, so hidden tabs must not auto-load in the background and disturb the active table state.

## Solution
- Attach subordinate infinite-scroll listeners to the nearest `.edit-form-body` instead of requiring `.subordinate-modal` on the modal.
- Track listeners per subordinate table container so multiple subordinate tabs do not replace each other's listener.
- Ignore inactive subordinate tab content when scroll events fire.
- Reattach the listener when switching back to an already loaded subordinate tab and after paste-driven table reloads.
- Keep pagination state available before render so re-renders can restore the listener consistently.

## How to reproduce
1. Open an edit form with a subordinate table containing more rows than the page size.
2. Open the subordinate table tab/modal and scroll to the bottom of the `.edit-form-body`.
3. Before this fix, no additional rows load in the expanded edit-form tab case.
4. After this fix, the next page loads while inactive subordinate tabs stay idle.

## Tests
- `node experiments/test-issue-2370-subordinate-modal-scroll.js`
- `node experiments/test-issue-2234-subordinate-duplicate-refresh.js`
- `node experiments/test-issue-603-delete-confirm-modal.js`
- `node experiments/test-issue-2059-cursor-loss.js`
- `node --check js/integram-table.js`
- `node --check experiments/test-issue-2370-subordinate-modal-scroll.js`
- `git diff --check`

Fixes #2370