### PR TITLE
Дашборд: убрать упоминания «План/Факт» из режима «Пары со стеком»

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-06T12:19:03.460Z for PR creation at branch issue-2405-a88acf61efcf for issue https://github.com/ideav/crm/issues/2405

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-06T12:19:03.460Z for PR creation at branch issue-2405-a88acf61efcf for issue https://github.com/ideav/crm/issues/2405

--- a/js/dash.js
+++ b/js/dash.js
@@ -3988,7 +3988,7 @@ function dashBuildFieldMapHtml(vizType, fieldMap, panelEl) {
             + '<option value="combo"' + (barMode === 'combo' ? ' selected' : '') + '>Комбинация</option>'
             + '<option value="pairedStacked"' + (barMode === 'pairedStacked' ? ' selected' : '') + '>Пары со стеком</option>'
             + '</select></div>'
-            + sel('stackField', 'Стек (план/факт)', fm.stackField || '');
+            + sel('stackField', 'Стек', fm.stackField || '');
     }
     if (vizType === 'area') {
         return dashBuildAreaModeHtml(fm)
@@ -4043,12 +4043,12 @@ function dashBuildReportFieldMapHtml(vizType, fieldMap, report) {
             + '<option value="grouped"' + (barMode === 'grouped' ? ' selected' : '') + '>Группы столбиков</option>'
             + '<option value="stacked"' + (barMode === 'stacked' ? ' selected' : '') + '>Сегменты</option>'
             + '<option value="combo"' + (barMode === 'combo' ? ' selected' : '') + '>Комбинация</option>'
-            + '<option value="pairedStacked"' + (barMode === 'pairedStacked' ? ' selected' : '') + '>Пары со стеком (план/факт + сегменты)</option>'
+            + '<option value="pairedStacked"' + (barMode === 'pairedStacked' ? ' selected' : '') + '>Пары со стеком</option>'
             + '</select></div>'
             + sel('labelField', 'Ось X', fm.labelField || fm.xField || '', dashReportColumnIsDimension)
             + sel('valueField', 'Значение', fm.valueField || '', dashReportColumnIsMeasure)
             + sel('seriesField', 'Серии (цвет)', fm.seriesField || '', dashReportColumnIsDimension)
-            + sel('stackField', 'Стек (план/факт)', fm.stackField || '', dashReportColumnIsDimension);
+            + sel('stackField', 'Стек', fm.stackField || '', dashReportColumnIsDimension);
     }
     if (vizType === 'line') {
         return sel('labelField', 'Ось X', fm.labelField || fm.xField || '', dashReportColumnIsDimension)


### PR DESCRIPTION
## Что сделано

Удалены упоминания «план/факт» из подписей режима `pairedStacked` в `js/dash.js`. Это универсальный инструмент, в котором может быть любое количество любых метрик, поэтому фиксировать конкретные термины «план» и «факт» в UI неверно.

## Изменения в `js/dash.js`

1. `dashBuildFieldMapHtml` (`vizType === 'bar'`): подпись поля `stackField` `«Стек (план/факт)»` → `«Стек»`.
2. `dashBuildReportFieldMapHtml` (`vizType === 'bar'`):
   - подпись опции `pairedStacked` `«Пары со стеком (план/факт + сегменты)»` → `«Пары со стеком»`;
   - подпись поля `stackField` `«Стек (план/факт)»` → `«Стек»`.

Логика и значения опций (`pairedStacked`, `stackField`) не менялись — затронуты только пользовательские подписи.

## Closes

Fixes #2405 (referenced PR #2404).

## Проверки

- [x] `node --check js/dash.js` — синтаксис OK
- [x] `grep -i 'план/факт'` по всему `js/dash.js` ничего не находит