### PR TITLE
google_sheets_sync.php: добавить номер строки google sheets в BKI-формат

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-11T07:54:15.351Z for PR creation at branch issue-2514-de259abd90ab for issue https://github.com/ideav/crm/issues/2514
+# Updated: 2026-05-11T08:30:40.589Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-11T07:54:15.351Z for PR creation at branch issue-2514-de259abd90ab for issue https://github.com/ideav/crm/issues/2514
-# Updated: 2026-05-11T08:30:40.589Z

--- a/experiments/test-issue-2450-google-sheets-sync.php
+++ b/experiments/test-issue-2450-google-sheets-sync.php
@@ -42,10 +42,10 @@ assertSameValue(['2025'], $records[1]['columns'], 'matches scalar column matcher
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;1773328460;\r\n"
-    . "89;;Выручка (ддо - b2b);2025;1773328460;\r\n";
+    . "123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;4;1773328460;\r\n"
+    . "89;;Выручка (ддо - b2b);2025;4;1773328460;\r\n";
 
-assertSameValue($expected, $content, 'builds DATA-prefixed BKI content in value/date/row/column/timestamp format and escapes delimiters');
+assertSameValue($expected, $content, 'builds DATA-prefixed BKI content in value/date/row/column/sheet_row_number/timestamp format and escapes delimiters');
 assertTrueValue(gss_pattern_matches('*.2026', '31.01.2026'), 'asterisk mask matches arbitrary leading text');
 assertTrueValue(gss_pattern_matches('ПЛ*', 'ПЛАН'), 'asterisk mask matches arbitrary trailing text');
 assertTrueValue(!gss_pattern_matches('2026', '2025'), 'exact matcher does not match different value');

--- a/experiments/test-issue-2456-google-sheets-sync-rules.php
+++ b/experiments/test-issue-2456-google-sheets-sync-rules.php
@@ -54,12 +54,12 @@ assertSameIssue2456('13', $records[4]['value'], 'captures the value under the ne
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "10;;Metric A;PLAN;1773328460;\r\n"
-    . "20;;Metric B;PLAN;1773328460;\r\n"
-    . "11;;Metric A;PLAN;1773328460;\r\n"
-    . "12;;Metric A;PLAN;1773328460;\r\n"
-    . "13;;Metric A;PLAN;1773328460;\r\n";
+    . "10;;Metric A;PLAN;4;1773328460;\r\n"
+    . "20;;Metric B;PLAN;5;1773328460;\r\n"
+    . "11;;Metric A;PLAN;6;1773328460;\r\n"
+    . "12;;Metric A;PLAN;10;1773328460;\r\n"
+    . "13;;Metric A;PLAN;10;1773328460;\r\n";
 
-assertSameIssue2456($expected, $content, 'builds BKI content with value/date/row/column/timestamp fields');
+assertSameIssue2456($expected, $content, 'builds BKI content with value/date/row/column/sheet_row_number/timestamp fields');
 
 echo "PASS issue 2456 Google Sheets sync row rules\n";

--- a/experiments/test-issue-2469-google-sheets-sync-format.php
+++ b/experiments/test-issue-2469-google-sheets-sync-format.php
@@ -34,8 +34,8 @@ assertSameIssue2469('ПЛАН', $records[0]['column'], 'uses the lowest matched 
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "900;01.01.2026;Region West;ПЛАН;1773328460;\r\n";
+    . "900;01.01.2026;Region West;ПЛАН;4;1773328460;\r\n";
 
-assertSameIssue2469($expected, $content, 'builds value/date/row/column/timestamp import lines');
+assertSameIssue2469($expected, $content, 'builds value/date/row/column/sheet_row_number/timestamp import lines');
 
 echo "PASS issue 2469 Google Sheets sync output format\n";

--- a/experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
+++ b/experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
@@ -22,9 +22,9 @@ $records = [
 
 $content = gss_build_bki_content($records, 1000000000);
 
-// Each data line must end with a semicolon: value;date;row;column;timestamp;
+// Each data line must end with a semicolon: value;date;row;column;sheet_row_number;timestamp;
 $expected = "DATA\r\n"
-    . "TestValue;01.01.2026;Row A;Col B;1000000000;\r\n";
+    . "TestValue;01.01.2026;Row A;Col B;;1000000000;\r\n";
 
 assertSameIssue2514($expected, $content, 'each BKI data line ends with a trailing semicolon');
 

--- a/experiments/test-issue-2518-google-sheets-row-number.php
+++ b/experiments/test-issue-2518-google-sheets-row-number.php
@@ -1,0 +1,82 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2518($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+// Test 1: sheet_row_number reflects the actual 1-based row index in the fetched values (no range offset)
+$values = [
+    ['Период', '01.01.2026', '2025'],
+    ['', '31.01.2026', ''],
+    ['', 'ПЛАН', ''],
+    ['Выручка', '123', '89'],
+];
+
+$records = gss_extract_sheet_records(
+    'TestSheet',
+    $values,
+    ['Выручка'],
+    [
+        ['*.2026', '*.2026', 'ПЛАН'],
+        '2025',
+    ]
+);
+
+assertSameIssue2518(2, count($records), 'extracts 2 records');
+assertSameIssue2518(4, $records[0]['sheet_row_number'], 'sheet_row_number is 4 for rowIndex=3 with no range offset');
+assertSameIssue2518(4, $records[1]['sheet_row_number'], 'sheet_row_number is 4 for second column match on same row');
+
+// Test 2: sheet_row_number accounts for range start offset (e.g. range starts at row 5)
+$valuesOffset = [
+    ['Header', '2025'],
+    ['Выручка', '89'],
+];
+
+$records2 = gss_extract_sheet_records(
+    'TestSheet',
+    $valuesOffset,
+    ['Выручка'],
+    ['2025'],
+    false,
+    4  // rangeStartRow = 4 means the first row of $values is actually Google Sheets row 5
+);
+
+assertSameIssue2518(1, count($records2), 'extracts 1 record with range offset');
+assertSameIssue2518(6, $records2[0]['sheet_row_number'], 'sheet_row_number is 6 when rangeStartRow=4 and rowIndex=1');
+
+// Test 3: BKI output includes sheet_row_number between column and timestamp
+$content = gss_build_bki_content($records, 1773328460);
+$expected = "DATA\r\n"
+    . "123;31.01.2026;Выручка;ПЛАН;4;1773328460;\r\n"
+    . "89;;Выручка;2025;4;1773328460;\r\n";
+
+assertSameIssue2518($expected, $content, 'BKI output includes sheet_row_number as {value};{date};{row};{column};{sheet_row_number};{timestamp};');
+
+// Test 4: BKI output with range offset
+$content2 = gss_build_bki_content($records2, 1773328460);
+$expected2 = "DATA\r\n"
+    . "89;;Выручка;2025;6;1773328460;\r\n";
+
+assertSameIssue2518($expected2, $content2, 'BKI output uses correct sheet_row_number with range offset');
+
+// Test 5: record without sheet_row_number (backward compat) produces empty field
+$manualRecord = [
+    'value' => 'Val',
+    'date' => '01.01.2026',
+    'row' => 'Row',
+    'column' => 'Col',
+    'rows' => ['Row'],
+    'columns' => ['Col'],
+];
+$content3 = gss_build_bki_content([$manualRecord], 12345);
+$expected3 = "DATA\r\n"
+    . "Val;01.01.2026;Row;Col;;12345;\r\n";
+
+assertSameIssue2518($expected3, $content3, 'record without sheet_row_number produces empty field in BKI');
+
+echo "PASS issue 2518 Google Sheets row number in BKI format\n";

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -137,13 +137,16 @@ function gss_sync($config) {
         }
 
         gss_debug($debug, "Fetching sheet '{$sheetName}'");
+        $sheetRange = !empty($sheetConfig['range']) ? (string)$sheetConfig['range'] : gss_quote_sheet_name($sheetName);
+        $rangeStartRow = gss_value_range_start_indexes($sheetRange)['row'];
         $values = gss_fetch_google_sheet_values($spreadsheetId, $sheetConfig, $accessToken, $httpOptions);
         $records = gss_extract_sheet_records(
             $sheetName !== '' ? $sheetName : (string)$sheetConfig['range'],
             $values,
             $sheetConfig['rows'] ?? [],
             $sheetConfig['columns'] ?? [],
-            !empty($config['skip_empty_values'])
+            !empty($config['skip_empty_values']),
+            $rangeStartRow
         );
 
         $allRecords = array_merge($allRecords, $records);
@@ -460,7 +463,7 @@ function gss_split_a1_notation($range) {
     return ['sheet' => '', 'cells' => $range];
 }
 
-function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMatchers, $skipEmptyValues = false) {
+function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMatchers, $skipEmptyValues = false, $rangeStartRow = 0) {
     if (!is_array($rowMatchers) || empty($rowMatchers)) {
         throw new RuntimeException("Sheet '{$sheetName}' must define non-empty row matchers.");
     }
@@ -511,6 +514,7 @@ function gss_extract_sheet_records($sheetName, $values, $rowMatchers, $columnMat
             $records[] = [
                 'sheet' => $sheetName,
                 'row_number' => $rowIndex + 1,
+                'sheet_row_number' => $rangeStartRow + $rowIndex + 1,
                 'rows' => gss_unique_preserve_order($matchedRows),
                 'columns' => gss_unique_preserve_order($matchedColumns),
                 'date' => gss_max_ddmmyyyy_value(gss_match_entry_values(array_merge($matchedRowEntries, $matchedColumnEntries))),
@@ -913,10 +917,13 @@ function gss_build_bki_content($records, $timestamp = null) {
             ? $record['column']
             : gss_last_list_value($columns);
 
+        $sheetRowNumber = array_key_exists('sheet_row_number', $record) ? $record['sheet_row_number'] : '';
+
         $lines[] = gss_escape_bki_value($record['value'])
             . ';' . gss_escape_bki_value($date)
             . ';' . gss_escape_bki_value($row)
             . ';' . gss_escape_bki_value($column)
+            . ';' . gss_escape_bki_value($sheetRowNumber)
             . ';' . gss_escape_bki_value($timestamp)
             . ';';
     }


### PR DESCRIPTION
## Проблема

Формат строки BKI-файла не содержал номер строки Google Sheets. Требуемый формат по условию задачи (issue #2518):

```
{Значение ячейки};{дата};{строка};{колонка};{номер строки google sheets};{штамп времени};
```

## Решение

- В `gss_extract_sheet_records` добавлен параметр `$rangeStartRow = 0` и вычисляется поле `sheet_row_number = $rangeStartRow + $rowIndex + 1` — фактический 1-based номер строки в Google Sheets.
- В `gss_sync` перед вызовом `gss_extract_sheet_records` вычисляется `$rangeStartRow` из конфигурации диапазона листа (через `gss_value_range_start_indexes`), чтобы корректно учитывать смещение при заданном диапазоне.
- В `gss_build_bki_content` поле `sheet_row_number` вставлено между колонкой и штампом времени.

## Воспроизведение и проверка

Добавлен тест `experiments/test-issue-2518-google-sheets-row-number.php`.

```
php experiments/test-issue-2518-google-sheets-row-number.php
# => PASS issue 2518 Google Sheets row number in BKI format
```

Обновлены тесты `test-issue-2450`, `test-issue-2456`, `test-issue-2469`, `test-issue-2514` под новый формат.

```
php experiments/test-issue-2450-google-sheets-sync.php
php experiments/test-issue-2456-google-sheets-sync-rules.php
php experiments/test-issue-2469-google-sheets-sync-format.php
php experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
# => все PASS
```

Fixes #2518