### PR TITLE
Сделать .subordinate-row-number светлее (lightgray) и отвязать видимость от появления .edit-icon

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T11:06:02.475Z for PR creation at branch issue-2380-438fa038b537 for issue https://github.com/ideav/crm/issues/2380

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T11:06:02.475Z for PR creation at branch issue-2380-438fa038b537 for issue https://github.com/ideav/crm/issues/2380

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -1400,16 +1400,12 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     justify-content: center;
     min-width: 24px;
     height: 24px; */
-    color: var(--md-text-hint, #9e9e9e);
+    color: lightgray;
     font-size: 0.6875rem;
     font-weight: 500;
     line-height: 1;
     pointer-events: none;
     transition: var(--md-transition);
-}
-
-.editable-cell:hover .subordinate-row-number-with-edit-icon {
-    opacity: 0;
 }
 
 .editable-cell:hover .edit-icon {


### PR DESCRIPTION
Fixes #2380

## Изменения

### Проблема
1. Элемент `.subordinate-row-number` (номер строки в подчинённой таблице) имел цвет `var(--md-text-hint, #9e9e9e)` — слишком тёмный.
2. При наведении на `.editable-cell` срабатывало правило `.editable-cell:hover .subordinate-row-number-with-edit-icon { opacity: 0 }`, которое скрывало номер строки в момент появления иконки редактирования.

### Решение
- Изменён цвет `.subordinate-row-number` с `var(--md-text-hint, #9e9e9e)` на `lightgray`.
- Удалено правило `opacity: 0` для `.subordinate-row-number-with-edit-icon` при ховере — номер строки теперь всегда виден, независимо от состояния `.edit-icon`.

## Затронутые файлы
- `css/integram-table.css`