### PR TITLE
Хранить настройки ИИ-чата в localStorage

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
 # Updated: 2026-05-08T11:19:30.013Z
-# Updated: 2026-05-10T17:01:10.080Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-06T21:07:15.570Z for PR creation at branch issue-2414-6ff35d21f586 for issue https://github.com/ideav/crm/issues/2414
 # Updated: 2026-05-07T08:13:24.930Z
 # Updated: 2026-05-08T11:19:30.013Z
+# Updated: 2026-05-10T17:01:10.080Z

--- a/experiments/test-issue-2474-ai-chat-global.js
+++ b/experiments/test-issue-2474-ai-chat-global.js
@@ -71,7 +71,7 @@ includesAll(aiScript, [
     'getDefaultAiServiceProfiles()',
     'getAiCommandPrompts()',
     'buildAiRequestPayload(',
-    'writeAiServiceCookie(',
+    'writeAiServiceStorage(',
     'create_table',
     'create_structure',
     'create_workspace',

--- a/experiments/test-issue-2481-ai-providers.js
+++ b/experiments/test-issue-2481-ai-providers.js
@@ -53,13 +53,19 @@ function createCookieDocument() {
 
 function createController() {
     const { document, elements, cookieStore } = createCookieDocument();
+    const storage = {};
     const context = {
         console,
         document,
         localStorage: {
-            getItem() { return null; },
-            setItem() {
-                throw new Error('AI provider settings must be saved to cookies, not localStorage');
+            getItem(key) {
+                return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null;
+            },
+            setItem(key, value) {
+                storage[key] = String(value);
+            },
+            removeItem(key) {
+                delete storage[key];
             }
         },
         navigator: {},
@@ -73,7 +79,7 @@ function createController() {
 
     vm.runInNewContext(aiScript, context, { filename: 'js/ai-chat.js' });
     const Controller = context.window.IntegramAiChatController;
-    return { controller: new Controller(), elements, cookieStore };
+    return { controller: new Controller(), elements, cookieStore, storage };
 }
 
 function assertTemplateProviders(template, label) {
@@ -90,7 +96,7 @@ function assertTemplateProviders(template, label) {
 assertTemplateProviders(mainTemplate, 'templates/main.html');
 assertTemplateProviders(ruMainTemplate, 'templates/ru/main.html');
 
-const { controller, elements, cookieStore } = createController();
+const { controller, elements, cookieStore, storage } = createController();
 assert.strictEqual(controller.aiActiveProviderId, 'gemini', 'Gemini should be the default provider');
 
 const profiles = controller.getDefaultAiServiceProfiles();
@@ -111,10 +117,11 @@ assert.strictEqual(elements['ai-token-mode'].disabled, true, 'Gemini credential 
 assert.strictEqual(elements['ai-service-token'].disabled, true, 'Gemini token input should be disabled');
 
 controller.saveAiServiceSettings();
-assert(cookieStore.integram_ai_chat_settings, 'AI settings should be saved into the settings cookie');
+assert(storage.integram_ai_chat_settings, 'AI settings should be saved into localStorage');
+assert(!cookieStore.integram_ai_chat_settings, 'AI settings should not be saved into a cookie');
 
-const saved = JSON.parse(decodeURIComponent(cookieStore.integram_ai_chat_settings));
-assert.strictEqual(saved.activeProviderId, 'gemini', 'Saved cookie should keep Gemini selected');
+const saved = JSON.parse(storage.integram_ai_chat_settings);
+assert.strictEqual(saved.activeProviderId, 'gemini', 'Saved localStorage settings should keep Gemini selected');
 assert.strictEqual(saved.profiles.gemini.tokenMode, 'adc', 'Saved Gemini profile should keep ADC mode');
 assert.strictEqual(saved.profiles.gemini.token, '', 'Saved Gemini profile should not store an API token');
 assert.strictEqual(saved.profiles.groq.endpoint, 'https://api.groq.com/openai/v1/chat/completions');
@@ -126,4 +133,4 @@ assert.strictEqual(payload.provider.credentialSource, 'application_default_crede
 assert.strictEqual(payload.provider.applicationDefaultCredentials, true);
 assert.strictEqual(payload.provider.hasUserToken, false);
 
-console.log('ok - issue 2481 AI providers use Gemini ADC defaults and cookie settings');
+console.log('ok - issue 2481 AI providers use Gemini ADC defaults and localStorage settings');

--- a/experiments/test-issue-2483-ai-chat-server.js
+++ b/experiments/test-issue-2483-ai-chat-server.js
@@ -52,6 +52,7 @@ function createElement(id, overrides = {}) {
 }
 
 const cookieStore = {};
+const storage = {};
 const elements = {
     'ai-chat-input': createElement('ai-chat-input', { value: 'Создай таблицу клиентов' }),
     'ai-target-db': createElement('ai-target-db', { value: 'demo' }),
@@ -98,7 +99,17 @@ const context = {
     console,
     document,
     navigator: {},
-    localStorage: { getItem() { return null; } },
+    localStorage: {
+        getItem(key) {
+            return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null;
+        },
+        setItem(key, value) {
+            storage[key] = String(value);
+        },
+        removeItem(key) {
+            delete storage[key];
+        }
+    },
     setTimeout(fn) { fn(); },
     db: 'demo',
     action: 'table',
@@ -133,6 +144,7 @@ const context = {
 context.window.window = context.window;
 context.window.document = document;
 context.window.fetch = context.fetch;
+context.window.localStorage = context.localStorage;
 
 vm.runInNewContext(aiScript, context, { filename: 'js/ai-chat.js' });
 const Controller = context.window.IntegramAiChatController;
@@ -153,7 +165,9 @@ controller.aiActiveProviderId = 'openai';
     assert.strictEqual(body.payload.context.targetDb, 'demo');
     assert.strictEqual(body.payload.provider.id, 'openai');
     assert.strictEqual(body.payload.messages[0].content, 'Создай таблицу клиентов');
-    assert(!fetchRequest.options.body.includes('sk-test-secret'), 'API tokens must not be copied into the visible command payload');
+    assert(!JSON.stringify(body.payload).includes('sk-test-secret'), 'API tokens must not be copied into the visible command payload');
+    assert.strictEqual(body.settings.profiles.openai.token, 'sk-test-secret', 'provider settings should be posted outside the visible command payload');
+    assert(!cookieStore.integram_ai_chat_settings, 'AI settings must not be persisted to cookies');
 
     assert.strictEqual(controller.aiCommandQueue.length, 1);
     assert.strictEqual(controller.aiCommandQueue[0].status, 'Получен ответ');

--- a/experiments/test-issue-2486-ai-chat-local-storage.js
+++ b/experiments/test-issue-2486-ai-chat-local-storage.js
@@ -1,0 +1,215 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const root = path.resolve(__dirname, '..');
+const aiScript = fs.readFileSync(path.join(root, 'js/ai-chat.js'), 'utf8');
+const indexPhp = fs.readFileSync(path.join(root, 'index.php'), 'utf8');
+
+assert(
+    !indexPhp.includes('$_COOKIE["integram_ai_chat_settings"]') &&
+        !indexPhp.includes("$_COOKIE['integram_ai_chat_settings']"),
+    'AI chat settings must not be read from request cookies'
+);
+assert(
+    indexPhp.includes('getAiChatSettings(isset($_POST["settings"])'),
+    'AI chat endpoint should read provider settings from the POST body'
+);
+
+function createElement(id, overrides = {}) {
+    return Object.assign({
+        id,
+        value: '',
+        checked: false,
+        disabled: false,
+        placeholder: '',
+        textContent: '',
+        innerHTML: '',
+        scrollTop: 0,
+        scrollHeight: 0,
+        children: [],
+        dataset: {},
+        classList: {
+            contains() { return false; },
+            add() {},
+            remove() {}
+        },
+        addEventListener() {},
+        appendChild(child) {
+            this.children.push(child);
+            this.scrollHeight = this.children.length;
+        },
+        querySelectorAll() {
+            return [];
+        },
+        setAttribute() {},
+        removeAttribute() {}
+    }, overrides);
+}
+
+function createCookieDocument(cookieStore) {
+    const elements = {
+        'ai-chat-input': createElement('ai-chat-input', { value: 'Создай таблицу клиентов' }),
+        'ai-target-db': createElement('ai-target-db', { value: 'demo' }),
+        'ai-service-endpoint': createElement('ai-service-endpoint', { value: 'https://api.openai.com/v1/chat/completions' }),
+        'ai-service-model': createElement('ai-service-model', { value: 'gpt-4.1-mini' }),
+        'ai-token-mode': createElement('ai-token-mode', { value: 'own' }),
+        'ai-service-token': createElement('ai-service-token', { value: 'sk-local-storage-secret' }),
+        'ai-charge-balance': createElement('ai-charge-balance', { checked: false }),
+        'ai-settings-state': createElement('ai-settings-state'),
+        'ai-chat-status': createElement('ai-chat-status'),
+        'ai-chat-messages': createElement('ai-chat-messages'),
+        'ai-command-queue': createElement('ai-command-queue')
+    };
+
+    const document = {
+        addEventListener() {},
+        getElementById(id) {
+            return elements[id] || null;
+        },
+        createElement(tagName) {
+            return createElement(tagName);
+        },
+        querySelector() {
+            return null;
+        }
+    };
+
+    Object.defineProperty(document, 'cookie', {
+        get() {
+            return Object.keys(cookieStore)
+                .map(name => `${name}=${cookieStore[name]}`)
+                .join('; ');
+        },
+        set(value) {
+            const pair = String(value).split(';')[0];
+            const eq = pair.indexOf('=');
+            if (eq === -1) return;
+            const name = pair.slice(0, eq);
+            const storedValue = pair.slice(eq + 1);
+            if (!storedValue) {
+                delete cookieStore[name];
+            } else {
+                cookieStore[name] = storedValue;
+            }
+        }
+    });
+
+    return { document, elements };
+}
+
+const legacySettings = {
+    activeProviderId: 'openai',
+    profiles: {
+        openai: {
+            endpoint: 'https://api.openai.com/v1/chat/completions',
+            model: 'gpt-4.1-mini',
+            tokenMode: 'own',
+            token: 'sk-legacy-cookie-secret',
+            chargeBalance: false
+        }
+    }
+};
+const cookieStore = {
+    integram_ai_chat_settings: encodeURIComponent(JSON.stringify(legacySettings))
+};
+const storage = {};
+const { document, elements } = createCookieDocument(cookieStore);
+let fetchRequest = null;
+const context = {
+    console,
+    document,
+    navigator: {},
+    localStorage: {
+        getItem(key) {
+            return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null;
+        },
+        setItem(key, value) {
+            storage[key] = String(value);
+        },
+        removeItem(key) {
+            delete storage[key];
+        }
+    },
+    setTimeout(fn) { fn(); },
+    db: 'demo',
+    action: 'table',
+    uid: '42',
+    xsrf: 'csrf-token',
+    menuData: [],
+    fetch: async (url, options) => {
+        fetchRequest = { url, options };
+        return {
+            ok: true,
+            status: 200,
+            json: async () => ({
+                assistant: { content: 'Ответ сервера', raw: 'Ответ сервера' },
+                command: { title: 'Создать таблицу', status: 'Получен ответ' },
+                provider: { id: 'openai', label: 'ChatGPT / OpenAI', model: 'gpt-4.1-mini' }
+            })
+        };
+    },
+    window: {
+        location: { pathname: '/demo/table' }
+    }
+};
+context.window.window = context.window;
+context.window.document = document;
+context.window.fetch = context.fetch;
+context.window.localStorage = context.localStorage;
+
+vm.runInNewContext(aiScript, context, { filename: 'js/ai-chat.js' });
+const Controller = context.window.IntegramAiChatController;
+const controller = new Controller();
+
+controller.loadAiServiceSettings();
+assert.strictEqual(controller.aiActiveProviderId, 'openai', 'legacy cookie settings should still be loaded');
+assert.strictEqual(
+    controller.aiServiceProfiles.openai.token,
+    'sk-legacy-cookie-secret',
+    'legacy cookie token should be migrated into the controller state'
+);
+assert(
+    storage.integram_ai_chat_settings,
+    'AI settings should be migrated into localStorage'
+);
+assert(
+    !cookieStore.integram_ai_chat_settings,
+    'legacy AI settings cookie should be deleted after migration'
+);
+
+controller.saveAiServiceSettings();
+const saved = JSON.parse(storage.integram_ai_chat_settings);
+assert.strictEqual(saved.activeProviderId, 'openai', 'localStorage should keep the selected provider');
+assert.strictEqual(saved.profiles.openai.token, 'sk-local-storage-secret', 'localStorage should save the user token');
+assert(
+    !cookieStore.integram_ai_chat_settings,
+    'saving AI settings should not recreate the settings cookie'
+);
+assert(
+    /localStorage|локаль/i.test(elements['ai-settings-state'].textContent),
+    'settings state should mention local storage instead of cookies'
+);
+
+(async () => {
+    await controller.sendAiChatMessage();
+
+    assert(fetchRequest, 'sendAiChatMessage should call the server');
+    assert(!cookieStore.integram_ai_chat_settings, 'sending a message should not create a settings cookie');
+
+    const body = JSON.parse(fetchRequest.options.body);
+    assert.strictEqual(body._xsrf, 'csrf-token');
+    assert.strictEqual(body.payload.provider.id, 'openai');
+    assert(!JSON.stringify(body.payload).includes('sk-local-storage-secret'), 'visible command payload must not include API tokens');
+    assert.strictEqual(
+        body.settings.profiles.openai.token,
+        'sk-local-storage-secret',
+        'server POST body should carry provider settings separately from the command payload'
+    );
+
+    console.log('ok - issue 2486 AI chat stores settings in localStorage, not cookies');
+})().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/index.php
+++ b/index.php
@@ -7891,7 +7891,7 @@ function handleAiChatRequest($com){
     $payload["context"]["accessibleDbs"] = $accessibleDbs;
 
     try {
-        $response = callAiChatProvider($payload, getAiChatSettings());
+        $response = callAiChatProvider($payload, getAiChatSettings(isset($_POST["settings"]) ? $_POST["settings"] : array()));
         api_dump(json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-chat.json");
     } catch(Exception $e) {
         $code = (int)$e->getCode();
@@ -7930,10 +7930,11 @@ function getAiAccessibleDbs(){
         $dbs[] = "my";
     return array_values(array_unique($dbs));
 }
-function getAiChatSettings(){
-    if(!isset($_COOKIE["integram_ai_chat_settings"]) || $_COOKIE["integram_ai_chat_settings"] === "")
-        return array();
-    $settings = json_decode(urldecode($_COOKIE["integram_ai_chat_settings"]), true);
+function getAiChatSettings($settings=array()){
+    if(is_string($settings)){
+        $decoded = json_decode($settings, true);
+        return is_array($decoded) ? $decoded : array();
+    }
     return is_array($settings) ? $settings : array();
 }
 function callAiChatProvider($payload, $settings){

--- a/js/ai-chat.js
+++ b/js/ai-chat.js
@@ -234,10 +234,13 @@
         }
 
         loadAiServiceSettings() {
-            try {
-                const raw = this.readAiServiceCookie() || this.readLegacyAiServiceStorage();
-                if (!raw) return;
+            const raw = this.readAiServiceStorage() || this.readAiServiceCookie();
+            if (!raw) {
+                this.clearAiServiceCookie();
+                return;
+            }
 
+            try {
                 const saved = JSON.parse(raw);
                 if (saved && saved.profiles) {
                     Object.keys(saved.profiles).forEach(id => {
@@ -250,8 +253,10 @@
                     this.aiActiveProviderId = saved.activeProviderId;
                 }
                 this.normalizeAiServiceProfiles();
+                this.persistAiServiceSettings();
             } catch (err) {
                 console.warn('[ai-chat] settings ignored:', err);
+                this.clearAiServiceCookie();
             }
         }
 
@@ -268,10 +273,27 @@
             }
         }
 
-        readLegacyAiServiceStorage() {
-            if (typeof localStorage === 'undefined' || !localStorage.getItem) return '';
+        readAiServiceStorage() {
+            const storage = this.getAiLocalStorage();
+            if (!storage || !storage.getItem) return '';
 
-            return localStorage.getItem(this.aiChatStorageKey) || localStorage.getItem(this.legacyAiChatStorageKey) || '';
+            return storage.getItem(this.aiChatStorageKey) || storage.getItem(this.legacyAiChatStorageKey) || '';
+        }
+
+        writeAiServiceStorage(value) {
+            const storage = this.getAiLocalStorage();
+            if (!storage || !storage.setItem) throw new Error('localStorage недоступен');
+
+            storage.setItem(this.aiChatStorageKey, value);
+            if (this.legacyAiChatStorageKey !== this.aiChatStorageKey && storage.removeItem) {
+                storage.removeItem(this.legacyAiChatStorageKey);
+            }
+        }
+
+        getAiLocalStorage() {
+            if (typeof localStorage !== 'undefined') return localStorage;
+            if (typeof window !== 'undefined' && window.localStorage) return window.localStorage;
+            return null;
         }
 
         normalizeAiServiceProfiles() {
@@ -349,7 +371,7 @@
             try {
                 this.persistAiServiceSettings();
                 const stateEl = document.getElementById('ai-settings-state');
-                if (stateEl) stateEl.textContent = 'Настройки сохранены в cookies';
+                if (stateEl) stateEl.textContent = 'Настройки сохранены в localStorage';
                 this.notify('Настройки ИИ-сервиса сохранены', 'success');
             } catch (err) {
                 console.error('[ai-chat] settings save failed:', err);
@@ -358,15 +380,26 @@
         }
 
         persistAiServiceSettings() {
-            this.normalizeAiServiceProfiles();
-            this.writeAiServiceCookie(JSON.stringify({
-                activeProviderId: this.aiActiveProviderId,
-                profiles: this.aiServiceProfiles
-            }));
+            this.writeAiServiceStorage(this.serializeAiServiceSettings());
+            this.clearAiServiceCookie();
         }
 
-        writeAiServiceCookie(value) {
-            document.cookie = this.aiChatCookieKey + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000; SameSite=Lax';
+        serializeAiServiceSettings() {
+            return JSON.stringify(this.getAiServiceSettingsSnapshot());
+        }
+
+        getAiServiceSettingsSnapshot() {
+            this.normalizeAiServiceProfiles();
+            return {
+                activeProviderId: this.aiActiveProviderId,
+                profiles: this.aiServiceProfiles
+            };
+        }
+
+        clearAiServiceCookie() {
+            if (typeof document === 'undefined') return;
+
+            document.cookie = this.aiChatCookieKey + '=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; max-age=0; SameSite=Lax';
         }
 
         connectAiService() {
@@ -590,7 +623,8 @@
                 },
                 body: JSON.stringify({
                     _xsrf: this.getXsrfToken(),
-                    payload: payload
+                    payload: payload,
+                    settings: this.getAiServiceSettingsSnapshot()
                 })
             });
 


### PR DESCRIPTION
Fixes #2486

## Что сделано
- Настройки ИИ-чата больше не записываются в cookie `integram_ai_chat_settings`; сохранение идет в `localStorage`.
- При загрузке старые настройки из cookie мигрируются в `localStorage`, после чего legacy cookie удаляется.
- `/my/ai/chat?JSON=1` получает настройки провайдера из POST body (`settings`), а не из request cookies, чтобы не раздувать заголовки запроса.
- Пользовательский API token остается вне видимого payload команды, но передается серверу отдельно в `settings` при отправке сообщения.

## Как воспроизвести
До исправления `node experiments/test-issue-2486-ai-chat-local-storage.js` падал, потому что backend читал `integram_ai_chat_settings` из `$_COOKIE`, а клиент продолжал сохранять полный профиль ИИ-провайдеров в cookie. При большом token/settings это раздувало request headers и приводило к `Bad Request: Size of a request header field exceeds server limit`.

## Проверка
- `node experiments/test-issue-2486-ai-chat-local-storage.js`
- `node experiments/test-issue-2483-ai-chat-server.js`
- `node experiments/test-issue-2481-ai-providers.js`
- `node experiments/test-issue-2474-ai-chat-global.js`
- `node experiments/test-issue-2471-ai-chat.js`
- `node --check js/ai-chat.js`
- `node --check experiments/test-issue-2486-ai-chat-local-storage.js`
- `node --check experiments/test-issue-2483-ai-chat-server.js`
- `node --check experiments/test-issue-2481-ai-providers.js`
- `php -l index.php`
- `git diff --check`
