### PR TITLE
Fix SQL sticky scrollbar after report DOM refresh

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T08:26:33.339Z for PR creation at branch issue-2376-73321b28c9f4 for issue https://github.com/ideav/crm/issues/2376

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T08:26:33.339Z for PR creation at branch issue-2376-73321b28c9f4 for issue https://github.com/ideav/crm/issues/2376

--- a/experiments/test-issue-2348-sql-sticky-scrollbar.js
+++ b/experiments/test-issue-2348-sql-sticky-scrollbar.js
@@ -64,13 +64,16 @@ const stickyScrollbar = {
 const stickyContent = {
     style: {}
 };
+let activeReport = report;
+let activeStickyScrollbar = stickyScrollbar;
+let activeStickyContent = stickyContent;
 
 const context = {
     Math,
     byId(id) {
-        if (id === 'ShowReport') return report;
-        if (id === 'ShowReportStickyScrollbar') return stickyScrollbar;
-        if (id === 'ShowReportStickyScrollbarContent') return stickyContent;
+        if (id === 'ShowReport') return activeReport;
+        if (id === 'ShowReportStickyScrollbar') return activeStickyScrollbar;
+        if (id === 'ShowReportStickyScrollbarContent') return activeStickyContent;
         return null;
     },
     window: {
@@ -84,7 +87,9 @@ const context = {
         }
     },
     showReportScrollbarAttached: false,
-    showReportScrollbarSyncing: false
+    showReportScrollbarSyncing: false,
+    showReportScrollbarReport: null,
+    showReportScrollbarSticky: null
 };
 
 vm.createContext(context);
@@ -142,6 +147,54 @@ assert(
 assert(
     listeners.window.some(listener => listener.type === 'resize'),
     'sticky scrollbar should update when the viewport is resized'
+);
+
+const replacementListeners = {
+    report: {},
+    scrollbar: {}
+};
+const replacementTable = {
+    scrollWidth: 1280
+};
+const replacementReport = {
+    clientWidth: 520,
+    scrollWidth: 1280,
+    scrollLeft: 0,
+    querySelector(selector) {
+        return selector === 'table' ? replacementTable : null;
+    },
+    getBoundingClientRect() {
+        return reportRect;
+    },
+    addEventListener(type, callback) {
+        replacementListeners.report[type] = callback;
+    }
+};
+const replacementStickyScrollbar = {
+    style: {},
+    scrollLeft: 0,
+    addEventListener(type, callback) {
+        replacementListeners.scrollbar[type] = callback;
+    }
+};
+const replacementStickyContent = {
+    style: {}
+};
+
+activeReport = replacementReport;
+activeStickyScrollbar = replacementStickyScrollbar;
+activeStickyContent = replacementStickyContent;
+context.attachShowReportScrollbar();
+
+assert(
+    typeof replacementListeners.scrollbar.scroll === 'function',
+    'reattaching after #one innerHTML replacement should bind the new sticky scrollbar'
+);
+replacementStickyScrollbar.scrollLeft = 520;
+replacementListeners.scrollbar.scroll();
+assert(
+    replacementReport.scrollLeft === 520,
+    'scrolling the replaced sticky scrollbar should move the replaced #ShowReport'
 );
 
 console.log('issue 2348 sql sticky scrollbar test passed');

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -464,7 +464,7 @@ center:hover .add-id-for-col {
 </div>
 <script>
 var timer,lastK,froms,repList=byId('list').innerHTML;
-var showReportScrollbarAttached=false,showReportScrollbarSyncing=false;
+var showReportScrollbarAttached=false,showReportScrollbarSyncing=false,showReportScrollbarReport,showReportScrollbarSticky;
 function getFrom(json){
     var i,alias,right,f='',h='<option value=""> </option>';
     for(i in json.object){
@@ -1053,7 +1053,7 @@ function attachShowReportScrollbar(){
         scrollbar=byId('ShowReportStickyScrollbar');
     if(!report||!scrollbar)
         return;
-    if(showReportScrollbarAttached){
+    if(showReportScrollbarAttached&&showReportScrollbarReport===report&&showReportScrollbarSticky===scrollbar){
         scheduleShowReportScrollbarUpdate();
         return;
     }
@@ -1072,9 +1072,13 @@ function attachShowReportScrollbar(){
             showReportScrollbarSyncing=false;
         }
     });
-    window.addEventListener('scroll',handleShowReportScrollbarWindowScroll,true);
-    window.addEventListener('resize',scheduleShowReportScrollbarUpdate);
+    if(!showReportScrollbarAttached){
+        window.addEventListener('scroll',handleShowReportScrollbarWindowScroll,true);
+        window.addEventListener('resize',scheduleShowReportScrollbarUpdate);
+    }
     showReportScrollbarAttached=true;
+    showReportScrollbarReport=report;
+    showReportScrollbarSticky=scrollbar;
     scheduleShowReportScrollbarUpdate();
 }
 function drawCol(id, drawIdButton){


### PR DESCRIPTION
## Summary
- Reattach SQL report sticky-scrollbar element listeners when `#one.innerHTML` refreshes and replaces `#ShowReport` / `#ShowReportStickyScrollbar`.
- Keep window scroll and resize listeners one-time so repeated report redraws do not duplicate global listeners.
- Extend the sticky-scrollbar regression test to cover the DOM replacement path from issue #2376.

## Reproduce
1. Open a SQL report with enough columns to overflow horizontally and enough rows for the native `#ShowReport` scrollbar to be below the viewport.
2. Let the report metadata load: the `one` response rewrites `#one.innerHTML`, replacing the report and sticky scrollbar nodes.
3. Drag or click the fixed scrollbar at the bottom of the viewport.
4. Before this fix, the fixed scrollbar thumb moved but the report stayed at the original horizontal position; the native scrollbar worked only after scrolling down to it. After this fix, the replaced sticky scrollbar is bound and moves `#ShowReport`.

## Tests
- `node experiments/test-issue-2348-sql-sticky-scrollbar.js`
- `node experiments/test-issue-1978-sql-hint-query-link.js`
- `node experiments/test-issue-2162-sql-datetime-report.js`
- `git diff --check`

Fixes #2376