### PR TITLE
Исправить project_id Gemini из ADC

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T20:36:55.292Z for PR creation at branch issue-2499-e82742a9df59 for issue https://github.com/ideav/crm/issues/2499

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T20:36:55.292Z for PR creation at branch issue-2499-e82742a9df59 for issue https://github.com/ideav/crm/issues/2499

--- a/experiments/test-issue-2499-gemini-project-id.php
+++ b/experiments/test-issue-2499-gemini-project-id.php
@@ -1,0 +1,119 @@
+<?php
+function assert_true($condition, $message){
+    if(!$condition)
+        throw new Exception($message);
+}
+
+function t9n($value){
+    return $value;
+}
+
+function extract_function_source($source, $name){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false)
+        throw new Exception("Function not found: ".$name);
+
+    $brace = strpos($source, "{", $start);
+    if($brace === false)
+        throw new Exception("Function body not found: ".$name);
+
+    $depth = 0;
+    $length = strlen($source);
+    for($i = $brace; $i < $length; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+
+    throw new Exception("Function body is not closed: ".$name);
+}
+
+function reset_google_project_env(){
+    foreach(array(
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_PROJECT_ID",
+        "GCLOUD_PROJECT",
+        "GCP_PROJECT",
+        "CLOUDSDK_CORE_PROJECT",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    ) as $name){
+        putenv($name);
+    }
+}
+
+function assert_project_endpoint($provider, $expectedProjectId, $message){
+    $endpoint = prepareAiProviderEndpoint($provider, array());
+    assert_true(
+        strpos($endpoint, "/projects/".$expectedProjectId."/") !== false,
+        $message
+    );
+    assert_true(
+        strpos($endpoint, "{project_id}") === false,
+        "Gemini endpoint should not keep the project_id placeholder"
+    );
+}
+
+$root = dirname(__DIR__);
+$indexPhp = file_get_contents($root."/index.php");
+foreach(array(
+    "getDefaultAiProviderConfig",
+    "prepareAiProviderEndpoint",
+    "getAiProviderProjectId",
+    "getGoogleApplicationDefaultProjectId",
+    "getGoogleCredentialsProjectId",
+    "getGoogleMetadataProjectId",
+    "aiConfigValue"
+) as $functionName){
+    eval(extract_function_source($indexPhp, $functionName));
+}
+
+$provider = getDefaultAiProviderConfig("gemini");
+$provider["id"] = "gemini";
+
+reset_google_project_env();
+$directProvider = $provider;
+$directProvider["projectId"] = "direct-gemini-project";
+assert_project_endpoint(
+    $directProvider,
+    "direct-gemini-project",
+    "Gemini endpoint should use projectId from merged provider settings"
+);
+
+reset_google_project_env();
+putenv("GOOGLE_APPLICATION_CREDENTIALS_JSON=".json_encode(array(
+    "type" => "service_account",
+    "project_id" => "demo-gemini-project",
+    "client_email" => "demo@example.iam.gserviceaccount.com",
+    "private_key" => "unused"
+)));
+assert_project_endpoint(
+    $provider,
+    "demo-gemini-project",
+    "Gemini endpoint should use project_id from GOOGLE_APPLICATION_CREDENTIALS_JSON"
+);
+
+reset_google_project_env();
+$credentialsPath = tempnam(sys_get_temp_dir(), "issue2499-gemini-");
+file_put_contents($credentialsPath, json_encode(array(
+    "type" => "authorized_user",
+    "quota_project_id" => "quota-gemini-project"
+)));
+putenv("GOOGLE_APPLICATION_CREDENTIALS=".$credentialsPath);
+try {
+    assert_project_endpoint(
+        $provider,
+        "quota-gemini-project",
+        "Gemini endpoint should use quota_project_id from GOOGLE_APPLICATION_CREDENTIALS"
+    );
+} finally {
+    unlink($credentialsPath);
+    reset_google_project_env();
+}
+
+echo "ok - issue 2499 Gemini project id is discovered from ADC credentials\n";

--- a/index.php
+++ b/index.php
@@ -8079,13 +8079,60 @@ function prepareAiProviderEndpoint($provider, $settings){
     return $endpoint;
 }
 function getAiProviderProjectId($provider, $settings){
-    $id = $provider["id"];
+    $id = isset($provider["id"]) ? $provider["id"] : "";
+    foreach(array("projectId", "project_id", "googleProjectId") as $key)
+        if(isset($provider[$key]) && trim((string)$provider[$key]) !== "")
+            return trim((string)$provider[$key]);
     if(isset($settings["profiles"]) && isset($settings["profiles"][$id]) && is_array($settings["profiles"][$id])){
         foreach(array("projectId", "project_id", "googleProjectId") as $key)
             if(isset($settings["profiles"][$id][$key]) && trim((string)$settings["profiles"][$id][$key]) !== "")
                 return trim((string)$settings["profiles"][$id][$key]);
     }
-    return aiConfigValue(array("GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID", "GCLOUD_PROJECT", "GCP_PROJECT"));
+    $projectId = aiConfigValue(array("GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID", "GCLOUD_PROJECT", "GCP_PROJECT", "CLOUDSDK_CORE_PROJECT"));
+    if($projectId !== "")
+        return $projectId;
+    return getGoogleApplicationDefaultProjectId();
+}
+function getGoogleApplicationDefaultProjectId(){
+    $credentialsJson = aiConfigValue(array("GOOGLE_APPLICATION_CREDENTIALS_JSON"));
+    if($credentialsJson !== ""){
+        $projectId = getGoogleCredentialsProjectId(json_decode($credentialsJson, true));
+        if($projectId !== "")
+            return $projectId;
+    }
+
+    $credentialsPath = aiConfigValue(array("GOOGLE_APPLICATION_CREDENTIALS"));
+    if($credentialsPath !== "" && is_readable($credentialsPath)){
+        $projectId = getGoogleCredentialsProjectId(json_decode(file_get_contents($credentialsPath), true));
+        if($projectId !== "")
+            return $projectId;
+    }
+
+    return getGoogleMetadataProjectId();
+}
+function getGoogleCredentialsProjectId($credentials){
+    if(!is_array($credentials))
+        return "";
+    foreach(array("project_id", "quota_project_id", "projectId") as $key)
+        if(isset($credentials[$key]) && trim((string)$credentials[$key]) !== "")
+            return trim((string)$credentials[$key]);
+    return "";
+}
+function getGoogleMetadataProjectId(){
+    if(!function_exists("curl_init"))
+        return "";
+    $ch = curl_init("http://metadata.google.internal/computeMetadata/v1/project/project-id");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, false);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Metadata-Flavor: Google"));
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 2);
+    $projectId = trim((string)curl_exec($ch));
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if($httpCode < 200 || $httpCode >= 300)
+        return "";
+    return $projectId;
 }
 function validateAiProviderEndpoint($endpoint){
     if($endpoint === "")


### PR DESCRIPTION
Fixes #2499

## Problem
Gemini is the default AI provider and uses the Vertex AI OpenAI-compatible endpoint with `{project_id}`. The server only looked for that project id in explicit provider settings or env variables, so a valid ADC setup with `project_id` in `GOOGLE_APPLICATION_CREDENTIALS_JSON` or the credentials file still failed with `{"error":"Не указан Google Cloud project_id для Gemini"}`.

## Solution
- Read `projectId`, `project_id`, or `googleProjectId` from the merged provider config before falling back to saved profile settings.
- Keep existing env support and add `CLOUDSDK_CORE_PROJECT`.
- Discover the project id from ADC JSON, ADC credentials files, and GCE metadata (`project/project-id`).
- Add a regression experiment covering direct provider config, ADC JSON, and ADC credentials file cases.
- Remove the generated `.gitkeep` placeholder from the PR diff.
- Merge the latest `origin/main` into this branch after PR #2498 landed.

## Reproduce
Before this change, `php experiments/test-issue-2499-gemini-project-id.php` fails with the reported Gemini `project_id` error even when ADC JSON contains `project_id`.

After this change, the Gemini endpoint is prepared with `/projects/<id>/...` and no `{project_id}` placeholder remains.

## Tests
- `php experiments/test-issue-2499-gemini-project-id.php`
- `node experiments/test-issue-2483-ai-chat-server.js`
- `node experiments/test-issue-2481-ai-providers.js`
- `node experiments/test-issue-2491-ai-chat-current-db.js`
- `node experiments/test-issue-2495-unique-key-ui.js`
- `node experiments/test-issue-2486-ai-chat-local-storage.js`
- `node experiments/test-issue-2471-ai-chat.js`
- `node experiments/test-issue-2474-ai-chat-global.js`
- `node experiments/test-issue-2488-ai-chat-button-border.js`
- `node --check js/ai-chat.js`
- `php -l index.php`
- `php -l experiments/test-issue-2499-gemini-project-id.php`
- `git diff --check origin/main...HEAD`