### PR TITLE
google_sheets_sync.php: добавить завершающую точку с запятой в конце каждой строки BKI

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-11T07:54:15.351Z for PR creation at branch issue-2514-de259abd90ab for issue https://github.com/ideav/crm/issues/2514

--- a/experiments/test-issue-2450-google-sheets-sync.php
+++ b/experiments/test-issue-2450-google-sheets-sync.php
@@ -42,8 +42,8 @@ assertSameValue(['2025'], $records[1]['columns'], 'matches scalar column matcher
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;1773328460\r\n"
-    . "89;;Выручка (ддо - b2b);2025;1773328460\r\n";
+    . "123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;1773328460;\r\n"
+    . "89;;Выручка (ддо - b2b);2025;1773328460;\r\n";
 
 assertSameValue($expected, $content, 'builds DATA-prefixed BKI content in value/date/row/column/timestamp format and escapes delimiters');
 assertTrueValue(gss_pattern_matches('*.2026', '31.01.2026'), 'asterisk mask matches arbitrary leading text');

--- a/experiments/test-issue-2456-google-sheets-sync-rules.php
+++ b/experiments/test-issue-2456-google-sheets-sync-rules.php
@@ -54,11 +54,11 @@ assertSameIssue2456('13', $records[4]['value'], 'captures the value under the ne
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "10;;Metric A;PLAN;1773328460\r\n"
-    . "20;;Metric B;PLAN;1773328460\r\n"
-    . "11;;Metric A;PLAN;1773328460\r\n"
-    . "12;;Metric A;PLAN;1773328460\r\n"
-    . "13;;Metric A;PLAN;1773328460\r\n";
+    . "10;;Metric A;PLAN;1773328460;\r\n"
+    . "20;;Metric B;PLAN;1773328460;\r\n"
+    . "11;;Metric A;PLAN;1773328460;\r\n"
+    . "12;;Metric A;PLAN;1773328460;\r\n"
+    . "13;;Metric A;PLAN;1773328460;\r\n";
 
 assertSameIssue2456($expected, $content, 'builds BKI content with value/date/row/column/timestamp fields');
 

--- a/experiments/test-issue-2469-google-sheets-sync-format.php
+++ b/experiments/test-issue-2469-google-sheets-sync-format.php
@@ -34,7 +34,7 @@ assertSameIssue2469('ПЛАН', $records[0]['column'], 'uses the lowest matched 
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "900;01.01.2026;Region West;ПЛАН;1773328460\r\n";
+    . "900;01.01.2026;Region West;ПЛАН;1773328460;\r\n";
 
 assertSameIssue2469($expected, $content, 'builds value/date/row/column/timestamp import lines');
 

--- a/experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
+++ b/experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
@@ -1,0 +1,36 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2514($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+$records = [
+    [
+        'value' => 'TestValue',
+        'date' => '01.01.2026',
+        'row' => 'Row A',
+        'column' => 'Col B',
+        'rows' => ['Row A'],
+        'columns' => ['Col B'],
+    ],
+];
+
+$content = gss_build_bki_content($records, 1000000000);
+
+// Each data line must end with a semicolon: value;date;row;column;timestamp;
+$expected = "DATA\r\n"
+    . "TestValue;01.01.2026;Row A;Col B;1000000000;\r\n";
+
+assertSameIssue2514($expected, $content, 'each BKI data line ends with a trailing semicolon');
+
+// Verify the trailing semicolon is present on the data line
+$lines = explode("\r\n", rtrim($content, "\r\n"));
+assertSameIssue2514('DATA', $lines[0], 'first line is DATA header');
+assertSameIssue2514(';', substr($lines[1], -1), 'data line ends with semicolon');
+
+echo "PASS issue 2514 BKI format trailing semicolon\n";

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -917,7 +917,8 @@ function gss_build_bki_content($records, $timestamp = null) {
             . ';' . gss_escape_bki_value($date)
             . ';' . gss_escape_bki_value($row)
             . ';' . gss_escape_bki_value($column)
-            . ';' . gss_escape_bki_value($timestamp);
+            . ';' . gss_escape_bki_value($timestamp)
+            . ';';
     }
 
     return implode("\r\n", $lines) . "\r\n";


### PR DESCRIPTION
## Проблема

Формат строки данных в BKI-файле не содержал завершающей точки с запятой. Требуемый формат по условию задачи:

```
{Значение ячейки};{дата};{строка};{колонка};{штамп времени};
```

## Решение

В функции `gss_build_bki_content` добавлена завершающая точка с запятой (`;`) после поля штампа времени.

## Воспроизведение и проверка

- Добавлен новый тест `experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php`, который воспроизводит проблему и проверяет исправление.
- Обновлены существующие тесты `test-issue-2450`, `test-issue-2456`, `test-issue-2469` под новый формат.

## Тест

```
php experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
# => PASS issue 2514 BKI format trailing semicolon
```


Fixes #2514