### PR TITLE
index.php: validate OAuth state before redirect (#2123)

### DIFF
--- a/index.php
+++ b/index.php
@@ -409,7 +409,10 @@ elseif(($z == "my") && !empty($_GET['code'])){
         	setcookie("idb_$z", $GLOBALS["GLOBAL_VARS"]["token"], time() + 2592000*12, "/"); # 30*12 days
         	createDb($id, $name, $email);
         }
-		header("Location: ".(!$isYandex && isset($_GET['state'])?$_GET['state']:"/$z"));
+		# Redirect to a validated local workspace only — never to raw $_GET['state'],
+		# which an attacker can set to an arbitrary URL (open redirect, issue #2123).
+		# $db was already validated against USER_DB_MASK at line 317 (Yandex) and 360 (Google).
+		header("Location: /".(!$isYandex && strlen($db) ? $db : $z));
     }
     else
         login("", "", "oauthError", isset($data['error_description']) ? $data['error_description'] : (isset($data['error']) ? $data['error'] : "tokenExchangeFailed"));


### PR DESCRIPTION
Closes #2123.

## Problem

`index.php:411` (now line 412) trusted `\$_GET['state']` as the post-login redirect target whenever the request wasn't a Yandex callback:

\`\`\`php
header(\"Location: \".(!\$isYandex && isset(\$_GET['state']) ? \$_GET['state'] : \"/\$z\"));
\`\`\`

`state` round-trips through Google's authorization endpoint — it's set by whoever crafted the authz URL, i.e. effectively the user agent. A crafted authz link with `state=https://evil.tld/phish` makes the post-login response redirect users off-site. After the bank/SaaS sign-in succeeds, the user lands on the attacker's clone — a textbook open-redirect-into-phishing primitive.

The earlier code at line 360 already validates `state` against `USER_DB_MASK` and stores the result as `\$db`:

\`\`\`php
\$db = isset(\$_GET['state']) ? (checkDbName(USER_DB_MASK, \$_GET['state']) ? \$_GET['state'] : \"\") : \"\";
\`\`\`

The redirect just wasn't reusing that validated value.

## Fix

\`\`\`php
header(\"Location: /\".(!\$isYandex && strlen(\$db) ? \$db : \$z));
\`\`\`

- Redirect only to `/\$db` — already validated against `USER_DB_MASK = /^[a-z]\\w{2,14}$/i`, so it's a single-segment alphanumeric workspace slug.
- Fall back to `/\$z` (the current DB context) when `\$db` is empty.
- Always prepend a leading `/`. Combined with the strict mask, neither protocol-relative URLs (`//evil.tld/...`) nor backslash tricks can escape same-origin.

This is the same pattern already used at `index.php:70` and `index.php:80`:

\`\`\`php
header(\"Location: /\".(\$oauthDupDb !== \"\" && preg_match(USER_DB_MASK, \$oauthDupDb) ? \$oauthDupDb : \"my\"));
\`\`\`

## Yandex parity

The Yandex branch (`\$isYandex`) keeps its existing `/\$z` redirect. It also has a validated `\$db` from line 317, but I'm not changing the Yandex landing target as part of a security-only patch — that's a behavioral choice the original code made and a follow-up commit can revisit it if needed.

## Test plan

- [ ] Google OAuth callback with `state=mywb` (valid USER_DB_MASK) → 302 to `/mywb`.
- [ ] Google OAuth callback with `state=https://evil.example/x` → state fails `USER_DB_MASK` → 302 to `/\$z` (no off-site redirect).
- [ ] Google OAuth callback with `state=//evil.example` → fails mask → 302 to `/\$z`.
- [ ] Google OAuth callback with `state=` (empty) or no state param → 302 to `/\$z`.
- [ ] Yandex OAuth callback continues to land on `/\$z` regardless of state.
- [ ] No regression for the existing pattern at lines 70/80 (it's unchanged).

## Follow-ups (out of scope)

The issue suggests treating `state` as an opaque CSRF nonce stored server-side (with the post-login return URL kept in session storage and validated as a same-origin path). That's a larger refactor of the OAuth init/callback handshake. This PR only closes the immediate open-redirect vulnerability; the nonce/return-URL split can land separately.