### PR TITLE
google_sheets_sync.php: изменить формат загрузки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
 # Updated: 2026-05-08T11:19:30.013Z
+# Updated: 2026-05-09T10:56:31.698Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
-# Updated: 2026-05-07T08:13:24.930Z
-# Updated: 2026-05-08T11:19:30.013Z
-# Updated: 2026-05-09T10:56:31.698Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,3 @@
+# .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
+# Updated: 2026-05-07T08:13:24.930Z
+# Updated: 2026-05-08T11:19:30.013Z

--- a/experiments/test-issue-2450-google-sheets-sync.php
+++ b/experiments/test-issue-2450-google-sheets-sync.php
@@ -42,10 +42,10 @@ assertSameValue(['2025'], $records[1]['columns'], 'matches scalar column matcher
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "Выручка (ддо - b2b):4:Выручка (ддо - b2b):01.01.2026,31.01.2026,ПЛАН;123\\:45\\;6\\,7;1773328460;\r\n"
-    . "Выручка (ддо - b2b):4:Выручка (ддо - b2b):2025;89;1773328460;\r\n";
+    . "123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;1773328460\r\n"
+    . "89;;Выручка (ддо - b2b);2025;1773328460\r\n";
 
-assertSameValue($expected, $content, 'builds DATA-prefixed BKI content and escapes delimiters');
+assertSameValue($expected, $content, 'builds DATA-prefixed BKI content in value/date/row/column/timestamp format and escapes delimiters');
 assertTrueValue(gss_pattern_matches('*.2026', '31.01.2026'), 'asterisk mask matches arbitrary leading text');
 assertTrueValue(gss_pattern_matches('ПЛ*', 'ПЛАН'), 'asterisk mask matches arbitrary trailing text');
 assertTrueValue(!gss_pattern_matches('2026', '2025'), 'exact matcher does not match different value');

--- a/experiments/test-issue-2456-google-sheets-sync-rules.php
+++ b/experiments/test-issue-2456-google-sheets-sync-rules.php
@@ -54,12 +54,12 @@ assertSameIssue2456('13', $records[4]['value'], 'captures the value under the ne
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "Rules:4:Metric A:2026,PLAN;10;1773328460;\r\n"
-    . "Rules:5:Metric B:2026,PLAN;20;1773328460;\r\n"
-    . "Rules:6:Metric A:2026,PLAN;11;1773328460;\r\n"
-    . "Rules:10:Metric A:2026,PLAN;12;1773328460;\r\n"
-    . "Rules:10:Metric A:2026,PLAN;13;1773328460;\r\n";
+    . "10;;Metric A;PLAN;1773328460\r\n"
+    . "20;;Metric B;PLAN;1773328460\r\n"
+    . "11;;Metric A;PLAN;1773328460\r\n"
+    . "12;;Metric A;PLAN;1773328460\r\n"
+    . "13;;Metric A;PLAN;1773328460\r\n";
 
-assertSameIssue2456($expected, $content, 'builds BKI content with sheet row number and Unix timestamp');
+assertSameIssue2456($expected, $content, 'builds BKI content with value/date/row/column/timestamp fields');
 
 echo "PASS issue 2456 Google Sheets sync row rules\n";

--- a/experiments/test-issue-2469-google-sheets-sync-format.php
+++ b/experiments/test-issue-2469-google-sheets-sync-format.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2469($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+$values = [
+    ['', '', '31.12.2025'],
+    ['', '', '01.01.2026'],
+    ['', '', 'ПЛАН'],
+    ['Metric A', 'Region West', '900'],
+];
+
+$records = gss_extract_sheet_records(
+    'NewFormat',
+    $values,
+    [
+        ['Region *', 'Metric *'],
+    ],
+    [
+        ['31.12.2025', '01.01.2026', 'ПЛАН'],
+    ]
+);
+
+assertSameIssue2469(1, count($records), 'selects the matching intersection');
+assertSameIssue2469('01.01.2026', $records[0]['date'], 'uses the maximum DD.MM.YYYY date from matched context');
+assertSameIssue2469('Region West', $records[0]['row'], 'uses the rightmost matched row value');
+assertSameIssue2469('ПЛАН', $records[0]['column'], 'uses the lowest matched column value');
+
+$content = gss_build_bki_content($records, 1773328460);
+$expected = "DATA\r\n"
+    . "900;01.01.2026;Region West;ПЛАН;1773328460\r\n";
+
+assertSameIssue2469($expected, $content, 'builds value/date/row/column/timestamp import lines');
+
+echo "PASS issue 2469 Google Sheets sync output format\n";

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -473,7 +473,7 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
     $records = [];
 
     foreach ($matrix as $rowIndex => $row) {
-        $rowSpecMatches = gss_match_specs($row, $rowMatchers);
+        $rowSpecMatches = gss_match_specs_with_entries($row, $rowMatchers);
         if (empty($rowSpecMatches)) {
             continue;
         }
@@ -481,15 +481,19 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
         for ($columnIndex = 0; $columnIndex < $maxColumns; $columnIndex++) {
             $matchedRows = [];
             $matchedColumns = [];
+            $matchedRowEntries = [];
+            $matchedColumnEntries = [];
             $hasColumnMatch = false;
             $column = gss_column_values_between($matrix, $columnIndex, 0, $rowIndex);
 
             foreach ($rowSpecMatches as $rowSpecMatch) {
                 foreach ($columnMatchers as $columnSpec) {
-                    $columnMatch = gss_match_spec($column, $columnSpec);
+                    $columnMatch = gss_match_spec_with_entries($column, $columnSpec);
                     if ($columnMatch['matched']) {
                         $matchedRows = array_merge($matchedRows, $rowSpecMatch['values']);
                         $matchedColumns = array_merge($matchedColumns, $columnMatch['values']);
+                        $matchedRowEntries = array_merge($matchedRowEntries, $rowSpecMatch['entries']);
+                        $matchedColumnEntries = array_merge($matchedColumnEntries, $columnMatch['entries']);
                         $hasColumnMatch = true;
                     }
                 }
@@ -509,6 +513,9 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
                 'row_number' => $rowIndex + 1,
                 'rows' => gss_unique_preserve_order($matchedRows),
                 'columns' => gss_unique_preserve_order($matchedColumns),
+                'date' => gss_max_ddmmyyyy_value(gss_match_entry_values(array_merge($matchedRowEntries, $matchedColumnEntries))),
+                'row' => gss_last_match_entry_value($matchedRowEntries),
+                'column' => gss_last_match_entry_value($matchedColumnEntries),
                 'value' => $value,
                 'row_index' => $rowIndex,
                 'column_index' => $columnIndex,
@@ -647,12 +654,24 @@ function gss_column_values_between($matrix, $columnIndex, $startRow, $endRow) {
 
 function gss_match_specs($cells, $specs) {
     $matches = [];
+    foreach (gss_match_specs_with_entries($cells, $specs) as $match) {
+        $matches[] = [
+            'key' => $match['key'],
+            'values' => $match['values'],
+        ];
+    }
+    return $matches;
+}
+
+function gss_match_specs_with_entries($cells, $specs) {
+    $matches = [];
     foreach ($specs as $specKey => $spec) {
-        $match = gss_match_spec($cells, $spec);
+        $match = gss_match_spec_with_entries($cells, $spec);
         if ($match['matched']) {
             $matches[] = [
                 'key' => (string)$specKey,
                 'values' => gss_unique_preserve_order($match['values']),
+                'entries' => $match['entries'],
             ];
         }
     }
@@ -668,18 +687,38 @@ function gss_match_any_spec($cells, $specs) {
 }
 
 function gss_match_spec($cells, $spec) {
+    $match = gss_match_spec_with_entries($cells, $spec);
+    return [
+        'matched' => $match['matched'],
+        'values' => $match['values'],
+    ];
+}
+
+function gss_match_spec_with_entries($cells, $spec) {
     $patterns = is_array($spec) ? array_values($spec) : [$spec];
-    $values = gss_match_pattern_sequence($cells, $patterns, 0, [], []);
-    if ($values === null) {
-        return ['matched' => false, 'values' => []];
+    $entries = gss_match_pattern_sequence_entries($cells, $patterns, 0, [], []);
+    if ($entries === null) {
+        return ['matched' => false, 'values' => [], 'entries' => []];
     }
 
-    return ['matched' => true, 'values' => $values];
+    return [
+        'matched' => true,
+        'values' => gss_match_entry_values($entries),
+        'entries' => $entries,
+    ];
 }
 
 function gss_match_pattern_sequence($cells, $patterns, $patternIndex, $usedIndexes, $values) {
+    $entries = gss_match_pattern_sequence_entries($cells, $patterns, $patternIndex, $usedIndexes, []);
+    if ($entries === null) {
+        return null;
+    }
+    return array_merge($values, gss_match_entry_values($entries));
+}
+
+function gss_match_pattern_sequence_entries($cells, $patterns, $patternIndex, $usedIndexes, $entries) {
     if ($patternIndex >= count($patterns)) {
-        return $values;
+        return $entries;
     }
 
     $matches = gss_find_matching_cell_entries($cells, $patterns[$patternIndex], $usedIndexes);
@@ -687,16 +726,77 @@ function gss_match_pattern_sequence($cells, $patterns, $patternIndex, $usedIndex
         $nextUsedIndexes = $usedIndexes;
         $nextUsedIndexes[$match['index']] = true;
 
-        $nextValues = $values;
-        $nextValues[] = $match['value'];
+        $nextEntries = $entries;
+        $nextEntries[] = $match;
 
-        $result = gss_match_pattern_sequence($cells, $patterns, $patternIndex + 1, $nextUsedIndexes, $nextValues);
+        $result = gss_match_pattern_sequence_entries($cells, $patterns, $patternIndex + 1, $nextUsedIndexes, $nextEntries);
         if ($result !== null) {
             return $result;
         }
     }
 
     return null;
+}
+
+function gss_match_entry_values($entries) {
+    $values = [];
+    foreach ($entries as $entry) {
+        $values[] = isset($entry['value']) ? $entry['value'] : '';
+    }
+    return $values;
+}
+
+function gss_last_match_entry_value($entries) {
+    $bestIndex = null;
+    $bestValue = '';
+
+    foreach ($entries as $entry) {
+        if (!isset($entry['index'])) {
+            continue;
+        }
+        $index = (int)$entry['index'];
+        if ($bestIndex === null || $index >= $bestIndex) {
+            $bestIndex = $index;
+            $bestValue = isset($entry['value']) ? gss_cell_to_string($entry['value']) : '';
+        }
+    }
+
+    return $bestValue;
+}
+
+function gss_max_ddmmyyyy_value($values) {
+    $bestKey = null;
+    $bestValue = '';
+
+    foreach ($values as $value) {
+        $value = trim(gss_cell_to_string($value));
+        $key = gss_ddmmyyyy_sort_key($value);
+        if ($key === null) {
+            continue;
+        }
+        if ($bestKey === null || $key > $bestKey) {
+            $bestKey = $key;
+            $bestValue = $value;
+        }
+    }
+
+    return $bestValue;
+}
+
+function gss_ddmmyyyy_sort_key($value) {
+    $value = trim(gss_cell_to_string($value));
+    if (preg_match('/^([0-9]{2})\.([0-9]{2})\.([0-9]{4})$/', $value, $matches) !== 1) {
+        return null;
+    }
+
+    $day = (int)$matches[1];
+    $month = (int)$matches[2];
+    $year = (int)$matches[3];
+    if (!checkdate($month, $day, $year)) {
+        return null;
+    }
+
+    return ($year * 10000) + ($month * 100) + $day;
 }
 
 function gss_find_matching_cell($cells, $pattern) {
@@ -801,20 +901,33 @@ function gss_build_bki_content($records, $timestamp = null) {
 
     $lines = ['DATA'];
     foreach ($records as $record) {
-        $rowNumber = isset($record['row_number'])
-            ? $record['row_number']
-            : (isset($record['row_index']) ? ((int)$record['row_index'] + 1) : '');
+        $rows = isset($record['rows']) && is_array($record['rows']) ? $record['rows'] : [];
+        $columns = isset($record['columns']) && is_array($record['columns']) ? $record['columns'] : [];
+        $date = array_key_exists('date', $record)
+            ? $record['date']
+            : gss_max_ddmmyyyy_value(array_merge($rows, $columns));
+        $row = array_key_exists('row', $record)
+            ? $record['row']
+            : gss_last_list_value($rows);
+        $column = array_key_exists('column', $record)
+            ? $record['column']
+            : gss_last_list_value($columns);
 
-        $lines[] = gss_escape_bki_value($record['sheet'])
-            . ':' . gss_escape_bki_value($rowNumber)
-            . ':' . gss_escape_bki_list($record['rows'])
-            . ':' . gss_escape_bki_list($record['columns'])
-            . ';' . gss_escape_bki_value($record['value'])
-            . ';' . gss_escape_bki_value($timestamp)
-            . ';';
+        $lines[] = gss_escape_bki_value($record['value'])
+            . ';' . gss_escape_bki_value($date)
+            . ';' . gss_escape_bki_value($row)
+            . ';' . gss_escape_bki_value($column)
+            . ';' . gss_escape_bki_value($timestamp);
     }
 
     return implode("\r\n", $lines) . "\r\n";
+}
+
+function gss_last_list_value($values) {
+    if (!is_array($values) || empty($values)) {
+        return '';
+    }
+    return gss_cell_to_string($values[count($values) - 1]);
 }
 
 function gss_escape_bki_list($values) {


### PR DESCRIPTION
Fixes #2469

## Что изменено
- Формат строк импорта изменен на `{значение};{дата};{строка};{колонка};{timestamp}` после строки `DATA`.
- `google_sheets_sync.php` теперь сохраняет контекст совпадений: максимальную дату формата `DD.MM.YYYY`, последнее совпавшее значение строки слева направо и нижнее совпавшее значение колонки сверху вниз.
- Обновлены существующие проверки Google Sheets sync под новый формат и добавлен воспроизводящий тест для issue 2469.

## Как воспроизвести
Запустить `php experiments/test-issue-2469-google-sheets-sync-format.php`. До исправления запись не содержала `date`, `row`, `column` и формировалась в старом формате; после исправления тест проходит.

## Проверка
- `find . -path './.git' -prune -o -path './vendor' -prune -o -name '*.php' -print0 | xargs -0 -n 1 php -l`
- `for f in experiments/test-issue-2450-google-sheets-sync.php experiments/test-issue-2452-google-sheets-sync-upload.php experiments/test-issue-2454-google-sheets-sync-overwrite.php experiments/test-issue-2456-google-sheets-sync-rules.php experiments/test-issue-2458-google-sheets-sync-full-height.php experiments/test-issue-2460-google-sheets-sync-or-rules.php experiments/test-issue-2463-google-sheets-sync-merged-cells.php experiments/test-issue-2469-google-sheets-sync-format.php; do php "$f" || exit 1; done`