### PR TITLE
Fix dashboard numeric input step

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
-# Updated: 2026-05-07T06:33:41.370Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
+# Updated: 2026-05-07T06:33:41.370Z

--- a/experiments/test-issue-2284-dashboard-viz-size.html
+++ b/experiments/test-issue-2284-dashboard-viz-size.html
@@ -42,7 +42,7 @@
                             <div class="dash-viz-size-title">Размер</div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Ширина</label>
-                                <input type="number" min="0" step="0.1" name="sizeWidthValue" value="50">
+                                <input type="number" min="0" step="1" name="sizeWidthValue" value="50">
                                 <select name="sizeWidthUnit">
                                     <option value="%" selected>%</option>
                                     <option value="px">px</option>
@@ -51,7 +51,7 @@
                             </div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Высота</label>
-                                <input type="number" min="0" step="0.1" name="sizeHeightValue" value="24">
+                                <input type="number" min="0" step="1" name="sizeHeightValue" value="24">
                                 <select name="sizeHeightUnit">
                                     <option value="%">%</option>
                                     <option value="px">px</option>
@@ -87,7 +87,7 @@
                             <div class="dash-viz-size-title">Размер</div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Ширина</label>
-                                <input type="number" min="0" step="0.1" name="sizeWidthValue" value="640">
+                                <input type="number" min="0" step="1" name="sizeWidthValue" value="640">
                                 <select name="sizeWidthUnit">
                                     <option value="%">%</option>
                                     <option value="px" selected>px</option>
@@ -96,7 +96,7 @@
                             </div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Высота</label>
-                                <input type="number" min="0" step="0.1" name="sizeHeightValue" value="360">
+                                <input type="number" min="0" step="1" name="sizeHeightValue" value="360">
                                 <select name="sizeHeightUnit">
                                     <option value="%">%</option>
                                     <option value="px" selected>px</option>

--- a/experiments/test-issue-2288-dashboard-selected-chart-rows.html
+++ b/experiments/test-issue-2288-dashboard-selected-chart-rows.html
@@ -73,7 +73,7 @@
                             <div class="dash-viz-size-title">Размер</div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Ширина</label>
-                                <input type="number" min="0" step="0.1" name="sizeWidthValue" value="640">
+                                <input type="number" min="0" step="1" name="sizeWidthValue" value="640">
                                 <select name="sizeWidthUnit">
                                     <option value="%">%</option>
                                     <option value="px" selected>px</option>
@@ -82,7 +82,7 @@
                             </div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Высота</label>
-                                <input type="number" min="0" step="0.1" name="sizeHeightValue" value="360">
+                                <input type="number" min="0" step="1" name="sizeHeightValue" value="360">
                                 <select name="sizeHeightUnit">
                                     <option value="%">%</option>
                                     <option value="px" selected>px</option>

--- a/experiments/test-issue-2338-dashboard-panel-max-width.html
+++ b/experiments/test-issue-2338-dashboard-panel-max-width.html
@@ -42,7 +42,7 @@
                             <div class="dash-viz-size-title">Размер</div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Ширина</label>
-                                <input type="number" min="0" step="0.1" name="sizeWidthValue" value="640">
+                                <input type="number" min="0" step="1" name="sizeWidthValue" value="640">
                                 <select name="sizeWidthUnit">
                                     <option value="%">%</option>
                                     <option value="px" selected>px</option>
@@ -51,7 +51,7 @@
                             </div>
                             <div class="dash-viz-field-row dash-viz-size-row">
                                 <label>Высота</label>
-                                <input type="number" min="0" step="0.1" name="sizeHeightValue" value="360">
+                                <input type="number" min="0" step="1" name="sizeHeightValue" value="360">
                                 <select name="sizeHeightUnit">
                                     <option value="%">%</option>
                                     <option value="px" selected>px</option>
@@ -67,7 +67,7 @@
                     <div class="dash-viz-size-title">Максимальная ширина панели</div>
                     <div class="dash-viz-field-row dash-panel-max-width-row">
                         <label>Десктоп</label>
-                        <input type="number" min="0" step="0.1" name="panelMaxWidthDesktopValue" value="960">
+                        <input type="number" min="0" step="1" name="panelMaxWidthDesktopValue" value="960">
                         <select name="panelMaxWidthDesktopUnit">
                             <option value="%">%</option>
                             <option value="px" selected>px</option>
@@ -75,7 +75,7 @@
                     </div>
                     <div class="dash-viz-field-row dash-panel-max-width-row">
                         <label>Мобильная</label>
-                        <input type="number" min="0" step="0.1" name="panelMaxWidthMobileValue" value="100">
+                        <input type="number" min="0" step="1" name="panelMaxWidthMobileValue" value="100">
                         <select name="panelMaxWidthMobileUnit">
                             <option value="%" selected>%</option>
                             <option value="px">px</option>

--- a/experiments/test-issue-2421-dashboard-number-step.js
+++ b/experiments/test-issue-2421-dashboard-number-step.js
@@ -1,0 +1,83 @@
+// Test for issue #2421: numeric inputs in dashboard display variant
+// settings use whole-number increments.
+
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+function assert(condition, message) {
+    if (!condition) throw new Error('FAIL: ' + message);
+    console.log('PASS: ' + message);
+}
+
+const code = `
+var DASH_VIZ_SIZE_UNITS = ['%', 'px', 'rem'];
+var DASH_PANEL_MAX_WIDTH_UNITS = ['%', 'px'];
+var DASH_GENERAL_AXIS_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_FONT_SIZES = [8, 9, 10, 12, 14, 16];
+var DASH_GENERAL_LEGEND_POSITIONS = ['top', 'bottom', 'left', 'right'];
+var DASH_GENERAL_X_ROTATIONS = [0, 45, 90];
+var DASH_GENERAL_TOOLTIP_DECIMALS = [0, 1, 2, 3];
+${extractFunction('dashAttr')}
+${extractFunction('dashNormalizeVizSizeValue')}
+${extractFunction('dashNormalizeVizSizeUnit')}
+${extractFunction('dashNormalizeVizSizeDimension')}
+${extractFunction('dashNormalizeVizSize')}
+${extractFunction('dashBuildVizSizeUnitOptions')}
+${extractFunction('dashBuildVizSizeRow')}
+${extractFunction('dashBuildVizSizeHtml')}
+${extractFunction('dashNormalizePanelMaxWidthUnit')}
+${extractFunction('dashNormalizePanelMaxWidthDimension')}
+${extractFunction('dashNormalizePanelMaxWidth')}
+${extractFunction('dashBuildPanelMaxWidthUnitOptions')}
+${extractFunction('dashBuildPanelMaxWidthRow')}
+${extractFunction('dashBuildPanelMaxWidthHtml')}
+${extractFunction('dashBuildSelectOptions')}
+${extractFunction('dashBuildPanelGeneralHtml')}
+`;
+
+const ctx = { console };
+vm.createContext(ctx);
+vm.runInContext(code, ctx);
+
+const html = [
+    ctx.dashBuildVizSizeHtml({
+        width: { value: 640, unit: 'px' },
+        height: { value: 360, unit: 'px' }
+    }),
+    ctx.dashBuildPanelMaxWidthHtml({
+        desktop: { value: 960, unit: 'px' },
+        mobile: { value: 100, unit: '%' }
+    }),
+    ctx.dashBuildPanelGeneralHtml({ yStepSize: 50 })
+].join('\n');
+
+[
+    'name="sizeWidthValue"',
+    'name="sizeHeightValue"',
+    'name="panelMaxWidthDesktopValue"',
+    'name="panelMaxWidthMobileValue"',
+    'name="generalYStepSize"'
+].forEach(function(nameAttr) {
+    const inputMatch = html.match(new RegExp('<input[^>]*' + nameAttr + '[^>]*>'));
+    assert(inputMatch, nameAttr + ' input is rendered');
+    assert(inputMatch[0].indexOf('step="1"') !== -1, nameAttr + ' uses step=1');
+    assert(inputMatch[0].indexOf('step="0.1"') === -1, nameAttr + ' does not use step=0.1');
+});
+
+console.log('\nissue-2421 dashboard number step: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -4396,7 +4396,7 @@ function dashBuildVizSizeRow(axis, label, dim) {
         , unit = dim ? dim.unit : 'px';
     return '<div class="dash-viz-field-row dash-viz-size-row">'
         + '<label>' + label + '</label>'
-        + '<input type="number" min="0" step="0.1" name="' + valueName + '" value="' + dashAttr(value) + '">'
+        + '<input type="number" min="0" step="1" name="' + valueName + '" value="' + dashAttr(value) + '">'
         + '<select name="' + unitName + '">' + dashBuildVizSizeUnitOptions(unit) + '</select>'
         + '</div>';
 }
@@ -4424,7 +4424,7 @@ function dashBuildPanelMaxWidthRow(device, label, dim) {
         , unit = dim ? dim.unit : 'px';
     return '<div class="dash-viz-field-row dash-panel-max-width-row">'
         + '<label>' + label + '</label>'
-        + '<input type="number" min="0" step="0.1" name="' + valueName + '" value="' + dashAttr(value) + '">'
+        + '<input type="number" min="0" step="1" name="' + valueName + '" value="' + dashAttr(value) + '">'
         + '<select name="' + unitName + '">' + dashBuildPanelMaxWidthUnitOptions(unit) + '</select>'
         + '</div>';
 }
@@ -4482,7 +4482,7 @@ function dashBuildPanelGeneralHtml(general) {
         + '<input type="number" min="0" max="100" step="1" name="generalYMaxTicksLimit" value="' + dashAttr(g.yMaxTicksLimit !== undefined ? g.yMaxTicksLimit : '') + '">'
         + '</div>'
         + '<div class="dash-viz-field-row"><label>Шаг</label>'
-        + '<input type="number" min="0" step="0.1" name="generalYStepSize" value="' + dashAttr(g.yStepSize !== undefined ? g.yStepSize : '') + '">'
+        + '<input type="number" min="0" step="1" name="generalYStepSize" value="' + dashAttr(g.yStepSize !== undefined ? g.yStepSize : '') + '">'
         + '</div>'
         + '</div>'
         + '<div class="dash-panel-general-group">'


### PR DESCRIPTION
## Summary
- Change dashboard display variant numeric controls from 0.1 increments to whole-number increments.
- Update mirrored dashboard experiment fixtures to match the generated markup.
- Add a focused regression test for issue #2421.

Fixes #2421

## Tests
- `node experiments/test-issue-2421-dashboard-number-step.js`
- `node experiments/test-issue-2412-dashboard-general-settings.js`
- `node experiments/test-issue-2414-dashboard-legend-and-small-fonts.js`