### PR TITLE
Update google_sheets_sync.php upload tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /credentials.json
+/include/credentials.json
 /google_sheets_sync.bki

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-08T07:59:24.626Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-08T07:59:24.626Z

--- a/experiments/test-issue-2452-google-sheets-sync-upload.php
+++ b/experiments/test-issue-2452-google-sheets-sync-upload.php
@@ -1,0 +1,59 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2452($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+function assertTrueIssue2452($condition, $message) {
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+    }
+}
+
+$config = gss_normalize_config([
+    'integram' => [
+        'enabled' => true,
+        'base_url' => 'https://ideav.ru',
+        'token' => 'token-123',
+        'xsrf' => 'xsrf-456',
+    ],
+], __DIR__);
+
+$integram = $config['integram'];
+assertSameIssue2452('/object/443296?JSON&import=1', $integram['upload_endpoint'], 'uses requested upload endpoint by default');
+assertTrueIssue2452(!array_key_exists('auth_endpoint', $integram), 'auth_endpoint is no longer a normalized setting');
+assertTrueIssue2452(!array_key_exists('xsrf_endpoint', $integram), 'xsrf_endpoint is no longer a normalized setting');
+assertSameIssue2452(
+    'https://ideav.ru/object/443296?JSON&import=1',
+    gss_integram_url($integram, $integram['upload_endpoint']),
+    'resolves leading-slash upload endpoint against the configured host without database path'
+);
+
+$oldServer = $_SERVER;
+$_SERVER['HTTP_HOST'] = 'crm.example.test';
+$_SERVER['HTTPS'] = 'on';
+assertSameIssue2452(
+    'https://crm.example.test/object/443296?JSON&import=1',
+    gss_integram_url(['base_url' => ''], '/object/443296?JSON&import=1'),
+    'resolves relative upload endpoint against current host when base_url is omitted'
+);
+$_SERVER = $oldServer;
+
+$tmpFile = tempnam(sys_get_temp_dir(), 'gss-2452-');
+file_put_contents($tmpFile, "DATA\r\n");
+$postFields = gss_integram_upload_post_fields($tmpFile, $integram);
+
+assertSameIssue2452('token-123', $postFields['token'], 'passes token as POST field');
+assertSameIssue2452('xsrf-456', $postFields['_xsrf'], 'passes xsrf as POST field');
+assertSameIssue2452('1', $postFields['import'], 'keeps import flag as POST field');
+assertTrueIssue2452($postFields['bki_file'] instanceof CURLFile, 'passes BKI content as multipart file');
+
+unlink($tmpFile);
+
+echo "PASS issue 2452 Google Sheets sync upload settings\n";

--- a/google_sheets_sync.config.php
+++ b/google_sheets_sync.config.php
@@ -2,9 +2,10 @@
 /**
  * Settings for google_sheets_sync.php.
  *
- * Copy real Google service-account credentials to credentials.json, share the
- * spreadsheet with that service-account email, then fill spreadsheet_id and
- * Integram credentials below. credentials.json is ignored by git.
+ * Copy real Google service-account credentials to include/credentials.json,
+ * share the spreadsheet with that service-account email, then fill
+ * spreadsheet_id and Integram upload tokens below. credentials.json is ignored
+ * by git.
  */
 
 return [
@@ -36,12 +37,8 @@ return [
     'integram' => [
         'enabled' => false,
         'base_url' => 'https://ideav.ru',
-        'database' => '',
-        'login' => '',
-        'password' => '',
-        'object' => '',
-        'auth_endpoint' => 'auth?JSON',
-        'xsrf_endpoint' => 'xsrf?JSON',
-        'upload_endpoint' => 'object/{object}?JSON&import=1',
+        'token' => '',
+        'xsrf' => '',
+        'upload_endpoint' => '/object/443296?JSON&import=1',
     ],
 ];

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -93,18 +93,15 @@ function gss_normalize_config($config, $configDir) {
         'enabled' => false,
         'base_url' => '',
         'database' => '',
-        'login' => '',
-        'password' => '',
         'token' => '',
         'xsrf' => '',
         'object' => '',
-        'auth_endpoint' => 'auth?JSON',
-        'xsrf_endpoint' => 'xsrf?JSON',
-        'upload_endpoint' => 'object/{object}?JSON&import=1',
+        'upload_endpoint' => '/object/443296?JSON&import=1',
         'base_url_has_database' => false,
         'url_template' => '',
     ];
     $config['integram'] = array_merge($integramDefaults, $config['integram']);
+    unset($config['integram']['auth_endpoint'], $config['integram']['xsrf_endpoint']);
 
     return $config;
 }
@@ -498,27 +495,10 @@ function gss_upload_to_integram($filePath, $integramConfig, $httpOptions = []) {
     if (!file_exists($filePath)) {
         throw new RuntimeException("Upload file not found: {$filePath}");
     }
-    if (empty($integramConfig['object'])) {
-        throw new RuntimeException('Integram upload requires integram.object in config.');
-    }
-
-    $session = gss_integram_session($integramConfig, $httpOptions);
-    if (empty($session['xsrf'])) {
-        throw new RuntimeException('Integram session does not contain XSRF token.');
-    }
-
-    $endpoint = str_replace(
-        '{object}',
-        rawurlencode((string)$integramConfig['object']),
-        $integramConfig['upload_endpoint']
-    );
+    $endpoint = gss_integram_upload_endpoint($integramConfig);
     $url = gss_integram_url($integramConfig, $endpoint);
-    $headers = gss_integram_auth_headers($session);
-    $postFields = [
-        '_xsrf' => $session['xsrf'],
-        'import' => '1',
-        'bki_file' => new CURLFile($filePath, 'application/octet-stream', 'import.bki'),
-    ];
+    $headers = ['Accept: application/json'];
+    $postFields = gss_integram_upload_post_fields($filePath, $integramConfig);
 
     $response = gss_http_request('POST', $url, $headers, $postFields, $httpOptions);
     gss_assert_success($response, 'Integram BKI upload');
@@ -531,101 +511,111 @@ function gss_upload_to_integram($filePath, $integramConfig, $httpOptions = []) {
     ];
 }
 
-function gss_integram_session($config, $httpOptions = []) {
-    if (!empty($config['token'])) {
-        return [
-            'token' => $config['token'],
-            'xsrf' => $config['xsrf'] ?? '',
-        ];
+function gss_integram_upload_endpoint($config) {
+    $endpoint = isset($config['upload_endpoint']) ? (string)$config['upload_endpoint'] : '';
+    if ($endpoint === '') {
+        throw new RuntimeException('Integram upload requires integram.upload_endpoint in config.');
     }
 
-    foreach (['base_url', 'database', 'login', 'password'] as $key) {
-        if (empty($config[$key]) && empty($config['url_template'])) {
-            throw new RuntimeException("Integram upload requires integram.{$key} in config.");
+    if (strpos($endpoint, '{object}') !== false) {
+        if (empty($config['object'])) {
+            throw new RuntimeException('Integram upload endpoint uses {object}, but integram.object is empty.');
         }
+        $endpoint = str_replace('{object}', rawurlencode((string)$config['object']), $endpoint);
     }
 
-    $authUrl = gss_integram_url($config, $config['auth_endpoint']);
-    $body = gss_form_encode([
-        'login' => $config['login'],
-        'pwd' => $config['password'],
-    ]);
-    $response = gss_http_request('POST', $authUrl, [
-        'Content-Type: application/x-www-form-urlencoded',
-        'Accept: application/json',
-    ], $body, $httpOptions);
+    return $endpoint;
+}
 
-    gss_assert_success($response, 'Integram auth request');
-    $json = gss_decode_json($response['body'], 'Integram auth response');
-    if (!empty($json['failed'])) {
-        throw new RuntimeException('Integram auth failed.');
-    }
+function gss_integram_upload_post_fields($filePath, $config) {
+    $tokens = gss_integram_tokens($config);
 
-    $session = [
-        'token' => $json['token'] ?? '',
-        'xsrf' => $json['_xsrf'] ?? '',
+    return [
+        'token' => $tokens['token'],
+        '_xsrf' => $tokens['xsrf'],
+        'import' => '1',
+        'bki_file' => new CURLFile($filePath, 'application/octet-stream', 'import.bki'),
     ];
+}
 
-    if (!empty($session['token']) && !empty($config['xsrf_endpoint'])) {
-        $xsrfUrl = gss_integram_url($config, $config['xsrf_endpoint']);
-        $xsrfResponse = gss_http_request('GET', $xsrfUrl, gss_integram_auth_headers($session), null, $httpOptions);
-        if ($xsrfResponse['status'] >= 200 && $xsrfResponse['status'] < 300) {
-            $xsrfJson = json_decode($xsrfResponse['body'], true);
-            if (is_array($xsrfJson)) {
-                $session['token'] = $xsrfJson['token'] ?? $session['token'];
-                $session['xsrf'] = $xsrfJson['_xsrf'] ?? $session['xsrf'];
-            }
-        }
+function gss_integram_tokens($config) {
+    $token = isset($config['token']) ? (string)$config['token'] : '';
+    $xsrf = isset($config['xsrf']) ? (string)$config['xsrf'] : '';
+
+    if ($token === '') {
+        throw new RuntimeException('Integram upload requires integram.token in config.');
+    }
+    if ($xsrf === '') {
+        throw new RuntimeException('Integram upload requires integram.xsrf in config.');
     }
 
-    return $session;
+    return [
+        'token' => $token,
+        'xsrf' => $xsrf,
+    ];
 }
 
 function gss_integram_url($config, $endpoint) {
-    $endpoint = ltrim((string)$endpoint, '/');
+    $endpoint = (string)$endpoint;
+    if ($endpoint === '') {
+        throw new RuntimeException('Integram endpoint is empty.');
+    }
+
+    if (preg_match('/^https?:\/\//i', $endpoint) === 1) {
+        return $endpoint;
+    }
 
     if (!empty($config['url_template'])) {
+        $baseUrl = isset($config['base_url']) ? rtrim((string)$config['base_url'], '/') : '';
+        $database = isset($config['database']) ? trim((string)$config['database'], '/') : '';
+
         return strtr($config['url_template'], [
-            '{base_url}' => rtrim((string)$config['base_url'], '/'),
-            '{database}' => trim((string)$config['database'], '/'),
-            '{endpoint}' => $endpoint,
+            '{base_url}' => $baseUrl,
+            '{database}' => $database,
+            '{endpoint}' => ltrim($endpoint, '/'),
         ]);
     }
 
-    $baseUrl = rtrim((string)$config['base_url'], '/');
-    if ($baseUrl === '') {
-        throw new RuntimeException('Integram base_url is empty.');
+    if ($endpoint[0] === '/') {
+        return rtrim(gss_integram_host_url($config), '/') . $endpoint;
     }
+
+    $endpoint = ltrim($endpoint, '/');
+    $baseUrl = rtrim(gss_integram_host_url($config), '/');
 
     if (!empty($config['base_url_has_database'])) {
         return $baseUrl . '/' . $endpoint;
     }
 
-    $database = trim((string)$config['database'], '/');
+    $database = isset($config['database']) ? trim((string)$config['database'], '/') : '';
     if ($database === '') {
-        throw new RuntimeException('Integram database is empty.');
+        return $baseUrl . '/' . $endpoint;
     }
 
     return $baseUrl . '/' . $database . '/' . $endpoint;
 }
 
-function gss_integram_auth_headers($session) {
-    $headers = ['Accept: application/json'];
-    if (!empty($session['token'])) {
-        $headers[] = 'X-Authorization: ' . $session['token'];
-        $headers[] = 'Cookie: token=' . $session['token'];
+function gss_integram_host_url($config) {
+    $baseUrl = isset($config['base_url']) ? rtrim((string)$config['base_url'], '/') : '';
+    if ($baseUrl !== '') {
+        return $baseUrl;
     }
-    return $headers;
-}
 
-function gss_form_encode($data) {
-    $parts = [];
-    foreach ($data as $key => $value) {
-        if ($value !== null) {
-            $parts[] = rawurlencode((string)$key) . '=' . rawurlencode((string)$value);
+    $host = $_SERVER['HTTP_HOST'] ?? $_SERVER['SERVER_NAME'] ?? '';
+    if ($host === '') {
+        throw new RuntimeException('Integram base_url is empty and current host is unavailable.');
+    }
+
+    $https = $_SERVER['HTTPS'] ?? '';
+    $scheme = (!empty($https) && strtolower((string)$https) !== 'off') ? 'https' : 'http';
+    if (strpos($host, ':') === false && !empty($_SERVER['SERVER_PORT'])) {
+        $port = (string)$_SERVER['SERVER_PORT'];
+        if (($scheme === 'https' && $port !== '443') || ($scheme === 'http' && $port !== '80')) {
+            $host .= ':' . $port;
         }
     }
-    return implode('&', $parts);
+
+    return $scheme . '://' . $host;
 }
 
 function gss_http_request($method, $url, $headers = [], $body = null, $options = []) {


### PR DESCRIPTION
Fixes #2452

## Summary
- Replaces the Integram auth/xsrf endpoint flow with configured `token` and `xsrf` upload settings.
- Sends `token` and `_xsrf` as multipart POST fields together with `import=1` and `bki_file`.
- Defaults `upload_endpoint` to `/object/443296?JSON&import=1` and resolves leading-slash endpoints against the configured host or current request host without adding a database path.
- Ignores `include/credentials.json`, matching the configured credentials path.

## Verification
- `php -l google_sheets_sync.php`
- `php -l google_sheets_sync.config.php`
- `php -l experiments/test-issue-2452-google-sheets-sync-upload.php`
- `php experiments/test-issue-2452-google-sheets-sync-upload.php`
- `php experiments/test-issue-2450-google-sheets-sync.php`
- `php google_sheets_sync.php --help`
- `git diff --check`
