### PR TITLE
Вынести .subordinate-row-number на уровень выше - в родительский td, прижать влево вверх

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T08:39:21.987Z for PR creation at branch issue-2378-ba3cab895f2d for issue https://github.com/ideav/crm/issues/2378

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T08:39:21.987Z for PR creation at branch issue-2378-ba3cab895f2d for issue https://github.com/ideav/crm/issues/2378

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -447,6 +447,7 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
 }
 
 .integram-table td {
+    position: relative;
     padding: 10px;
     border-bottom: 1px solid var(--md-divider);
     border-left: none;
@@ -1392,8 +1393,8 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
 
 .subordinate-row-number {
     position: absolute;
-    bottom: 4px;
-    right: 4px;
+    top: 2px;
+    left: 2px;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1897,21 +1897,6 @@ class IntegramTable{
             return `<span class="${ className }">${ rowIndex + 1 }</span>`;
         }
 
-        addSubordinateRowNumberToCellContent(cellHtml, rowIndex) {
-            if (cellHtml.includes('subordinate-row-number')) {
-                return cellHtml;
-            }
-
-            const hasEditIcon = cellHtml.includes('class="edit-icon"');
-            const rowNumberHtml = this.renderSubordinateRowNumber(rowIndex, hasEditIcon);
-
-            if (cellHtml.includes('class="cell-content-wrapper"')) {
-                return cellHtml.replace(/<\/div>\s*$/, `${ rowNumberHtml }</div>`);
-            }
-
-            return `<div class="cell-content-wrapper"><span>${ cellHtml }</span>${ rowNumberHtml }</div>`;
-        }
-
         renderCell(column, value, rowIndex, colIndex) {
             // Determine display format:
             // 1. For report data sources, column.format may already be a symbolic format like 'BOOLEAN'
@@ -2422,11 +2407,13 @@ class IntegramTable{
                 }
             }
 
+            let rowNumberHtml = '';
             if (this.shouldRenderSubordinateRowNumber(rowIndex, colIndex)) {
-                escapedValue = this.addSubordinateRowNumberToCellContent(escapedValue, rowIndex);
+                const withEditIcon = escapedValue.includes('class="edit-icon"');
+                rowNumberHtml = this.renderSubordinateRowNumber(rowIndex, withEditIcon);
             }
 
-            return `<td class="${ cellClass }" data-row="${ rowIndex }" data-col="${ colIndex }" data-source-type="${ this.getDataSourceType() }"${ dataTypeAttrs }${ customStyle }${ editableAttrs }>${ escapedValue }</td>`;
+            return `<td class="${ cellClass }" data-row="${ rowIndex }" data-col="${ colIndex }" data-source-type="${ this.getDataSourceType() }"${ dataTypeAttrs }${ customStyle }${ editableAttrs }>${ escapedValue }${ rowNumberHtml }</td>`;
         }
 
         /**
@@ -19330,7 +19317,7 @@ class IntegramCreateFormHelper {
 
                 // Main value column (clickable)
                 const mainValue = values[0] || '';
-                html += `<td class="subordinate-cell-clickable subordinate-cell-with-row-number" data-row="${rowIndex}" data-record-id="${recordId}" data-type-id="${arrId}"><div class="cell-content-wrapper"><span>${this.escapeHtml(mainValue)}</span><span class="subordinate-row-number">${rowIndex + 1}</span></div></td>`;
+                html += `<td class="subordinate-cell-clickable subordinate-cell-with-row-number" data-row="${rowIndex}" data-record-id="${recordId}" data-type-id="${arrId}">${this.escapeHtml(mainValue)}<span class="subordinate-row-number">${rowIndex + 1}</span></td>`;
 
                 // Requisite columns
                 let valIdx = 1;

--- a/js/integram-table/06-render-cell.js
+++ b/js/integram-table/06-render-cell.js
@@ -21,21 +21,6 @@
             return `<span class="${ className }">${ rowIndex + 1 }</span>`;
         }
 
-        addSubordinateRowNumberToCellContent(cellHtml, rowIndex) {
-            if (cellHtml.includes('subordinate-row-number')) {
-                return cellHtml;
-            }
-
-            const hasEditIcon = cellHtml.includes('class="edit-icon"');
-            const rowNumberHtml = this.renderSubordinateRowNumber(rowIndex, hasEditIcon);
-
-            if (cellHtml.includes('class="cell-content-wrapper"')) {
-                return cellHtml.replace(/<\/div>\s*$/, `${ rowNumberHtml }</div>`);
-            }
-
-            return `<div class="cell-content-wrapper"><span>${ cellHtml }</span>${ rowNumberHtml }</div>`;
-        }
-
         renderCell(column, value, rowIndex, colIndex) {
             // Determine display format:
             // 1. For report data sources, column.format may already be a symbolic format like 'BOOLEAN'
@@ -546,11 +531,13 @@
                 }
             }
 
+            let rowNumberHtml = '';
             if (this.shouldRenderSubordinateRowNumber(rowIndex, colIndex)) {
-                escapedValue = this.addSubordinateRowNumberToCellContent(escapedValue, rowIndex);
+                const withEditIcon = escapedValue.includes('class="edit-icon"');
+                rowNumberHtml = this.renderSubordinateRowNumber(rowIndex, withEditIcon);
             }
 
-            return `<td class="${ cellClass }" data-row="${ rowIndex }" data-col="${ colIndex }" data-source-type="${ this.getDataSourceType() }"${ dataTypeAttrs }${ customStyle }${ editableAttrs }>${ escapedValue }</td>`;
+            return `<td class="${ cellClass }" data-row="${ rowIndex }" data-col="${ colIndex }" data-source-type="${ this.getDataSourceType() }"${ dataTypeAttrs }${ customStyle }${ editableAttrs }>${ escapedValue }${ rowNumberHtml }</td>`;
         }
 
         /**

--- a/js/integram-table/25-create-form-helper.js
+++ b/js/integram-table/25-create-form-helper.js
@@ -1634,7 +1634,7 @@ class IntegramCreateFormHelper {
 
                 // Main value column (clickable)
                 const mainValue = values[0] || '';
-                html += `<td class="subordinate-cell-clickable subordinate-cell-with-row-number" data-row="${rowIndex}" data-record-id="${recordId}" data-type-id="${arrId}"><div class="cell-content-wrapper"><span>${this.escapeHtml(mainValue)}</span><span class="subordinate-row-number">${rowIndex + 1}</span></div></td>`;
+                html += `<td class="subordinate-cell-clickable subordinate-cell-with-row-number" data-row="${rowIndex}" data-record-id="${recordId}" data-type-id="${arrId}">${this.escapeHtml(mainValue)}<span class="subordinate-row-number">${rowIndex + 1}</span></td>`;
 
                 // Requisite columns
                 let valIdx = 1;


### PR DESCRIPTION
Fixes #2378

## Изменения

### Проблема
Элемент `.subordinate-row-number` (номер строки в подчинённой таблице) находился внутри `div.cell-content-wrapper` и был позиционирован в правом нижнем углу (`bottom: 4px; right: 4px`).

### Решение
1. **JS**: Удалён метод `addSubordinateRowNumberToCellContent` — span с номером строки теперь добавляется напрямую в `<td>`, а не внутрь `cell-content-wrapper`.
2. **CSS**: Позиционирование изменено с `bottom: 4px; right: 4px` на `top: 2px; left: 2px` (левый верхний угол).
3. **CSS**: Добавлен `position: relative` к `.integram-table td` чтобы абсолютно позиционированный span привязывался к ячейке, а не к ближайшему позиционированному предку.

Аналогичное изменение применено и в `25-create-form-helper.js` для subordinate-таблиц в форме создания.

## Затронутые файлы
- `css/integram-table.css`
- `js/integram-table/06-render-cell.js`
- `js/integram-table/25-create-form-helper.js`
- `js/integram-table.js` (бандл)