### PR TITLE
Настроить Project number Gemini

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-10T22:15:51.627Z for PR creation at branch issue-2505-2299457c12b3 for issue https://github.com/ideav/crm/issues/2505

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-10T22:15:51.627Z for PR creation at branch issue-2505-2299457c12b3 for issue https://github.com/ideav/crm/issues/2505

--- a/experiments/test-issue-2481-ai-providers.js
+++ b/experiments/test-issue-2481-ai-providers.js
@@ -105,6 +105,7 @@ assert(profiles.groq, 'Groq profile should exist');
 assert(profiles.mistral, 'Mistral AI profile should exist');
 assert.strictEqual(profiles.gemini.tokenMode, 'adc', 'Gemini should use Application Default Credentials');
 assert.strictEqual(profiles.gemini.model, 'google/gemini-2.5-flash', 'Gemini should use a Vertex Gemini model id');
+assert.strictEqual(profiles.gemini.defaultProjectNumber, '944712482341', 'Gemini should include the default Vertex AI project number');
 assert(
     profiles.gemini.endpoint.includes('aiplatform.googleapis.com') &&
         profiles.gemini.endpoint.includes('/endpoints/openapi/chat/completions'),
@@ -124,6 +125,7 @@ const saved = JSON.parse(storage.integram_ai_chat_settings);
 assert.strictEqual(saved.activeProviderId, 'gemini', 'Saved localStorage settings should keep Gemini selected');
 assert.strictEqual(saved.profiles.gemini.tokenMode, 'adc', 'Saved Gemini profile should keep ADC mode');
 assert.strictEqual(saved.profiles.gemini.token, '', 'Saved Gemini profile should not store an API token');
+assert.strictEqual(saved.profiles.gemini.defaultProjectNumber, '944712482341', 'Saved Gemini profile should keep the default project number');
 assert.strictEqual(saved.profiles.groq.endpoint, 'https://api.groq.com/openai/v1/chat/completions');
 assert.strictEqual(saved.profiles.mistral.endpoint, 'https://api.mistral.ai/v1/chat/completions');
 

--- a/experiments/test-issue-2499-gemini-project-id.php
+++ b/experiments/test-issue-2499-gemini-project-id.php
@@ -40,6 +40,9 @@ function reset_google_project_env(){
         "GCLOUD_PROJECT",
         "GCP_PROJECT",
         "CLOUDSDK_CORE_PROJECT",
+        "GOOGLE_CLOUD_PROJECT_NUMBER",
+        "GOOGLE_PROJECT_NUMBER",
+        "GCP_PROJECT_NUMBER",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_APPLICATION_CREDENTIALS_JSON"
     ) as $name){

--- a/experiments/test-issue-2501-gemini-project-id.php
+++ b/experiments/test-issue-2501-gemini-project-id.php
@@ -45,6 +45,9 @@ function resetGoogleProjectEnvIssue2501(){
         "GCLOUD_PROJECT",
         "GCP_PROJECT",
         "CLOUDSDK_CORE_PROJECT",
+        "GOOGLE_CLOUD_PROJECT_NUMBER",
+        "GOOGLE_PROJECT_NUMBER",
+        "GCP_PROJECT_NUMBER",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "GOOGLE_APPLICATION_CREDENTIALS_JSON"
     ) as $name){

--- a/experiments/test-issue-2505-gemini-project-number.php
+++ b/experiments/test-issue-2505-gemini-project-number.php
@@ -1,0 +1,94 @@
+<?php
+function assertIssue2505($condition, $message){
+    if(!$condition){
+        fwrite(STDERR, $message."\n");
+        exit(1);
+    }
+}
+
+function t9n($value){
+    return $value;
+}
+
+function extractFunctionSourceIssue2505($source, $name, $required = true){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false){
+        if($required)
+            throw new Exception("Function not found: ".$name);
+        return "";
+    }
+
+    $brace = strpos($source, "{", $start);
+    if($brace === false)
+        throw new Exception("Function body not found: ".$name);
+
+    $depth = 0;
+    $length = strlen($source);
+    for($i = $brace; $i < $length; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+
+    throw new Exception("Function body is not closed: ".$name);
+}
+
+function resetGoogleProjectEnvIssue2505(){
+    foreach(array(
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_PROJECT_ID",
+        "GCLOUD_PROJECT",
+        "GCP_PROJECT",
+        "CLOUDSDK_CORE_PROJECT",
+        "GOOGLE_CLOUD_PROJECT_NUMBER",
+        "GOOGLE_PROJECT_NUMBER",
+        "GCP_PROJECT_NUMBER",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    ) as $name){
+        putenv($name);
+    }
+}
+
+$root = dirname(__DIR__);
+$indexPhp = file_get_contents($root."/index.php");
+foreach(array(
+    "getDefaultAiProviderConfig",
+    "prepareAiProviderEndpoint",
+    "getAiProviderProjectId",
+    "getGoogleApplicationDefaultProjectId",
+    "getGoogleCredentialsProjectId",
+    "getGoogleMetadataProjectId",
+    "aiConfigValue"
+) as $functionName){
+    eval(extractFunctionSourceIssue2505($indexPhp, $functionName));
+}
+
+resetGoogleProjectEnvIssue2505();
+$provider = getDefaultAiProviderConfig("gemini");
+$provider["id"] = "gemini";
+
+try {
+    $endpoint = prepareAiProviderEndpoint($provider, array());
+} catch(Exception $exception) {
+    fwrite(STDERR, "Gemini endpoint should use the configured default project number\n".$exception->getMessage()."\n");
+    exit(1);
+} finally {
+    resetGoogleProjectEnvIssue2505();
+}
+
+assertIssue2505(
+    strpos($endpoint, "/projects/944712482341/") !== false,
+    "Gemini endpoint should use project number 944712482341 by default\nEndpoint: ".$endpoint
+);
+assertIssue2505(
+    strpos($endpoint, "{project_id}") === false,
+    "Gemini endpoint should not keep the project_id placeholder"
+);
+
+echo "ok - issue 2505 Gemini uses default project number 944712482341\n";

--- a/index.php
+++ b/index.php
@@ -8010,6 +8010,7 @@ function getDefaultAiProviderConfig($id){
         "gemini" => array(
             "label" => "Google Gemini",
             "endpoint" => "https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/global/endpoints/openapi/chat/completions",
+            "defaultProjectNumber" => "944712482341",
             "model" => "google/gemini-2.5-flash",
             "tokenMode" => "adc",
             "chargeBalance" => false
@@ -8073,27 +8074,40 @@ function prepareAiProviderEndpoint($provider, $settings){
     if(strpos($endpoint, "{project_id}") !== false){
         $projectId = getAiProviderProjectId($provider, $settings);
         if($projectId === "")
-            throw new Exception(t9n("[RU]Не указан Google Cloud project_id для Gemini[EN]Google Cloud project_id is not set for Gemini"), 503);
+            throw new Exception(t9n("[RU]Не указан Google Cloud project_id/project number для Gemini[EN]Google Cloud project_id/project number is not set for Gemini"), 503);
         $endpoint = str_replace("{project_id}", rawurlencode($projectId), $endpoint);
     }
     return $endpoint;
 }
 function getAiProviderProjectId($provider, $settings){
     $id = isset($provider["id"]) ? $provider["id"] : "";
-    foreach(array("projectId", "project_id", "googleProjectId") as $key)
+    $projectKeys = array("projectId", "project_id", "googleProjectId", "projectNumber", "project_number", "googleProjectNumber");
+    foreach($projectKeys as $key)
         if(isset($provider[$key]) && trim((string)$provider[$key]) !== "")
             return trim((string)$provider[$key]);
     if(isset($settings["profiles"]) && isset($settings["profiles"][$id]) && is_array($settings["profiles"][$id])){
-        foreach(array("projectId", "project_id", "googleProjectId") as $key)
+        foreach($projectKeys as $key)
             if(isset($settings["profiles"][$id][$key]) && trim((string)$settings["profiles"][$id][$key]) !== "")
                 return trim((string)$settings["profiles"][$id][$key]);
     }
-    $projectId = aiConfigValue(array("GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID", "GCLOUD_PROJECT", "GCP_PROJECT", "CLOUDSDK_CORE_PROJECT"));
+    $projectId = aiConfigValue(array("GOOGLE_CLOUD_PROJECT", "GOOGLE_PROJECT_ID", "GCLOUD_PROJECT", "GCP_PROJECT", "CLOUDSDK_CORE_PROJECT", "GOOGLE_CLOUD_PROJECT_NUMBER", "GOOGLE_PROJECT_NUMBER", "GCP_PROJECT_NUMBER"));
     if($projectId !== "")
         return $projectId;
-    return getGoogleApplicationDefaultProjectId();
+    $projectId = getGoogleApplicationDefaultProjectId(false);
+    if($projectId !== "")
+        return $projectId;
+    $defaultProjectKeys = array("defaultProjectId", "default_project_id", "defaultGoogleProjectId", "defaultProjectNumber", "default_project_number", "defaultGoogleProjectNumber");
+    foreach($defaultProjectKeys as $key)
+        if(isset($provider[$key]) && trim((string)$provider[$key]) !== "")
+            return trim((string)$provider[$key]);
+    if(isset($settings["profiles"]) && isset($settings["profiles"][$id]) && is_array($settings["profiles"][$id])){
+        foreach($defaultProjectKeys as $key)
+            if(isset($settings["profiles"][$id][$key]) && trim((string)$settings["profiles"][$id][$key]) !== "")
+                return trim((string)$settings["profiles"][$id][$key]);
+    }
+    return getGoogleMetadataProjectId();
 }
-function getGoogleApplicationDefaultProjectId(){
+function getGoogleApplicationDefaultProjectId($includeMetadata = true){
     $credentialsJson = aiConfigValue(array("GOOGLE_APPLICATION_CREDENTIALS_JSON"));
     if($credentialsJson !== ""){
         $projectId = getGoogleCredentialsProjectId(json_decode($credentialsJson, true));
@@ -8108,12 +8122,14 @@ function getGoogleApplicationDefaultProjectId(){
             return $projectId;
     }
 
+    if(!$includeMetadata)
+        return "";
     return getGoogleMetadataProjectId();
 }
 function getGoogleCredentialsProjectId($credentials){
     if(!is_array($credentials))
         return "";
-    foreach(array("project_id", "quota_project_id", "projectId") as $key)
+    foreach(array("project_id", "quota_project_id", "projectId", "project_number", "quota_project_number", "projectNumber") as $key)
         if(isset($credentials[$key]) && trim((string)$credentials[$key]) !== "")
             return trim((string)$credentials[$key]);
     return "";

--- a/js/ai-chat.js
+++ b/js/ai-chat.js
@@ -37,6 +37,7 @@
                 gemini: {
                     label: 'Google Gemini',
                     endpoint: 'https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/global/endpoints/openapi/chat/completions',
+                    defaultProjectNumber: '944712482341',
                     model: 'google/gemini-2.5-flash',
                     tokenMode: 'adc',
                     defaultTokenMode: 'adc',


### PR DESCRIPTION
## Summary
- Set Gemini's default Vertex AI project number to `944712482341` in the server and shared AI chat defaults.
- Keep explicit provider/settings values, env/config values, and ADC credential files ahead of the built-in fallback.
- Support project-number aliases for provider settings and env/config, then fall back to metadata only after the default project number.
- Remove the initial PR placeholder `.gitkeep`.

Fixes #2505

## Reproduce
With no Google project env/config or ADC credential project configured, Gemini endpoint preparation previously failed with `Google Cloud project_id is not set for Gemini`. The new regression covers that path and verifies the endpoint resolves to `/projects/944712482341/`.

## Tests
- `php -l index.php`
- `php -l experiments/test-issue-2499-gemini-project-id.php`
- `php -l experiments/test-issue-2501-gemini-project-id.php`
- `php -l experiments/test-issue-2505-gemini-project-number.php`
- `php experiments/test-issue-2505-gemini-project-number.php`
- `php experiments/test-issue-2501-gemini-project-id.php`
- `php experiments/test-issue-2499-gemini-project-id.php`
- `node --check js/ai-chat.js`
- `node --check experiments/test-issue-2481-ai-providers.js`
- `node experiments/test-issue-2481-ai-providers.js`
- `node experiments/test-issue-2474-ai-chat-global.js`
- `node experiments/test-issue-2483-ai-chat-server.js`
- `node experiments/test-issue-2486-ai-chat-local-storage.js`
- `node experiments/test-issue-2491-ai-chat-current-db.js`
- `node experiments/test-issue-2471-ai-chat.js`
- `git diff --check`
