### PR TITLE
Ensure Google Sheets import file is overwritten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /credentials.json
 /include/credentials.json
 /google_sheets_sync.bki
+/logs/google_sheets_sync.bki

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,2 @@
+# .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
+# Updated: 2026-05-07T08:13:24.930Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-08T08:58:58.084Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
-# Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-08T08:58:58.084Z

--- a/experiments/test-issue-2454-google-sheets-sync-overwrite.php
+++ b/experiments/test-issue-2454-google-sheets-sync-overwrite.php
@@ -1,0 +1,51 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2454($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+function assertTrueIssue2454($condition, $message) {
+    if (!$condition) {
+        fwrite(STDERR, "FAIL: {$message}\n");
+        exit(1);
+    }
+}
+
+$tmpDir = sys_get_temp_dir() . '/gss-2454-' . uniqid('', true);
+$outputFile = $tmpDir . '/nested/import.bki';
+
+try {
+    $staleContent = "DATA\r\nold-sheet:old-row:old-column;stale;\r\n";
+    $freshContent = "DATA\r\nnew-sheet:new-row:new-column;fresh;\r\n";
+
+    gss_write_file($outputFile, $staleContent);
+    assertSameIssue2454($staleContent, file_get_contents($outputFile), 'writes initial import file content');
+
+    gss_write_file($outputFile, $freshContent);
+    $rewrittenContent = file_get_contents($outputFile);
+
+    assertSameIssue2454($freshContent, $rewrittenContent, 'overwrites import file instead of appending to it');
+    assertTrueIssue2454(strpos($rewrittenContent, 'stale') === false, 'removes stale rows from previous imports');
+
+    $emptyImportContent = gss_build_bki_content([]);
+    gss_write_file($outputFile, $emptyImportContent);
+
+    assertSameIssue2454("DATA\r\n", file_get_contents($outputFile), 'rewrites import file from scratch even when no records are selected');
+
+    echo "PASS issue 2454 Google Sheets sync overwrite\n";
+} finally {
+    if (is_file($outputFile)) {
+        unlink($outputFile);
+    }
+    if (is_dir(dirname($outputFile))) {
+        rmdir(dirname($outputFile));
+    }
+    if (is_dir($tmpDir)) {
+        rmdir($tmpDir);
+    }
+}

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -188,7 +188,8 @@ function gss_write_file($path, $content) {
         throw new RuntimeException("Failed to create directory: {$dir}");
     }
 
-    if (file_put_contents($path, $content) === false) {
+    $bytes = file_put_contents($path, $content, LOCK_EX);
+    if ($bytes === false || $bytes !== strlen($content)) {
         throw new RuntimeException("Failed to write file: {$path}");
     }
 }


### PR DESCRIPTION
Fixes #2454

## Summary
- Makes `google_sheets_sync.php` write the generated BKI import file with an explicit locked overwrite and byte-count validation.
- Adds an issue #2454 regression experiment that writes stale import content, rewrites shorter/current content, and verifies stale rows are removed.
- Ignores the default generated `logs/google_sheets_sync.bki` file and removes the draft `.gitkeep` placeholder.

## Reproduction
- Run `php experiments/test-issue-2454-google-sheets-sync-overwrite.php`; the test writes an old import file, rewrites it with fresh content, then rewrites it as a DATA-only file to confirm each run starts from scratch.

## Verification
- `php -l google_sheets_sync.php`
- `php -l google_sheets_sync.config.php`
- `php -l experiments/test-issue-2450-google-sheets-sync.php`
- `php -l experiments/test-issue-2452-google-sheets-sync-upload.php`
- `php -l experiments/test-issue-2454-google-sheets-sync-overwrite.php`
- `php experiments/test-issue-2450-google-sheets-sync.php`
- `php experiments/test-issue-2452-google-sheets-sync-upload.php`
- `php experiments/test-issue-2454-google-sheets-sync-overwrite.php`
- `php google_sheets_sync.php --help`
- `git diff --check`
