### PR TITLE
Добавить признак Ключ для составной уникальности

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T19:37:18.068Z for PR creation at branch issue-2490-4852cb24f955 for issue https://github.com/ideav/crm/issues/2490

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T19:37:18.068Z for PR creation at branch issue-2490-4852cb24f955 for issue https://github.com/ideav/crm/issues/2490

--- a/css/edit-types.css
+++ b/css/edit-types.css
@@ -66,6 +66,15 @@
     color: var(--text-secondary);
 }
 
+/* Composite uniqueness key indicator */
+.icon-key-enabled {
+    color: var(--color-warning, #b7791f);
+}
+
+.icon-key-disabled {
+    color: var(--text-secondary);
+}
+
 /* Disabled input field */
 .input-disabled {
     background-color: var(--bg-secondary);

--- a/experiments/test-issue-2485-attrs-json.js
+++ b/experiments/test-issue-2485-attrs-json.js
@@ -7,6 +7,7 @@ const serialize = IntegramTable.serializeAttrsValue;
 assert.deepStrictEqual(parse(':!NULL::MULTI::ALIAS=Owner:[USER_ID]'), {
     required: true,
     multi: true,
+    key: false,
     alias: 'Owner',
     defaultValue: '[USER_ID]'
 });
@@ -14,6 +15,7 @@ assert.deepStrictEqual(parse(':!NULL::MULTI::ALIAS=Owner:[USER_ID]'), {
 assert.deepStrictEqual(parse('{"required":true,"multi":true,"alias":"Owner","default":"[USER_ID]"}'), {
     required: true,
     multi: true,
+    key: false,
     alias: 'Owner',
     defaultValue: '[USER_ID]'
 });
@@ -21,6 +23,7 @@ assert.deepStrictEqual(parse('{"required":true,"multi":true,"alias":"Owner","def
 assert.deepStrictEqual(parse('{\\"required\\":true,\\"alias\\":\\"Escaped\\"}'), {
     required: true,
     multi: false,
+    key: false,
     alias: 'Escaped',
     defaultValue: null
 });
@@ -28,14 +31,31 @@ assert.deepStrictEqual(parse('{\\"required\\":true,\\"alias\\":\\"Escaped\\"}'),
 assert.deepStrictEqual(parse('{"display":"wide","required":true}'), {
     required: true,
     multi: false,
+    key: false,
     alias: null,
     defaultValue: null,
     display: 'wide'
 });
 
+assert.deepStrictEqual(parse('{"required":true,"key":true,"alias":"Owner","default":"[USER_ID]"}'), {
+    required: true,
+    multi: false,
+    key: true,
+    alias: 'Owner',
+    defaultValue: '[USER_ID]'
+});
+
+assert.deepStrictEqual(parse(':!NULL::KEY:legacy-default'), {
+    required: true,
+    multi: false,
+    key: true,
+    alias: null,
+    defaultValue: 'legacy-default'
+});
+
 assert.strictEqual(
-    serialize({ required: true, multi: true, alias: 'Owner', defaultValue: '[USER_ID]' }),
-    '{"required":true,"multi":true,"alias":"Owner","default":"[USER_ID]"}'
+    serialize({ required: true, multi: true, key: true, alias: 'Owner', defaultValue: '[USER_ID]' }),
+    '{"required":true,"multi":true,"key":true,"alias":"Owner","default":"[USER_ID]"}'
 );
 
 assert.strictEqual(

--- a/experiments/test-issue-2490-field-key-attrs.php
+++ b/experiments/test-issue-2490-field-key-attrs.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once __DIR__ . "/../include/field_attrs.php";
+
+function assertSameIssue2490($expected, $actual, $message)
+{
+	if($expected !== $actual){
+		fwrite(STDERR, $message."\nExpected: ".var_export($expected, true)."\nActual: ".var_export($actual, true)."\n");
+		exit(1);
+	}
+}
+
+$parsed = FieldAttrsParse('{"required":true,"multi":true,"key":true,"alias":"Owner","default":"[USER_ID]"}');
+assertSameIssue2490(true, $parsed["required"], "JSON required flag should parse");
+assertSameIssue2490(true, $parsed["multi"], "JSON multi flag should parse");
+assertSameIssue2490(true, $parsed["key"], "JSON key flag should parse");
+assertSameIssue2490("Owner", $parsed["alias"], "JSON alias should parse");
+assertSameIssue2490("[USER_ID]", $parsed["default"], "JSON default should parse");
+
+$legacy = FieldAttrsParse(":!NULL::KEY:legacy-default");
+assertSameIssue2490(true, $legacy["required"], "Legacy required flag should parse");
+assertSameIssue2490(true, $legacy["key"], "Legacy key flag should parse");
+assertSameIssue2490("legacy-default", $legacy["default"], "Legacy key mask should not leak into default value");
+
+assertSameIssue2490(
+	'{"required":true,"key":true,"alias":"Owner","default":"[USER_ID]"}',
+	FieldAttrsBuild("[USER_ID]", true, false, "Owner", true),
+	"FieldAttrsBuild should serialize the key flag"
+);
+
+assertSameIssue2490(true, FieldAttrsHasKey('{"key":true}'), "FieldAttrsHasKey should detect JSON key flag");
+assertSameIssue2490(false, FieldAttrsHasKey('{"key":false}'), "FieldAttrsHasKey should reject false key flag");
+
+echo "issue-2490 field key attrs: ok\n";

--- a/include/field_attrs.php
+++ b/include/field_attrs.php
@@ -2,6 +2,7 @@
 
 defined("NOT_NULL_MASK") || define("NOT_NULL_MASK", ":!NULL:");
 defined("MULTI_MASK") || define("MULTI_MASK", ":MULTI:");
+defined("KEY_MASK") || define("KEY_MASK", ":KEY:");
 defined("ALIAS_MASK") || define("ALIAS_MASK", "/:ALIAS=(.*?):/u");
 defined("ALIAS_DEF") || define("ALIAS_DEF", ":ALIAS=");
 
@@ -10,6 +11,7 @@ function FieldAttrsEmpty()
 	return array(
 		"required" => false,
 		"multi" => false,
+		"key" => false,
 		"alias" => null,
 		"default" => ""
 	);
@@ -49,6 +51,9 @@ function FieldAttrsParse($attrs)
 					case "multi":
 						$result["multi"] = FieldAttrsBool($value);
 						break;
+					case "key":
+						$result["key"] = FieldAttrsBool($value);
+						break;
 					case "alias":
 						$result["alias"] = is_null($value) ? null : (string)$value;
 						break;
@@ -67,9 +72,10 @@ function FieldAttrsParse($attrs)
 
 	$result["required"] = strpos($attrs, NOT_NULL_MASK) !== false;
 	$result["multi"] = strpos($attrs, MULTI_MASK) !== false;
+	$result["key"] = strpos($attrs, KEY_MASK) !== false;
 	if(preg_match(ALIAS_MASK, $attrs, $alias))
 		$result["alias"] = $alias[1];
-	$result["default"] = preg_replace(ALIAS_MASK, "", str_replace(MULTI_MASK, "", str_replace(NOT_NULL_MASK, "", $attrs)));
+	$result["default"] = preg_replace(ALIAS_MASK, "", str_replace(KEY_MASK, "", str_replace(MULTI_MASK, "", str_replace(NOT_NULL_MASK, "", $attrs))));
 	return $result;
 }
 
@@ -79,7 +85,7 @@ function FieldAttrsSerialize($attrs)
 	$json = array();
 
 	foreach($parsed as $key => $value){
-		if(in_array($key, array("required", "notNull", "not_null", "multi", "alias", "default", "defaultValue"), true))
+		if(in_array($key, array("required", "notNull", "not_null", "multi", "key", "alias", "default", "defaultValue"), true))
 			continue;
 		if(!is_null($value))
 			$json[$key] = $value;
@@ -88,6 +94,8 @@ function FieldAttrsSerialize($attrs)
 		$json["required"] = true;
 	if(FieldAttrsBool($parsed["multi"]))
 		$json["multi"] = true;
+	if(FieldAttrsBool($parsed["key"]))
+		$json["key"] = true;
 	if(isset($parsed["alias"]) && $parsed["alias"] !== "")
 		$json["alias"] = (string)$parsed["alias"];
 	$default = isset($parsed["default"]) ? $parsed["default"] : (isset($parsed["defaultValue"]) ? $parsed["defaultValue"] : "");
@@ -107,6 +115,12 @@ function FieldAttrsHasMulti($attrs)
 {
 	$parsed = FieldAttrsParse($attrs);
 	return $parsed["multi"];
+}
+
+function FieldAttrsHasKey($attrs)
+{
+	$parsed = FieldAttrsParse($attrs);
+	return $parsed["key"];
 }
 
 function FieldAttrsAlias($attrs, $fallback="")
@@ -142,11 +156,12 @@ function FieldAttrsSetAlias($attrs, $alias)
 	return FieldAttrsSerialize($parsed);
 }
 
-function FieldAttrsBuild($default="", $required=false, $multi=false, $alias=null)
+function FieldAttrsBuild($default="", $required=false, $multi=false, $alias=null, $key=false)
 {
 	return FieldAttrsSerialize(array(
 		"required" => $required,
 		"multi" => $multi,
+		"key" => $key,
 		"alias" => $alias,
 		"default" => $default
 	));

--- a/index.php
+++ b/index.php
@@ -8395,6 +8395,179 @@ function checkDuplicatedReqs($id, $t){
     while($row = mysqli_fetch_array($data_set))
         Delete($row["id"]);
 }
+function UniqueKeyReqs($typ){
+	global $z;
+	$typ = (int)$typ;
+	$reqs = array();
+	$sql = "SELECT req.id, req.t, req.val attrs"
+			.", CASE WHEN req.t=1 THEN 1 ELSE refs.id END ref_id"
+			.", CASE WHEN req.t=1 THEN 1 WHEN refs.id IS NULL THEN typs.t ELSE refs.t END base_typ"
+			." FROM $z req"
+			." LEFT JOIN $z typs ON typs.id=req.t AND req.t!=1"
+			." LEFT JOIN $z refs ON refs.id=typs.t AND refs.t!=refs.id"
+			." WHERE req.up=$typ ORDER BY req.ord";
+	$data_set = Exec_sql($sql, "Get unique key reqs");
+	while($row = mysqli_fetch_array($data_set))
+		if(FieldAttrsHasKey($row["attrs"])){
+			$row["id"] = (int)$row["id"];
+			$row["ref_id"] = is_null($row["ref_id"]) ? 0 : (int)$row["ref_id"];
+			$row["multi"] = FieldAttrsHasMulti($row["attrs"]);
+			$reqs[$row["id"]] = $row;
+		}
+	return $reqs;
+}
+function UniqueKeyNormalizeValue($t, $value){
+	if(is_array($value))
+		$value = implode(",", $value);
+	if(!in_array((string)$t, array("101", "102", "103", "132", "49"), true))
+		$value = BuiltIn($value);
+	return Format_Val($t, $value);
+}
+function UniqueKeyNormalizeRefs($req, $value){
+	global $z;
+	$refs = is_array($value) ? $value : explode(",", (string)$value);
+	$ids = array();
+	$seen = array();
+	$hasMissingRef = false;
+	foreach($refs as $ref){
+		$ref = trim((string)$ref);
+		if($ref === "")
+			continue;
+		if(is_numeric($ref)){
+			$ref = (int)$ref;
+			if($ref > 0 && !isset($seen[$ref])){
+				$ids[] = $ref;
+				$seen[$ref] = true;
+			}
+			continue;
+		}
+		if((int)$req["ref_id"] === 1){
+			$hasMissingRef = true;
+			continue;
+		}
+		$escaped = addcslashes($ref, "\\\'");
+		$result = Exec_sql("SELECT id FROM $z WHERE val='$escaped' AND t=".(int)$req["ref_id"]." LIMIT 1", "Resolve unique key ref");
+		if($row = mysqli_fetch_array($result)){
+			$ref = (int)$row["id"];
+			if(!isset($seen[$ref])){
+				$ids[] = $ref;
+				$seen[$ref] = true;
+			}
+		}
+		else
+			$hasMissingRef = true;
+	}
+	if(!$req["multi"] && count($ids) > 1)
+		$ids = array($ids[0]);
+	elseif($req["multi"])
+		sort($ids);
+	return array(
+		"kind" => "ref",
+		"ref_id" => (int)$req["ref_id"],
+		"values" => $ids,
+		"multi" => $req["multi"],
+		"has_missing_ref" => $hasMissingRef
+	);
+}
+function UniqueKeyStoredValues($recordId, $keyReqs){
+	global $z;
+	$values = array();
+	foreach($keyReqs as $reqId => $req)
+		$values[$reqId] = $req["ref_id"]
+			? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
+			: array("kind" => "value", "value" => "");
+	if((int)$recordId <= 0 || !count($keyReqs))
+		return $values;
+
+	foreach($keyReqs as $reqId => $req){
+		if($req["ref_id"]){
+			$refType = (int)$req["ref_id"];
+			$result = Exec_sql("SELECT reqs.t FROM $z reqs JOIN $z refs ON refs.id=reqs.t"
+							." WHERE reqs.up=".(int)$recordId." AND reqs.val='".addcslashes((string)$reqId, "\\\'")."'"
+							." AND (refs.t=$refType OR $refType=1) ORDER BY reqs.ord", "Get stored unique key refs");
+			while($row = mysqli_fetch_array($result))
+				$values[$reqId]["values"][(int)$row["t"]] = (int)$row["t"];
+			$values[$reqId]["values"] = array_values(array_unique($values[$reqId]["values"]));
+			sort($values[$reqId]["values"]);
+		}
+		else{
+			$result = Exec_sql("SELECT val FROM $z WHERE up=".(int)$recordId." AND t=".(int)$reqId." ORDER BY id DESC LIMIT 1", "Get stored unique key value");
+			if($row = mysqli_fetch_array($result))
+				$values[$reqId] = array("kind" => "value", "value" => $row["val"]);
+		}
+	}
+	return $values;
+}
+function UniqueKeyValuesFromRequest($typ, $recordId, $request, $keyReqs=false){
+	$keyReqs = $keyReqs === false ? UniqueKeyReqs($typ) : $keyReqs;
+	$values = UniqueKeyStoredValues($recordId, $keyReqs);
+	foreach($keyReqs as $reqId => $req){
+		$field = "t$reqId";
+		$newField = "NEW_$reqId";
+		if($req["ref_id"] && isset($request[$newField]) && trim((string)$request[$newField]) !== ""){
+			$values[$reqId] = UniqueKeyNormalizeRefs($req, $request[$newField]);
+			continue;
+		}
+		if(!array_key_exists($field, $request))
+			continue;
+		$values[$reqId] = $req["ref_id"]
+			? UniqueKeyNormalizeRefs($req, $request[$field])
+			: array("kind" => "value", "value" => UniqueKeyNormalizeValue($reqId, $request[$field]));
+	}
+	return $values;
+}
+function FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues){
+	global $z;
+	foreach($keyValues as $keyValue)
+		if($keyValue["kind"] === "ref" && $keyValue["has_missing_ref"])
+			return false;
+	$sql = "SELECT obj.id, obj.ord FROM $z obj WHERE obj.t=".(int)$typ
+			." AND obj.up=".(int)$up
+			." AND obj.val='".addcslashes($val, "\\\'")."'";
+	if((int)$skipId > 0)
+		$sql .= " AND obj.id!=".(int)$skipId;
+	$i = 0;
+	foreach($keyValues as $reqId => $keyValue){
+		$i++;
+		$reqId = (int)$reqId;
+		if($keyValue["kind"] === "ref"){
+			$reqVal = addcslashes((string)$reqId, "\\\'");
+			$refType = (int)$keyValue["ref_id"];
+			if(!count($keyValue["values"])){
+				$sql .= " AND NOT EXISTS(SELECT 1 FROM $z uk$i JOIN $z ukref$i ON ukref$i.id=uk$i.t WHERE uk$i.up=obj.id AND uk$i.val='$reqVal' AND (ukref$i.t=$refType OR $refType=1))";
+				continue;
+			}
+			if($keyValue["multi"])
+				$sql .= " AND (SELECT COUNT(DISTINCT ukc$i.t) FROM $z ukc$i JOIN $z ukcref$i ON ukcref$i.id=ukc$i.t WHERE ukc$i.up=obj.id AND ukc$i.val='$reqVal' AND (ukcref$i.t=$refType OR $refType=1))=".count($keyValue["values"]);
+			foreach($keyValue["values"] as $ref){
+				$i++;
+				$sql .= " AND EXISTS(SELECT 1 FROM $z uk$i JOIN $z ukref$i ON ukref$i.id=uk$i.t WHERE uk$i.up=obj.id AND uk$i.val='$reqVal' AND uk$i.t=".(int)$ref." AND (ukref$i.t=$refType OR $refType=1))";
+				if(!$keyValue["multi"])
+					break;
+			}
+		}
+		else{
+			$value = (string)$keyValue["value"];
+			if($value === "")
+				$sql .= " AND NOT EXISTS(SELECT 1 FROM $z uk$i WHERE uk$i.up=obj.id AND uk$i.t=$reqId AND uk$i.val!='')";
+			else
+				$sql .= " AND EXISTS(SELECT 1 FROM $z uk$i WHERE uk$i.up=obj.id AND uk$i.t=$reqId AND uk$i.val='".addcslashes($value, "\\\'")."')";
+		}
+	}
+	$sql .= " LIMIT 1";
+	$result = Exec_sql($sql, "Check composite unique Obj");
+	return mysqli_fetch_array($result);
+}
+function FindUniqueRecordDuplicateFromRequest($typ, $skipId, $up, $val, $request){
+	$keyReqs = UniqueKeyReqs($typ);
+	$keyValues = UniqueKeyValuesFromRequest($typ, $skipId, $request, $keyReqs);
+	return FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues);
+}
+function CheckUniqueRecordFromRequest($typ, $recordId, $up, $val, $request){
+	$row = FindUniqueRecordDuplicateFromRequest($typ, $recordId, $up, $val, $request);
+	if($row)
+		my_die(t9n("[RU]Запись с таким ключом уже существует[EN]The record with this key already exists")." #".$row["id"]);
+}
 function base64UrlDecode($input) {
     $remainder = strlen($input) % 4;
     if ($remainder) {
@@ -8970,7 +9143,7 @@ if(Validate_Token())
 			# Get the Object's ID value and Type
 			if($id === "")
 			    my_die(t9n("[RU]Неверный ID[EN]Invalid ID"));
-			$result = Exec_sql("SELECT a.val, a.t typ, a.up, a.ord, typs.t FROM $z typs, $z a WHERE typs.id=a.t AND a.id=$id", "Get current Val and Type");
+			$result = Exec_sql("SELECT a.val, a.t typ, a.up, a.ord, typs.t, typs.ord uniq FROM $z typs, $z a WHERE typs.id=a.t AND a.id=$id", "Get current Val and Type");
 			if($row = mysqli_fetch_array($result))
 				$cur_val = $row["val"];
 			else
@@ -8979,6 +9152,7 @@ if(Validate_Token())
 				exit("Cannot update meta-data");
 			$typ = $row["typ"];
 			$base_typ = $GLOBALS["basics"][$row["t"]];
+			$unique = (int)$row["uniq"];
 			$up = $row["up"];
 			if($up > 1)
 				$arg = "F_U=$up";  # Retain this for Array elements only
@@ -9019,6 +9193,12 @@ if(Validate_Token())
 			$GLOBALS["REQ_TYPS"][$typ] = $id;
 			Get_Current_Values($id, $typ);
 			$GLOBALS["REQS"][$typ] = $cur_val;
+			if($unique && !$copy){
+				$uniqueVal = $cur_val;
+				if(isset($_REQUEST["t$typ"]) && !(($typ == TOKEN || $typ == XSRF || $typ == PASSWORD) && $_REQUEST["t$typ"] === PASSWORDSTARS))
+					$uniqueVal = UniqueKeyNormalizeValue($typ, $_REQUEST["t$typ"]);
+				CheckUniqueRecordFromRequest($typ, $id, $up, $uniqueVal, $_REQUEST);
+			}
 			trace("GLOBALS[REQS] " . print_r($GLOBALS["REQS"], TRUE));
 
 			foreach($_REQUEST as $key => $value){
@@ -9430,8 +9610,7 @@ if(Validate_Token())
 					$val = Format_Val($base_typ, BuiltIn($val));
 				# The Type must be unique - let's check this
 				if($unique && !isset($max_val))
-					if($row = mysqli_fetch_array(Exec_sql("SELECT id, ord FROM $z WHERE t=$id AND val='".addslashes($val)."' AND up=$up LIMIT 1"
-														, "Check Obj's uniquity")))
+					if($row = FindUniqueRecordDuplicateFromRequest($id, 0, $up, $val, $_REQUEST))
 						if(strlen($row[0])){
 						    $msg = t9n("[RU]Запись уже существует[EN]The record already exists");
                 			$arg = "exists1=1";
@@ -9711,9 +9890,9 @@ if(Validate_Token())
 							, "Check the req and obj");
 			if($row = mysqli_fetch_array($result))
 				Update_Val($id, FieldAttrsToggleFlag($row["val"], "required"));
-    		else
-    		    my_die(t9n("[RU]Неверный реквизит $id [EN]Invalid requisite $id "));
-    		$obj = $row["id"];
+			else
+				my_die(t9n("[RU]Неверный реквизит $id [EN]Invalid requisite $id "));
+			$obj = $row["id"];
 			break;
 
 		case "_d_multi":
@@ -9727,13 +9906,25 @@ if(Validate_Token())
     		$obj = $row["id"];
 			break;
 
+		case "_d_key":
+		case "_setkey":
+			$result = Exec_sql("SELECT obj.id, req.val FROM $z req LEFT JOIN $z obj ON obj.id=req.up WHERE req.id=$id and obj.up=0"
+							, "Check the req and obj");
+			if($row = mysqli_fetch_array($result))
+				Update_Val($id, FieldAttrsToggleFlag($row["val"], "key"));
+			else
+				my_die(t9n("[RU]Неверный реквизит $id [EN]Invalid requisite $id "));
+			$obj = $row["id"];
+			break;
+
 		case "_d_attrs":
 		case "_modifiers":
 			$val = FieldAttrsBuild(
 				$val,
 				isset($_REQUEST["set_null"]),
 				isset($_REQUEST["multi"]),
-				isset($_REQUEST["alias"]) ? $_REQUEST["alias"] : null
+				isset($_REQUEST["alias"]) ? $_REQUEST["alias"] : null,
+				isset($_REQUEST["key"])
 			);
 			Update_Val($id, $val);
 			$obj = $up;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -17543,6 +17543,7 @@ function parseIntegramAttrs(attrs) {
     const result = {
         required: false,
         multi: false,
+        key: false,
         alias: null,
         defaultValue: null
     };
@@ -17571,12 +17572,13 @@ function parseIntegramAttrs(attrs) {
 
     if (jsonAttrs) {
         Object.keys(jsonAttrs).forEach((key) => {
-            if (!['required', 'notNull', 'not_null', 'multi', 'alias', 'default', 'defaultValue'].includes(key)) {
+            if (!['required', 'notNull', 'not_null', 'multi', 'key', 'alias', 'default', 'defaultValue'].includes(key)) {
                 result[key] = jsonAttrs[key];
             }
         });
         result.required = parseBool(jsonAttrs.required ?? jsonAttrs.notNull ?? jsonAttrs.not_null);
         result.multi = parseBool(jsonAttrs.multi);
+        result.key = parseBool(jsonAttrs.key);
         result.alias = jsonAttrs.alias ? String(jsonAttrs.alias) : null;
         const defaultValue = jsonAttrs.default ?? jsonAttrs.defaultValue;
         result.defaultValue = defaultValue !== undefined && defaultValue !== null && String(defaultValue).length > 0
@@ -17587,6 +17589,7 @@ function parseIntegramAttrs(attrs) {
 
     result.required = raw.includes(':!NULL:');
     result.multi = raw.includes(':MULTI:');
+    result.key = raw.includes(':KEY:');
 
     const aliasMatch = raw.match(/:ALIAS=(.*?):/u);
     if (aliasMatch) {
@@ -17596,6 +17599,7 @@ function parseIntegramAttrs(attrs) {
     const stripped = raw
         .replace(/:!NULL:/g, '')
         .replace(/:MULTI:/g, '')
+        .replace(/:KEY:/g, '')
         .replace(/:ALIAS=(.*?):/gu, '')
         .trim();
     if (stripped.length > 0) {
@@ -17609,12 +17613,13 @@ function serializeIntegramAttrs(attrs) {
     const source = attrs || {};
     const result = {};
     Object.keys(source).forEach((key) => {
-        if (!['required', 'notNull', 'not_null', 'multi', 'alias', 'default', 'defaultValue'].includes(key) && source[key] !== null) {
+        if (!['required', 'notNull', 'not_null', 'multi', 'key', 'alias', 'default', 'defaultValue'].includes(key) && source[key] !== null) {
             result[key] = source[key];
         }
     });
     if (source.required) result.required = true;
     if (source.multi) result.multi = true;
+    if (source.key) result.key = true;
     if (source.alias) result.alias = String(source.alias);
     const defaultValue = source.defaultValue ?? source.default;
     if (defaultValue !== undefined && defaultValue !== null && String(defaultValue).length > 0) {
@@ -17635,8 +17640,8 @@ function setIntegramAttrAlias(attrs, alias) {
     return serializeIntegramAttrs(parsed);
 }
 
-function buildIntegramAttrs(defaultValue = '', required = false, multi = false, alias = null) {
-    return serializeIntegramAttrs({ defaultValue, required, multi, alias });
+function buildIntegramAttrs(defaultValue = '', required = false, multi = false, alias = null, key = false) {
+    return serializeIntegramAttrs({ defaultValue, required, multi, alias, key });
 }
 
 if (typeof IntegramTable !== 'undefined') {

--- a/js/integram-table/24-global-functions.js
+++ b/js/integram-table/24-global-functions.js
@@ -8,6 +8,7 @@ function parseIntegramAttrs(attrs) {
     const result = {
         required: false,
         multi: false,
+        key: false,
         alias: null,
         defaultValue: null
     };
@@ -36,12 +37,13 @@ function parseIntegramAttrs(attrs) {
 
     if (jsonAttrs) {
         Object.keys(jsonAttrs).forEach((key) => {
-            if (!['required', 'notNull', 'not_null', 'multi', 'alias', 'default', 'defaultValue'].includes(key)) {
+            if (!['required', 'notNull', 'not_null', 'multi', 'key', 'alias', 'default', 'defaultValue'].includes(key)) {
                 result[key] = jsonAttrs[key];
             }
         });
         result.required = parseBool(jsonAttrs.required ?? jsonAttrs.notNull ?? jsonAttrs.not_null);
         result.multi = parseBool(jsonAttrs.multi);
+        result.key = parseBool(jsonAttrs.key);
         result.alias = jsonAttrs.alias ? String(jsonAttrs.alias) : null;
         const defaultValue = jsonAttrs.default ?? jsonAttrs.defaultValue;
         result.defaultValue = defaultValue !== undefined && defaultValue !== null && String(defaultValue).length > 0
@@ -52,6 +54,7 @@ function parseIntegramAttrs(attrs) {
 
     result.required = raw.includes(':!NULL:');
     result.multi = raw.includes(':MULTI:');
+    result.key = raw.includes(':KEY:');
 
     const aliasMatch = raw.match(/:ALIAS=(.*?):/u);
     if (aliasMatch) {
@@ -61,6 +64,7 @@ function parseIntegramAttrs(attrs) {
     const stripped = raw
         .replace(/:!NULL:/g, '')
         .replace(/:MULTI:/g, '')
+        .replace(/:KEY:/g, '')
         .replace(/:ALIAS=(.*?):/gu, '')
         .trim();
     if (stripped.length > 0) {
@@ -74,12 +78,13 @@ function serializeIntegramAttrs(attrs) {
     const source = attrs || {};
     const result = {};
     Object.keys(source).forEach((key) => {
-        if (!['required', 'notNull', 'not_null', 'multi', 'alias', 'default', 'defaultValue'].includes(key) && source[key] !== null) {
+        if (!['required', 'notNull', 'not_null', 'multi', 'key', 'alias', 'default', 'defaultValue'].includes(key) && source[key] !== null) {
             result[key] = source[key];
         }
     });
     if (source.required) result.required = true;
     if (source.multi) result.multi = true;
+    if (source.key) result.key = true;
     if (source.alias) result.alias = String(source.alias);
     const defaultValue = source.defaultValue ?? source.default;
     if (defaultValue !== undefined && defaultValue !== null && String(defaultValue).length > 0) {
@@ -100,8 +105,8 @@ function setIntegramAttrAlias(attrs, alias) {
     return serializeIntegramAttrs(parsed);
 }
 
-function buildIntegramAttrs(defaultValue = '', required = false, multi = false, alias = null) {
-    return serializeIntegramAttrs({ defaultValue, required, multi, alias });
+function buildIntegramAttrs(defaultValue = '', required = false, multi = false, alias = null, key = false) {
+    return serializeIntegramAttrs({ defaultValue, required, multi, alias, key });
 }
 
 if (typeof IntegramTable !== 'undefined') {

--- a/templates/edit_types.html
+++ b/templates/edit_types.html
@@ -75,7 +75,7 @@ var editable=ext=false,curid=0,isRef=false,prefix=0
     ,ajax='<img width="25px" src="/i/ajax.gif">';
 var HTML='',o=[],s=[],a=[],v=[];
 function parseFieldAttrs(attrs){
-    var result={required:false,multi:false,alias:null,defaultValue:''};
+    var result={required:false,multi:false,key:false,alias:null,defaultValue:''};
     if(!attrs) return result;
     attrs=String(attrs);
     var raw=attrs.trim();
@@ -100,6 +100,7 @@ function parseFieldAttrs(attrs){
     if(json){
         result.required=parseBool(json.required!==undefined?json.required:(json.notNull!==undefined?json.notNull:json.not_null));
         result.multi=parseBool(json.multi);
+        result.key=parseBool(json.key);
         result.alias=json.alias?String(json.alias):null;
         var defaultValue=json.default!==undefined?json.default:json.defaultValue;
         result.defaultValue=defaultValue!==undefined&&defaultValue!==null?String(defaultValue):'';
@@ -107,9 +108,10 @@ function parseFieldAttrs(attrs){
     }
     result.required=attrs.indexOf(':!NULL:')!==-1;
     result.multi=attrs.indexOf(':MULTI:')!==-1;
+    result.key=attrs.indexOf(':KEY:')!==-1;
     var alias=attrs.match(/:ALIAS=(.*?):/u);
     result.alias=alias?alias[1]:null;
-    result.defaultValue=attrs.replace(/:!NULL:/g,'').replace(/:MULTI:/g,'').replace(/:ALIAS=(.*?):/gu,'').trim();
+    result.defaultValue=attrs.replace(/:!NULL:/g,'').replace(/:MULTI:/g,'').replace(/:KEY:/g,'').replace(/:ALIAS=(.*?):/gu,'').trim();
     return result;
 }
 <!-- Begin:_ID -->
@@ -398,6 +400,9 @@ function closeDef(i){
 function setMulti(i){
     myApi('POST','_d_multi/'+i+'?JSON','d');
 }
+function setKey(i){
+    myApi('POST','_d_key/'+i+'?JSON','d');
+}
 function editDef(i,u){
     byId('a'+i).classList.add('hidden');
     byId('edit-alias'+i).classList.add('hidden');
@@ -433,7 +438,7 @@ function checkHash(i){
         },100);
 }
 function drawReqs(i,ext,force){
-	var def_ref_dd,def_ref_class,base,reqs=id=def_val=alias='',nullable,multiple;
+	var def_ref_dd,def_ref_class,base,reqs=id=def_val=alias='',nullable,multiple,isKey;
 	var parsedAttrs;
 	if(ext)
 		reqs+='<table class="table" width="100%">';
@@ -441,6 +446,7 @@ function drawReqs(i,ext,force){
         parsedAttrs=parseFieldAttrs(r[i][req].a);
 		nullable=parsedAttrs.required;
 		multiple=!parsedAttrs.multi;
+		isKey=parsedAttrs.key;
 		def_val=parsedAttrs.defaultValue;
 		if(!t[r[i][req].t]){
 		    console.log('No t[r['+i+']['+req+'].t]');
@@ -501,9 +507,14 @@ function drawReqs(i,ext,force){
 					        +(nullable?'Нажмите, чтобы сделать поле необязательным'
 					               :'Нажмите, чтобы сделать поле обязательным')
 					    +'"><i class="pi pi-exclamation-circle '+(nullable?'icon-required':'icon-optional')+'" style="font-size: 1.25rem;"></i></A>';
+					reqs+='&nbsp;<A onclick="setKey('+r[i][req].i+');setAjax(this)" TITLE="'
+					        +(isKey?'Убрать поле из составного ключа уникальности'
+					               :'Добавить поле в составной ключ уникальности')
+					    +'"><i class="pi pi-key '+(isKey?'icon-key-enabled':'icon-key-disabled')+'" style="font-size: 1.25rem;"></i></A>';
 					reqs+='&nbsp;<nobr></td><td valign="top"><FORM method="post" id="frm'+r[i][req].i+'" action="/{_global_.Z}/_d_attrs/'+r[i][req].i+'/?up='+i+'"><input type="hidden" name="_xsrf" value="{_global_.xsrf}">';
 					reqs+=nullable?'<input type="hidden" name="set_null" value="1">':'';
 					reqs+=multiple?'':'<input type="hidden" name="multi" value="1">';
+					reqs+=isKey?'<input type="hidden" name="key" value="1">':'';
 					if(alias!=t[id].v)
 						reqs+='<input type="hidden" name="alias" value="'+alias+'">';
 					reqs+='<input id="v'+r[i][req].i+'" type="text" size="10" name="val" value="'+def_val+'" onfocus="saveBtn('+r[i][req].i+','+id+')" oninput=saveBtn('+r[i][req].i+')'+def_ref_class+'>'+def_ref_dd+'</FORM>'
@@ -516,6 +527,8 @@ function drawReqs(i,ext,force){
 					reqs+='&nbsp;<A TITLE="'+'Обязательное поле'+'""><i class="pi pi-exclamation-triangle icon-required" style="font-size: 1.25rem;"></i></A>&nbsp;';
 				else
 					reqs+='&nbsp;<A TITLE="'+'Необязательное поле'+'""><i class="pi pi-exclamation-triangle icon-optional" style="font-size: 1.25rem;"></i></A>';
+				if(isKey)
+					reqs+='&nbsp;<A TITLE="'+'Поле входит в составной ключ уникальности'+'"><i class="pi pi-key icon-key-enabled" style="font-size: 1.25rem;"></i></A>';
 				reqs+='</td><td><input type="text" name="val" value="'+def_val+'" class="input-disabled">';
 			}
 			reqs+='</td></tr>';


### PR DESCRIPTION
Fixes #2490

## Что сделано
- Добавлен атрибут реквизита `key` / «Ключ» в общий PHP/JS парсинг и сериализацию metadata attrs с поддержкой legacy-маски `:KEY:`.
- В редактор типов добавлена кнопка ключа рядом с обязательностью/множественностью; сохранение default/alias теперь не сбрасывает этот признак.
- Проверка уникальности для уникальных типов теперь ищет дубликат по первой колонке и всем реквизитам с признаком «Ключ», включая обычные поля, ссылки и multiselect-ссылки.

## Как воспроизвести
1. Создать уникальный тип с реквизитом, отмеченным как «Ключ».
2. Создать запись `Название = A`, `Ключ = 1`.
3. Создать запись `Название = A`, `Ключ = 2`.
4. До исправления вторая запись считалась дублем только по первой колонке. После исправления она разрешена, а повтор `Название = A`, `Ключ = 1` блокируется как дубль составного ключа.

## Проверка
- `bash build.sh`
- `php -l include/field_attrs.php`
- `php -l index.php`
- `php -l experiments/test-issue-2490-field-key-attrs.php`
- `php experiments/test-issue-2490-field-key-attrs.php`
- `php experiments/test-issue-2485-attrs-json.php`
- `node experiments/test-issue-2485-attrs-json.js`
- `git diff --check`