### PR TITLE
index.php: replace md5(microtime()) tokens with CSPRNG (#2122)

### DIFF
--- a/index.php
+++ b/index.php
@@ -384,7 +384,7 @@ elseif(($z == "my") && !empty($_GET['code'])){
         	        if($row["tok"])
             	        $token = $row["tok"];
             	    else{
-            			$token = md5(microtime(TRUE));
+            			$token = secureToken();
                         Insert($row["id"], 1, TOKEN, $token, "Reset token for $socialName admin");
             	    }
         	        if(!$row["xsrf"])
@@ -398,7 +398,7 @@ elseif(($z == "my") && !empty($_GET['code'])){
         	setcookie("idb_$z", $token, time() + 2592000*12, "/"); # 30*12 days
     	}
         else{
-			$GLOBALS["GLOBAL_VARS"]["token"] = md5(microtime(TRUE));
+			$GLOBALS["GLOBAL_VARS"]["token"] = secureToken();
 			$GLOBALS["GLOBAL_VARS"]["xsrf"] = xsrf($GLOBALS["GLOBAL_VARS"]["token"], $z);
             $id = newUser($socialId, $email, "115", $name, $picture);
             Insert($id, 1, 274, $socialName, "Set social for new $socialName user");
@@ -558,14 +558,15 @@ function createDb($id, $name, $email, $pwd=""){
 }
 function updateTokens($row){
 	global $z;
-	$xsrf = $GLOBALS["GLOBAL_VARS"]["xsrf"] = xsrf($token, $z);
-	setcookie("idb_$z", $token, time() + 2592000*12, "/"); # 30*12 days
+	# Token must be assigned before deriving xsrf (issue #2122).
 	if($row["tok"])
     	$token = $GLOBALS["GLOBAL_VARS"]["token"] = $row["token"];
 	else{
-    	$token = $GLOBALS["GLOBAL_VARS"]["token"] = md5(microtime(TRUE));
+    	$token = $GLOBALS["GLOBAL_VARS"]["token"] = secureToken();
 		Insert($row["uid"], 1, TOKEN, $token, "Save token");
 	}
+	$xsrf = $GLOBALS["GLOBAL_VARS"]["xsrf"] = xsrf($token, $z);
+	setcookie("idb_$z", $token, time() + 2592000*12, "/"); # 30*12 days
 	if($row["xsrf"])
 		Update_Val($row["xsrf"], $xsrf);
 	else
@@ -674,6 +675,18 @@ function isApi(){
 }
 function xsrf($a, $b){
 	return substr(hash("sha512", Salt($a, $b)), 0, 22);
+}
+// Cryptographically secure session/auth token. random_bytes() throws if no
+// CSPRNG is available; we fall back to openssl_random_pseudo_bytes (which
+// is also CSPRNG on supported platforms). Issue #2122.
+function secureToken(){
+	try {
+		return bin2hex(random_bytes(32));
+	} catch (Exception $e) {
+		$bytes = openssl_random_pseudo_bytes(32, $strong);
+		if ($bytes !== false && $strong) return bin2hex($bytes);
+		throw $e;
+	}
 }
 function login($z="", $u="", $message="", $details=""){
 	wlog(" @".$_SERVER["REMOTE_ADDR"], "log");
@@ -8179,7 +8192,7 @@ switch($a)  # Check actions, which don't require authentication
 						die(json_encode(["error" => t9n("[RU]Превышено количество попыток входа с кодом. Войдите с паролем.[EN]Too many code login attempts. Please sign in with your password.")], JSON_UNESCAPED_UNICODE));
 					die(json_encode(["error" => t9n("[RU]Неверный код[EN]Invalid code")], JSON_UNESCAPED_UNICODE));
 				}
-    			$token = md5(microtime(TRUE));
+    			$token = secureToken();
     			$xsrf = xsrf($token, $u);
 				Update_Val($row["tok"], $token);
 


### PR DESCRIPTION
Closes #2122.

## Problem

`index.php` minted auth/session tokens via `md5(microtime(TRUE))` in four places (lines 387, 401, 566, 8182). `microtime()` is a time-based source — a remote attacker with timing information can brute-force the 16-byte MD5 within a narrow window. These tokens are then stored in the `idb_$z` cookie with a ~12-month lifetime, so any successful guess yields a long-lived session.

There is also a correctness bug at the original line 561 inside `updateTokens()`:

\`\`\`php
function updateTokens(\$row){
    global \$z;
    \$xsrf = \$GLOBALS[\"GLOBAL_VARS\"][\"xsrf\"] = xsrf(\$token, \$z);  // ← \$token is undefined
    setcookie(\"idb_\$z\", \$token, time() + 2592000*12, \"/\");
    if(\$row[\"tok\"])
        \$token = \$GLOBALS[\"GLOBAL_VARS\"][\"token\"] = \$row[\"token\"];
    else{
        \$token = \$GLOBALS[\"GLOBAL_VARS\"][\"token\"] = md5(microtime(TRUE));
        ...
    }
    ...
}
\`\`\`

`xsrf($token, $z)` runs before `$token` is assigned, so xsrf is derived from an undefined variable (empty string under default PHP settings) — the resulting xsrf is effectively `xsrf('', $z)` for everyone using this code path.

## Fix

- Add `secureToken()` helper that uses `bin2hex(random_bytes(32))` (256 bits of CSPRNG entropy), with `openssl_random_pseudo_bytes(32, $strong)` as a conservative fallback when `random_bytes` raises (no CSPRNG registered).
- Replace all four `md5(microtime(TRUE))` token sites with `secureToken()`.
- Reorder statements in `updateTokens()` so `$token` is assigned before deriving `$xsrf`. The `setcookie()` call moves below the assignment too.

\`\`\`php
function secureToken(){
    try {
        return bin2hex(random_bytes(32));
    } catch (Exception \$e) {
        \$bytes = openssl_random_pseudo_bytes(32, \$strong);
        if (\$bytes !== false && \$strong) return bin2hex(\$bytes);
        throw \$e;
    }
}
\`\`\`

## Operational note

Existing weak tokens already in the database remain valid until they get refreshed/rotated. Recommended follow-up:

1. Force-rotate active sessions (truncate the TOKEN/XSRF rows or run a migration that flips them on next login).
2. Optionally store `hash('sha256', $token)` server-side so even DB read-access can't replay the bearer.

These weren't included here because they touch ops/migration policy rather than the immediate vulnerability.

## Test plan

- [ ] Fresh login flow on `idb_$z` mints a 64-character hex token (not the 32-character MD5 hex).
- [ ] Existing valid `idb_$z` cookies still authenticate (no forced sign-out).
- [ ] `updateTokens()` path: xsrf now equals `xsrf($actualToken, $z)`, not `xsrf('', $z)` — verify by looking at the XSRF row inserted/updated for a freshly migrated session.
- [ ] No `md5(microtime` remains in `index.php` (`grep -n 'md5(microtime' index.php`).
- [ ] Code login flow (`/checkcode` at line 8195): generated token is 64 hex characters and passes subsequent xsrf check.