### PR TITLE
dash: sticky table header when panel overflows height (issue #2432)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-07T13:50:21.572Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-07T13:50:21.572Z

--- a/css/dash.css
+++ b/css/dash.css
@@ -278,11 +278,17 @@
 }
 /* Sub-header row for RGcolumns (column group names) */
 .f-subhead th {
-    background: transparent;
+    position: sticky;
+    top: var(--dash-head-height, 0px);
+    z-index: 2;
+    background: var(--bg-secondary, #f8f9fa);
     font-weight: 500;
     text-align: center;
     font-size: 0.8em;
     border-top: none;
+}
+.f-subhead th:first-child {
+    z-index: 4;
 }
 @media (max-width: 900px) {
     .dash-head th { top: 0; }

--- a/experiments/test-issue-2432-sticky-header.html
+++ b/experiments/test-issue-2432-sticky-header.html
@@ -1,0 +1,169 @@
+<!doctype html>
+<html lang="ru">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Issue 2432: Sticky table header when panel has max-height</title>
+    <link rel="stylesheet" href="../assets/vendor/primeicons/primeicons.css">
+    <link rel="stylesheet" href="../css/dash.css">
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: #eef1f5;
+            font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            padding: 1rem;
+        }
+        h2 {
+            margin: 0 0 0.5rem;
+        }
+        .test-case {
+            margin-bottom: 2rem;
+            padding: 1rem;
+            background: #fff;
+            border: 1px solid #dee2e6;
+            border-radius: 6px;
+        }
+        .test-label {
+            font-size: 0.85rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            color: #6c757d;
+        }
+        .pass { color: green; }
+        .fail { color: red; }
+    </style>
+</head>
+<body>
+<h2>Issue 2432: Sticky table header in panel with height constraint</h2>
+<p>Test: when a table panel has a max-height set (height constraint), the table header should stick to the top while scrolling vertically.</p>
+
+<!-- Test 1: f-table-wrap with height set inline (simulates JS setting height) -->
+<div class="test-case">
+    <div class="test-label">Test 1: f-table-wrap with explicit height (should have sticky header)</div>
+    <div class="f-panel" style="max-width: 600px;">
+        <div class="f-panel-header">
+            <h4>Panel with height constraint (300px)</h4>
+        </div>
+        <div class="f-panel-content">
+            <div class="f-table-wrap" style="height: 300px; max-height: 300px; min-height: 0;">
+                <table class="table table-sm table-bordered w-auto">
+                    <thead>
+                        <tr class="dash-head f-head">
+                            <th>Name</th>
+                            <th>Value 1</th>
+                            <th>Value 2</th>
+                            <th>Value 3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="dash-item"><td>Row 1</td><td>100</td><td>200</td><td>300</td></tr>
+                        <tr class="dash-item"><td>Row 2</td><td>150</td><td>250</td><td>350</td></tr>
+                        <tr class="dash-item"><td>Row 3</td><td>200</td><td>300</td><td>400</td></tr>
+                        <tr class="dash-item"><td>Row 4</td><td>250</td><td>350</td><td>450</td></tr>
+                        <tr class="dash-item"><td>Row 5</td><td>300</td><td>400</td><td>500</td></tr>
+                        <tr class="dash-item"><td>Row 6</td><td>350</td><td>450</td><td>550</td></tr>
+                        <tr class="dash-item"><td>Row 7</td><td>400</td><td>500</td><td>600</td></tr>
+                        <tr class="dash-item"><td>Row 8</td><td>450</td><td>550</td><td>650</td></tr>
+                        <tr class="dash-item"><td>Row 9</td><td>500</td><td>600</td><td>700</td></tr>
+                        <tr class="dash-item"><td>Row 10</td><td>550</td><td>650</td><td>750</td></tr>
+                        <tr class="dash-item"><td>Row 11</td><td>600</td><td>700</td><td>800</td></tr>
+                        <tr class="dash-item"><td>Row 12</td><td>650</td><td>750</td><td>850</td></tr>
+                        <tr class="dash-item"><td>Row 13</td><td>700</td><td>800</td><td>900</td></tr>
+                        <tr class="dash-item"><td>Row 14</td><td>750</td><td>850</td><td>950</td></tr>
+                        <tr class="dash-item"><td>Row 15</td><td>800</td><td>900</td><td>1000</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <p>Expected: scroll vertically within the box, header row stays visible at the top</p>
+</div>
+
+<!-- Test 2: f-table-wrap WITHOUT height (no constraint) -->
+<div class="test-case">
+    <div class="test-label">Test 2: f-table-wrap without height (no constraint - natural behavior)</div>
+    <div class="f-panel" style="max-width: 600px;">
+        <div class="f-panel-header">
+            <h4>Panel without height constraint</h4>
+        </div>
+        <div class="f-panel-content">
+            <div class="f-table-wrap">
+                <table class="table table-sm table-bordered w-auto">
+                    <thead>
+                        <tr class="dash-head f-head">
+                            <th>Name</th>
+                            <th>Value 1</th>
+                            <th>Value 2</th>
+                            <th>Value 3</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="dash-item"><td>Row 1</td><td>100</td><td>200</td><td>300</td></tr>
+                        <tr class="dash-item"><td>Row 2</td><td>150</td><td>250</td><td>350</td></tr>
+                        <tr class="dash-item"><td>Row 3</td><td>200</td><td>300</td><td>400</td></tr>
+                        <tr class="dash-item"><td>Row 4</td><td>250</td><td>350</td><td>450</td></tr>
+                        <tr class="dash-item"><td>Row 5</td><td>300</td><td>400</td><td>500</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <p>Expected: no vertical scroll on the container, table just shows all rows</p>
+</div>
+
+<!-- Test 3: f-table-wrap with height AND wide table -->
+<div class="test-case">
+    <div class="test-label">Test 3: f-table-wrap with height constraint AND wide table (both scrollbars)</div>
+    <div class="f-panel" style="max-width: 300px;">
+        <div class="f-panel-header">
+            <h4>Wide table in narrow container (200px height)</h4>
+        </div>
+        <div class="f-panel-content">
+            <div class="f-table-wrap" style="height: 200px; max-height: 200px; min-height: 0;">
+                <table class="table table-sm table-bordered w-auto">
+                    <thead>
+                        <tr class="dash-head f-head">
+                            <th>Name</th>
+                            <th>Value 1</th>
+                            <th>Value 2</th>
+                            <th>Value 3</th>
+                            <th>Value 4</th>
+                            <th>Value 5</th>
+                            <th>Value 6</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr class="dash-item"><td>Row 1</td><td>100</td><td>200</td><td>300</td><td>400</td><td>500</td><td>600</td></tr>
+                        <tr class="dash-item"><td>Row 2</td><td>150</td><td>250</td><td>350</td><td>450</td><td>550</td><td>650</td></tr>
+                        <tr class="dash-item"><td>Row 3</td><td>200</td><td>300</td><td>400</td><td>500</td><td>600</td><td>700</td></tr>
+                        <tr class="dash-item"><td>Row 4</td><td>250</td><td>350</td><td>450</td><td>550</td><td>650</td><td>750</td></tr>
+                        <tr class="dash-item"><td>Row 5</td><td>300</td><td>400</td><td>500</td><td>600</td><td>700</td><td>800</td></tr>
+                        <tr class="dash-item"><td>Row 6</td><td>350</td><td>450</td><td>550</td><td>650</td><td>750</td><td>850</td></tr>
+                        <tr class="dash-item"><td>Row 7</td><td>400</td><td>500</td><td>600</td><td>700</td><td>800</td><td>900</td></tr>
+                        <tr class="dash-item"><td>Row 8</td><td>450</td><td>550</td><td>650</td><td>750</td><td>850</td><td>950</td></tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <p>Expected: scroll both horizontally AND vertically, header row stays visible at the top when scrolling vertically</p>
+</div>
+
+<script>
+// Verify sticky header behavior
+window.addEventListener('load', function() {
+    var wraps = document.querySelectorAll('.f-table-wrap');
+    wraps.forEach(function(wrap, i) {
+        var ths = wrap.querySelectorAll('.dash-head th');
+        ths.forEach(function(th, j) {
+            var cs = window.getComputedStyle(th);
+            var wrapCs = window.getComputedStyle(wrap);
+            console.log('Test ' + (i+1) + ' th[' + j + '] position=' + cs.position + ' top=' + cs.top);
+            console.log('Test ' + (i+1) + ' wrap overflow-x=' + wrapCs.overflowX + ' overflow-y=' + wrapCs.overflowY);
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/experiments/test-issue-2432-sticky-header.js
+++ b/experiments/test-issue-2432-sticky-header.js
@@ -1,0 +1,94 @@
+// Test for issue #2432: table header should stick to top when panel has max-height
+// and content overflows vertically.
+//
+// Root cause analysis:
+// 1. .f-panel .f-table-wrap has overflow: auto — creates scroll container
+// 2. .dash-head th has position: sticky; top: 0 — sticky within the scroll container
+// 3. When height is set on f-table-wrap via JS (dashApplyVizSizeStyles), the container
+//    becomes a vertical scroll container, and sticky header SHOULD work.
+// 4. The f-subhead row (sub-headers for RGcolumns) is NOT sticky, so when both
+//    dash-head and f-subhead are present, only dash-head sticks.
+//
+// Requirements from issue:
+// - When the table (or chart) overflows the panel's maximum height, it scrolls vertically
+// - During vertical scrolling, the table header (thead) must stay visible at the top
+//
+// The fix needed:
+// 1. Verify current CSS is correct for sticky behavior when height is set
+// 2. Make f-subhead sticky when dash-head is sticky
+// 3. Ensure overflow-y is properly set when height constraint is active
+
+const fs = require('fs');
+const css = fs.readFileSync('css/dash.css', 'utf8');
+const js = fs.readFileSync('js/dash.js', 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function ok(condition, message) {
+    if (condition) {
+        console.log('ok - ' + message);
+        passed++;
+    } else {
+        console.error('not ok - ' + message);
+        failed++;
+    }
+}
+
+// Test 1: Main header row has sticky positioning
+ok(
+    /\.dash-head\s+th\s*\{[^}]*position\s*:\s*sticky/s.test(css),
+    'dash-head th has position: sticky'
+);
+
+// Test 2: Main header has top: 0
+ok(
+    /\.dash-head\s+th\s*\{[^}]*top\s*:\s*0/s.test(css),
+    'dash-head th has top: 0'
+);
+
+// Test 3: f-table-wrap has overflow: auto (creates scroll container)
+ok(
+    /\.f-panel\s+\.f-table-wrap\s*\{[^}]*overflow\s*:\s*auto/s.test(css),
+    'f-panel .f-table-wrap has overflow: auto'
+);
+
+// Test 4: f-subhead th should also be sticky when present (new requirement)
+// The f-subhead row appears below dash-head for RGcolumns — it should also stick
+ok(
+    /\.f-subhead\s+th\s*\{[^}]*position\s*:\s*sticky/s.test(css),
+    'f-subhead th has position: sticky (for multi-row sticky header)'
+);
+
+// Test 5: f-subhead th should have the correct top offset (below dash-head)
+// The top value should be dynamic or set to an appropriate offset
+ok(
+    /\.f-subhead\s+th\s*\{[^}]*top\s*:/s.test(css),
+    'f-subhead th has top defined'
+);
+
+// Test 6: Main header (dash-head) has opaque background for proper sticky visual
+ok(
+    /\.dash-head\s+th\s*\{[^}]*background/s.test(css),
+    'dash-head th has background (needed for sticky to look correct)'
+);
+
+// Test 7: dashUpdateSubheadStickyTop function exists for computing sticky top offset
+ok(
+    /function dashUpdateSubheadStickyTop/.test(js),
+    'dashUpdateSubheadStickyTop function exists'
+);
+
+// Test 8: dashUpdateSubheadStickyTop is called after table render
+ok(
+    /dashUpdateSubheadStickyTop\(/.test(js),
+    'dashUpdateSubheadStickyTop is called after table render'
+);
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');
+if (failed > 0) {
+    console.log('\nFailing tests indicate required changes:');
+    console.log('- Tests 4,5: Add position:sticky and proper top offset to f-subhead th');
+    console.log('- Tests 7,8: dashApplyVizSizeStyles should explicitly set overflow-y');
+    process.exit(1);
+}

--- a/js/dash.js
+++ b/js/dash.js
@@ -1816,6 +1816,7 @@ function dashDrawPeriods() {
                 if (!activeIcon || activeIcon.dataset.vizType === 'table')
                     dashRenderReportTable(panel);
             }
+            dashUpdateSubheadStickyTop(panel);
         });
     }
     dashDebug();
@@ -1823,6 +1824,15 @@ function dashDrawPeriods() {
 
 function dashUpdateTableWrapOverflow() {
     // overflow-x: auto is set via CSS; no dynamic toggle needed.
+}
+
+function dashUpdateSubheadStickyTop(panelEl) {
+    var tableWrap = panelEl ? panelEl.querySelector('.f-table-wrap') : null;
+    if (!tableWrap) return;
+    var headRow = tableWrap.querySelector('thead .dash-head');
+    if (!headRow) return;
+    var headHeight = headRow.getBoundingClientRect().height;
+    tableWrap.style.setProperty('--dash-head-height', headHeight + 'px');
 }
 
 function dashDebug() {
@@ -3670,6 +3680,7 @@ function dashRenderChart(panelEl, vizType, fieldMap, vizConfig) {
         tableWrap.style.display = '';
         chartWrap.style.display = 'none';
         panelEl.classList.remove('f-panel--chart');
+        dashUpdateSubheadStickyTop(panelEl);
         return;
     }
 


### PR DESCRIPTION
## Problem

When a dashboard panel has a maximum height configured (via panel visualization settings), the `f-table-wrap` scrolls vertically. The main header row (`dash-head`) was already sticky (`position: sticky; top: 0`), but the sub-header row (`f-subhead`, which shows column group names for RGcolumns) was **not sticky** — it would scroll out of view, leaving the data body without visible column headers.

## Root Cause

`.f-subhead th` had `background: transparent` and no sticky positioning. When both a `dash-head` row and a `f-subhead` row are present (panels with grouped columns), only the first row stuck. Also, the `top` offset for `f-subhead` must dynamically match the height of `dash-head`, which varies by content and font size.

## Solution

**`css/dash.css`**
- Added `position: sticky` and `top: var(--dash-head-height, 0px)` to `.f-subhead th`
- Changed `background: transparent` → `background: var(--bg-secondary, #f8f9fa)` so scrolled content doesn't bleed through
- Added `.f-subhead th:first-child { z-index: 4 }` to keep the row-header cell on top

**`js/dash.js`**
- Added `dashUpdateSubheadStickyTop(panelEl)` which measures `dash-head` height at runtime with `getBoundingClientRect().height` and sets `--dash-head-height` as a CSS custom property on `f-table-wrap`
- Called from `dashRenderChart` (table view switch) and from the data-load callback (after each panel renders)

## How to Reproduce

1. Create a dashboard panel with a table visualization
2. In visualization settings, set a maximum height (e.g. 300px)
3. Load enough rows to overflow the height
4. **Before fix**: scroll down — `f-subhead` disappears; **after fix**: both header rows stay visible

## Tests

- `experiments/test-issue-2432-sticky-header.js` — 8 automated CSS/JS checks, all passing
- `experiments/test-issue-2432-sticky-header.html` — visual test page with 3 scenarios (height-constrained, unconstrained, both scrollbars)
- No regressions in `test-issue-2127-dashboard-sticky-bg.js` or `test-issue-2336-dashboard-table-resize.js`


Fixes #2432