### PR TITLE
Дашборд: режим столбчатой диаграммы «Пары со стеком» (план/факт + сегменты)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -1055,16 +1055,26 @@ function dashCollectReportVizData(report, vizConfig) {
     labelCol = dashReportDefaultColumn(columns, fieldMap.labelField || fieldMap.xField, dashReportColumnIsDimension) || columns[0];
     valueCol = dashReportDefaultColumn(columns, fieldMap.valueField, dashReportColumnIsMeasure);
     seriesCol = dashReportColumnByField(columns, fieldMap.seriesField);
+    var stackCol = dashReportColumnByField(columns, fieldMap.stackField);
+    if (stackCol && seriesCol && stackCol.id === seriesCol.id) stackCol = null;
+    var stackOrder = [], stackSeen = {};
 
     rows.forEach(function(row) {
         var label = dashReportValueLabel(dashReportRowValue(row, labelCol))
             , series = seriesCol ? dashReportValueLabel(dashReportRowValue(row, seriesCol)) : (valueCol ? valueCol.name : 'Количество')
+            , stack = stackCol ? dashReportValueLabel(dashReportRowValue(row, stackCol)) : null
             , value = valueCol ? dashGetFloat(dashReportRowValue(row, valueCol)) : 1;
         if (isNaN(value)) value = 0;
         dashReportAddOrdered(labels, labelSeen, label);
         dashReportAddOrdered(seriesOrder, seriesSeen, series);
+        if (stackCol) dashReportAddOrdered(stackOrder, stackSeen, stack);
         if (!buckets[series]) buckets[series] = {};
-        buckets[series][label] = (buckets[series][label] || 0) + value;
+        if (stackCol) {
+            if (!buckets[series][stack]) buckets[series][stack] = {};
+            buckets[series][stack][label] = (buckets[series][stack][label] || 0) + value;
+        } else {
+            buckets[series][label] = (buckets[series][label] || 0) + value;
+        }
     });
 
     if (type === 'pie') {
@@ -1073,10 +1083,29 @@ function dashCollectReportVizData(report, vizConfig) {
             data: labels.map(function(label) {
                 var sum = 0;
                 seriesOrder.forEach(function(series) {
-                    sum += (buckets[series] && buckets[series][label]) || 0;
+                    if (stackCol) {
+                        stackOrder.forEach(function(stack) {
+                            sum += (buckets[series] && buckets[series][stack] && buckets[series][stack][label]) || 0;
+                        });
+                    } else {
+                        sum += (buckets[series] && buckets[series][label]) || 0;
+                    }
                 });
                 return sum;
             })
+        });
+    } else if (stackCol) {
+        seriesOrder.forEach(function(series) {
+            stackOrder.forEach(function(stack) {
+                datasets.push({
+                    label: series + ' / ' + stack,
+                    data: labels.map(function(label) {
+                        return (buckets[series] && buckets[series][stack] && buckets[series][stack][label]) || 0;
+                    }),
+                    _series: series,
+                    _stack: stack
+                });
+            });
         });
     } else {
         seriesOrder.forEach(function(series) {
@@ -3386,10 +3415,25 @@ function dashRenderChart(panelEl, vizType, fieldMap, vizConfig) {
         } else if (vizType === 'bar') {
             var barMode = (fieldMap && fieldMap.barMode) || 'grouped';
             chartType = 'bar';
-            chartDatasets = data.datasets.map(function(ds, i) {
-                return { label: ds.label, data: ds.data, backgroundColor: CHART_COLORS[i % CHART_COLORS.length] };
-            });
-            options = { scales: { x: { stacked: barMode === 'stacked' || barMode === 'combo' }, y: { stacked: barMode === 'stacked' } } };
+            var hasPairedMeta = data.datasets.some(function(ds) { return ds && ds._stack; });
+            if (barMode === 'pairedStacked' && hasPairedMeta) {
+                var seriesIndex = {}, nextSeriesIdx = 0;
+                data.datasets.forEach(function(ds) {
+                    var key = ds._series == null ? ds.label : ds._series;
+                    if (!(key in seriesIndex)) seriesIndex[key] = nextSeriesIdx++;
+                });
+                chartDatasets = data.datasets.map(function(ds) {
+                    var key = ds._series == null ? ds.label : ds._series;
+                    var color = CHART_COLORS[seriesIndex[key] % CHART_COLORS.length];
+                    return { label: ds.label, data: ds.data, backgroundColor: color, stack: String(ds._stack || 'default') };
+                });
+                options = { scales: { x: { stacked: true }, y: { stacked: true } } };
+            } else {
+                chartDatasets = data.datasets.map(function(ds, i) {
+                    return { label: ds.label, data: ds.data, backgroundColor: CHART_COLORS[i % CHART_COLORS.length] };
+                });
+                options = { scales: { x: { stacked: barMode === 'stacked' || barMode === 'combo' }, y: { stacked: barMode === 'stacked' } } };
+            }
 
         } else if (vizType === 'bubble') {
             chartType = 'bubble';
@@ -3942,7 +3986,9 @@ function dashBuildFieldMapHtml(vizType, fieldMap, panelEl) {
             + '<option value="grouped"' + (barMode === 'grouped' ? ' selected' : '') + '>Группы столбиков</option>'
             + '<option value="stacked"' + (barMode === 'stacked' ? ' selected' : '') + '>Сегменты</option>'
             + '<option value="combo"' + (barMode === 'combo' ? ' selected' : '') + '>Комбинация</option>'
-            + '</select></div>';
+            + '<option value="pairedStacked"' + (barMode === 'pairedStacked' ? ' selected' : '') + '>Пары со стеком</option>'
+            + '</select></div>'
+            + sel('stackField', 'Стек (план/факт)', fm.stackField || '');
     }
     if (vizType === 'area') {
         return dashBuildAreaModeHtml(fm)
@@ -3997,10 +4043,12 @@ function dashBuildReportFieldMapHtml(vizType, fieldMap, report) {
             + '<option value="grouped"' + (barMode === 'grouped' ? ' selected' : '') + '>Группы столбиков</option>'
             + '<option value="stacked"' + (barMode === 'stacked' ? ' selected' : '') + '>Сегменты</option>'
             + '<option value="combo"' + (barMode === 'combo' ? ' selected' : '') + '>Комбинация</option>'
+            + '<option value="pairedStacked"' + (barMode === 'pairedStacked' ? ' selected' : '') + '>Пары со стеком (план/факт + сегменты)</option>'
             + '</select></div>'
             + sel('labelField', 'Ось X', fm.labelField || fm.xField || '', dashReportColumnIsDimension)
             + sel('valueField', 'Значение', fm.valueField || '', dashReportColumnIsMeasure)
-            + sel('seriesField', 'Серии', fm.seriesField || '', dashReportColumnIsDimension);
+            + sel('seriesField', 'Серии (цвет)', fm.seriesField || '', dashReportColumnIsDimension)
+            + sel('stackField', 'Стек (план/факт)', fm.stackField || '', dashReportColumnIsDimension);
     }
     if (vizType === 'line') {
         return sel('labelField', 'Ось X', fm.labelField || fm.xField || '', dashReportColumnIsDimension)


### PR DESCRIPTION
## Что добавлено

Новый режим столбчатой диаграммы `pairedStacked`. В каждой X-категории (например, по месяцам) строятся два стэка рядом — по значениям новой колонки `stackField` (План / Факт), каждый стэк сложен из сегментов по `seriesField` (B2B / B2C / B2G). Один сегмент сохраняет общий цвет в обоих стэках, чтобы взгляд легко сопоставлял план и факт.

## Зачем

В текущем `bar`-режиме можно либо группировать, либо стэкать, но нельзя одновременно — а это типовой кейс для CRM-дашборда: «по месяцам сравнить план и факт по сегментам клиентов».

## Изменения в `js/dash.js` (4 точечных правки)

1. **`dashCollectReportVizData`** — при заданном `fieldMap.stackField` (≠ `seriesField`) корзина становится тройной: `buckets[series][stack][label]`. На выходе — по одному датасету на каждую пару `(series, stack)` с метаданными `_series` и `_stack`.
2. **`dashRenderChart` → ветка `vizType === 'bar'`** — если `barMode === 'pairedStacked'` и датасеты пришли с `_stack`, рендер проставляет:
   - `stack` = значение `stackField`
   - `backgroundColor` = цвет по индексу серии (одинаковый цвет одного и того же сегмента в обоих стэках)
   - `scales.x.stacked = true`, `scales.y.stacked = true`

   В остальных случаях — прежняя логика без изменений.
3. **`dashBuildPanelFieldMapHtml`** — 4-й option «Пары со стеком» + select `stackField`.
4. **`dashBuildReportFieldMapHtml`** — 4-й option + select `stackField` (для report-driven панелей с настройкой колонок отчёта).

## Поведение крайних случаев

- `pairedStacked` без `stackField` → тихий откат на `grouped`.
- `stackField === seriesField` → `stackField` игнорируется (нет смысла стэкать по той же оси, что и серии).
- Если в каком-то месяце нет, например, факта — стэк «Факт» в этом месяце пустой, Chart.js обрабатывает корректно.

## Как использовать

В настройках визуализации `bar`-панели:
- **Режим** → «Пары со стеком (план/факт + сегменты)»
- **Ось X** → Месяц
- **Значение** → Сумма
- **Серии (цвет)** → Сегмент (B2B/B2C/B2G)
- **Стек (план/факт)** → Тип

## Что проверено

- [x] `node --check js/dash.js` — синтаксис OK
- [ ] Функциональная проверка на dev-стенде с реальными данными (нужно прогнать)
- [ ] Регрессия `grouped`/`stacked`/`combo` не задета (логика обёрнута в `if (barMode === 'pairedStacked' && hasPairedMeta)`, иначе — старый путь)

## Затронутые места

- `js/dash.js`: ~4 хунка, +56 / -8 строк, никаких новых файлов и зависимостей.
- Chart.js остаётся v4 UMD из CDN, как и был.