### PR TITLE
Исправить project_id Gemini из ADC

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T20:48:54.136Z for PR creation at branch issue-2501-c2495de5e715 for issue https://github.com/ideav/crm/issues/2501

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T20:48:54.136Z for PR creation at branch issue-2501-c2495de5e715 for issue https://github.com/ideav/crm/issues/2501

--- a/experiments/test-issue-2501-gemini-project-id.php
+++ b/experiments/test-issue-2501-gemini-project-id.php
@@ -1,0 +1,143 @@
+<?php
+function assertIssue2501($condition, $message){
+    if(!$condition){
+        fwrite(STDERR, $message."\n");
+        exit(1);
+    }
+}
+
+function t9n($value){
+    return $value;
+}
+
+function extractFunctionSourceIssue2501($source, $name, $required = true){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false){
+        if($required)
+            throw new Exception("Function not found: ".$name);
+        return "";
+    }
+
+    $brace = strpos($source, "{", $start);
+    if($brace === false)
+        throw new Exception("Function body not found: ".$name);
+
+    $depth = 0;
+    $length = strlen($source);
+    for($i = $brace; $i < $length; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+
+    throw new Exception("Function body is not closed: ".$name);
+}
+
+function resetGoogleProjectEnvIssue2501(){
+    foreach(array(
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_PROJECT_ID",
+        "GCLOUD_PROJECT",
+        "GCP_PROJECT",
+        "CLOUDSDK_CORE_PROJECT",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    ) as $name){
+        putenv($name);
+    }
+}
+
+function assertGeminiProjectEndpointIssue2501($provider, $expectedProjectId, $message){
+    try {
+        $endpoint = prepareAiProviderEndpoint($provider, array());
+    } catch(Exception $exception) {
+        fwrite(STDERR, $message."\n".$exception->getMessage()."\n");
+        exit(1);
+    }
+    assertIssue2501(
+        strpos($endpoint, "/projects/".$expectedProjectId."/") !== false,
+        $message."\nEndpoint: ".$endpoint
+    );
+    assertIssue2501(
+        strpos($endpoint, "{project_id}") === false,
+        "Gemini endpoint should not keep the project_id placeholder"
+    );
+}
+
+$root = dirname(__DIR__);
+$indexPhp = file_get_contents($root."/index.php");
+foreach(array(
+    "getDefaultAiProviderConfig",
+    "prepareAiProviderEndpoint",
+    "getAiProviderProjectId",
+    "aiConfigValue"
+) as $functionName){
+    eval(extractFunctionSourceIssue2501($indexPhp, $functionName));
+}
+foreach(array(
+    "getGoogleApplicationDefaultProjectId",
+    "getGoogleCredentialsProjectId",
+    "getGoogleMetadataProjectId"
+) as $functionName){
+    $source = extractFunctionSourceIssue2501($indexPhp, $functionName, false);
+    if($source !== "")
+        eval($source);
+}
+
+$provider = getDefaultAiProviderConfig("gemini");
+$provider["id"] = "gemini";
+
+resetGoogleProjectEnvIssue2501();
+$directProvider = $provider;
+$directProvider["projectId"] = "direct-gemini-project";
+assertGeminiProjectEndpointIssue2501(
+    $directProvider,
+    "direct-gemini-project",
+    "Gemini endpoint should use projectId from merged provider settings"
+);
+
+resetGoogleProjectEnvIssue2501();
+putenv("CLOUDSDK_CORE_PROJECT=cloudsdk-gemini-project");
+assertGeminiProjectEndpointIssue2501(
+    $provider,
+    "cloudsdk-gemini-project",
+    "Gemini endpoint should use CLOUDSDK_CORE_PROJECT"
+);
+
+resetGoogleProjectEnvIssue2501();
+putenv("GOOGLE_APPLICATION_CREDENTIALS_JSON=".json_encode(array(
+    "type" => "service_account",
+    "project_id" => "demo-gemini-project",
+    "client_email" => "demo@example.iam.gserviceaccount.com",
+    "private_key" => "unused"
+)));
+assertGeminiProjectEndpointIssue2501(
+    $provider,
+    "demo-gemini-project",
+    "Gemini endpoint should use project_id from GOOGLE_APPLICATION_CREDENTIALS_JSON"
+);
+
+resetGoogleProjectEnvIssue2501();
+$credentialsPath = tempnam(sys_get_temp_dir(), "issue2501-gemini-");
+file_put_contents($credentialsPath, json_encode(array(
+    "type" => "authorized_user",
+    "quota_project_id" => "quota-gemini-project"
+)));
+putenv("GOOGLE_APPLICATION_CREDENTIALS=".$credentialsPath);
+try {
+    assertGeminiProjectEndpointIssue2501(
+        $provider,
+        "quota-gemini-project",
+        "Gemini endpoint should use quota_project_id from GOOGLE_APPLICATION_CREDENTIALS"
+    );
+} finally {
+    unlink($credentialsPath);
+    resetGoogleProjectEnvIssue2501();
+}
+
+echo "ok - issue 2501 Gemini project id is discovered from provider and ADC credentials\n";

--- a/index.php
+++ b/index.php
@@ -8079,13 +8079,60 @@ function prepareAiProviderEndpoint($provider, $settings){
     return $endpoint;
 }
 function getAiProviderProjectId($provider, $settings){
-    $id = $provider["id"];
+    $id = isset($provider["id"]) ? $provider["id"] : "";
+    foreach(array("projectId", "project_id", "googleProjectId") as $key)
+        if(isset($provider[$key]) && trim((string)$provider[$key]) !== "")
+            return trim((string)$provider[$key]);
     if(isset($settings["profiles"]) && isset($settings["profiles"][$id]) && is_array($settings["profiles"][$id])){
         foreach(array("projectId", "project_id", "googleProjectId") as $key)
             if(isset($settings["profiles"][$id][$key]) && trim((string)$settings["profiles"][$id][$key]) !== "")
                 return trim((string)$settings["profiles"][$id][$key]);
     }
-    return aiConfigValue(array("GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID", "GCLOUD_PROJECT", "GCP_PROJECT"));
+    $projectId = aiConfigValue(array("GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID", "GCLOUD_PROJECT", "GCP_PROJECT", "CLOUDSDK_CORE_PROJECT"));
+    if($projectId !== "")
+        return $projectId;
+    return getGoogleApplicationDefaultProjectId();
+}
+function getGoogleApplicationDefaultProjectId(){
+    $credentialsJson = aiConfigValue(array("GOOGLE_APPLICATION_CREDENTIALS_JSON"));
+    if($credentialsJson !== ""){
+        $projectId = getGoogleCredentialsProjectId(json_decode($credentialsJson, true));
+        if($projectId !== "")
+            return $projectId;
+    }
+
+    $credentialsPath = aiConfigValue(array("GOOGLE_APPLICATION_CREDENTIALS"));
+    if($credentialsPath !== "" && is_readable($credentialsPath)){
+        $projectId = getGoogleCredentialsProjectId(json_decode(file_get_contents($credentialsPath), true));
+        if($projectId !== "")
+            return $projectId;
+    }
+
+    return getGoogleMetadataProjectId();
+}
+function getGoogleCredentialsProjectId($credentials){
+    if(!is_array($credentials))
+        return "";
+    foreach(array("project_id", "quota_project_id", "projectId") as $key)
+        if(isset($credentials[$key]) && trim((string)$credentials[$key]) !== "")
+            return trim((string)$credentials[$key]);
+    return "";
+}
+function getGoogleMetadataProjectId(){
+    if(!function_exists("curl_init"))
+        return "";
+    $ch = curl_init("http://metadata.google.internal/computeMetadata/v1/project/project-id");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, false);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array("Metadata-Flavor: Google"));
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 1);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 2);
+    $projectId = trim((string)curl_exec($ch));
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if($httpCode < 200 || $httpCode >= 300)
+        return "";
+    return $projectId;
 }
 function validateAiProviderEndpoint($endpoint){
     if($endpoint === "")


### PR DESCRIPTION
Fixes #2501

Related: #2499, #2500

## Problem
Gemini uses the Vertex AI OpenAI-compatible endpoint with a `{project_id}` placeholder. The server only resolved that project id from saved profile settings or a small set of environment variables, so ADC configurations that already contain a Google Cloud project id still failed with:

```json
{"error":"Не указан Google Cloud project_id для Gemini"}
```

## Solution
- Read `projectId`, `project_id`, or `googleProjectId` from the merged provider config before falling back to saved profile settings.
- Preserve existing Google project env support and add `CLOUDSDK_CORE_PROJECT`.
- Discover the project id from `GOOGLE_APPLICATION_CREDENTIALS_JSON`, `GOOGLE_APPLICATION_CREDENTIALS` files, and GCE metadata.
- Add a regression experiment for provider config, Cloud SDK env, ADC JSON, and ADC credentials-file project ids.
- Remove the generated `.gitkeep` placeholder from the final PR diff.

## Reproduce
Before this change, `php experiments/test-issue-2501-gemini-project-id.php` fails while preparing the Gemini endpoint because the project id is not found.

After this change, the Gemini endpoint is prepared with `/projects/<id>/...` and no `{project_id}` placeholder remains.

## Tests
- `php experiments/test-issue-2501-gemini-project-id.php`
- `php -l index.php`
- `php -l experiments/test-issue-2501-gemini-project-id.php`
- `node --check js/ai-chat.js`
- `node experiments/test-issue-2483-ai-chat-server.js`
- `node experiments/test-issue-2481-ai-providers.js`
- `node experiments/test-issue-2491-ai-chat-current-db.js`
- `node experiments/test-issue-2486-ai-chat-local-storage.js`
- `node experiments/test-issue-2471-ai-chat.js`
- `node experiments/test-issue-2474-ai-chat-global.js`
- `node experiments/test-issue-2488-ai-chat-button-border.js`
- `node experiments/test-issue-2495-unique-key-ui.js`
- `git diff --check origin/main...HEAD`
