### PR TITLE
dash.js: читать метку из позиционного r[] в ответе JSON_OBJ (#2392)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-05T15:36:16.864Z for PR creation at branch issue-2386-651b17320519 for issue https://github.com/ideav/crm/issues/2386
+# Updated: 2026-05-05T16:02:50.857Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T15:36:16.864Z for PR creation at branch issue-2386-651b17320519 for issue https://github.com/ideav/crm/issues/2386
-# Updated: 2026-05-05T16:02:50.857Z

--- a/experiments/test-issue-2392-jsonobj-label-positional.js
+++ b/experiments/test-issue-2392-jsonobj-label-positional.js
@@ -1,0 +1,211 @@
+// Issue #2392: PR #2391 решал #2390 неверно.
+//
+// Спецификация из issue #2385 однозначна:
+//   В запросе object/1010 передавать значение метки в качестве параметра:
+//   1. если она непустая, то F_155556=%
+//   2. если непустая [пустая], то F_155556=!%
+//
+// То есть серверный фильтр — литеральный `%` / `!%` (any-label / no-label
+// bucket), а клиент уже применяет правила сопоставления (а/б/в) по
+// подстроке. PR #2391 поменял URL на `%<label>%` — это не соответствует
+// спеке и теряет правило (а): запись с меткой "вводные" не нашлась бы
+// для строки дэшборда с меткой "вводные кв1".
+//
+// Корень проблемы #2390: ответ object/<type>?JSON_OBJ — позиционные
+// массивы `r`, у `rec['Метка']` всегда undefined. Правильное решение —
+// читать метку из `r[index]`, где index определяется по `metadata.reqs`
+// (r[0] = main value, r[1..N] = reqs). Тогда серверный фильтр остаётся
+// `%`/`!%`, а клиентский фильтр корректно сравнивает реальные метки.
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function extractWindowFn(name) {
+    const marker = 'window.' + name + ' = function';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing window fn ' + name);
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) {
+            const fnStart = source.indexOf('function', start);
+            const argsStart = source.indexOf('(', fnStart);
+            return 'function ' + name + source.slice(argsStart, i + 1);
+        }
+    }
+    throw new Error('Unclosed window fn ' + name);
+}
+
+const harness = `
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+const DASH_VALUE_LABEL_FIELD_ID = '155556';
+const DASH_MATRIX_LABEL_FIELD_ID = '155557';
+const DASH_MATRIX_DATE_FIELD_ID = '155552';
+const DASH_MATRIX_LINE_FIELD_ID = '155553';
+const DASH_MATRIX_COL_FIELD_ID = '155554';
+
+let dashMetadata = null;
+
+const callRecord = [];
+function newApi(method, url, callback, params, ctx) {
+    callRecord.push({ method, url, callback, params, ctx });
+}
+function dashSetStatus() {}
+function dashFormatNumberText(v) { return v; }
+function dashCalcCells() {}
+function dashCalcRGFormulas() {}
+function dashShowMultivalModal() { callRecord.push({ method: 'MODAL' }); }
+function dashTodayYMD() { return '20260101'; }
+function dashCellItemRef(td) { return td.dataset.itemRef || ''; }
+function dashCellRgHead(td) { return td.dataset.rgHead || ''; }
+function dashCellDateFr(td) { return td.dataset.fr || null; }
+function dashCellDateTo(td) { return td.dataset.to || null; }
+function dashMatrixUsesDates() { return false; }
+function dashMatrixSheetInputValue() { return ''; }
+
+${extractFunction('dashNormalizeMatrixKey')}
+${extractFunction('dashMatrixLabelScore')}
+${extractFunction('dashMatrixLabelMatches')}
+${extractFunction('dashFindTypeMetadata')}
+${extractFunction('dashRecordReqIndex')}
+${extractFunction('dashRecordLabel')}
+${extractFunction('dashMatrixDashLabel')}
+${extractFunction('dashMatrixSearchUrl')}
+${extractFunction('dashMatrixValueSearchDone')}
+${extractFunction('dashValueSearchUrl')}
+${extractWindowFn('dashValueSearchDone')}
+
+function makeCell(opts) {
+    const dataset = Object.assign({}, opts || {});
+    return {
+        dataset,
+        style: {},
+        textContent: '',
+        setAttribute() {},
+        getAttribute() { return null; },
+        closest() { return null; }
+    };
+}
+
+const ISSUE_PAYLOAD = [{
+    "i": 159454, "u": 1, "o": 1,
+    "r": ["2", "01.01.2026", "2811:сайт", "", "", "", "1974:Кол-во", "вводные"]
+}];
+const VALUE_METADATA_1010 = {
+    id: '1010', val: 'Значение',
+    reqs: [
+        { num: 1, id: '1039',   val: 'Дата' },
+        { num: 2, id: '1042',   val: 'Строка бюджета' },
+        { num: 3, id: '2012',   val: 'Столбец' },
+        { num: 4, id: '1047',   val: 'Факт' },
+        { num: 5, id: '1048',   val: 'Ед.изм.' },
+        { num: 6, id: '1104',   val: 'Колонка группы' },
+        { num: 7, id: '155556', val: 'Метка' }
+    ]
+};
+
+// === Case 1: server URL keeps literal '%' (NOT '%вводные%') per spec ===
+let td = makeCell({
+    valueItemId: '2811',
+    fr: '20260101', to: '20260131',
+    rgHead: 'Кол-во',
+    dashLabel: 'вводные'
+});
+let url = dashValueSearchUrl(td);
+assert(/[?&]F_155556=%(&|$)/.test(url),
+    'value URL must use literal F_155556=% per #2385 spec, got: ' + url);
+assert(url.indexOf('%' + encodeURIComponent('вводные')) === -1,
+    'value URL must NOT include %<label>% (regression of #2391), got: ' + url);
+
+// === Case 2: empty label still uses literal '!%' ===
+td = makeCell({ valueItemId: '2811', fr: '20260101', to: '20260131' });
+url = dashValueSearchUrl(td);
+assert(/[?&]F_155556=!%(&|$)/.test(url),
+    'value URL with empty label must use F_155556=!%, got: ' + url);
+
+// === Case 3: matrix URL mirrors the same spec ===
+td = makeCell({ matrixLine: 'L', matrixCol: 'C', dashLabel: 'вводные' });
+url = dashMatrixSearchUrl(td);
+assert(/[?&]F_155557=%(&|$)/.test(url),
+    'matrix URL must use literal F_155557=%, got: ' + url);
+
+td = makeCell({ matrixLine: 'L', matrixCol: 'C' });
+url = dashMatrixSearchUrl(td);
+assert(/[?&]F_155557=!%(&|$)/.test(url),
+    'matrix URL with empty label must use F_155557=!%, got: ' + url);
+
+// === Case 4: post-filter reads label via metadata.reqs index, not rec['Метка'] ===
+dashMetadata = [VALUE_METADATA_1010];
+const idx = dashRecordReqIndex('1010', '155556');
+assert(idx === 7, 'expected reqs index 7 for Метка via metadata, got: ' + idx);
+assert(dashRecordLabel(ISSUE_PAYLOAD[0], '1010', '155556') === 'вводные',
+    'must read "вводные" from r[7] via metadata');
+
+// === Case 5: end-to-end "clear value with label" → _m_del fires ===
+const cell = makeCell({
+    valueItemId: '2811',
+    fr: '20260101', to: '20260131',
+    rgHead: 'Кол-во',
+    dashLabel: 'вводные',
+    src: 'rg'
+});
+callRecord.length = 0;
+dashValueSearchDone(ISSUE_PAYLOAD, {
+    td: cell, newVal: '', originalVal: '2',
+    itemRef: 'сайт', fr: null, to: null, rgHead: 'Кол-во',
+    dashLabel: 'вводные'
+});
+assert(callRecord.length === 1, 'expected one POST after search, got: ' + callRecord.length);
+assert(callRecord[0].method === 'POST', 'expected POST, got: ' + callRecord[0].method);
+assert(callRecord[0].url.indexOf('_m_del/159454') === 0,
+    'expected _m_del/159454 (post-filter must keep the matching record), got: ' + callRecord[0].url);
+
+// === Case 6: with NO metadata cached, fallback to last r element still works ===
+dashMetadata = null;
+assert(dashRecordLabel(ISSUE_PAYLOAD[0], '1010', '155556') === 'вводные',
+    'fallback to r[r.length - 1] must yield "вводные"');
+
+// === Case 7: rule (а) — empty stored label vs non-empty dashLabel — should NOT match ===
+dashMetadata = [VALUE_METADATA_1010];
+const empty = { i: 1, r: ['', '', '', '', '', '', '', ''] };
+assert(!dashMatrixLabelMatches('вводные', dashRecordLabel(empty, '1010', '155556')),
+    'empty stored label must not match non-empty dash label');
+
+// === Case 8: rule (а) — substring direction "stored ⊂ dash" ===
+const partial = { i: 2, r: ['', '', '', '', '', '', '', 'ввод'] };
+assert(dashMatrixLabelMatches('вводные', dashRecordLabel(partial, '1010', '155556')),
+    'rule (а): stored "ввод" ⊂ dash "вводные" must match');
+
+// === Case 9: rule (б) — substring direction "dash ⊂ stored" ===
+const longer = { i: 3, r: ['', '', '', '', '', '', '', 'вводные кв1'] };
+assert(dashMatrixLabelMatches('вводные', dashRecordLabel(longer, '1010', '155556')),
+    'rule (б): dash "вводные" ⊂ stored "вводные кв1" must match');
+
+// === Case 10: rule (в) — both empty ===
+const both = { i: 4, r: ['', '', '', '', '', '', '', ''] };
+assert(dashMatrixLabelMatches('', dashRecordLabel(both, '1010', '155556')),
+    'rule (в): both empty must match');
+`;
+
+vm.runInNewContext(harness, { console });
+console.log('issue-2392 jsonobj label positional: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -312,6 +312,52 @@ function dashMatrixLabelMatches(dashLabel, matrixLabel) {
     return dashMatrixLabelScore(dashLabel, matrixLabel) > 0;
 }
 
+// Find the cached metadata entry for a given object type id.
+// dashMetadata may be an array of {id, reqs, ...} (the typical /metadata
+// payload — see js/integram-table/16-state.js) or an object keyed by id.
+function dashFindTypeMetadata(typeId) {
+    if (!dashMetadata) return null;
+    var key = String(typeId);
+    var num = Number(typeId);
+    if (Array.isArray(dashMetadata)) {
+        for (var i = 0; i < dashMetadata.length; i++) {
+            var item = dashMetadata[i];
+            if (item && (String(item.id) === key || item.id === num)) return item;
+        }
+        return null;
+    }
+    if (typeof dashMetadata === 'object') {
+        return dashMetadata[key] || dashMetadata[num] || null;
+    }
+    return null;
+}
+
+// Returns the index in a JSON_OBJ record's `r` array where the given req
+// field lives, or -1 if not resolvable. Layout: r[0] = main value,
+// r[1..N] = reqs in metadata.reqs order (issue #857).
+function dashRecordReqIndex(typeId, fieldId) {
+    var meta = dashFindTypeMetadata(typeId);
+    if (!meta || !Array.isArray(meta.reqs)) return -1;
+    for (var i = 0; i < meta.reqs.length; i++) {
+        if (meta.reqs[i] && String(meta.reqs[i].id) === String(fieldId)) return i + 1;
+    }
+    return -1;
+}
+
+// Reads the dashboard label off a record returned by object/<type>?JSON_OBJ.
+// JSON_OBJ payloads expose values only via the positional `r` array — there
+// is no `rec['Метка']` key — so we resolve the index via cached metadata
+// and fall back to the last req when metadata is unavailable (the dashboard
+// schemas keep the label field as the trailing req on both 1010 and 155551).
+function dashRecordLabel(rec, typeId, labelFieldId) {
+    if (!rec) return '';
+    if (Object.prototype.hasOwnProperty.call(rec, 'Метка')) return rec['Метка'] || '';
+    if (!Array.isArray(rec.r)) return '';
+    var idx = dashRecordReqIndex(typeId, labelFieldId);
+    if (idx >= 0 && idx < rec.r.length) return rec.r[idx] || '';
+    return rec.r[rec.r.length - 1] || '';
+}
+
 function dashSumMatrixValues(rows) {
     var acc = 0, hasNumeric = false, vals = [], ids = [];
     rows.forEach(function(row) {
@@ -4926,10 +4972,12 @@ function dashMatrixValueSearchDone(json, ctx) {
     if (!Array.isArray(json)) json = [];
     var td = ctx.td, newVal = ctx.newVal;
 
-    // Filter results by label matching rules (а/б/в) using the row's dashboard label
+    // Filter results by label matching rules (а/б/в) using the row's dashboard label.
+    // The server-side filter is the literal F_155557=% / =!% per the issue spec, which
+    // narrows to "any label" / "no label" — we still need the substring rules client-side.
     var dashLabel = dashMatrixDashLabel(td);
     json = json.filter(function(rec) {
-        return dashMatrixLabelMatches(dashLabel, (rec && rec['Метка']) || '');
+        return dashMatrixLabelMatches(dashLabel, dashRecordLabel(rec, '155551', DASH_MATRIX_LABEL_FIELD_ID));
     });
 
     if (json.length === 0) {
@@ -5043,9 +5091,11 @@ window.dashValueSearchDone = function(json, ctx) {
     var fr = ctx.fr, to = ctx.to, rgHead = ctx.rgHead;
     var dashLabel = ctx.dashLabel || '';
 
-    // Filter results by label matching rules (а/б/в) using the row's dashboard label
+    // Filter results by label matching rules (а/б/в) using the row's dashboard label.
+    // The server-side filter is the literal F_155556=% / =!% per the issue spec, which
+    // narrows to "any label" / "no label" — we still need the substring rules client-side.
     json = (json || []).filter(function(rec) {
-        return dashMatrixLabelMatches(dashLabel, (rec && rec['Метка']) || '');
+        return dashMatrixLabelMatches(dashLabel, dashRecordLabel(rec, '1010', DASH_VALUE_LABEL_FIELD_ID));
     });
 
     if (json.length === 0) {


### PR DESCRIPTION
Closes #2392, фактически чинит #2390.

## Что произошло

В #2387 я добавил клиентский пост-фильтр после ответа `object/<type>?JSON_OBJ` для применения правил сопоставления меток (а/б/в) — но читал метку как `rec['Метка']`. У формата `JSON_OBJ` ключей по имени нет, есть только позиционный массив `r`, поэтому фильтр всегда отбрасывал записи с непустой `dashLabel`. Пример из #2390/#2392:

\`\`\`json
[{ "i":159454, "u":1, "o":1,
   "r":["2","01.01.2026","2811:сайт","","","","1974:Кол-во","вводные"] }]
\`\`\`

Метка `"вводные"` есть, но в `r[7]`, а `rec['Метка']` — `undefined`. Очищение значения в ячейке со меткой переставало отправлять `_m_del`.

## Почему PR #2391 решал не так

PR #2391 поменял серверный фильтр на `F_155556=%<label>%` и удалил пост-фильтр. Это:

1. Противоречит явной формулировке #2385 — там сказано `F_155556=%` / `F_155556=!%` (литерал, без подстановки значения).
2. Ломает правило (а) из правил сопоставления: запись с меткой `"ввод"` не найдётся, если у строки дэшборда метка `"вводные"`, потому что `%вводные%` не матчит `"ввод"` на стороне БД.

## Правильное решение

Оставить серверный фильтр как в спеке (`%` / `!%` — bucket-фильтр по «есть/нет метки»), а клиентский фильтр научить читать метку из правильного места:

- **`dashFindTypeMetadata(typeId)`** — достаёт описание типа из кэша `dashMetadata` (поддерживает и массив `[{id, reqs, ...}]`, и объект-словарь по id).
- **`dashRecordReqIndex(typeId, fieldId)`** — возвращает индекс поля в `r[]`. Layout: `r[0]` — main value типа, `r[1..N]` — reqs в порядке `metadata.reqs` (см. [issue #857](https://github.com/ideav/crm/issues/857) и `js/integram-table/16-state.js:450`).
- **`dashRecordLabel(rec, typeId, labelFieldId)`** — берёт метку через индекс из метадаты. Fallback: `rec.r[r.length - 1]` (метка — последняя req и в схеме 1010, и в 155551).

Серверные URL и параметры сохранения (`t155556`, `t155557`) — без изменений.

## Тесты

`experiments/test-issue-2392-jsonobj-label-positional.js` покрывает 10 случаев:

1. `dashValueSearchUrl` оставляет литеральный `F_155556=%` (без `%вводные%` — отсутствие регрессии #2391).
2. Пустая метка → `F_155556=!%`.
3. Аналогично для `dashMatrixSearchUrl` (`F_155557`).
4. Пустая метка матрицы → `!%`.
5. `dashRecordReqIndex('1010', '155556')` через метадату возвращает `7`; `dashRecordLabel` достаёт `"вводные"` из `r[7]`.
6. End-to-end: payload из issue + `newVal=''` + `dashLabel='вводные'` → ровно один POST `_m_del/159454`.
7. Без метадаты в кэше — fallback на `r[r.length-1]` тоже даёт `"вводные"`.
8. Правило (а): пустая запись vs непустая dash — НЕ матч.
9. Правило (а): `"ввод"` ⊂ `"вводные"` — матч.
10. Правило (б): `"вводные"` ⊂ `"вводные кв1"` — матч.
11. Правило (в): обе пустые — матч.

\`\`\`bash
$ node experiments/test-issue-2392-jsonobj-label-positional.js
issue-2392 jsonobj label positional: ok
\`\`\`

## Test plan

- [ ] Дэшборд со строкой меткой `"вводные"`, в БД запись с `Метка="вводные"`. Очищение ячейки → `_m_del` в Network. Reload — значение действительно ушло.
- [ ] Та же строка, ввод нового значения вместо пустой ячейки → запрос `object/1010?...&F_155556=%`, при пустом ответе `_m_new/1010` с `t155556=вводные`.
- [ ] Строка с меткой `"вводные"` и записи в БД с `Метка="ввод"` (правило а): значение должно резолвиться и сохраняться (одна запись после client-side фильтра).
- [ ] Строка с пустой меткой и записи без метки (правило в): сохранение/обновление работает как раньше — регрессии #2387 нет.
- [ ] Аналогичный сценарий для матричных значений (`object/155551`, `_m_new/155551`).