### PR TITLE
integram-table: press Enter in .add-column-modal to trigger Создать (#2398)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-05T18:05:46.621Z for PR creation at branch issue-2398-6a4773788bd5 for issue https://github.com/ideav/crm/issues/2398

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-05T18:05:46.621Z for PR creation at branch issue-2398-6a4773788bd5 for issue https://github.com/ideav/crm/issues/2398

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -8296,6 +8296,15 @@ class IntegramTable{
             // Cancel button handler
             modal.querySelector(`#cancel-add-column-btn-${instanceName}`).addEventListener('click', closeAddColumnModal);
 
+            // Enter in any form field triggers Создать (issue #2398)
+            modal.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && suggestionsDiv.style.display === 'none') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    modal.querySelector(`#create-column-btn-${instanceName}`).click();
+                }
+            });
+
             // Create button handler
             modal.querySelector(`#create-column-btn-${instanceName}`).addEventListener('click', async () => {
                 const columnName = modal.querySelector(`#new-column-name-${instanceName}`).value.trim();

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -1118,6 +1118,15 @@
             // Cancel button handler
             modal.querySelector(`#cancel-add-column-btn-${instanceName}`).addEventListener('click', closeAddColumnModal);
 
+            // Enter in any form field triggers Создать (issue #2398)
+            modal.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' && suggestionsDiv.style.display === 'none') {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    modal.querySelector(`#create-column-btn-${instanceName}`).click();
+                }
+            });
+
             // Create button handler
             modal.querySelector(`#create-column-btn-${instanceName}`).addEventListener('click', async () => {
                 const columnName = modal.querySelector(`#new-column-name-${instanceName}`).value.trim();


### PR DESCRIPTION
## Summary

Fixes #2398

Pressing Enter in any field of the `.add-column-modal` form (column name input, type select, checkboxes) now clicks the **Создать** button — matching the behaviour already present in the column-edit modal.

## Changes

- `js/integram-table/11-column-settings.js` — added a `keydown` listener on the modal element that calls `#create-column-btn-{instanceName}.click()` when `Enter` is pressed and the suggestions dropdown is not visible.
- `js/integram-table.js` — regenerated via `build.sh`.

## How it works

The handler is attached to the modal container (not individual inputs) so it covers all form fields. The check `suggestionsDiv.style.display === 'none'` ensures that when the column-name suggestion dropdown is open, Enter selects a suggestion rather than submitting the form — the same way the colEditModal handles Enter (line 437–444 of the source file).

## How to reproduce / verify

1. Open a table and click the button to add a new column.
2. Type something in the **Имя колонки** field.
3. Press **Enter** → the column should be created (same as clicking Создать).
4. Repeat with focus in the **Базовый тип** select → same result.
5. While the suggestion dropdown is visible, press **Enter** → a suggestion is selected, not the form submitted.