### PR TITLE
index.php: проверять составной ключ уникальности, когда первая колонка не уникальна

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520

--- a/experiments/test-issue-2520-composite-key-without-first-column-unique.php
+++ b/experiments/test-issue-2520-composite-key-without-first-column-unique.php
@@ -1,0 +1,217 @@
+<?php
+
+/**
+ * Test for issue #2520:
+ * "При проверке уникальности первая колонка может не быть уникальной,
+ *  а только какие-то из других колонок уникальны"
+ *
+ * The bug: composite-key uniqueness check (FindUniqueRecordDuplicate) used to
+ * always require the FIRST column's value to match (obj.val='$val'). It was
+ * only invoked when the type's first column was itself marked as unique.
+ *
+ * The fix:
+ *   1) Add $includeVal parameter to FindUniqueRecordDuplicate, defaulting to
+ *      true (the old behavior). When false, the obj.val match is dropped from
+ *      the WHERE clause, so uniqueness is determined purely by the composite
+ *      key reqs.
+ *   2) In edit/create/import flows, also enter the uniqueness branch when the
+ *      type itself is NOT marked unique but there are composite key reqs.
+ *      When entering in that mode, $includeVal is passed as false.
+ *
+ * The test runs the production logic directly (copied below in lockstep with
+ * index.php FindUniqueRecordDuplicate) and verifies the SQL it builds. To keep
+ * the test free of DB dependencies, Exec_sql and fetch are captured via simple
+ * callable hooks rather than redefining mysqli_fetch_array (a built-in).
+ */
+
+class Issue2520TestHarness {
+    public static $capturedSql = "";
+
+    public static function execSql($sql, $label = ""){
+        self::$capturedSql = $sql;
+        return new stdClass();
+    }
+
+    public static function fetchArray($result){
+        return false;
+    }
+
+    /**
+     * Copy of the production FindUniqueRecordDuplicate function (kept in sync
+     * with index.php). Calls are routed via static helpers above so we do not
+     * have to redefine mysqli_fetch_array (a built-in).
+     */
+    public static function findDuplicate($typ, $skipId, $up, $val, $keyValues, $includeVal=true){
+        $z = "z";
+        if(!$includeVal){
+            if(!count($keyValues))
+                return false;
+            $hasValue = false;
+            foreach($keyValues as $keyValue){
+                if($keyValue["kind"] === "ref"){
+                    if(count($keyValue["values"])){ $hasValue = true; break; }
+                }
+                elseif((string)$keyValue["value"] !== ""){
+                    $hasValue = true; break;
+                }
+            }
+            if(!$hasValue)
+                return false;
+        }
+        foreach($keyValues as $keyValue)
+            if($keyValue["kind"] === "ref" && $keyValue["has_missing_ref"])
+                return false;
+        $sql = "SELECT obj.id, obj.ord FROM $z obj WHERE obj.t=".(int)$typ
+                ." AND obj.up=".(int)$up;
+        if($includeVal)
+            $sql .= " AND obj.val='".addcslashes($val, "\\\'")."'";
+        if((int)$skipId > 0)
+            $sql .= " AND obj.id!=".(int)$skipId;
+        $i = 0;
+        foreach($keyValues as $reqId => $keyValue){
+            $i++;
+            $reqId = (int)$reqId;
+            if($keyValue["kind"] === "ref"){
+                $reqVal = addcslashes((string)$reqId, "\\\'");
+                $refType = (int)$keyValue["ref_id"];
+                if(!count($keyValue["values"])){
+                    $sql .= " AND NOT EXISTS(SELECT 1 FROM $z uk$i JOIN $z ukref$i ON ukref$i.id=uk$i.t WHERE uk$i.up=obj.id AND uk$i.val='$reqVal' AND (ukref$i.t=$refType OR $refType=1))";
+                    continue;
+                }
+                if($keyValue["multi"])
+                    $sql .= " AND (SELECT COUNT(DISTINCT ukc$i.t) FROM $z ukc$i JOIN $z ukcref$i ON ukcref$i.id=ukc$i.t WHERE ukc$i.up=obj.id AND ukc$i.val='$reqVal' AND (ukcref$i.t=$refType OR $refType=1))=".count($keyValue["values"]);
+                foreach($keyValue["values"] as $ref){
+                    $i++;
+                    $sql .= " AND EXISTS(SELECT 1 FROM $z uk$i JOIN $z ukref$i ON ukref$i.id=uk$i.t WHERE uk$i.up=obj.id AND uk$i.val='$reqVal' AND uk$i.t=".(int)$ref." AND (ukref$i.t=$refType OR $refType=1))";
+                    if(!$keyValue["multi"])
+                        break;
+                }
+            }
+            else{
+                $value = (string)$keyValue["value"];
+                if($value === "")
+                    $sql .= " AND NOT EXISTS(SELECT 1 FROM $z uk$i WHERE uk$i.up=obj.id AND uk$i.t=$reqId AND uk$i.val!='')";
+                else
+                    $sql .= " AND EXISTS(SELECT 1 FROM $z uk$i WHERE uk$i.up=obj.id AND uk$i.t=$reqId AND uk$i.val='".addcslashes($value, "\\\'")."')";
+            }
+        }
+        $sql .= " LIMIT 1";
+        $result = self::execSql($sql, "Check composite unique Obj");
+        return self::fetchArray($result);
+    }
+}
+
+function assertEq($expected, $actual, $message){
+    if($expected !== $actual){
+        fwrite(STDERR, "FAIL: $message\n  Expected: " . var_export($expected, true) . "\n  Actual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+function assertContains($needle, $haystack, $message){
+    if(strpos($haystack, $needle) === false){
+        fwrite(STDERR, "FAIL: $message\n  Expected to find: $needle\n  In:               $haystack\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+function assertNotContains($needle, $haystack, $message){
+    if(strpos($haystack, $needle) !== false){
+        fwrite(STDERR, "FAIL: $message\n  Did NOT expect to find: $needle\n  In: $haystack\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+// =============================================================================
+// Case 1: First column marked unique (legacy behavior). includeVal=true.
+// SQL must restrict obj.val='Acme'.
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+$keyValues = array(
+    100 => array("kind" => "value", "value" => "2026-01-31")
+);
+Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", $keyValues, true);
+assertContains("obj.val='Acme'", Issue2520TestHarness::$capturedSql,
+    "Case 1: legacy includeVal=true restricts by obj.val");
+assertContains("uk1.t=100", Issue2520TestHarness::$capturedSql,
+    "Case 1: composite key req 100 is checked");
+
+// =============================================================================
+// Case 2: First column NOT marked unique, but composite key req has a value.
+// includeVal=false. SQL must NOT restrict obj.val and must still check req.
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", $keyValues, false);
+assertNotContains("obj.val=", Issue2520TestHarness::$capturedSql,
+    "Case 2: includeVal=false omits obj.val restriction");
+assertContains("uk1.t=100", Issue2520TestHarness::$capturedSql,
+    "Case 2: composite key req 100 still drives the duplicate check");
+
+// =============================================================================
+// Case 3: First column NOT unique and NO composite key values at all.
+// Must early-return false without running SQL.
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+$result = Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", array(), false);
+assertEq(false, $result,
+    "Case 3: empty keyValues + includeVal=false -> early return false (no false-positive duplicates)");
+assertEq("", Issue2520TestHarness::$capturedSql,
+    "Case 3: SQL not executed when there is nothing to check");
+
+// =============================================================================
+// Case 4: First column NOT unique, composite key reqs exist but all empty.
+// Must early-return false (cannot claim duplicate from a key with no values).
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+$emptyKeyValues = array(
+    100 => array("kind" => "value", "value" => ""),
+    101 => array("kind" => "ref", "ref_id" => 7, "values" => array(), "multi" => false, "has_missing_ref" => false)
+);
+$result = Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", $emptyKeyValues, false);
+assertEq(false, $result,
+    "Case 4: all-empty key values + includeVal=false -> early return false");
+assertEq("", Issue2520TestHarness::$capturedSql,
+    "Case 4: SQL not executed for an all-empty composite key");
+
+// =============================================================================
+// Case 5: First column NOT unique, composite key has a REF with one value.
+// includeVal=false; must check ref existence and skip obj.val.
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+$refKeyValues = array(
+    200 => array("kind" => "ref", "ref_id" => 9, "values" => array(42), "multi" => false, "has_missing_ref" => false)
+);
+Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", $refKeyValues, false);
+assertNotContains("obj.val=", Issue2520TestHarness::$capturedSql,
+    "Case 5: includeVal=false omits obj.val restriction (ref key)");
+assertContains("uk2.t=42", Issue2520TestHarness::$capturedSql,
+    "Case 5: ref value 42 enforced via EXISTS subquery");
+
+// =============================================================================
+// Case 6: First column NOT unique, ref key with has_missing_ref must short-circuit
+// (the incoming row references a value that does not exist, so it cannot match
+// an existing record).
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+$missingRefKey = array(
+    200 => array("kind" => "ref", "ref_id" => 9, "values" => array(42), "multi" => false, "has_missing_ref" => true)
+);
+$result = Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", $missingRefKey, false);
+assertEq(false, $result,
+    "Case 6: has_missing_ref short-circuits to false (no duplicate)");
+
+// =============================================================================
+// Case 7: Legacy includeVal=true still restricts by obj.val even when key reqs
+// have ref-with-missing-ref (the function returns early before SQL is built).
+// =============================================================================
+Issue2520TestHarness::$capturedSql = "";
+$result = Issue2520TestHarness::findDuplicate(50, 0, 1, "Acme", $missingRefKey, true);
+assertEq(false, $result,
+    "Case 7: legacy mode + has_missing_ref short-circuits before SQL");
+assertEq("", Issue2520TestHarness::$capturedSql,
+    "Case 7: no SQL executed when missing ref");
+
+echo "\nAll tests passed for issue-2520.\n";

--- a/index.php
+++ b/index.php
@@ -5833,8 +5833,8 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
     					$object[0] = Format_Val($GLOBALS["base"][$id], UnMaskDelimiters($object[0]));
 					    $reqs = Array();
 					    $ids = Array();
-    					if($isUnique){
-    					    $keyReqs = UniqueKeyReqs($id);
+    					$keyReqs = UniqueKeyReqs($id);
+    					if($isUnique || count($keyReqs)){
     					    if(count($keyReqs)){
     					        // Build key values from CSV columns to support composite uniqueness key
     					        $keyValues = array();
@@ -5855,7 +5855,7 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
     					                    ? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
     					                    : array("kind" => "value", "value" => "");
     					        }
-    					        if($existingRow = FindUniqueRecordDuplicate($id, 0, $parent, $object[0], $keyValues)){
+    					        if($existingRow = FindUniqueRecordDuplicate($id, 0, $parent, $object[0], $keyValues, (bool)$isUnique)){
     					            $existing = $existingRow["id"];
     					            trace(" found existing $existing ".$object[0]." (composite key)");
     					            $reqs_data = Exec_sql("SELECT reqs.t, reqs.val, reqs.id reqid FROM $z reqs WHERE reqs.up=$existing AND reqs.t!=0", "Load reqs of existing Obj for import");
@@ -8612,14 +8612,32 @@ function UniqueKeyValuesFromRequest($typ, $recordId, $request, $keyReqs=false){
 	}
 	return $values;
 }
-function FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues){
+function FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues, $includeVal=true){
 	global $z;
+	// When uniqueness is enforced solely by composite-key reqs (the first column is not marked unique),
+	// there must be at least one key req with a non-empty value to detect a real duplicate.
+	if(!$includeVal){
+		if(!count($keyValues))
+			return false;
+		$hasValue = false;
+		foreach($keyValues as $keyValue){
+			if($keyValue["kind"] === "ref"){
+				if(count($keyValue["values"])){ $hasValue = true; break; }
+			}
+			elseif((string)$keyValue["value"] !== ""){
+				$hasValue = true; break;
+			}
+		}
+		if(!$hasValue)
+			return false;
+	}
 	foreach($keyValues as $keyValue)
 		if($keyValue["kind"] === "ref" && $keyValue["has_missing_ref"])
 			return false;
 	$sql = "SELECT obj.id, obj.ord FROM $z obj WHERE obj.t=".(int)$typ
-			." AND obj.up=".(int)$up
-			." AND obj.val='".addcslashes($val, "\\\'")."'";
+			." AND obj.up=".(int)$up;
+	if($includeVal)
+		$sql .= " AND obj.val='".addcslashes($val, "\\\'")."'";
 	if((int)$skipId > 0)
 		$sql .= " AND obj.id!=".(int)$skipId;
 	$i = 0;
@@ -8654,13 +8672,13 @@ function FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues){
 	$result = Exec_sql($sql, "Check composite unique Obj");
 	return mysqli_fetch_array($result);
 }
-function FindUniqueRecordDuplicateFromRequest($typ, $skipId, $up, $val, $request){
+function FindUniqueRecordDuplicateFromRequest($typ, $skipId, $up, $val, $request, $includeVal=true){
 	$keyReqs = UniqueKeyReqs($typ);
 	$keyValues = UniqueKeyValuesFromRequest($typ, $skipId, $request, $keyReqs);
-	return FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues);
+	return FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues, $includeVal);
 }
-function CheckUniqueRecordFromRequest($typ, $recordId, $up, $val, $request){
-	$row = FindUniqueRecordDuplicateFromRequest($typ, $recordId, $up, $val, $request);
+function CheckUniqueRecordFromRequest($typ, $recordId, $up, $val, $request, $includeVal=true){
+	$row = FindUniqueRecordDuplicateFromRequest($typ, $recordId, $up, $val, $request, $includeVal);
 	if($row)
 		my_die(t9n("[RU]Запись с таким ключом уже существует[EN]The record with this key already exists")." #".$row["id"]);
 }
@@ -9289,11 +9307,14 @@ if(Validate_Token())
 			$GLOBALS["REQ_TYPS"][$typ] = $id;
 			Get_Current_Values($id, $typ);
 			$GLOBALS["REQS"][$typ] = $cur_val;
-			if($unique && !$copy){
-				$uniqueVal = $cur_val;
-				if(isset($_REQUEST["t$typ"]) && !(($typ == TOKEN || $typ == XSRF || $typ == PASSWORD) && $_REQUEST["t$typ"] === PASSWORDSTARS))
-					$uniqueVal = UniqueKeyNormalizeValue($typ, $_REQUEST["t$typ"]);
-				CheckUniqueRecordFromRequest($typ, $id, $up, $uniqueVal, $_REQUEST);
+			if(!$copy){
+				$hasKeyReqs = $unique ? false : (count(UniqueKeyReqs($typ)) > 0);
+				if($unique || $hasKeyReqs){
+					$uniqueVal = $cur_val;
+					if(isset($_REQUEST["t$typ"]) && !(($typ == TOKEN || $typ == XSRF || $typ == PASSWORD) && $_REQUEST["t$typ"] === PASSWORDSTARS))
+						$uniqueVal = UniqueKeyNormalizeValue($typ, $_REQUEST["t$typ"]);
+					CheckUniqueRecordFromRequest($typ, $id, $up, $uniqueVal, $_REQUEST, (bool)$unique);
+				}
 			}
 			trace("GLOBALS[REQS] " . print_r($GLOBALS["REQS"], TRUE));
 
@@ -9705,8 +9726,9 @@ if(Validate_Token())
 				else
 					$val = Format_Val($base_typ, BuiltIn($val));
 				# The Type must be unique - let's check this
-				if($unique && !isset($max_val))
-					if($row = FindUniqueRecordDuplicateFromRequest($id, 0, $up, $val, $_REQUEST))
+				$hasKeyReqs = $unique ? false : (!isset($max_val) && count(UniqueKeyReqs($id)) > 0);
+				if(!isset($max_val) && ($unique || $hasKeyReqs))
+					if($row = FindUniqueRecordDuplicateFromRequest($id, 0, $up, $val, $_REQUEST, (bool)$unique))
 						if(strlen($row[0])){
 						    $msg = t9n("[RU]Запись уже существует[EN]The record already exists");
                 			$arg = "exists1=1";


### PR DESCRIPTION
## Проблема

Fixes #2520

Проверка уникальности `CheckUniqueRecordFromRequest` / `FindUniqueRecordDuplicateFromRequest` в `index.php` запускалась только когда сам Тип (первая колонка) помечен как уникальный (`typs.ord = 1`). Если первая колонка не отмечена как уникальная, но какие-то другие реквизиты помечены `attrs.key = true` (часть составного ключа), уникальность вообще не проверялась.

## Решение

1. В функцию `FindUniqueRecordDuplicate` добавлен параметр `$includeVal` (по умолчанию `true` — старое поведение).
   - При `$includeVal = false` ограничение `obj.val = '$val'` (первая колонка) из `WHERE` опускается, и проверка ведется только по реквизитам составного ключа.
   - Чтобы не пометить дубликатами все записи с пустым ключом, в этом режиме функция возвращает `false`, если ни у одного реквизита ключа нет непустого значения.

2. `FindUniqueRecordDuplicateFromRequest` и `CheckUniqueRecordFromRequest` пробрасывают тот же параметр.

3. Три точки вызова в `index.php` расширены:
   - **CSV-импорт** (`Get_block_data`, около строки 5836): вход в ветку также если `UniqueKeyReqs($id)` непуст.
   - **Сохранение из формы** (`edit_obj`, около строки 9292).
   - **Создание объекта** (`create_obj`, около строки 9708).
  
   Если в проверку зашли из-за составного ключа без уникальности первой колонки, передается `includeVal = false`, и SQL ищет дубликат только по полям ключа.

## Как воспроизвести

1. Создать таблицу, у которой первая колонка **не** отмечена как «Уникальные значения», но один или несколько других реквизитов в `attrs` содержат `\"key\": true`.
2. До исправления: дубликаты по составному ключу можно было создать без ошибки.
3. После исправления: при создании/сохранении/импорте записи с уже существующим набором значений ключа выдается ошибка «Запись с таким ключом уже существует».

## Тест

`experiments/test-issue-2520-composite-key-without-first-column-unique.php` — проверяет, что:
- в режиме совместимости (`includeVal = true`) SQL по-прежнему фильтрует по `obj.val`;
- в новом режиме (`includeVal = false`) фильтр `obj.val` опускается, но условия по реквизитам ключа остаются;
- пустой набор ключевых значений и `includeVal = false` коротко возвращают `false` без обращения к БД;
- `has_missing_ref` короткозамыкает результат до `false`.

```
php experiments/test-issue-2520-composite-key-without-first-column-unique.php
# => All tests passed for issue-2520.
```

Существующие тесты:

```
php experiments/test-issue-2490-field-key-attrs.php   # PASS
php experiments/test-issue-2510-unique-key-date-format.php  # PASS
php -l index.php   # No syntax errors
```