### PR TITLE
Fix update.php: don't cache commit SHA when downloads fail

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-07T15:04:52.244Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-07T15:04:52.244Z

--- a/update.php
+++ b/update.php
@@ -363,7 +363,11 @@ function syncWithCache($config, $configName) {
     $kept = [];
     foreach ($tasks as $t) $kept[$t['target']] = true;
     $configEntry['files'] = array_intersect_key($configEntry['files'], $kept);
-    $configEntry['commit_sha'] = $head['commit_sha'];
+    // Only advance the cached commit SHA when every pending download succeeded.
+    // If any download failed the next run must retry rather than fast-pathing.
+    if (empty($results['errors'])) {
+        $configEntry['commit_sha'] = $head['commit_sha'];
+    }
     $configEntry['updated_at'] = date('c');
     $manifest['configs'][$configName] = $configEntry;
 


### PR DESCRIPTION
## Problem

When `update.php` runs and some file downloads fail (e.g. `HTTP 0`), the script still writes the latest HEAD commit SHA into the manifest cache. On the very next run, the cached SHA matches HEAD, so the script takes the fast-path and reports:

> **Up to date. HEAD не двигался — скачивать нечего.**

…even though the files were never actually downloaded. The failed files are silently skipped forever.

## Root Cause

In `syncWithCache()`, line 366 (before this fix):

```php
$configEntry['commit_sha'] = $head['commit_sha'];
```

This line executed unconditionally — even when `$results['errors']` was non-empty.

## Fix

`commit_sha` is now only advanced when the sync completed without errors:

```php
if (empty($results['errors'])) {
    $configEntry['commit_sha'] = $head['commit_sha'];
}
```

If any error occurred (download failure, missing file, tree fetch failure), the cached SHA is left at its previous value. The next run will detect a SHA mismatch and retry the full download cycle.

## How to reproduce

1. Break network access to `raw.githubusercontent.com` temporarily (or use a bad token).
2. Run `update.php?config=update.conf&ignore_cache=1`.
3. **Before fix:** errors are shown, but the cache is updated. Next run says "Up to date".
4. **After fix:** errors are shown, cache is NOT updated. Next run retries all files.

## Test plan

- [ ] Verify that after a failed download run, the next run retries instead of fast-pathing.
- [ ] Verify that after a fully successful run, the next run correctly fast-paths.

Fixes #2438