### PR TITLE
google_sheets_sync.php: убрать ограничение поиска до предыдущего совпадения

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-08T11:19:30.013Z

--- a/experiments/test-issue-2456-google-sheets-sync-rules.php
+++ b/experiments/test-issue-2456-google-sheets-sync-rules.php
@@ -34,25 +34,29 @@ $records = gss_extract_sheet_records(
     ]
 );
 
-assertSameIssue2456(4, count($records), 'selects only rows with matching row conditions and fresh column conditions');
+assertSameIssue2456(5, count($records), 'selects rows with matching row conditions and current-or-earlier column conditions');
 assertSameIssue2456(4, $records[0]['row_number'], 'stores the 1-based sheet row number');
 assertSameIssue2456(['Metric A'], $records[0]['rows'], 'deduplicates repeated row match values');
 assertSameIssue2456(['2026', 'PLAN'], $records[0]['columns'], 'deduplicates repeated column match values');
 assertSameIssue2456('10', $records[0]['value'], 'captures the first metric value');
 
-assertSameIssue2456(5, $records[1]['row_number'], 'keeps independent last-found state per row condition');
+assertSameIssue2456(5, $records[1]['row_number'], 'keeps independent matches per row condition');
 assertSameIssue2456(['Metric B'], $records[1]['rows'], 'captures another row condition in the same header block');
 assertSameIssue2456('20', $records[1]['value'], 'captures the second metric value');
 
-assertSameIssue2456(10, $records[2]['row_number'], 'captures the repeated row condition after a new matching header block');
-assertSameIssue2456('12', $records[2]['value'], 'captures the value under the refreshed existing column');
-assertSameIssue2456(10, $records[3]['row_number'], 'does not let one selected column block another column on the same row');
-assertSameIssue2456('13', $records[3]['value'], 'captures the value under the newly matching column');
+assertSameIssue2456(6, $records[2]['row_number'], 'keeps using earlier column conditions for repeated row matches');
+assertSameIssue2456('11', $records[2]['value'], 'captures the repeated metric value under the same header block');
+
+assertSameIssue2456(10, $records[3]['row_number'], 'captures the repeated row condition after a new matching header block');
+assertSameIssue2456('12', $records[3]['value'], 'captures the value under the refreshed existing column');
+assertSameIssue2456(10, $records[4]['row_number'], 'does not let one selected column block another column on the same row');
+assertSameIssue2456('13', $records[4]['value'], 'captures the value under the newly matching column');
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
     . "Rules:4:Metric A:2026,PLAN;10;1773328460;\r\n"
     . "Rules:5:Metric B:2026,PLAN;20;1773328460;\r\n"
+    . "Rules:6:Metric A:2026,PLAN;11;1773328460;\r\n"
     . "Rules:10:Metric A:2026,PLAN;12;1773328460;\r\n"
     . "Rules:10:Metric A:2026,PLAN;13;1773328460;\r\n";
 

--- a/experiments/test-issue-2458-google-sheets-sync-full-height.php
+++ b/experiments/test-issue-2458-google-sheets-sync-full-height.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2458($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+$values = [
+    ['', '2026', ''],
+    ['', '2026', ''],
+    ['', 'PLAN', ''],
+    ['Metric A', '10', 'future-only'],
+    ['Metric A', '11', 'still-before-header'],
+    ['', '', '2026'],
+    ['', '', '2026'],
+    ['', '', 'PLAN'],
+    ['Metric A', '12', '13'],
+];
+
+$records = gss_extract_sheet_records(
+    'FullHeight',
+    $values,
+    ['Metric A'],
+    [
+        ['2026', '2026', 'PLAN'],
+    ]
+);
+
+assertSameIssue2458(4, count($records), 'matches column conditions from sheet top through the current row, not only after the previous match');
+assertSameIssue2458([4, 5, 9, 9], array_column($records, 'row_number'), 'keeps reusing earlier headers for later matching rows');
+assertSameIssue2458(['10', '11', '12', '13'], array_column($records, 'value'), 'does not select values under future headers before those headers are above the row');
+
+echo "PASS issue 2458 Google Sheets sync full-height column matching\n";

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -309,7 +309,6 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
     $matrix = gss_normalize_matrix($values);
     $maxColumns = gss_max_columns($matrix);
     $records = [];
-    $lastMatchedRows = [];
 
     foreach ($matrix as $rowIndex => $row) {
         $rowSpecMatches = gss_match_specs($row, $rowMatchers);
@@ -320,29 +319,21 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
         for ($columnIndex = 0; $columnIndex < $maxColumns; $columnIndex++) {
             $matchedRows = [];
             $matchedColumns = [];
-            $matchedStateKeys = [];
+            $hasColumnMatch = false;
+            $column = gss_column_values_between($matrix, $columnIndex, 0, $rowIndex);
 
             foreach ($rowSpecMatches as $rowSpecMatch) {
-                foreach ($columnMatchers as $columnSpecKey => $columnSpec) {
-                    $stateKey = $rowSpecMatch['key'] . "\0" . $columnSpecKey . "\0" . $columnIndex;
-                    $startRow = array_key_exists($stateKey, $lastMatchedRows)
-                        ? $lastMatchedRows[$stateKey] + 1
-                        : 0;
-                    if ($startRow > $rowIndex) {
-                        continue;
-                    }
-
-                    $column = gss_column_values_between($matrix, $columnIndex, $startRow, $rowIndex);
+                foreach ($columnMatchers as $columnSpec) {
                     $columnMatch = gss_match_spec($column, $columnSpec);
                     if ($columnMatch['matched']) {
                         $matchedRows = array_merge($matchedRows, $rowSpecMatch['values']);
                         $matchedColumns = array_merge($matchedColumns, $columnMatch['values']);
-                        $matchedStateKeys[$stateKey] = true;
+                        $hasColumnMatch = true;
                     }
                 }
             }
 
-            if (empty($matchedStateKeys)) {
+            if (!$hasColumnMatch) {
                 continue;
             }
 
@@ -360,10 +351,6 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
                 'row_index' => $rowIndex,
                 'column_index' => $columnIndex,
             ];
-
-            foreach ($matchedStateKeys as $stateKey => $_) {
-                $lastMatchedRows[$stateKey] = $rowIndex;
-            }
         }
     }
 


### PR DESCRIPTION
Fixes #2458

## Что изменено
- В `gss_extract_sheet_records()` убрано состояние `lastMatchedRows`, которое начинало поиск условий колонок после предыдущей выбранной строки.
- Условия колонок теперь проверяются по диапазону от начала листа до текущей строки включительно.
- Обновлен регрессионный сценарий issue 2456 и добавлен сценарий issue 2458 для полного просмотра вверх.

## Как воспроизвести
`php experiments/test-issue-2458-google-sheets-sync-full-height.php` проверяет повторное использование заголовков, расположенных выше текущей строки. До исправления сценарий падал: ожидалось 4 записи, фактически выбиралось 2.

## Проверка
- `php experiments/test-issue-2450-google-sheets-sync.php`
- `php experiments/test-issue-2452-google-sheets-sync-upload.php`
- `php experiments/test-issue-2454-google-sheets-sync-overwrite.php`
- `php experiments/test-issue-2456-google-sheets-sync-rules.php`
- `php experiments/test-issue-2458-google-sheets-sync-full-height.php`
- `php -l google_sheets_sync.php`
- `php -l experiments/test-issue-2458-google-sheets-sync-full-height.php`
- `git diff --check origin/main...HEAD`

Скриншоты не нужны: изменение не затрагивает UI.