### PR TITLE
google_sheets_sync.php: добавить номер строки и ограничить выборку

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-08T11:01:18.756Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-08T11:01:18.756Z

--- a/experiments/test-issue-2450-google-sheets-sync.php
+++ b/experiments/test-issue-2450-google-sheets-sync.php
@@ -40,10 +40,10 @@ assertSameValue(['01.01.2026', '31.01.2026', 'ПЛАН'], $records[0]['columns']
 assertSameValue('123:45;6,7', $records[0]['value'], 'keeps source cell value unchanged before BKI escaping');
 assertSameValue(['2025'], $records[1]['columns'], 'matches scalar column matcher');
 
-$content = gss_build_bki_content($records);
+$content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "Выручка (ддо - b2b):Выручка (ддо - b2b):01.01.2026,31.01.2026,ПЛАН;123\\:45\\;6\\,7;\r\n"
-    . "Выручка (ддо - b2b):Выручка (ддо - b2b):2025;89;\r\n";
+    . "Выручка (ддо - b2b):4:Выручка (ддо - b2b):01.01.2026,31.01.2026,ПЛАН;123\\:45\\;6\\,7;1773328460;\r\n"
+    . "Выручка (ддо - b2b):4:Выручка (ддо - b2b):2025;89;1773328460;\r\n";
 
 assertSameValue($expected, $content, 'builds DATA-prefixed BKI content and escapes delimiters');
 assertTrueValue(gss_pattern_matches('*.2026', '31.01.2026'), 'asterisk mask matches arbitrary leading text');

--- a/experiments/test-issue-2456-google-sheets-sync-rules.php
+++ b/experiments/test-issue-2456-google-sheets-sync-rules.php
@@ -1,0 +1,61 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2456($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+$values = [
+    ['', '', '2026', ''],
+    ['', '', '2026', ''],
+    ['', '', 'PLAN', ''],
+    ['Metric A', 'Metric A', '10', 'future-only'],
+    ['Metric B', '', '20', ''],
+    ['Metric A', 'Metric A', '11', 'same-header-duplicate'],
+    ['', '', '2026', '2026'],
+    ['', '', '2026', '2026'],
+    ['', '', 'PLAN', 'PLAN'],
+    ['Metric A', 'Metric A', '12', '13'],
+];
+
+$records = gss_extract_sheet_records(
+    'Rules',
+    $values,
+    [
+        ['Metric A', 'Metric A'],
+        'Metric B',
+    ],
+    [
+        ['2026', '2026', 'PLAN'],
+    ]
+);
+
+assertSameIssue2456(4, count($records), 'selects only rows with matching row conditions and fresh column conditions');
+assertSameIssue2456(4, $records[0]['row_number'], 'stores the 1-based sheet row number');
+assertSameIssue2456(['Metric A'], $records[0]['rows'], 'deduplicates repeated row match values');
+assertSameIssue2456(['2026', 'PLAN'], $records[0]['columns'], 'deduplicates repeated column match values');
+assertSameIssue2456('10', $records[0]['value'], 'captures the first metric value');
+
+assertSameIssue2456(5, $records[1]['row_number'], 'keeps independent last-found state per row condition');
+assertSameIssue2456(['Metric B'], $records[1]['rows'], 'captures another row condition in the same header block');
+assertSameIssue2456('20', $records[1]['value'], 'captures the second metric value');
+
+assertSameIssue2456(10, $records[2]['row_number'], 'captures the repeated row condition after a new matching header block');
+assertSameIssue2456('12', $records[2]['value'], 'captures the value under the refreshed existing column');
+assertSameIssue2456(10, $records[3]['row_number'], 'does not let one selected column block another column on the same row');
+assertSameIssue2456('13', $records[3]['value'], 'captures the value under the newly matching column');
+
+$content = gss_build_bki_content($records, 1773328460);
+$expected = "DATA\r\n"
+    . "Rules:4:Metric A:2026,PLAN;10;1773328460;\r\n"
+    . "Rules:5:Metric B:2026,PLAN;20;1773328460;\r\n"
+    . "Rules:10:Metric A:2026,PLAN;12;1773328460;\r\n"
+    . "Rules:10:Metric A:2026,PLAN;13;1773328460;\r\n";
+
+assertSameIssue2456($expected, $content, 'builds BKI content with sheet row number and Unix timestamp');
+
+echo "PASS issue 2456 Google Sheets sync row rules\n";

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -307,40 +307,63 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
     }
 
     $matrix = gss_normalize_matrix($values);
-    $rowMatches = [];
-    $columnMatches = [];
     $maxColumns = gss_max_columns($matrix);
+    $records = [];
+    $lastMatchedRows = [];
 
     foreach ($matrix as $rowIndex => $row) {
-        $matches = gss_match_any_spec($row, $rowMatchers);
-        if (!empty($matches)) {
-            $rowMatches[$rowIndex] = $matches;
+        $rowSpecMatches = gss_match_specs($row, $rowMatchers);
+        if (empty($rowSpecMatches)) {
+            continue;
         }
-    }
 
-    for ($columnIndex = 0; $columnIndex < $maxColumns; $columnIndex++) {
-        $column = gss_column_values($matrix, $columnIndex);
-        $matches = gss_match_any_spec($column, $columnMatchers);
-        if (!empty($matches)) {
-            $columnMatches[$columnIndex] = $matches;
-        }
-    }
+        for ($columnIndex = 0; $columnIndex < $maxColumns; $columnIndex++) {
+            $matchedRows = [];
+            $matchedColumns = [];
+            $matchedStateKeys = [];
 
-    $records = [];
-    foreach ($rowMatches as $rowIndex => $matchedRows) {
-        foreach ($columnMatches as $columnIndex => $matchedColumns) {
+            foreach ($rowSpecMatches as $rowSpecMatch) {
+                foreach ($columnMatchers as $columnSpecKey => $columnSpec) {
+                    $stateKey = $rowSpecMatch['key'] . "\0" . $columnSpecKey . "\0" . $columnIndex;
+                    $startRow = array_key_exists($stateKey, $lastMatchedRows)
+                        ? $lastMatchedRows[$stateKey] + 1
+                        : 0;
+                    if ($startRow > $rowIndex) {
+                        continue;
+                    }
+
+                    $column = gss_column_values_between($matrix, $columnIndex, $startRow, $rowIndex);
+                    $columnMatch = gss_match_spec($column, $columnSpec);
+                    if ($columnMatch['matched']) {
+                        $matchedRows = array_merge($matchedRows, $rowSpecMatch['values']);
+                        $matchedColumns = array_merge($matchedColumns, $columnMatch['values']);
+                        $matchedStateKeys[$stateKey] = true;
+                    }
+                }
+            }
+
+            if (empty($matchedStateKeys)) {
+                continue;
+            }
+
             $value = isset($matrix[$rowIndex][$columnIndex]) ? $matrix[$rowIndex][$columnIndex] : '';
             if ($skipEmptyValues && trim((string)$value) === '') {
                 continue;
             }
+
             $records[] = [
                 'sheet' => $sheetName,
-                'rows' => $matchedRows,
-                'columns' => $matchedColumns,
+                'row_number' => $rowIndex + 1,
+                'rows' => gss_unique_preserve_order($matchedRows),
+                'columns' => gss_unique_preserve_order($matchedColumns),
                 'value' => $value,
                 'row_index' => $rowIndex,
                 'column_index' => $columnIndex,
             ];
+
+            foreach ($matchedStateKeys as $stateKey => $_) {
+                $lastMatchedRows[$stateKey] = $rowIndex;
+            }
         }
     }
 
@@ -386,13 +409,37 @@ function gss_column_values($matrix, $columnIndex) {
     return $values;
 }
 
-function gss_match_any_spec($cells, $specs) {
+function gss_column_values_between($matrix, $columnIndex, $startRow, $endRow) {
+    $values = [];
+    $startRow = max(0, (int)$startRow);
+    $endRow = min(count($matrix) - 1, (int)$endRow);
+
+    for ($rowIndex = $startRow; $rowIndex <= $endRow; $rowIndex++) {
+        $row = $matrix[$rowIndex];
+        $values[] = isset($row[$columnIndex]) ? $row[$columnIndex] : '';
+    }
+
+    return $values;
+}
+
+function gss_match_specs($cells, $specs) {
     $matches = [];
-    foreach ($specs as $spec) {
+    foreach ($specs as $specKey => $spec) {
         $match = gss_match_spec($cells, $spec);
         if ($match['matched']) {
-            $matches = array_merge($matches, $match['values']);
+            $matches[] = [
+                'key' => (string)$specKey,
+                'values' => gss_unique_preserve_order($match['values']),
+            ];
         }
+    }
+    return $matches;
+}
+
+function gss_match_any_spec($cells, $specs) {
+    $matches = [];
+    foreach (gss_match_specs($cells, $specs) as $match) {
+        $matches = array_merge($matches, $match['values']);
     }
     return gss_unique_preserve_order($matches);
 }
@@ -463,13 +510,23 @@ function gss_unique_preserve_order($values) {
     return $result;
 }
 
-function gss_build_bki_content($records) {
+function gss_build_bki_content($records, $timestamp = null) {
+    if ($timestamp === null) {
+        $timestamp = time();
+    }
+
     $lines = ['DATA'];
     foreach ($records as $record) {
+        $rowNumber = isset($record['row_number'])
+            ? $record['row_number']
+            : (isset($record['row_index']) ? ((int)$record['row_index'] + 1) : '');
+
         $lines[] = gss_escape_bki_value($record['sheet'])
+            . ':' . gss_escape_bki_value($rowNumber)
             . ':' . gss_escape_bki_list($record['rows'])
             . ':' . gss_escape_bki_list($record['columns'])
             . ';' . gss_escape_bki_value($record['value'])
+            . ';' . gss_escape_bki_value($timestamp)
             . ';';
     }
 


### PR DESCRIPTION
Fixes #2456

## Что изменено
- Формат BKI-строки обновлен до `{имя листа}:{номер строки}:{совпавшие строки}:{совпавшие колонки};{значение};{unix timestamp};`.
- Подбор условий колонок теперь идет только от текущей строки вверх до строки после предыдущего найденного совпадения для той же пары условий строки/колонки и конкретного столбца.
- Совпавшие значения строк и колонок дедуплицируются с сохранением порядка.

## Как воспроизвести
Сценарий `experiments/test-issue-2456-google-sheets-sync-rules.php` покрывает случай, где старая логика выбирала 8 записей вместо 4 из-за будущих заголовков и повторного использования уже найденного блока.

## Проверка
- `php experiments/test-issue-2450-google-sheets-sync.php`
- `php experiments/test-issue-2452-google-sheets-sync-upload.php`
- `php experiments/test-issue-2454-google-sheets-sync-overwrite.php`
- `php experiments/test-issue-2456-google-sheets-sync-rules.php`
- `php -l google_sheets_sync.php`
- `git diff --check origin/main...HEAD`

Скриншоты не нужны: изменение не затрагивает UI.
