### PR TITLE
Rename dashboard visualization tab to Диаграммы

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
-# Updated: 2026-05-07T06:31:29.976Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
+# Updated: 2026-05-07T06:31:29.976Z

--- a/experiments/test-issue-2419-dashboard-viz-tab-label.js
+++ b/experiments/test-issue-2419-dashboard-viz-tab-label.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const template = fs.readFileSync('templates/dash.html', 'utf8');
+const tabMatch = template.match(/<li\b[^>]*class="dash-viz-tab active"[^>]*data-viz-tab="panels"[^>]*>([^<]*)<\/li>/);
+
+assert(tabMatch, 'dashboard visualization panels tab should exist and stay active by default');
+assert.strictEqual(tabMatch[1].trim(), 'Диаграммы');
+assert(template.includes('data-viz-tab-pane="panels"'), 'panels tab content pane should keep its data binding');
+
+console.log('issue-2419 dashboard visualization tab label: ok');

--- a/templates/dash.html
+++ b/templates/dash.html
@@ -51,7 +51,7 @@
     <div class="dash-modal-box dash-viz-modal-box">
         <h6>Варианты отображения панели</h6>
         <ul class="dash-viz-tabs" role="tablist">
-            <li class="dash-viz-tab active" data-viz-tab="panels" role="tab" aria-selected="true" tabindex="0">Панели</li>
+            <li class="dash-viz-tab active" data-viz-tab="panels" role="tab" aria-selected="true" tabindex="0">Диаграммы</li>
             <li class="dash-viz-tab" data-viz-tab="general" role="tab" aria-selected="false" tabindex="0">Общие настройки</li>
         </ul>
         <div class="dash-viz-tab-pane active" data-viz-tab-pane="panels">


### PR DESCRIPTION
## Summary
- Rename the active dashboard visualization tab in templates/dash.html from `Панели` to `Диаграммы`.
- Add a small regression check for the tab label and existing panels tab binding.

Fixes #2419

## Reproduction
Before the fix, `node experiments/test-issue-2419-dashboard-viz-tab-label.js` failed because the tab label was `Панели`.

## Tests
- `node experiments/test-issue-2419-dashboard-viz-tab-label.js`
- `git diff --check`