### PR TITLE
Fix empty non-functional vertical scrollbar in sql.html

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T12:19:51.667Z for PR creation at branch issue-2382-7cfe15f0153e for issue https://github.com/ideav/crm/issues/2382

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T12:19:51.667Z for PR creation at branch issue-2382-7cfe15f0153e for issue https://github.com/ideav/crm/issues/2382

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -178,7 +178,7 @@ center:hover .add-id-for-col {
 }
 #ShowReport {
     overflow-x: auto;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 #ShowReportStickyScrollbar {
     position: fixed;


### PR DESCRIPTION
## Problem

In `templates/sql.html`, the `#ShowReport` div had `overflow-y: scroll`, which **always** forces a vertical scrollbar to be displayed — even when the table content does not overflow vertically. This produced a visible but non-functional empty scrollbar on the right side of the table.

## Fix

Changed `overflow-y: scroll` → `overflow-y: auto` so the vertical scrollbar only appears when the content actually overflows.

```diff
 #ShowReport {
     overflow-x: auto;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
```

## How to reproduce

Open the SQL query builder (`/sql/`), run any query that produces a table shorter than the viewport height. The empty scrollbar on the right disappears after this fix.

Fixes #2382