### PR TITLE
Fix area chart: remove stroke and legend border, use palette fill color

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-07T14:29:00.832Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-07T14:29:00.832Z

--- a/js/dash.js
+++ b/js/dash.js
@@ -2436,10 +2436,11 @@ function dashBuildAreaDatasets(datasets, fieldMap, palette) {
         var dataset = {
             label: ds.label,
             data: ds.data,
-            borderColor: color,
-            backgroundColor: dashColorWithAlpha(color, 0.3),
+            borderWidth: 0,
+            backgroundColor: color,
             tension: 0.3,
-            fill: true
+            fill: true,
+            pointRadius: 0
         };
         if (areaMode !== 'plain') dataset.stack = 'area';
         return dataset;
@@ -2448,8 +2449,9 @@ function dashBuildAreaDatasets(datasets, fieldMap, palette) {
 
 function dashBuildAreaChartOptions(fieldMap) {
     var areaMode = dashNormalizeAreaMode(fieldMap && fieldMap.areaMode)
-        , yScale;
-    if (areaMode === 'plain') return {};
+        , yScale
+        , base = { plugins: { legend: { labels: { borderWidth: 0 } } } };
+    if (areaMode === 'plain') return base;
 
     yScale = { stacked: true };
     if (areaMode === 'normalized') {
@@ -2462,7 +2464,7 @@ function dashBuildAreaChartOptions(fieldMap) {
             }
         };
     }
-    return { scales: { y: yScale } };
+    return Object.assign(base, { scales: { y: yScale } });
 }
 
 function dashEnsureChartJs(cb) {


### PR DESCRIPTION
## Summary

- Removed `borderColor` and stroke lines from area chart datasets (`dashBuildAreaDatasets`)
- Set `borderWidth: 0` on datasets so no stroke is drawn on the chart
- Set `pointRadius: 0` to hide data points (no dots on lines)
- Use palette color directly as `backgroundColor` instead of semi-transparent variant (`dashColorWithAlpha(color, 0.3)`)
- Set `borderWidth: 0` on legend labels via `dashBuildAreaChartOptions` so legend boxes show only background fill, no border

## How to reproduce

Open a dashboard with an "Area chart" (Диаграмма с областями) widget. Before the fix, each series had a colored stroke line and the legend boxes had a colored border around them.

## Fix

Changes are in `js/dash.js` in `dashBuildAreaDatasets` and `dashBuildAreaChartOptions`.

Closes #2436