### PR TITLE
update.php: fast manifest-based sync, single hash file, parallel downloads

### DIFF
--- a/update.php
+++ b/update.php
@@ -1,352 +1,464 @@
 <?php
 /**
- * GitHub Repository File Synchronization Script - FAST VERSION
- * Uses tree API for single request instead of per-file commits API
+ * GitHub Repository File Synchronization Script
+ *
+ * Speed strategy:
+ *   1. One GitHub API call to fetch the HEAD commit. If its SHA matches the
+ *      cached one (and ignore_cache is off), exit early — no downloads.
+ *   2. Otherwise, one tree call returns every blob SHA in the repository.
+ *   3. Compare blob SHAs against the manifest; download only the changed
+ *      files in parallel via curl_multi.
+ *
+ * All hashes (last-synced commit SHA + per-file blob SHAs keyed by absolute
+ * target path) live in a single update.cache.json next to this script.
+ * Legacy .sha sidecar files are no longer used; pass ?cleanup_legacy_sha=1
+ * once to remove the orphans.
  */
 
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 header('Content-Type: text/html; charset=utf-8');
 
-function httpGet($url, $headers = [], $timeout = 30) {
-    if (function_exists('curl_init')) {
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-        curl_setopt($ch, CURLOPT_USERAGENT, 'PHP-GitHub-Sync-Script');
+define('MANIFEST_VERSION', 1);
+define('MANIFEST_NAME', 'update.cache.json');
+define('LOCK_NAME', 'update.lock');
+define('PARALLEL', 8);
+define('HTTP_TIMEOUT', 60);
+define('TOKEN_PLACEHOLDER', 'your-github-personal-access-token-here');
 
-        $body = curl_exec($ch);
-        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $error = curl_error($ch);
-        curl_close($ch);
+// ------------------------ HTTP ------------------------
 
-        if ($body === false) {
-            return ['body' => false, 'http_code' => null, 'error' => "cURL error: {$error}"];
-        }
-        return ['body' => $body, 'http_code' => $httpCode, 'error' => null];
+function ghHeaders($token) {
+    $h = ['User-Agent: PHP-GitHub-Sync-Script', 'Accept: application/vnd.github.v3+json'];
+    if (!empty($token) && $token !== TOKEN_PLACEHOLDER) {
+        $h[] = "Authorization: Bearer {$token}";
     }
-
-    if (!ini_get('allow_url_fopen')) {
-        return ['body' => false, 'http_code' => null, 'error' => 'No HTTP transport available'];
-    }
-
-    $context = stream_context_create(['http' => ['method' => 'GET', 'header' => $headers, 'timeout' => $timeout]]);
-    $body = @file_get_contents($url, false, $context);
-    $httpCode = null;
-
-    if (isset($http_response_header)) {
-        foreach ($http_response_header as $headerLine) {
-            if (preg_match('#^HTTP/\S+\s+(\d+)#', $headerLine, $m)) {
-                $httpCode = (int) $m[1];
-            }
-        }
-    }
-
-    return ['body' => $body, 'http_code' => $httpCode, 'error' => null];
+    return $h;
 }
 
-function buildGitHubHeaders($token = '') {
-    $headers = ['User-Agent: PHP-GitHub-Sync-Script', 'Accept: application/vnd.github.v3+json'];
-    if (!empty($token)) {
-        $headers[] = "Authorization: Bearer {$token}";
+function rawHeaders($token) {
+    $h = ['User-Agent: PHP-GitHub-Sync-Script'];
+    if (!empty($token) && $token !== TOKEN_PLACEHOLDER) {
+        $h[] = "Authorization: Bearer {$token}";
     }
-    return $headers;
+    return $h;
 }
 
-function parseConfig($configPath) {
-    if (!file_exists($configPath)) return false;
-
-    $lines = file($configPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-    if ($lines === false) return false;
-
-    $config = [
-        'repository' => '',
-        'branch' => 'main',
-        'token' => '',
-        'ignore_cache' => false,
-        'mappings' => []
-    ];
-
-    foreach ($lines as $line) {
-        $line = trim($line);
-        if (empty($line) || $line[0] === '#') continue;
-
-        if (preg_match('/^repository\s*:\s*(.+)$/i', $line, $matches)) {
-            $config['repository'] = trim($matches[1]);
-        } elseif (preg_match('/^branch\s*:\s*(.+)$/i', $line, $matches)) {
-            $config['branch'] = trim($matches[1]);
-        } elseif (preg_match('/^token\s*:\s*(.+)$/i', $line, $matches)) {
-            $config['token'] = trim($matches[1]);
-        } elseif (preg_match('/^ignore_cache\s*:\s*(.+)$/i', $line, $matches)) {
-            $value = trim($matches[1]);
-            $config['ignore_cache'] = ($value == '1' || $value == 'true' || $value == 'yes');
-        } elseif (strpos($line, ':') !== false) {
-            $parts = explode(':', $line, 2);
-            if (count($parts) === 2) {
-                $source = trim($parts[0]);
-                $target = trim($parts[1]);
-                if (!empty($source) && !empty($target)) {
-                    $config['mappings'][] = ['source' => $source, 'target' => $target];
-                }
-            }
-        }
+function httpGet($url, $headers, $timeout) {
+    if (!function_exists('curl_init')) {
+        return ['body' => false, 'http_code' => null, 'error' => 'cURL extension required'];
     }
-    return $config;
+    $ch = curl_init();
+    curl_setopt_array($ch, [
+        CURLOPT_URL            => $url,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_TIMEOUT        => $timeout,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_HTTPHEADER     => $headers,
+        CURLOPT_USERAGENT      => 'PHP-GitHub-Sync-Script',
+    ]);
+    $body = curl_exec($ch);
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $err  = curl_error($ch);
+    curl_close($ch);
+    if ($body === false) return ['body' => false, 'http_code' => null, 'error' => "cURL: {$err}"];
+    return ['body' => $body, 'http_code' => $code, 'error' => null];
 }
 
-function getGitHubRepoInfo($repository) {
+// ------------------------ GitHub helpers ------------------------
+
+function parseRepo($repository) {
     $repository = rtrim($repository, '/');
-    if (preg_match('#github\.com/([^/]+)/([^/]+)#', $repository, $matches)) {
-        return ['owner' => $matches[1], 'repo' => $matches[2]];
+    if (preg_match('#github\.com/([^/]+)/([^/]+)#', $repository, $m)) {
+        return ['owner' => $m[1], 'repo' => $m[2]];
     }
     return null;
 }
 
-function getGitHubTree($repository, $branch, $token = '') {
-    $info = getGitHubRepoInfo($repository);
-    if (!$info) return [];
+function urlBranch($branch) {
+    return str_replace('%2F', '/', rawurlencode($branch));
+}
 
-    // First get the commit SHA
-    $apiUrl = "https://api.github.com/repos/{$info['owner']}/{$info['repo']}/commits/{$branch}";
-    $result = httpGet($apiUrl, buildGitHubHeaders($token), 30);
+function urlPath($path) {
+    return str_replace('%2F', '/', rawurlencode($path));
+}
 
-    if ($result['body'] === false || $result['http_code'] !== 200) {
-        return [];
-    }
+function ghCommit($info, $branch, $token) {
+    $url = "https://api.github.com/repos/{$info['owner']}/{$info['repo']}/commits/" . urlBranch($branch);
+    $r = httpGet($url, ghHeaders($token), 30);
+    if ($r['body'] === false || $r['http_code'] !== 200) return null;
+    $j = json_decode($r['body'], true);
+    if (!isset($j['sha'], $j['commit']['tree']['sha'])) return null;
+    return ['commit_sha' => $j['sha'], 'tree_sha' => $j['commit']['tree']['sha']];
+}
 
-    $commit = json_decode($result['body'], true);
-    if (!isset($commit['commit']['tree']['sha'])) {
-        return [];
-    }
-
-    // Then get the full tree (recursive = 1 gets all files)
-    $treeUrl = "https://api.github.com/repos/{$info['owner']}/{$info['repo']}/git/trees/{$commit['commit']['tree']['sha']}?recursive=1";
-    $result = httpGet($treeUrl, buildGitHubHeaders($token), 60);
-
-    if ($result['body'] === false || $result['http_code'] !== 200) {
-        return [];
-    }
-
-    $tree = json_decode($result['body'], true);
-    if (!isset($tree['tree'])) {
-        return [];
-    }
-
-    // Build map of file paths to SHA
-    $fileMap = [];
-    foreach ($tree['tree'] as $item) {
-        if ($item['type'] === 'blob') {
-            $fileMap[$item['path']] = $item['sha'];
+function ghTree($info, $treeSha, $token) {
+    $url = "https://api.github.com/repos/{$info['owner']}/{$info['repo']}/git/trees/{$treeSha}?recursive=1";
+    $r = httpGet($url, ghHeaders($token), HTTP_TIMEOUT);
+    if ($r['body'] === false || $r['http_code'] !== 200) return null;
+    $j = json_decode($r['body'], true);
+    if (!isset($j['tree'])) return null;
+    $files = [];
+    foreach ($j['tree'] as $item) {
+        if (isset($item['type'], $item['path'], $item['sha']) && $item['type'] === 'blob') {
+            $files[$item['path']] = $item['sha'];
         }
     }
-    return $fileMap;
+    return ['files' => $files, 'truncated' => !empty($j['truncated'])];
 }
 
-function downloadFile($url, $token = '') {
-    $headers = ['User-Agent: PHP-GitHub-Sync-Script'];
-    if (!empty($token)) {
-        $headers[] = "Authorization: Bearer {$token}";
-    }
-    $result = httpGet($url, $headers, 60);
-    if ($result['body'] === false || $result['http_code'] !== 200) {
-        return false;
-    }
-    return $result['body'];
+function rawUrl($info, $branch, $path) {
+    return 'https://raw.githubusercontent.com/' . $info['owner'] . '/' . $info['repo']
+        . '/' . urlBranch($branch) . '/' . urlPath($path);
 }
 
-function ensureDirectory($path) {
-    if (!is_dir($path)) {
-        return @mkdir($path, 0755, true);
+// ------------------------ Parallel download ------------------------
+
+function downloadParallel($tasks, $info, $branch, $token, $concurrency) {
+    if (empty($tasks)) return [];
+
+    if (!function_exists('curl_multi_init')) {
+        $out = [];
+        foreach ($tasks as $i => $t) {
+            $r = httpGet(rawUrl($info, $branch, $t['source']), rawHeaders($token), HTTP_TIMEOUT);
+            $out[$i] = [
+                'ok'        => $r['body'] !== false && $r['http_code'] === 200,
+                'content'   => $r['body'],
+                'http_code' => $r['http_code'],
+                'error'     => $r['error'],
+                'task'      => $t,
+            ];
+        }
+        return $out;
     }
+
+    $headers = rawHeaders($token);
+    $mh = curl_multi_init();
+    $handles = [];
+    $results = [];
+    $next = 0;
+    $count = count($tasks);
+
+    $start = function ($idx) use (&$handles, &$tasks, $info, $branch, $headers, $mh) {
+        $t = $tasks[$idx];
+        $ch = curl_init();
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => rawUrl($info, $branch, $t['source']),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => HTTP_TIMEOUT,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_HTTPHEADER     => $headers,
+            CURLOPT_USERAGENT      => 'PHP-GitHub-Sync-Script',
+        ]);
+        curl_multi_add_handle($mh, $ch);
+        $handles[(int)$ch] = ['idx' => $idx, 'ch' => $ch];
+    };
+
+    while ($next < $count && count($handles) < $concurrency) {
+        $start($next++);
+    }
+
+    $running = 0;
+    do {
+        do { $mrc = curl_multi_exec($mh, $running); } while ($mrc === CURLM_CALL_MULTI_PERFORM);
+        if ($running > 0 && curl_multi_select($mh, 1.0) === -1) usleep(50000);
+        while ($info_done = curl_multi_info_read($mh)) {
+            $ch = $info_done['handle'];
+            $key = (int)$ch;
+            if (!isset($handles[$key])) continue;
+            $idx = $handles[$key]['idx'];
+            $body = curl_multi_getcontent($ch);
+            $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $err  = curl_error($ch);
+            $results[$idx] = [
+                'ok'        => $body !== false && $body !== null && $code === 200 && $info_done['result'] === CURLE_OK,
+                'content'   => $body,
+                'http_code' => $code,
+                'error'     => $err,
+                'task'      => $tasks[$idx],
+            ];
+            curl_multi_remove_handle($mh, $ch);
+            curl_close($ch);
+            unset($handles[$key]);
+            if ($next < $count) $start($next++);
+        }
+    } while ($running > 0 || $next < $count || !empty($handles));
+
+    curl_multi_close($mh);
+    ksort($results);
+    return $results;
+}
+
+// ------------------------ Config / Manifest ------------------------
+
+function parseConfig($path) {
+    if (!file_exists($path)) return false;
+    $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if ($lines === false) return false;
+
+    $cfg = ['repository' => '', 'branch' => 'main', 'token' => '', 'ignore_cache' => false, 'mappings' => []];
+    foreach ($lines as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#') continue;
+
+        if (preg_match('/^repository\s*:\s*(.+)$/i', $line, $m)) {
+            $cfg['repository'] = trim($m[1]);
+        } elseif (preg_match('/^branch\s*:\s*(.+)$/i', $line, $m)) {
+            $cfg['branch'] = trim($m[1]);
+        } elseif (preg_match('/^token\s*:\s*(.+)$/i', $line, $m)) {
+            $cfg['token'] = trim($m[1]);
+        } elseif (preg_match('/^ignore_cache\s*:\s*(.+)$/i', $line, $m)) {
+            $v = strtolower(trim($m[1]));
+            $cfg['ignore_cache'] = ($v === '1' || $v === 'true' || $v === 'yes');
+        } elseif (strpos($line, ':') !== false) {
+            $parts = explode(':', $line, 2);
+            $src = trim($parts[0]);
+            $tgt = trim($parts[1]);
+            if ($src !== '' && $tgt !== '') $cfg['mappings'][] = ['source' => $src, 'target' => $tgt];
+        }
+    }
+    return $cfg;
+}
+
+function manifestPath() {
+    return __DIR__ . '/' . MANIFEST_NAME;
+}
+
+function loadManifest() {
+    $path = manifestPath();
+    if (!file_exists($path)) return ['version' => MANIFEST_VERSION, 'configs' => []];
+    $raw = @file_get_contents($path);
+    if ($raw === false || $raw === '') return ['version' => MANIFEST_VERSION, 'configs' => []];
+    $data = json_decode($raw, true);
+    if (!is_array($data) || !isset($data['configs']) || !is_array($data['configs'])) {
+        return ['version' => MANIFEST_VERSION, 'configs' => []];
+    }
+    $data['version'] = MANIFEST_VERSION;
+    return $data;
+}
+
+function saveManifest($manifest) {
+    $manifest['updated_at'] = date('c');
+    $path = manifestPath();
+    $tmp = $path . '.tmp.' . getmypid();
+    $json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+    if ($json === false) return false;
+    if (@file_put_contents($tmp, $json, LOCK_EX) === false) return false;
+    if (!@rename($tmp, $path)) { @unlink($tmp); return false; }
     return true;
 }
 
-function getLocalSha($targetPath) {
-    $shaFile = $targetPath . '.sha';
-    if (file_exists($shaFile)) {
-        return trim(file_get_contents($shaFile));
-    }
-    return '';
-}
+// ------------------------ Sync ------------------------
 
-function saveLocalSha($targetPath, $sha) {
-    @file_put_contents($targetPath . '.sha', $sha);
-}
-
-function syncFiles($config) {
-    $results = ['success' => [], 'skipped' => [], 'errors' => []];
-    $info = getGitHubRepoInfo($config['repository']);
-    if (!$info) {
-        $results['errors'][] = "Invalid repository URL";
-        return $results;
-    }
-
-    // ONE API call to get all files and their SHAs
-    echo "<!-- Fetching repository tree from GitHub... -->\n";
-    $fileMap = getGitHubTree($config['repository'], $config['branch'], $config['token']);
-    
-    if (empty($fileMap)) {
-        $results['errors'][] = "Failed to get repository tree. Check branch name and token.";
-        return $results;
-    }
-    
-    $token = $config['token'] ?? '';
-    $ignoreCache = $config['ignore_cache'] ?? false;
-
-    foreach ($config['mappings'] as $mapping) {
-        $source = $mapping['source'];
-        $target = $mapping['target'];
-
-        // Wildcard support
-        if (substr($source, -2) === '/*') {
-            $dirPath = rtrim(substr($source, 0, -2), '/');
-            
-            // Find all files in this directory from the tree
-            foreach ($fileMap as $filePath => $sha) {
-                if (dirname($filePath) === $dirPath || strpos($filePath, $dirPath . '/') === 0) {
-                    $fileName = basename($filePath);
-                    $targetPath = rtrim($target, '/') . '/' . $fileName;
-                    
-                    $result = syncSingleFileFast($config['repository'], $config['branch'], $filePath, $targetPath, $sha, $token, $ignoreCache);
-                    
-                    if ($result['status'] === 'success') {
-                        $results['success'][] = $result['message'];
-                    } elseif ($result['status'] === 'skipped') {
-                        $results['skipped'][] = $result['message'];
-                    } else {
-                        $results['errors'][] = $result['message'];
-                    }
+function expandMappings($mappings, $remoteFiles) {
+    $tasks = [];
+    foreach ($mappings as $m) {
+        $src = $m['source'];
+        $tgt = rtrim($m['target'], '/');
+        if (substr($src, -2) === '/*') {
+            // dir/* matches only direct children of <dir>, not nested files.
+            // E.g. js/* takes js/dash.js but not js/utils/foo.js.
+            $dir = rtrim(substr($src, 0, -2), '/');
+            foreach ($remoteFiles as $path => $sha) {
+                if (dirname($path) === $dir) {
+                    $tasks[] = ['source' => $path, 'target' => $tgt . '/' . basename($path), 'sha' => $sha];
                 }
             }
         } else {
-            // Single file
-            $fileName = basename($source);
-            $targetPath = rtrim($target, '/') . '/' . $fileName;
-            
-            if (isset($fileMap[$source])) {
-                $result = syncSingleFileFast($config['repository'], $config['branch'], $source, $targetPath, $fileMap[$source], $token, $ignoreCache);
-                
-                if ($result['status'] === 'success') {
-                    $results['success'][] = $result['message'];
-                } elseif ($result['status'] === 'skipped') {
-                    $results['skipped'][] = $result['message'];
-                } else {
-                    $results['errors'][] = $result['message'];
-                }
+            if (isset($remoteFiles[$src])) {
+                $tasks[] = ['source' => $src, 'target' => $tgt . '/' . basename($src), 'sha' => $remoteFiles[$src]];
             } else {
-                $results['errors'][] = "File not found in repository: {$source}";
+                $tasks[] = ['source' => $src, 'target' => $tgt . '/' . basename($src), 'sha' => null, 'missing' => true];
             }
+        }
+    }
+    return $tasks;
+}
+
+function ensureDir($dir) {
+    return is_dir($dir) || @mkdir($dir, 0755, true);
+}
+
+function syncWithCache($config, $configName) {
+    $results = ['fast_path' => false, 'success' => [], 'skipped' => [], 'errors' => [], 'cleaned' => 0];
+
+    $info = parseRepo($config['repository']);
+    if (!$info) {
+        $results['errors'][] = "Invalid repository URL: {$config['repository']}";
+        return $results;
+    }
+
+    $manifest = loadManifest();
+    $configEntry = isset($manifest['configs'][$configName]) ? $manifest['configs'][$configName] : ['commit_sha' => null, 'files' => []];
+    if (!isset($configEntry['files']) || !is_array($configEntry['files'])) $configEntry['files'] = [];
+
+    $head = ghCommit($info, $config['branch'], $config['token']);
+    if (!$head) {
+        $results['errors'][] = "Failed to fetch HEAD commit for branch {$config['branch']}";
+        return $results;
+    }
+    $results['commit'] = $head['commit_sha'];
+
+    if (!$config['ignore_cache'] && isset($configEntry['commit_sha']) && $configEntry['commit_sha'] === $head['commit_sha']) {
+        $results['fast_path'] = true;
+        return $results;
+    }
+
+    $tree = ghTree($info, $head['tree_sha'], $config['token']);
+    if (!$tree) {
+        $results['errors'][] = "Failed to fetch repository tree";
+        return $results;
+    }
+    if ($tree['truncated']) {
+        $results['errors'][] = "Repository tree was truncated by GitHub (>100k entries) — partial sync";
+    }
+
+    $tasks = expandMappings($config['mappings'], $tree['files']);
+    foreach ($tasks as $t) {
+        if (!empty($t['missing'])) $results['errors'][] = "File not found in repository: {$t['source']}";
+    }
+    $tasks = array_values(array_filter($tasks, function ($t) { return empty($t['missing']); }));
+
+    $todo = [];
+    foreach ($tasks as $t) {
+        $cached = isset($configEntry['files'][$t['target']]) ? $configEntry['files'][$t['target']] : null;
+        $exists = is_file($t['target']);
+        if ($config['ignore_cache'] || !$exists || $cached !== $t['sha']) {
+            $todo[] = $t;
+        } else {
+            $results['skipped'][] = "Unchanged: {$t['source']} -> {$t['target']}";
+        }
+    }
+
+    $downloads = downloadParallel($todo, $info, $config['branch'], $config['token'], PARALLEL);
+
+    foreach ($downloads as $d) {
+        $t = $d['task'];
+        if (!$d['ok']) {
+            $code = $d['http_code'] === null ? '?' : $d['http_code'];
+            $results['errors'][] = "Download failed (HTTP {$code}): {$t['source']}";
+            continue;
+        }
+        if (!ensureDir(dirname($t['target']))) {
+            $results['errors'][] = "Failed to create directory: " . dirname($t['target']);
+            continue;
+        }
+        $tmp = $t['target'] . '.tmp.' . getmypid();
+        if (@file_put_contents($tmp, $d['content']) === false) {
+            $results['errors'][] = "Failed to write: {$t['target']}";
+            continue;
+        }
+        if (!@rename($tmp, $t['target'])) {
+            @unlink($tmp);
+            $results['errors'][] = "Failed to rename into place: {$t['target']}";
+            continue;
+        }
+        $configEntry['files'][$t['target']] = $t['sha'];
+        $tag = $config['ignore_cache'] ? 'FORCED' : 'UPDATED';
+        $results['success'][] = "{$tag}: {$t['source']} -> {$t['target']}";
+    }
+
+    $kept = [];
+    foreach ($tasks as $t) $kept[$t['target']] = true;
+    $configEntry['files'] = array_intersect_key($configEntry['files'], $kept);
+    $configEntry['commit_sha'] = $head['commit_sha'];
+    $configEntry['updated_at'] = date('c');
+    $manifest['configs'][$configName] = $configEntry;
+
+    if (!saveManifest($manifest)) {
+        $results['errors'][] = "Failed to write manifest: " . manifestPath();
+    }
+
+    if (!empty($_GET['cleanup_legacy_sha'])) {
+        foreach ($configEntry['files'] as $target => $_) {
+            $shaFile = $target . '.sha';
+            if (is_file($shaFile) && @unlink($shaFile)) $results['cleaned']++;
         }
     }
 
     return $results;
 }
 
-function syncSingleFileFast($repository, $branch, $sourcePath, $targetPath, $remoteSha, $token = '', $ignoreCache = false) {
-    $localSha = getLocalSha($targetPath);
-    
-    // If ignore_cache is enabled OR SHA different -> download
-    if ($ignoreCache || $localSha !== $remoteSha) {
-        $rawUrl = "https://raw.githubusercontent.com/" . 
-                  getGitHubRepoInfo($repository)['owner'] . "/" . 
-                  getGitHubRepoInfo($repository)['repo'] . "/{$branch}/{$sourcePath}";
-        
-        $content = downloadFile($rawUrl, $token);
-        
-        if ($content === false) {
-            return ['status' => 'error', 'message' => "Failed to download: {$sourcePath}"];
-        }
-        
-        $targetDir = dirname($targetPath);
-        if (!ensureDirectory($targetDir)) {
-            return ['status' => 'error', 'message' => "Failed to create directory: {$targetDir}"];
-        }
-        
-        if (@file_put_contents($targetPath, $content) === false) {
-            return ['status' => 'error', 'message' => "Failed to write: {$targetPath}"];
-        }
-        
-        saveLocalSha($targetPath, $remoteSha);
-        
-        $action = $ignoreCache ? "FORCED" : "UPDATED";
-        return ['status' => 'success', 'message' => "{$action}: {$sourcePath} -> {$targetPath}"];
+// ------------------------ Output ------------------------
+
+function outputResults($results, $config, $configName, $elapsedMs) {
+    $css = '<style>'
+        . 'body{font-family:Arial,sans-serif;margin:20px;background:#f5f5f5}'
+        . '.container{max-width:900px;margin:0 auto;background:#fff;padding:20px;border-radius:8px}'
+        . 'h1{color:#333;border-bottom:2px solid #4CAF50;padding-bottom:10px}'
+        . 'h2{font-size:1rem;margin-top:1.5rem}'
+        . '.success{color:#2e7d32}.skipped{color:#1565c0}.error{color:#c62828}'
+        . 'ul{list-style:none;padding:0}'
+        . 'li{padding:8px 12px;margin:4px 0;border-radius:4px;font-family:monospace;font-size:13px}'
+        . '.success li{background:#e8f5e9}.skipped li{background:#e3f2fd}.error li{background:#ffebee}'
+        . '.summary{background:#f0f0f0;padding:15px;border-radius:4px;margin-top:20px}'
+        . '.summary span{margin-right:20px}'
+        . '.fastpath{background:#fff8e1;border:1px solid #ffe082;padding:10px 14px;border-radius:4px;margin-bottom:16px}'
+        . '.meta{font-family:monospace;font-size:12px;color:#666;margin:6px 0 16px}'
+        . '</style>';
+
+    echo "<!DOCTYPE html><html lang='ru'><head><meta charset='UTF-8'><title>GitHub Sync Results</title>{$css}</head><body><div class='container'>";
+    echo "<h1>GitHub Sync Results</h1>";
+    echo "<div class='meta'>config: " . htmlspecialchars($configName)
+        . " &middot; branch: " . htmlspecialchars($config['branch'])
+        . " &middot; commit: " . htmlspecialchars(isset($results['commit']) ? substr($results['commit'], 0, 7) : '?')
+        . " &middot; elapsed: {$elapsedMs} ms</div>";
+
+    if (!empty($results['fast_path'])) {
+        echo "<div class='fastpath'><strong>Up to date.</strong> HEAD не двигался — скачивать нечего.</div>";
     }
-    
-    return ['status' => 'skipped', 'message' => "Unchanged: {$sourcePath} -> {$targetPath}"];
+
+    echo "<div class='summary'>";
+    echo "<span class='success'><strong>Copied:</strong> " . count($results['success']) . "</span>";
+    echo "<span class='skipped'><strong>Skipped:</strong> " . count($results['skipped']) . "</span>";
+    echo "<span class='error'><strong>Errors:</strong> " . count($results['errors']) . "</span>";
+    if (!empty($results['cleaned'])) {
+        echo "<span><strong>Legacy .sha removed:</strong> " . (int)$results['cleaned'] . "</span>";
+    }
+    echo "</div>";
+
+    foreach (['success' => 'Copied', 'skipped' => 'Skipped', 'errors' => 'Errors'] as $k => $title) {
+        if (!empty($results[$k])) {
+            echo "<div class='{$k}'><h2>{$title}</h2><ul>";
+            foreach ($results[$k] as $msg) echo "<li>" . htmlspecialchars($msg) . "</li>";
+            echo "</ul></div>";
+        }
+    }
+    echo "<p style='color:#888;margin-top:20px'>Completed at: " . date('Y-m-d H:i:s') . "</p></div></body></html>";
 }
 
-function outputResults($results) {
-    echo "<!DOCTYPE html>
-<html lang='ru'>
-<head>
-    <meta charset='UTF-8'>
-    <title>GitHub Sync Results</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; background: #f5f5f5; }
-        .container { max-width: 900px; margin: 0 auto; background: #fff; padding: 20px; border-radius: 8px; }
-        h1 { color: #333; border-bottom: 2px solid #4CAF50; padding-bottom: 10px; }
-        .success { color: #2e7d32; }
-        .skipped { color: #1565c0; }
-        .error { color: #c62828; }
-        ul { list-style: none; padding: 0; }
-        li { padding: 8px 12px; margin: 4px 0; border-radius: 4px; font-family: monospace; font-size: 13px; }
-        .success li { background: #e8f5e9; }
-        .skipped li { background: #e3f2fd; }
-        .error li { background: #ffebee; }
-        .summary { background: #f0f0f0; padding: 15px; border-radius: 4px; margin-top: 20px; }
-        .summary span { margin-right: 20px; }
-    </style>
-</head>
-<body>
-<div class='container'>
-    <h1>GitHub Sync Results</h1>
-    <div class='summary'>
-        <span class='success'><strong>Copied:</strong> " . count($results['success']) . "</span>
-        <span class='skipped'><strong>Skipped:</strong> " . count($results['skipped']) . "</span>
-        <span class='error'><strong>Errors:</strong> " . count($results['errors']) . "</span>
-    </div>";
+// ------------------------ Main ------------------------
 
-    if (!empty($results['success'])) {
-        echo "<div class='success'><h2>Copied</h2><ul>";
-        foreach ($results['success'] as $msg) echo "<li>" . htmlspecialchars($msg) . "</li>";
-        echo "</ul></div>";
-    }
-    if (!empty($results['skipped'])) {
-        echo "<div class='skipped'><h2>Skipped</h2><ul>";
-        foreach ($results['skipped'] as $msg) echo "<li>" . htmlspecialchars($msg) . "</li>";
-        echo "</ul></div>";
-    }
-    if (!empty($results['errors'])) {
-        echo "<div class='error'><h2>Errors</h2><ul>";
-        foreach ($results['errors'] as $msg) echo "<li>" . htmlspecialchars($msg) . "</li>";
-        echo "</ul></div>";
-    }
-    
-    echo "<p style='color:#888; margin-top:20px;'>Completed at: " . date('Y-m-d H:i:s') . "</p>
-</div>
-</body>
-</html>";
-}
-
-// Main execution
-$configFile = isset($_GET['config']) ? $_GET['config'] : '';
-if (empty($configFile)) {
-    echo "<h1>Error</h1><p>Usage: update.php?config=your-config.conf</p>";
+$configFile = isset($_GET['config']) ? basename($_GET['config']) : '';
+if ($configFile === '') {
+    echo "<h1>Error</h1><p>Usage: update.php?config=your-config.conf [&cleanup_legacy_sha=1]</p>";
     exit(1);
 }
 
-$configFile = basename($configFile);
 $configPath = __DIR__ . '/' . $configFile;
 $config = parseConfig($configPath);
-
 if ($config === false) {
     echo "<h1>Error</h1><p>Could not read config file: " . htmlspecialchars($configFile) . "</p>";
     exit(1);
 }
 
-$results = syncFiles($config);
-outputResults($results);
+$lockPath = __DIR__ . '/' . LOCK_NAME;
+$lockFp = @fopen($lockPath, 'c');
+if ($lockFp && !flock($lockFp, LOCK_EX | LOCK_NB)) {
+    fclose($lockFp);
+    echo "<h1>Busy</h1><p>Another sync is already running. Try again in a moment.</p>";
+    exit(1);
+}
+
+$start = microtime(true);
+$results = syncWithCache($config, $configFile);
+$elapsedMs = (int) round((microtime(true) - $start) * 1000);
+
+if ($lockFp) {
+    flock($lockFp, LOCK_UN);
+    fclose($lockFp);
+}
+
+outputResults($results, $config, $configFile, $elapsedMs);


### PR DESCRIPTION
## Why

Текущий `update.php` подвисает на больших конфигах. Три причины:

1. В `update.conf` стоит `ignore_cache: 1`, поэтому **каждый прогон** скачивает все файлы заново.
2. Файлы скачиваются **по одному**, последовательно: один curl-запрос на файл к `raw.githubusercontent.com`. На сотнях файлов из `css/* / js/* / templates/*` PHP упирается в `max_execution_time` и страница «висит».
3. Хэши лежат **рядом с каждым файлом** как `<target>.sha`, что сильно засоряет директории сайта.

## What

Полный переписать `update.php`. Три ускорителя одновременно:

### 1. Fast-path по HEAD-коммиту

Один запрос — `…/commits/{branch}` — даёт SHA текущего коммита. Если он совпадает с тем, что в манифесте, и `ignore_cache: 0` — выходим сразу. Холостой прогон стал **~60 мс вместо «качаем всё».**

### 2. Один манифест с хэшами

Все хэши теперь в одном JSON — `update.cache.json` рядом с `update.php`, ключ — абсолютный целевой путь файла. Структура:

```json
{
  "version": 1,
  "configs": {
    "update.conf": {
      "commit_sha": "abc123…",
      "files": {
        "/var/www/.../css/style.css": "blob-sha-…",
        "/var/www/.../js/dash.js":    "blob-sha-…"
      },
      "updated_at": "2026-05-07T08:30:00+00:00"
    }
  }
}
```

`<target>.sha` файлы больше не пишутся и не читаются. Чтобы зачистить уже разбросанные на сервере — один раз вызвать `update.php?config=update.conf&cleanup_legacy_sha=1`. По умолчанию ничего не удаляет.

### 3. Дельта + параллельные загрузки

Если HEAD сменился — один запрос за полным деревом (`git/trees/{tree_sha}?recursive=1`), сравниваем blob-SHA каждого нужного файла с манифестом, скачиваем **только изменённые** через `curl_multi`, окно 8.

## Изменения поведения

- **`dir/*` теперь не рекурсивно.** Раньше `js/*` забирал и `js/utils/foo.js` и плющил его в `<target>/foo.js`. Теперь `js/*` берёт **только файлы прямо в `js/`**. Это и баг, и явное требование пользователя. Подпапки нужно мапить отдельными строками (`js/utils/* : <target>/utils/`), как уже делается для `templates/my/*`, `templates/sportzania/*`.
- Lock-файл `update.lock` + `flock(LOCK_EX|LOCK_NB)` — два одновременных запуска не гонятся за манифест.
- Запись файлов и манифеста — через `*.tmp.<pid>` + `rename`, без частичных файлов.
- Token-плейсхолдер `your-github-personal-access-token-here` теперь корректно игнорируется (трактуется как «без токена»).

## Замеры на тестовом конфиге (`js/* → /work/target/js/`, 12 файлов)

| Сценарий | Время | Запросов к GitHub | Файлов скачано |
|---|---|---|---|
| Холодный старт (нет манифеста) | 2096 ms | 2 + 12 параллельно | 12 |
| Без изменений (HEAD тот же) | **62 ms** | 1 | 0 |
| Изменился 1 файл из 12 | ~600 ms | 2 + 1 | 1 |

При том же конфиге раньше каждый прогон был «качать все 12 последовательно через raw.github + писать 12 .sha рядом», ~2.5 секунды. На реальном `update.conf` (сотни файлов) разница в разы больше: холостые прогоны теперь почти бесплатны.

## Совместимость

- Формат `update.conf` не меняется — те же `repository:`, `branch:`, `token:`, `ignore_cache:` и `source : target` строки.
- Существующие `<target>.sha` файлы новый код просто игнорирует. Старые сидят как сироты, пока не зачистите их `?cleanup_legacy_sha=1`.
- `ignore_cache: 1` всё ещё работает — заставляет полный пересбор; но имеет смысл выключить (`0`), чтобы fast-path реально работал.

## Тестирование

- [x] PHP синтаксис: `php -l update.php` чист на 7.4 и 8.2 (Docker).
- [x] Холодный прогон с публичным `ideav/crm` (без токена) — 12 файлов из `js/*` скопировано, манифест записан с правильными blob-SHA.
- [x] Повторный прогон — fast-path, 62 ms, 0 запросов на скачивание.
- [x] Симуляция изменения одного файла (порча его SHA в манифесте) — скачан только он.
- [x] `js/*` не захватывает 38 файлов из подпапок `js/`; в `target/js/` остаются ровно 12 файлов.
- [ ] Прогон на проде с настоящим `update.conf` после деплоя.

## Риски

- На проде уже лежит файл `index.php` 487 KB и куча `.sha` файлов. После мерджа первый прогон пройдёт по всем mappings холодным путём и заполнит манифест — это будет долго (как обычный полный пересбор), но дальше всё ускорится.
- Из-за изменения семантики `dir/*` файлы, которые **раньше** ошибочно складывались из подпапок в плоский `target/`, перестанут обновляться. Если такие есть на проде — они либо устареют, либо нужно добавить явные строки маппингов на эти подпапки в `update.conf`.