### PR TITLE
Fix reference field after creating lookup record

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
 # Updated: 2026-05-08T11:19:30.013Z
-# Updated: 2026-05-08T12:51:07.143Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
 # Updated: 2026-05-08T11:19:30.013Z
+# Updated: 2026-05-08T12:51:07.143Z

--- a/experiments/test-issue-246-reference-create-selection.js
+++ b/experiments/test-issue-246-reference-create-selection.js
@@ -1,0 +1,216 @@
+/**
+ * Regression coverage for issue #246 / #238.
+ *
+ * The original failure happened because the reference editor's outside-click
+ * handler treated clicks inside the nested "create reference record" modal as
+ * clicks outside the edited cell. That canceled inline editing before
+ * saveRecordForReference could apply the newly created record.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+function loadTable(fetchImpl) {
+    const code = fs.readFileSync('js/integram-table.js', 'utf8');
+    const context = {
+        console,
+        URLSearchParams,
+        setTimeout,
+        clearTimeout,
+        fetch: fetchImpl || (async () => {
+            throw new Error('Unexpected fetch call');
+        }),
+        window: {
+            location: { search: '' },
+            INTEGRAM_DEBUG: false
+        },
+        document: {
+            readyState: 'loading',
+            getElementById: () => ({}),
+            addEventListener: () => {},
+            querySelectorAll: () => []
+        },
+        FormData: class FakeFormData {
+            constructor(form) {
+                this.form = form;
+            }
+
+            get(name) {
+                const entry = this.form._entries.find(([key]) => key === name);
+                return entry ? entry[1] : null;
+            }
+
+            entries() {
+                return this.form._entries[Symbol.iterator]();
+            }
+        }
+    };
+    context.globalThis = context;
+    vm.createContext(context);
+    vm.runInContext(`${code}\nthis.IntegramTable = IntegramTable;`, context);
+    return Object.create(context.IntegramTable.prototype);
+}
+
+function makeTarget({ inReferenceCreateModal = false, inOverlay = false } = {}) {
+    return {
+        closest(selector) {
+            if (selector === '[data-is-reference-create="true"]') {
+                return inReferenceCreateModal ? {} : null;
+            }
+            if (selector === '.edit-form-overlay') {
+                return inOverlay ? {} : null;
+            }
+            return null;
+        }
+    };
+}
+
+function testOutsideClickDecision() {
+    const table = loadTable();
+
+    assert.strictEqual(
+        typeof table._shouldCancelReferenceEditorForClick,
+        'function',
+        'reference editor outside-click helper should exist'
+    );
+
+    const cell = { contains: () => false };
+    const modalTarget = makeTarget({ inReferenceCreateModal: true });
+    const overlayTarget = makeTarget({ inOverlay: true });
+
+    assert.strictEqual(
+        !cell.contains(modalTarget),
+        true,
+        'original outside-cell check would cancel a click inside the create modal'
+    );
+    assert.strictEqual(
+        table._shouldCancelReferenceEditorForClick(modalTarget, cell),
+        false,
+        'clicks inside the reference create modal keep the inline reference editor active'
+    );
+    assert.strictEqual(
+        table._shouldCancelReferenceEditorForClick(overlayTarget, cell),
+        false,
+        'clicks on the reference create overlay keep the inline reference editor active'
+    );
+
+    const insideCellTarget = makeTarget();
+    const containingCell = { contains: target => target === insideCellTarget };
+    assert.strictEqual(
+        table._shouldCancelReferenceEditorForClick(insideCellTarget, containingCell),
+        false,
+        'clicks inside the edited cell do not cancel the editor'
+    );
+
+    const fixedDropdownTarget = makeTarget();
+    table.currentEditingCell = {
+        fixedDropdown: {
+            contains: target => target === fixedDropdownTarget
+        }
+    };
+    assert.strictEqual(
+        table._shouldCancelReferenceEditorForClick(fixedDropdownTarget, cell),
+        false,
+        'clicks inside the detached reference dropdown do not cancel the editor'
+    );
+
+    const outsideTarget = makeTarget();
+    table.currentEditingCell = null;
+    assert.strictEqual(
+        table._shouldCancelReferenceEditorForClick(outsideTarget, cell),
+        true,
+        'ordinary outside clicks still cancel the editor'
+    );
+}
+
+async function testSaveRecordAppliesCreatedReference() {
+    let request;
+    const table = loadTable(async (url, options) => {
+        request = { url, options };
+        return {
+            ok: true,
+            text: async () => JSON.stringify({
+                id: 6546,
+                obj: 6546,
+                ord: 1,
+                next_act: 'edit_obj',
+                args: 'new1=1&',
+                val: 'Server value'
+            })
+        };
+    });
+
+    const toasts = [];
+    let cacheCleared = false;
+    let savedReference = null;
+
+    table.getApiBase = () => '/api';
+    table.getServerError = () => '';
+    table.decodeHtmlEntities = value => value;
+    table.showToast = (message, type) => toasts.push({ message, type });
+    table.clearAllReferenceOptionCaches = () => {
+        cacheCleared = true;
+    };
+    table.saveReferenceEdit = async (id, value) => {
+        savedReference = {
+            id,
+            value,
+            hadEditingCell: Boolean(table.currentEditingCell)
+        };
+        table.currentEditingCell = null;
+    };
+    table.currentEditingCell = {
+        cell: { innerHTML: '<div class="inline-editor-reference"></div>' },
+        isMultiReference: false
+    };
+
+    const form = {
+        _entries: [
+            ['main', 'Typed value'],
+            ['t123', '']
+        ],
+        checkValidity: () => true,
+        reportValidity: () => {
+            throw new Error('reportValidity should not run for a valid form');
+        }
+    };
+    let modalRemoved = false;
+    let overlayRemoved = false;
+    const modal = {
+        querySelector: selector => selector === '#edit-form-ref-create' ? form : null,
+        remove: () => {
+            modalRemoved = true;
+        },
+        _overlayElement: {
+            remove: () => {
+                overlayRemoved = true;
+            }
+        }
+    };
+
+    await table.saveRecordForReference(modal, '777', '42');
+
+    assert.strictEqual(request.url, '/api/_m_new/777?JSON&up=1');
+    assert.strictEqual(request.options.method, 'POST');
+    assert.strictEqual(new URLSearchParams(request.options.body).get('t777'), 'Typed value');
+    assert.strictEqual(modalRemoved, true, 'create modal is removed after successful save');
+    assert.strictEqual(overlayRemoved, true, 'create modal overlay is removed after successful save');
+    assert.strictEqual(cacheCleared, true, 'reference option caches are cleared');
+    assert.deepStrictEqual(savedReference, {
+        id: 6546,
+        value: 'Server value',
+        hadEditingCell: true
+    });
+    assert.strictEqual(
+        toasts.some(toast => toast.type === 'success'),
+        true,
+        'success toast is shown'
+    );
+}
+
+(async () => {
+    testOutsideClickDecision();
+    await testSaveRecordAppliesCreatedReference();
+    console.log('PASS issue #246 reference create selection regression');
+})();

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -4407,6 +4407,31 @@ class IntegramTable{
             }
         }
 
+        _isReferenceCreateModalClick(target) {
+            if (!target || typeof target.closest !== 'function') {
+                return false;
+            }
+            return Boolean(
+                target.closest('[data-is-reference-create="true"]') ||
+                target.closest('.edit-form-overlay')
+            );
+        }
+
+        _shouldCancelReferenceEditorForClick(target, cell) {
+            if (!target || !cell) {
+                return false;
+            }
+            if (this._isReferenceCreateModalClick(target)) {
+                return false;
+            }
+            // Issue #1384: dropdown is detached from cell (appended to body), so check it separately
+            const fixedDropdown = this.currentEditingCell && this.currentEditingCell.fixedDropdown;
+            if (fixedDropdown && fixedDropdown.contains(target)) {
+                return false;
+            }
+            return !cell.contains(target);
+        }
+
         async renderReferenceEditor(cell, currentValue) {
             // Save original content for cancel
             const originalContent = cell.innerHTML;
@@ -4650,29 +4675,27 @@ class IntegramTable{
                 const editingCellRef = this.currentEditingCell;
                 setTimeout(() => {
                     const outsideClickHandler = (e) => {
-                        // Don't cancel if clicking inside reference creation modal
-                        const refModal = e.target.closest('[data-is-reference-create="true"]');
-                        const refOverlay = e.target.closest('.edit-form-overlay');
-                        if (refModal || refOverlay) {
-                            return;
-                        }
-                        // Issue #1384: dropdown is detached from cell (appended to body), so check it separately
-                        const fixedDropdown = this.currentEditingCell && this.currentEditingCell.fixedDropdown;
-                        if (fixedDropdown && fixedDropdown.contains(e.target)) {
-                            return;
-                        }
-                        if (!cell.contains(e.target)) {
-                            document.removeEventListener('click', outsideClickHandler);
-
-                            // Check if click is on another editable cell - preserve focus (issue #518)
-                            const clickedCell = e.target.closest('td[data-editable="true"]');
-                            if (clickedCell && clickedCell !== cell) {
-                                // Remember the clicked cell to edit after cancel completes
-                                this.pendingCellClick = clickedCell;
+                        if (!this._shouldCancelReferenceEditorForClick(e.target, cell)) {
+                            if (window.INTEGRAM_DEBUG && this._isReferenceCreateModalClick(e.target)) {
+                                console.log('[TRACE] renderReferenceEditor - ignored click inside reference create modal');
                             }
-
-                            this.cancelInlineEdit(originalContent);
+                            return;
                         }
+                        if (window.INTEGRAM_DEBUG) {
+                            console.log('[TRACE] renderReferenceEditor - outside click cancels reference editor');
+                        }
+                        document.removeEventListener('click', outsideClickHandler);
+
+                        // Check if click is on another editable cell - preserve focus (issue #518)
+                        const clickedCell = e.target && typeof e.target.closest === 'function'
+                            ? e.target.closest('td[data-editable="true"]')
+                            : null;
+                        if (clickedCell && clickedCell !== cell) {
+                            // Remember the clicked cell to edit after cancel completes
+                            this.pendingCellClick = clickedCell;
+                        }
+
+                        this.cancelInlineEdit(originalContent);
                     };
                     document.addEventListener('click', outsideClickHandler);
 
@@ -5790,6 +5813,15 @@ class IntegramTable{
                 // Use the value from the response (result.val) if available, otherwise use the input value
                 const createdValue = this.decodeHtmlEntities(result.val || mainValue);
 
+                if (window.INTEGRAM_DEBUG) {
+                    console.log('[TRACE] saveRecordForReference - created reference response', {
+                        result,
+                        createdId,
+                        createdValue,
+                        hasCurrentEditingCell: Boolean(this.currentEditingCell),
+                        isMultiReference: Boolean(this.currentEditingCell && this.currentEditingCell.isMultiReference)
+                    });
+                }
 
                 // Close the create form modal
                 modal.remove();
@@ -5806,6 +5838,12 @@ class IntegramTable{
                 // Now set the created record in the reference field that's still open
                 if (this.currentEditingCell && createdId) {
                     if (this.currentEditingCell.isMultiReference) {
+                        if (window.INTEGRAM_DEBUG) {
+                            console.log('[TRACE] saveRecordForReference - adding created record to multi-reference editor', {
+                                createdId,
+                                createdValue
+                            });
+                        }
                         // Issue #875: For multi-reference, add the new item to selected items
                         if (!this.currentEditingCell.selectedItems.find(s => s.id === String(createdId))) {
                             this.currentEditingCell.selectedItems.push({ id: String(createdId), text: createdValue });
@@ -5817,9 +5855,21 @@ class IntegramTable{
                             this.currentEditingCell.cell.querySelector('.inline-editor-reference-search')?.focus();
                         }
                     } else {
+                        if (window.INTEGRAM_DEBUG) {
+                            console.log('[TRACE] saveRecordForReference - applying created record to reference editor', {
+                                createdId,
+                                createdValue
+                            });
+                        }
                         await this.saveReferenceEdit(createdId, createdValue);
                     }
                 } else {
+                    if (window.INTEGRAM_DEBUG) {
+                        console.log('[TRACE] saveRecordForReference - cannot apply created record to reference editor', {
+                            hasCurrentEditingCell: Boolean(this.currentEditingCell),
+                            createdId
+                        });
+                    }
                     // Fallback: just close the inline editor
                     if (this.currentEditingCell) {
                         this.cancelInlineEdit(this.currentEditingCell.cell.innerHTML);

--- a/js/integram-table/07-inline-edit.js
+++ b/js/integram-table/07-inline-edit.js
@@ -1080,6 +1080,31 @@
             }
         }
 
+        _isReferenceCreateModalClick(target) {
+            if (!target || typeof target.closest !== 'function') {
+                return false;
+            }
+            return Boolean(
+                target.closest('[data-is-reference-create="true"]') ||
+                target.closest('.edit-form-overlay')
+            );
+        }
+
+        _shouldCancelReferenceEditorForClick(target, cell) {
+            if (!target || !cell) {
+                return false;
+            }
+            if (this._isReferenceCreateModalClick(target)) {
+                return false;
+            }
+            // Issue #1384: dropdown is detached from cell (appended to body), so check it separately
+            const fixedDropdown = this.currentEditingCell && this.currentEditingCell.fixedDropdown;
+            if (fixedDropdown && fixedDropdown.contains(target)) {
+                return false;
+            }
+            return !cell.contains(target);
+        }
+
         async renderReferenceEditor(cell, currentValue) {
             // Save original content for cancel
             const originalContent = cell.innerHTML;
@@ -1323,29 +1348,27 @@
                 const editingCellRef = this.currentEditingCell;
                 setTimeout(() => {
                     const outsideClickHandler = (e) => {
-                        // Don't cancel if clicking inside reference creation modal
-                        const refModal = e.target.closest('[data-is-reference-create="true"]');
-                        const refOverlay = e.target.closest('.edit-form-overlay');
-                        if (refModal || refOverlay) {
-                            return;
-                        }
-                        // Issue #1384: dropdown is detached from cell (appended to body), so check it separately
-                        const fixedDropdown = this.currentEditingCell && this.currentEditingCell.fixedDropdown;
-                        if (fixedDropdown && fixedDropdown.contains(e.target)) {
-                            return;
-                        }
-                        if (!cell.contains(e.target)) {
-                            document.removeEventListener('click', outsideClickHandler);
-
-                            // Check if click is on another editable cell - preserve focus (issue #518)
-                            const clickedCell = e.target.closest('td[data-editable="true"]');
-                            if (clickedCell && clickedCell !== cell) {
-                                // Remember the clicked cell to edit after cancel completes
-                                this.pendingCellClick = clickedCell;
+                        if (!this._shouldCancelReferenceEditorForClick(e.target, cell)) {
+                            if (window.INTEGRAM_DEBUG && this._isReferenceCreateModalClick(e.target)) {
+                                console.log('[TRACE] renderReferenceEditor - ignored click inside reference create modal');
                             }
-
-                            this.cancelInlineEdit(originalContent);
+                            return;
                         }
+                        if (window.INTEGRAM_DEBUG) {
+                            console.log('[TRACE] renderReferenceEditor - outside click cancels reference editor');
+                        }
+                        document.removeEventListener('click', outsideClickHandler);
+
+                        // Check if click is on another editable cell - preserve focus (issue #518)
+                        const clickedCell = e.target && typeof e.target.closest === 'function'
+                            ? e.target.closest('td[data-editable="true"]')
+                            : null;
+                        if (clickedCell && clickedCell !== cell) {
+                            // Remember the clicked cell to edit after cancel completes
+                            this.pendingCellClick = clickedCell;
+                        }
+
+                        this.cancelInlineEdit(originalContent);
                     };
                     document.addEventListener('click', outsideClickHandler);
 
@@ -2463,6 +2486,15 @@
                 // Use the value from the response (result.val) if available, otherwise use the input value
                 const createdValue = this.decodeHtmlEntities(result.val || mainValue);
 
+                if (window.INTEGRAM_DEBUG) {
+                    console.log('[TRACE] saveRecordForReference - created reference response', {
+                        result,
+                        createdId,
+                        createdValue,
+                        hasCurrentEditingCell: Boolean(this.currentEditingCell),
+                        isMultiReference: Boolean(this.currentEditingCell && this.currentEditingCell.isMultiReference)
+                    });
+                }
 
                 // Close the create form modal
                 modal.remove();
@@ -2479,6 +2511,12 @@
                 // Now set the created record in the reference field that's still open
                 if (this.currentEditingCell && createdId) {
                     if (this.currentEditingCell.isMultiReference) {
+                        if (window.INTEGRAM_DEBUG) {
+                            console.log('[TRACE] saveRecordForReference - adding created record to multi-reference editor', {
+                                createdId,
+                                createdValue
+                            });
+                        }
                         // Issue #875: For multi-reference, add the new item to selected items
                         if (!this.currentEditingCell.selectedItems.find(s => s.id === String(createdId))) {
                             this.currentEditingCell.selectedItems.push({ id: String(createdId), text: createdValue });
@@ -2490,9 +2528,21 @@
                             this.currentEditingCell.cell.querySelector('.inline-editor-reference-search')?.focus();
                         }
                     } else {
+                        if (window.INTEGRAM_DEBUG) {
+                            console.log('[TRACE] saveRecordForReference - applying created record to reference editor', {
+                                createdId,
+                                createdValue
+                            });
+                        }
                         await this.saveReferenceEdit(createdId, createdValue);
                     }
                 } else {
+                    if (window.INTEGRAM_DEBUG) {
+                        console.log('[TRACE] saveRecordForReference - cannot apply created record to reference editor', {
+                            hasCurrentEditingCell: Boolean(this.currentEditingCell),
+                            createdId
+                        });
+                    }
                     // Fallback: just close the inline editor
                     if (this.currentEditingCell) {
                         this.cancelInlineEdit(this.currentEditingCell.cell.innerHTML);


### PR DESCRIPTION
## Summary
- Keep the inline reference editor active while the nested reference-create modal or its overlay is clicked, so the newly created record can be applied back to the field.
- Preserve the detached reference dropdown handling and add debug-only trace logs behind `window.INTEGRAM_DEBUG` for this flow.
- Add an executable regression script covering the original outside-click failure mode and the `_m_new` response path that applies `obj` / `val` to the reference editor.

Related: #246, #238

## Test plan
- `node experiments/test-issue-246-reference-create-selection.js`
- `node --check js/integram-table.js`
- `node experiments/test-issue-525-null-race-condition.js`
- `node experiments/test-issue-1431-immediate-save.js`


Fixes #246