### PR TITLE
dash: close visualization settings without saving

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-07T16:45:22.529Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-07T16:45:22.529Z

--- a/experiments/test-issue-2444-dashboard-viz-modal-close.js
+++ b/experiments/test-issue-2444-dashboard-viz-modal-close.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+const template = fs.readFileSync('templates/dash.html', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+if (!template.includes('dash-viz-modal')) {
+    throw new Error('dashboard template must include the visualization modal');
+}
+if (!template.includes('dash-viz-modal-box')) {
+    throw new Error('dashboard template must include the visualization modal box');
+}
+
+const code = `
+let dashVizModalCtx = { panelEl: { id: 'panel-1' }, panelKey: 'panel-1' };
+
+const assert = require('assert');
+
+function makeModal(open) {
+    const classes = new Set(open ? ['open'] : []);
+    return {
+        classList: {
+            contains(name) { return classes.has(name); },
+            add(name) { classes.add(name); },
+            remove(name) { classes.delete(name); }
+        }
+    };
+}
+
+let modal = makeModal(true);
+const document = {
+    getElementById(id) {
+        assert.strictEqual(id, 'dash-viz-modal');
+        return modal;
+    }
+};
+
+${extractFunction('dashVizModalIsOpen')}
+${extractFunction('dashCloseVizModal')}
+${extractFunction('dashHandleVizModalKeydown')}
+${extractFunction('dashHandleVizModalBackdropClick')}
+
+let prevented = false;
+let stopped = false;
+dashHandleVizModalKeydown({
+    key: 'Escape',
+    preventDefault() { prevented = true; },
+    stopPropagation() { stopped = true; }
+});
+assert.strictEqual(modal.classList.contains('open'), false, 'Escape must close the open visualization modal');
+assert.strictEqual(dashVizModalCtx, null, 'Escape must clear the visualization modal context');
+assert.strictEqual(prevented, true, 'Escape close should prevent the browser default');
+assert.strictEqual(stopped, true, 'Escape close should stop propagation to dashboard shortcuts');
+
+modal = makeModal(true);
+dashVizModalCtx = { panelEl: { id: 'panel-1' }, panelKey: 'panel-1' };
+dashHandleVizModalKeydown({
+    key: 'Enter',
+    preventDefault() { throw new Error('Enter must not close the visualization modal'); },
+    stopPropagation() { throw new Error('Enter must not close the visualization modal'); }
+});
+assert.strictEqual(modal.classList.contains('open'), true, 'non-Escape keys must leave the modal open');
+assert.notStrictEqual(dashVizModalCtx, null, 'non-Escape keys must keep the modal context');
+
+const modalBox = {};
+dashHandleVizModalBackdropClick({ target: modalBox });
+assert.strictEqual(modal.classList.contains('open'), true, 'clicking inside the modal box must not close it');
+
+dashHandleVizModalBackdropClick({ target: modal });
+assert.strictEqual(modal.classList.contains('open'), false, 'clicking the backdrop must close the visualization modal');
+assert.strictEqual(dashVizModalCtx, null, 'backdrop click must clear the visualization modal context');
+`;
+
+vm.runInNewContext(code, { require });
+console.log('issue-2444 dashboard visualization modal close: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -4949,6 +4949,30 @@ function dashCollectPanelGeneral() {
     return has ? result : null;
 }
 
+function dashVizModalIsOpen() {
+    var modal = document.getElementById('dash-viz-modal');
+    return !!(modal && modal.classList.contains('open'));
+}
+
+function dashCloseVizModal() {
+    var modal = document.getElementById('dash-viz-modal');
+    if (modal) modal.classList.remove('open');
+    dashVizModalCtx = null;
+}
+
+function dashHandleVizModalKeydown(e) {
+    if (!e || (e.key !== 'Escape' && e.keyCode !== 27)) return;
+    if (!dashVizModalIsOpen()) return;
+    if (e.preventDefault) e.preventDefault();
+    if (e.stopPropagation) e.stopPropagation();
+    dashCloseVizModal();
+}
+
+function dashHandleVizModalBackdropClick(e) {
+    var modal = document.getElementById('dash-viz-modal');
+    if (modal && e && e.target === modal) dashCloseVizModal();
+}
+
 function dashVizModalActivateTab(name) {
     var modal = document.getElementById('dash-viz-modal');
     if (!modal) return;
@@ -5021,8 +5045,7 @@ function dashVizModalCollectSettings() {
 }
 
 document.getElementById('dash-viz-cancel').addEventListener('click', function() {
-    document.getElementById('dash-viz-modal').classList.remove('open');
-    dashVizModalCtx = null;
+    dashCloseVizModal();
 });
 
 document.querySelectorAll('#dash-viz-modal .dash-viz-tab').forEach(function(tab) {
@@ -5044,6 +5067,8 @@ document.getElementById('dash-viz-modal').addEventListener('keydown', function(e
         document.getElementById('dash-viz-save').click();
     }
 });
+document.addEventListener('keydown', dashHandleVizModalKeydown);
+document.getElementById('dash-viz-modal').addEventListener('click', dashHandleVizModalBackdropClick);
 
 document.getElementById('dash-viz-save').addEventListener('click', function() {
     if (!dashVizModalCtx) return;


### PR DESCRIPTION
## Summary
- close the dashboard visualization settings modal on Esc or backdrop click
- reuse the same unsaved-close path for the Cancel button
- add a regression experiment for Esc/backdrop close behavior

Fixes #2444

## Tests
- node experiments/test-issue-2444-dashboard-viz-modal-close.js
- node experiments/test-issue-2317-dashboard-panel-filter-close.js
- node experiments/test-issue-2428-dashboard-tile-layout.js
- node experiments/test-issue-2414-dashboard-legend-and-small-fonts.js