### PR TITLE
index.php: mask sensitive data in logs (Authorization, cookies, tokens, secrets, reset codes)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T18:02:31.008Z for PR creation at branch issue-2396-cc0dbd43ad03 for issue https://github.com/ideav/crm/issues/2396

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T18:02:31.008Z for PR creation at branch issue-2396-cc0dbd43ad03 for issue https://github.com/ideav/crm/issues/2396

--- a/index.php
+++ b/index.php
@@ -104,7 +104,7 @@ $locale = isset($_COOKIE[$z."_locale"]) ? $_COOKIE[$z."_locale"] : (isset($_COOK
 																									
 # The trace cookie to be deleted upon the session close
 if(isset($_GET["TRACE_IT"]) || isset($_COOKIE["TRACE_IT"])){
-	$GLOBALS["TRACE"] = "****".$_SERVER["REQUEST_URI"]."<br/>\n";
+	$GLOBALS["TRACE"] = "****".preg_replace('/([?&](secret|token|c|code|reset)=)[^&]*/i', '$1***', $_SERVER["REQUEST_URI"])."<br/>\n";
     if(isset($_GET["TRACE_IT"]))
 	    setcookie("TRACE_IT", 1, time() + 3600*3, "/$z"); // 3 hours
 	$logPath = "templates/custom/$z/logs";
@@ -115,8 +115,11 @@ if(isset($_GET["TRACE_IT"]) || isset($_COOKIE["TRACE_IT"])){
     fwrite($file, $GLOBALS["TRACE"]."\n");
     $headers =  getallheaders();
     $hdr = "";
-    foreach($headers as $key=>$val)
-        $hdr .= $key . ': ' . $val . '<br>';
+    $sensitiveHeaders = ['authorization', 'x-authorization', 'cookie', 'set-cookie'];
+    foreach($headers as $key=>$val){
+        $masked = in_array(strtolower($key), $sensitiveHeaders) ? '***' : $val;
+        $hdr .= $key . ': ' . $masked . '<br>';
+    }
     wlog(" headers: $hdr", "log");
     fclose($file);
 }
@@ -131,13 +134,15 @@ if(strlen(file_get_contents('php://input'))){
         foreach($json AS $key => $value)
             $_POST[$key] = $_REQUEST[$key] = $value;
 }
+$sensitivePostKeys = ['pwd', 'password', 'token', 'secret', 'reset', 'regpwd', 'regpwd1'];
 foreach($_POST AS $key => $value)
 	if(is_array($value))
 		$params .= "\n $key " . print_r($value, true) . "\n";
 	else
-		if(strlen($value) && ($key != "pwd"))	# Do not log passwords
+		if(strlen($value) && !in_array(strtolower($key), $sensitivePostKeys))
 			$params .= " $key=$value;";
-wlog($_SERVER["REMOTE_ADDR"]." ".$_SERVER["REQUEST_URI"]." $params", "log");
+$safeUri = preg_replace('/([?&](secret|token|c|code|reset)=)[^&]*/i', '$1***', $_SERVER["REQUEST_URI"]);
+wlog($_SERVER["REMOTE_ADDR"]." ".$safeUri." $params", "log");
 if(($z === "my") && ((isset($com[2]) ? $com[2] : "") === "register")){ # Register the user
     # Check if this is a confirmation request
     if(isset($_GET["c"]) && isset($_GET["u"])){
@@ -1409,7 +1414,6 @@ function Validate_Token(){ # Validates the cookie token and gathers the user per
 	elseif(isApi()){
 		foreach(getallheaders() as $key => $value){
 	        $value = htmlentities($value);
-	        wlog("$key => $value");
     		if(strtolower($key) === "x-authorization"){
         		$tok = htmlentities($value);
         		break;


### PR DESCRIPTION
## Problem

`index.php` logged sensitive data in multiple places, as identified in #2124 and tracked by #2396:

1. **TRACE_IT header logging (lines 116–122)**: All request headers including `Authorization`, `X-Authorization`, `Cookie`, and `Set-Cookie` were written to log verbatim — capturing bearer tokens, API keys, and session cookies.
2. **TRACE_IT URI logging (line 107)**: `REQUEST_URI` was written to the trace log with no masking, potentially exposing `?secret=`, `?token=`, `?c=` (registration/reset codes), and `?code=` (OAuth codes).
3. **API auth header logging (line 1412)**: `wlog("$key => $value")` ran for every header inside `Validate_Token()`, logging the full `Authorization` / `X-Authorization` token value on every API request.
4. **Request log URI (line 143)**: `REQUEST_URI` logged without masking sensitive query params.
5. **POST key filter**: Only `pwd` was excluded; `token`, `secret`, `password`, `reset`, `regpwd`, `regpwd1` were not filtered.

## Fix

- **TRACE_IT headers**: Mask value to `***` when header name matches `authorization`, `x-authorization`, `cookie`, or `set-cookie`.
- **URI masking**: Apply `preg_replace` to redact values of `secret`, `token`, `c`, `code`, `reset` query parameters in all logged URIs (TRACE_IT and regular request log).
- **API auth block**: Remove the unconditional `wlog("$key => $value")` that ran before checking the header name.
- **POST key filter**: Extend the exclusion list with `password`, `token`, `secret`, `reset`, `regpwd`, `regpwd1`.

## How to reproduce

Before this fix, enabling `TRACE_IT` (e.g. `curl 'https://example.com/mydb/?TRACE_IT=1' -H 'Authorization: Bearer mysecrettoken'`) would write `Authorization: Bearer mysecrettoken` to the trace log. Similarly, any API request would log the full token via `Validate_Token`.

## Verification

- Trace logs now show `Authorization: ***` instead of the raw token.
- Logged URIs show `?secret=***&code=***` instead of real values.
- API requests no longer produce a per-header log line containing the token.


Fixes #2396