### PR TITLE
Добавить подсказку к полю проверки уникальности

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T20:33:13.193Z for PR creation at branch issue-2497-5bb9f0771a41 for issue https://github.com/ideav/crm/issues/2497

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T20:33:13.193Z for PR creation at branch issue-2497-5bb9f0771a41 for issue https://github.com/ideav/crm/issues/2497

--- a/experiments/test-issue-2495-unique-key-ui.js
+++ b/experiments/test-issue-2495-unique-key-ui.js
@@ -253,6 +253,13 @@ async function testColumnEditCanToggleUniqueKey() {
 
     table.showColumnEditForm(column);
 
+    const modal = fakeDocument.body.children.find(el => el.className.includes('col-edit-modal'));
+    const uniqueKeyTitle = 'Система контролирует уникальность комбинации первой колонки и всех ключей';
+    assert(
+        modal.innerHTML.includes(`title="${uniqueKeyTitle}"`),
+        'uniqueness-check checkbox label should explain the full composite uniqueness rule'
+    );
+
     const keyCheckbox = fakeDocument.getElementById('col-edit-key-issue2495Table');
     assert(keyCheckbox, 'column edit modal should render the uniqueness-check checkbox for requisites');
     assert.strictEqual(keyCheckbox.checked, true, 'checkbox should reflect the current attrs.key state');

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -7528,6 +7528,7 @@ class IntegramTable{
             const nameFieldHtml = isRef
                 ? `<a href="${ this.escapeHtml(refTableUrl) }" target="${ refTypeId }" style="color: grey;">${ this.escapeHtml(currentName) }</a>`
                 : `<input type="text" id="col-edit-name-${instanceName}" class="form-control form-control-sm col-edit-input" value="${ this.escapeHtml(currentName) }" placeholder="Введите название колонки" autocomplete="off">`;
+            const uniqueKeyTitle = 'Система контролирует уникальность комбинации первой колонки и всех ключей';
 
             colEditModal.innerHTML = `
                 <h3 style="margin: 0 0 16px 0; font-weight: 500; font-size: 1.125rem;">Редактирование колонки: <em style="font-style: normal; color: var(--md-primary, #1976d2);">${ this.escapeHtml(col.name) }</em></h3>
@@ -7550,7 +7551,7 @@ class IntegramTable{
                         </label>
                     </div>` : '' }
                     ${ !isFirstColumn ? `<div class="col-edit-row">
-                        <label class="col-edit-label col-edit-check-label">
+                        <label class="col-edit-label col-edit-check-label" title="${ this.escapeHtml(uniqueKeyTitle) }">
                             <input type="checkbox" id="col-edit-key-${instanceName}" ${ isKey ? 'checked' : '' }>
                             Входит в проверку уникальности
                         </label>

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -350,6 +350,7 @@
             const nameFieldHtml = isRef
                 ? `<a href="${ this.escapeHtml(refTableUrl) }" target="${ refTypeId }" style="color: grey;">${ this.escapeHtml(currentName) }</a>`
                 : `<input type="text" id="col-edit-name-${instanceName}" class="form-control form-control-sm col-edit-input" value="${ this.escapeHtml(currentName) }" placeholder="Введите название колонки" autocomplete="off">`;
+            const uniqueKeyTitle = 'Система контролирует уникальность комбинации первой колонки и всех ключей';
 
             colEditModal.innerHTML = `
                 <h3 style="margin: 0 0 16px 0; font-weight: 500; font-size: 1.125rem;">Редактирование колонки: <em style="font-style: normal; color: var(--md-primary, #1976d2);">${ this.escapeHtml(col.name) }</em></h3>
@@ -372,7 +373,7 @@
                         </label>
                     </div>` : '' }
                     ${ !isFirstColumn ? `<div class="col-edit-row">
-                        <label class="col-edit-label col-edit-check-label">
+                        <label class="col-edit-label col-edit-check-label" title="${ this.escapeHtml(uniqueKeyTitle) }">
                             <input type="checkbox" id="col-edit-key-${instanceName}" ${ isKey ? 'checked' : '' }>
                             Входит в проверку уникальности
                         </label>


### PR DESCRIPTION
## Summary
- добавлен `title` для поля `Входит в проверку уникальности` в форме редактирования колонки
- пересобран `js/integram-table.js` из модульного исходника
- расширен экспериментальный тест уникального ключа проверкой текста подсказки

Fixes #2497

## Reproduce
1. Открыть настройки колонок таблицы.
2. Открыть редактирование не первой колонки.
3. Навести курсор на поле `Входит в проверку уникальности`.

До исправления у поля не было `title`. После исправления браузер показывает: `Система контролирует уникальность комбинации первой колонки и всех ключей`.

## Verification
- `node experiments/test-issue-2495-unique-key-ui.js`
- `node -c js/integram-table.js`
- `git diff --check`
- Playwright DOM check on `experiments/test-issue-2495-unique-key-ui.html`: label title equals the requested text
