### PR TITLE
dash: legend size/position + 8/9 px axis font sizes in general settings (issue #2414)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414

--- a/experiments/test-issue-2412-dashboard-general-settings.js
+++ b/experiments/test-issue-2412-dashboard-general-settings.js
@@ -36,7 +36,9 @@ const code = `
 var DASH_VIZ_SIZE_UNITS = ['%', 'px', 'rem'];
 var DASH_PANEL_MAX_WIDTH_UNITS = ['%', 'px'];
 var DASH_PANEL_MAX_WIDTH_MOBILE_BREAKPOINT = 767;
-var DASH_GENERAL_AXIS_FONT_SIZES = [10, 12, 14, 16];
+var DASH_GENERAL_AXIS_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_POSITIONS = ['top', 'bottom', 'left', 'right'];
 var DASH_GENERAL_X_ROTATIONS = [0, 45, 90];
 var DASH_GENERAL_TOOLTIP_DECIMALS = [0, 1, 2, 3];
 var dashModelData = {};
@@ -189,6 +191,67 @@ vm.runInContext(code, ctx);
     assertEqual(opts.plugins.legend.position, 'right', 'preserves existing plugin config');
 }
 
+// Legend size and position normalization (issue #2414)
+{
+    const g = ctx.dashNormalizeGeneralSettings({
+        legendFontSize: '8',
+        legendPosition: 'top'
+    });
+    assert(g, 'legend-only settings produce a non-null normalized object');
+    assertEqual(g.legendFontSize, 8, 'legendFontSize 8px accepted');
+    assertEqual(g.legendPosition, 'top', 'legendPosition top accepted');
+
+    const g2 = ctx.dashNormalizeGeneralSettings({
+        legendFontSize: '9',
+        legendPosition: 'bottom'
+    });
+    assertEqual(g2.legendFontSize, 9, 'legendFontSize 9px accepted');
+    assertEqual(g2.legendPosition, 'bottom', 'legendPosition bottom accepted');
+
+    const invalid = ctx.dashNormalizeGeneralSettings({
+        legendFontSize: '7',
+        legendPosition: 'middle'
+    });
+    assert(invalid === null, 'invalid legend values rejected');
+}
+
+// Axis font sizes 8px and 9px accepted (issue #2414)
+{
+    const g8 = ctx.dashNormalizeGeneralSettings({ axisFontSize: '8' });
+    assertEqual(g8.axisFontSize, 8, 'axisFontSize 8px accepted');
+    const g9 = ctx.dashNormalizeGeneralSettings({ axisFontSize: '9' });
+    assertEqual(g9.axisFontSize, 9, 'axisFontSize 9px accepted');
+}
+
+// Legend options applied to chart (issue #2414)
+{
+    const opts = ctx.dashApplyGeneralChartOptions({}, 'bar', {
+        legendFontSize: 9,
+        legendPosition: 'bottom'
+    });
+    assertEqual(opts.plugins.legend.position, 'bottom', 'legend position applied');
+    assertEqual(opts.plugins.legend.labels.font.size, 9, 'legend font size applied');
+}
+
+// Legend position overrides existing chart-default legend position (issue #2414)
+{
+    const initial = { plugins: { legend: { position: 'right' } } };
+    const opts = ctx.dashApplyGeneralChartOptions(initial, 'pie', { legendPosition: 'top' });
+    assertEqual(opts.plugins.legend.position, 'top', 'general legend position overrides default');
+}
+
+// Legend settings round-trip through settings array (issue #2414)
+{
+    let settings = [{ type: 'bar' }];
+    settings = ctx.dashSetGeneralSettingsInSettings(settings, {
+        legendFontSize: '8',
+        legendPosition: 'top'
+    });
+    const general = ctx.dashGeneralSettingsFromSettings(settings);
+    assertEqual(general.legendFontSize, 8, 'legendFontSize persisted');
+    assertEqual(general.legendPosition, 'top', 'legendPosition persisted');
+}
+
 // HTML builder produces all expected fields
 {
     const html = ctx.dashBuildPanelGeneralHtml({
@@ -205,6 +268,8 @@ vm.runInContext(code, ctx);
     [
         'generalBarThickness',
         'generalAxisFontSize',
+        'generalLegendFontSize',
+        'generalLegendPosition',
         'generalYMaxTicksLimit',
         'generalYStepSize',
         'generalXLabelRotation',
@@ -226,6 +291,8 @@ vm.runInContext(code, ctx);
     const inputs = {
         '[name="generalBarThickness"]': { value: '60' },
         '[name="generalAxisFontSize"]': { value: '14' },
+        '[name="generalLegendFontSize"]': { value: '8' },
+        '[name="generalLegendPosition"]': { value: 'top' },
         '[name="generalYMaxTicksLimit"]': { value: '4' },
         '[name="generalYStepSize"]': { value: '25' },
         '[name="generalXLabelRotation"]': { value: '90' },
@@ -241,6 +308,8 @@ vm.runInContext(code, ctx);
     const collected = ctx.dashCollectPanelGeneral();
     assertEqual(collected.barThickness, 60, 'bar thickness collected');
     assertEqual(collected.axisFontSize, 14, 'axis font size collected');
+    assertEqual(collected.legendFontSize, 8, 'legend font size collected');
+    assertEqual(collected.legendPosition, 'top', 'legend position collected');
     assertEqual(collected.yMaxTicksLimit, 4, 'y ticks limit collected');
     assertEqual(collected.yStepSize, 25, 'y step size collected');
     assertEqual(collected.xLabelRotation, 90, 'x label rotation collected');

--- a/experiments/test-issue-2414-dashboard-legend-and-small-fonts.js
+++ b/experiments/test-issue-2414-dashboard-legend-and-small-fonts.js
@@ -1,0 +1,161 @@
+// Test for issue #2414: extension of the dashboard "Общие настройки" tab
+// (introduced in PR #2413) to support:
+//   1. legend size and position (top/bottom in particular)
+//   2. additional axis label font sizes 8 px and 9 px
+//
+// The added settings are persisted alongside the rest of the general
+// configuration and applied to chart options for charts that expose a
+// legend (Chart.js plugins.legend).
+
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error('FAIL: ' + message);
+    console.log('PASS: ' + message);
+}
+
+function assertEqual(actual, expected, message) {
+    assert(actual === expected, message + ' (expected ' + JSON.stringify(expected) + ', got ' + JSON.stringify(actual) + ')');
+}
+
+const code = `
+var DASH_GENERAL_AXIS_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_POSITIONS = ['top', 'bottom', 'left', 'right'];
+var DASH_GENERAL_X_ROTATIONS = [0, 45, 90];
+var DASH_GENERAL_TOOLTIP_DECIMALS = [0, 1, 2, 3];
+${extractFunction('dashAttr')}
+${extractFunction('dashNormalizePositiveNumber')}
+${extractFunction('dashNormalizeIntegerInRange')}
+${extractFunction('dashNormalizeEnum')}
+${extractFunction('dashNormalizeGeneralSettings')}
+${extractFunction('dashGeneralSettingsFromSettings')}
+${extractFunction('dashSetGeneralSettingsInSettings')}
+${extractFunction('dashFormatTooltipValue')}
+${extractFunction('dashApplyGeneralChartOptions')}
+${extractFunction('dashApplyGeneralBarDataset')}
+${extractFunction('dashBuildSelectOptions')}
+${extractFunction('dashBuildPanelGeneralHtml')}
+${extractFunction('dashCollectPanelGeneral')}
+`;
+
+const ctx = { console, document: {}, window: {} };
+vm.createContext(ctx);
+vm.runInContext(code, ctx);
+
+// 1. Axis font sizes 8 and 9 are accepted
+{
+    [8, 9, 10, 12, 14, 16].forEach(function(size) {
+        const g = ctx.dashNormalizeGeneralSettings({ axisFontSize: String(size) });
+        assertEqual(g && g.axisFontSize, size, 'axisFontSize accepts ' + size);
+    });
+    [7, 11, 18].forEach(function(size) {
+        const g = ctx.dashNormalizeGeneralSettings({ axisFontSize: String(size) });
+        assert(g === null, 'axisFontSize rejects ' + size);
+    });
+}
+
+// 2. Legend font sizes are accepted with the same set
+{
+    [8, 9, 10, 12, 14, 16].forEach(function(size) {
+        const g = ctx.dashNormalizeGeneralSettings({ legendFontSize: String(size) });
+        assertEqual(g && g.legendFontSize, size, 'legendFontSize accepts ' + size);
+    });
+    [7, 11, 18].forEach(function(size) {
+        const g = ctx.dashNormalizeGeneralSettings({ legendFontSize: String(size) });
+        assert(g === null, 'legendFontSize rejects ' + size);
+    });
+}
+
+// 3. Legend position accepts top/bottom (and left/right) but rejects unknown values
+{
+    ['top', 'bottom', 'left', 'right'].forEach(function(pos) {
+        const g = ctx.dashNormalizeGeneralSettings({ legendPosition: pos });
+        assertEqual(g && g.legendPosition, pos, 'legendPosition accepts ' + pos);
+    });
+    ['middle', '', 'TOP', 'auto'].forEach(function(pos) {
+        const g = ctx.dashNormalizeGeneralSettings({ legendPosition: pos });
+        assert(g === null, 'legendPosition rejects ' + JSON.stringify(pos));
+    });
+}
+
+// 4. dashApplyGeneralChartOptions wires legend.position and legend.labels.font.size
+{
+    const opts = ctx.dashApplyGeneralChartOptions({}, 'bar', {
+        legendPosition: 'top',
+        legendFontSize: 9
+    });
+    assertEqual(opts.plugins.legend.position, 'top', 'legend position propagates to bar');
+    assertEqual(opts.plugins.legend.labels.font.size, 9, 'legend font size propagates to bar');
+}
+
+// 5. Legend settings work for pie chart (the one with default `position: right`)
+{
+    // mirrors how dashRenderChart sets up pie initially
+    const initial = { plugins: { legend: { position: 'right' } } };
+    const opts = ctx.dashApplyGeneralChartOptions(initial, 'pie', { legendPosition: 'bottom' });
+    assertEqual(opts.plugins.legend.position, 'bottom', 'pie legend overrides default position');
+}
+
+// 6. Round-trip through settings array (sentinel `{ general: {...} }`)
+{
+    let settings = [{ type: 'pie' }];
+    settings = ctx.dashSetGeneralSettingsInSettings(settings, {
+        legendPosition: 'top',
+        legendFontSize: '8',
+        axisFontSize: '9'
+    });
+    const general = ctx.dashGeneralSettingsFromSettings(settings);
+    assertEqual(general.legendPosition, 'top', 'legendPosition persisted');
+    assertEqual(general.legendFontSize, 8, 'legendFontSize persisted');
+    assertEqual(general.axisFontSize, 9, 'axisFontSize persisted');
+}
+
+// 7. HTML builder renders legend controls
+{
+    const html = ctx.dashBuildPanelGeneralHtml({
+        legendFontSize: 8,
+        legendPosition: 'bottom'
+    });
+    assert(html.indexOf('name="generalLegendFontSize"') !== -1, 'HTML has legend font size select');
+    assert(html.indexOf('name="generalLegendPosition"') !== -1, 'HTML has legend position select');
+    assert(html.indexOf('value="8" selected') !== -1, 'legend font size 8 marked selected');
+    assert(html.indexOf('value="bottom" selected') !== -1, 'legend position bottom marked selected');
+    assert(html.indexOf('value="9"') !== -1, 'legend font size 9 is in select options');
+    // axis font select also includes the new sizes
+    assert(html.indexOf('name="generalAxisFontSize"') !== -1, 'HTML has axis font size select');
+}
+
+// 8. dashCollectPanelGeneral reads legend inputs from the modal DOM
+{
+    const inputs = {
+        '[name="generalLegendFontSize"]': { value: '8' },
+        '[name="generalLegendPosition"]': { value: 'top' }
+    };
+    const container = {
+        querySelector(selector) { return inputs[selector] || { value: '', checked: false }; }
+    };
+    ctx.document = { getElementById(id) { return id === 'dash-panel-general-settings' ? container : null; } };
+    const collected = ctx.dashCollectPanelGeneral();
+    assertEqual(collected.legendFontSize, 8, 'collected legendFontSize');
+    assertEqual(collected.legendPosition, 'top', 'collected legendPosition');
+}
+
+console.log('\nissue-2414 dashboard legend & small fonts: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -2561,7 +2561,9 @@ function dashApplyPanelMaxWidth(panelEl) {
 // Panel-wide chart settings (applied across all visualizations of the panel
 // where each chart property supports them).
 
-var DASH_GENERAL_AXIS_FONT_SIZES = [10, 12, 14, 16];
+var DASH_GENERAL_AXIS_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_POSITIONS = ['top', 'bottom', 'left', 'right'];
 var DASH_GENERAL_X_ROTATIONS = [0, 45, 90];
 var DASH_GENERAL_TOOLTIP_DECIMALS = [0, 1, 2, 3];
 
@@ -2602,6 +2604,12 @@ function dashNormalizeGeneralSettings(general) {
 
     val = dashNormalizeEnum(general.axisFontSize, DASH_GENERAL_AXIS_FONT_SIZES);
     if (val !== null) { result.axisFontSize = val; has = true; }
+
+    val = dashNormalizeEnum(general.legendFontSize, DASH_GENERAL_LEGEND_FONT_SIZES);
+    if (val !== null) { result.legendFontSize = val; has = true; }
+
+    val = dashNormalizeEnum(general.legendPosition, DASH_GENERAL_LEGEND_POSITIONS);
+    if (val !== null) { result.legendPosition = val; has = true; }
 
     val = dashNormalizePositiveNumber(general.yMaxTicksLimit, 100);
     if (val !== null) { result.yMaxTicksLimit = Math.round(val); has = true; }
@@ -2710,6 +2718,17 @@ function dashApplyGeneralChartOptions(options, vizType, general) {
         if (general.xLabelAutoSkip) {
             xAxis.ticks = xAxis.ticks || {};
             xAxis.ticks.autoSkip = true;
+        }
+    }
+
+    if (typeof general.legendFontSize === 'number' || typeof general.legendPosition === 'string') {
+        plugins.legend = plugins.legend || {};
+        if (typeof general.legendPosition === 'string') {
+            plugins.legend.position = general.legendPosition;
+        }
+        if (typeof general.legendFontSize === 'number') {
+            plugins.legend.labels = plugins.legend.labels || {};
+            plugins.legend.labels.font = Object.assign({}, plugins.legend.labels.font || {}, { size: general.legendFontSize });
         }
     }
 
@@ -4404,6 +4423,9 @@ function dashBuildSelectOptions(values, selected, valueFormatter) {
 function dashBuildPanelGeneralHtml(general) {
     var g = general || {}
         , fontOptions = dashBuildSelectOptions(DASH_GENERAL_AXIS_FONT_SIZES, g.axisFontSize, function(v) { return v + ' px'; })
+        , legendFontOptions = dashBuildSelectOptions(DASH_GENERAL_LEGEND_FONT_SIZES, g.legendFontSize, function(v) { return v + ' px'; })
+        , legendPositionLabels = { top: 'Сверху', bottom: 'Снизу', left: 'Слева', right: 'Справа' }
+        , legendPositionOptions = dashBuildSelectOptions(DASH_GENERAL_LEGEND_POSITIONS, g.legendPosition, function(v) { return legendPositionLabels[v] || v; })
         , rotationOptions = dashBuildSelectOptions(DASH_GENERAL_X_ROTATIONS, g.xLabelRotation, function(v) { return v + '°'; })
         , decimalOptions = dashBuildSelectOptions(DASH_GENERAL_TOOLTIP_DECIMALS, g.tooltipDecimals);
     return '<div class="dash-panel-general-group">'
@@ -4416,6 +4438,15 @@ function dashBuildPanelGeneralHtml(general) {
         + '<div class="dash-viz-size-title">Размер шрифта подписей осей</div>'
         + '<div class="dash-viz-field-row"><label>Размер</label>'
         + '<select name="generalAxisFontSize"><option value="">(по умолчанию)</option>' + fontOptions + '</select>'
+        + '</div>'
+        + '</div>'
+        + '<div class="dash-panel-general-group">'
+        + '<div class="dash-viz-size-title">Легенда</div>'
+        + '<div class="dash-viz-field-row"><label>Положение</label>'
+        + '<select name="generalLegendPosition"><option value="">(по умолчанию)</option>' + legendPositionOptions + '</select>'
+        + '</div>'
+        + '<div class="dash-viz-field-row"><label>Размер шрифта</label>'
+        + '<select name="generalLegendFontSize"><option value="">(по умолчанию)</option>' + legendFontOptions + '</select>'
         + '</div>'
         + '</div>'
         + '<div class="dash-panel-general-group">'
@@ -4469,6 +4500,12 @@ function dashCollectPanelGeneral() {
 
     val = dashNormalizeEnum(read('generalAxisFontSize'), DASH_GENERAL_AXIS_FONT_SIZES);
     if (val !== null) { result.axisFontSize = val; has = true; }
+
+    val = dashNormalizeEnum(read('generalLegendFontSize'), DASH_GENERAL_LEGEND_FONT_SIZES);
+    if (val !== null) { result.legendFontSize = val; has = true; }
+
+    val = dashNormalizeEnum(read('generalLegendPosition'), DASH_GENERAL_LEGEND_POSITIONS);
+    if (val !== null) { result.legendPosition = val; has = true; }
 
     val = dashNormalizePositiveNumber(read('generalYMaxTicksLimit'), 100);
     if (val !== null) { result.yMaxTicksLimit = Math.round(val); has = true; }


### PR DESCRIPTION
## Summary

Extends the panel-wide **«Общие настройки»** tab introduced in PR #2413 with the two settings requested in #2414:

- **Легенда** — добавлен новый блок:
  - **Положение**: Сверху / Снизу / Слева / Справа (по умолчанию используется поведение chart.js).
  - **Размер шрифта**: 8 / 9 / 10 / 12 / 14 / 16 px.
- **Размер шрифта подписей осей** — расширен список значений: добавлены **8 px** и **9 px** (теперь 8/9/10/12/14/16).

Параметры применяются ко всем визуализациям панели, поддерживающим легенду в Chart.js (`plugins.legend.position`, `plugins.legend.labels.font.size`). Если общее значение положения легенды задано, оно переопределяет дефолт конкретного типа графика (например, `position: 'right'` у pie).

Хранение — через тот же массив `settings` панели в сентинеле `{ general: { ... } }`, что и остальные общие настройки из #2413; обратная совместимость с раннее сохранёнными значениями сохранена.

Fixes #2414

## Затронутые файлы

- `js/dash.js`:
  - константы: `DASH_GENERAL_AXIS_FONT_SIZES` теперь `[8, 9, 10, 12, 14, 16]`; добавлены `DASH_GENERAL_LEGEND_FONT_SIZES` и `DASH_GENERAL_LEGEND_POSITIONS`.
  - `dashNormalizeGeneralSettings` — нормализует `legendFontSize` и `legendPosition` (валидация по белому списку).
  - `dashApplyGeneralChartOptions` — настраивает `plugins.legend.position` и `plugins.legend.labels.font.size`.
  - `dashBuildPanelGeneralHtml` — добавлен блок «Легенда» с двумя select-ами; русские подписи для положения.
  - `dashCollectPanelGeneral` — читает новые поля из модалки.
- `experiments/test-issue-2412-dashboard-general-settings.js` — обновлён под расширенный список значений и новые поля.
- `experiments/test-issue-2414-dashboard-legend-and-small-fonts.js` — новый тест для текущей задачи.

## Test plan

- [x] `node experiments/test-issue-2414-dashboard-legend-and-small-fonts.js` — все проверки проходят (нормализация 8/9 px; принимаемые/отклоняемые значения легенды; round-trip через `settings`; HTML рендер; чтение DOM; применение к Chart.js options для bar/pie с переопределением дефолтной позиции).
- [x] `node experiments/test-issue-2412-dashboard-general-settings.js` — все проверки проходят, включая дополнительные кейсы для legend и 8/9 px.
- [x] Связанные тесты (не должны были задеть): `2284`, `2288`, `2308`, `2338`, `2358` — проходят.
- [x] Существующие настройки из #2413 (толщина столбца, шрифт осей, деления Y, поворот меток X, формат тултипа, max-width) сохраняют поведение.

## How to verify in UI

1. Открыть панель в дашборде → «Варианты отображения панели» → вкладка **«Общие настройки»**.
2. Найти новый блок **«Легенда»**: выбрать положение (например, «Снизу») и размер шрифта (например, 8 px).
3. В блоке **«Размер шрифта подписей осей»** убедиться, что доступны значения 8 px и 9 px.
4. Сохранить настройки — диаграммы панели применяют значения; сохранённые настройки восстанавливаются при повторном открытии модалки.