### PR TITLE
dash: apply general axis settings to funnel chart (issue #2416)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -2688,7 +2688,7 @@ function dashApplyGeneralChartOptions(options, vizType, general) {
     var opts = options || {}
         , scales = opts.scales || (opts.scales = {})
         , plugins = opts.plugins || (opts.plugins = {})
-        , supportsAxes = vizType === 'bar' || vizType === 'line' || vizType === 'area' || vizType === 'bubble'
+        , supportsAxes = vizType === 'bar' || vizType === 'line' || vizType === 'area' || vizType === 'bubble' || vizType === 'funnel'
         , xAxis, yAxis;
 
     if (supportsAxes) {


### PR DESCRIPTION
## Summary

Follow-up to #2417 / #2416. The funnel chart renders as a horizontal bar chart with visible axes (values on X, stage labels on Y), but it was not listed in `supportsAxes` inside `dashApplyGeneralChartOptions`. As a result, the panel-level "Общие настройки" added in #2414 (axis font size, `yMaxTicksLimit`, `yStepSize`) silently skipped funnel panels.

## Change

Single line in `js/dash.js`, function `dashApplyGeneralChartOptions`:

```diff
- , supportsAxes = vizType === 'bar' || vizType === 'line' || vizType === 'area' || vizType === 'bubble'
+ , supportsAxes = vizType === 'bar' || vizType === 'line' || vizType === 'area' || vizType === 'bubble' || vizType === 'funnel'
```

`pie` and `pivot` correctly stay excluded — they don't render Cartesian axes. Funnel does.

## Why this is safe

- The branch is gated by `supportsAxes`; before this PR the gate was simply skipped for funnel, so all general settings went through the no-op path. After the change, only the **already-tested** axis branch runs, applying the same settings that bar/line/area/bubble already accept.
- `funnel` already sets `scales: { x: { beginAtZero: true }, y: { ticks: { autoSkip: false } } }` in `dashRenderChart`. The general-settings code merges into existing `scales.x` / `scales.y` via `xAxis = scales.x || (scales.x = {})`, so existing keys are preserved and only the new font/tick-limit fields are added.

## Test plan

- [x] Logic: applying general axis font size to a funnel panel now reaches the `supportsAxes` branch (verified by reading the diff against the existing branches for bar/line/area/bubble).
- [ ] UI: open a panel set to "Диаграмма-воронка", change axis font size in "Общие настройки", confirm the Y-axis stage labels and X-axis value labels respect the new size; confirm `yMaxTicksLimit` / `yStepSize` are applied to the X-axis (the value axis on a horizontal bar chart). 

Fixes a follow-up item from the post-merge review of #2417.