### PR TITLE
index.php: распространить удаление по пустому значению на getParent (issue #2524)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
+# Updated: 2026-05-11T09:10:52.359Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
-# Updated: 2026-05-11T09:10:52.359Z

--- a/experiments/test-issue-2524-getparent-empty-value-delete-by-unique-key.php
+++ b/experiments/test-issue-2524-getparent-empty-value-delete-by-unique-key.php
@@ -1,0 +1,253 @@
+<?php
+
+/**
+ * Test for issue #2524:
+ * "https://github.com/ideav/crm/pull/2523 getParent() не отменяет логики очистки
+ *  значений для уникальных строк, просто значение не в первой колонке файла, а
+ *  во второй"
+ *
+ * Behavior under test (CSV plain-data import in Get_block_data, getParent mode):
+ *   - When $getParent is active, CSV column 0 is the parent reference and the
+ *     record's own value lives in column 1 (the second column). After the import
+ *     resolves the parent and `array_shift`s, the value moves to $object[0].
+ *   - If that value is empty AND the type has uniqueness defined by composite
+ *     key reqs, the import must look up the existing record under the resolved
+ *     parent by the remaining (composite key) columns and DELETE it — mirroring
+ *     the issue-2522 fix that was previously skipped for getParent.
+ *   - If the parent reference (column 0) itself is empty, the legacy
+ *     "skip" branch at the top of the loop handles the row; the issue-2522
+ *     branch still does not run under getParent because there is no parent to
+ *     scope the lookup. This part is unchanged by issue-2524.
+ *
+ * Like the issue-2522 test, this stays free of a live DB by reimplementing the
+ * production logic block from Get_block_data using callable hooks for
+ * Delete/FindUniqueRecordDuplicate to verify the dispatched call.
+ */
+
+class Issue2524TestHarness {
+    public static $deletedId = null;
+    public static $findCalls = array();
+    public static $findResult = false;
+    public static $warningSuffix = "";
+
+    public static function reset(){
+        self::$deletedId = null;
+        self::$findCalls = array();
+        self::$findResult = false;
+        self::$warningSuffix = "";
+    }
+
+    public static function findUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues, $includeVal=true){
+        self::$findCalls[] = array(
+            "typ" => $typ, "skipId" => $skipId, "up" => $up, "val" => $val,
+            "keyValues" => $keyValues, "includeVal" => $includeVal,
+        );
+        return self::$findResult;
+    }
+
+    public static function deleteObj($id){
+        self::$deletedId = $id;
+    }
+
+    /**
+     * Simulates the post-array_shift empty-value branch added for issue-2524
+     * in Get_block_data. Kept in sync with index.php.
+     *
+     * Inputs:
+     *   $object       — CSV columns AFTER getParent's array_shift (so $object[0]
+     *                   is the record value, $object[1..] are reqs in local_struct order).
+     *   $resolvedParent — id resolved from the original first column.
+     *   $keyReqs      — UniqueKeyReqs($id) result. Empty = no composite key.
+     */
+    public static function postShiftRow($object, $localStruct, $typeId, $keyReqs, $resolvedParent){
+        if($object[0] !== "")
+            return "imported"; // value is present; out of scope for this fix
+        if(!count($keyReqs)){
+            self::$warningSuffix = "skipped";
+            return "skipped"; // legacy skip: no key, nothing to delete by
+        }
+        $keyValues = array();
+        $ord = 0;
+        foreach($localStruct[$typeId] as $reqId => $reqName){
+            if($reqId == 0) continue;
+            $ord++;
+            if(!isset($keyReqs[$reqId])) continue;
+            $req = $keyReqs[$reqId];
+            $rawVal = isset($object[$ord]) ? $object[$ord] : "";
+            $keyValues[$reqId] = $req["ref_id"]
+                ? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
+                : array("kind" => "value", "value" => $rawVal);
+        }
+        foreach($keyReqs as $reqId => $req){
+            if(!isset($keyValues[$reqId]))
+                $keyValues[$reqId] = $req["ref_id"]
+                    ? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
+                    : array("kind" => "value", "value" => "");
+        }
+        $existingRow = self::findUniqueRecordDuplicate($typeId, 0, $resolvedParent, "", $keyValues, false);
+        if($existingRow){
+            self::deleteObj($existingRow["id"]);
+            self::$warningSuffix = "deleted";
+            return "deleted";
+        }
+        self::$warningSuffix = "skipped";
+        return "skipped";
+    }
+}
+
+function assertEq($expected, $actual, $message){
+    if($expected !== $actual){
+        fwrite(STDERR, "FAIL: $message\n  Expected: " . var_export($expected, true) . "\n  Actual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+function assertTrue($cond, $message){
+    if(!$cond){
+        fwrite(STDERR, "FAIL: $message\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+// Shared fixtures: a child type whose composite key spans both reqs.
+$typeId = 60;
+$resolvedParent = 4242; // id resolved from the CSV's first column (parent ref)
+$localStruct = array(
+    60 => array(
+        0   => "self",
+        110 => "year",
+        111 => "vendor",
+    ),
+);
+$keyReqsBoth = array(
+    110 => array("t" => 110, "ref_id" => 0, "multi" => false, "key" => true),
+    111 => array("t" => 111, "ref_id" => 12, "multi" => false, "key" => true),
+);
+$keyReqsValueOnly = array(
+    110 => array("t" => 110, "ref_id" => 0, "multi" => false, "key" => true),
+);
+$noKeyReqs = array();
+
+// =============================================================================
+// Case 1: getParent + empty value (column 1) + composite key + match -> delete.
+//         (Post-shift state: $object[0]="", $object[1]="2026", $object[2]="Acme".)
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = array("id" => 8001, "ord" => 3);
+$row = array("", "2026", "Acme");
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $keyReqsBoth, $resolvedParent);
+assertEq("deleted", $result,
+    "Case 1: empty value under getParent + composite key + existing -> deleted");
+assertEq(8001, Issue2524TestHarness::$deletedId,
+    "Case 1: Delete() called with the existing record id");
+assertEq(1, count(Issue2524TestHarness::$findCalls),
+    "Case 1: FindUniqueRecordDuplicate called once");
+$call = Issue2524TestHarness::$findCalls[0];
+assertEq(false, $call["includeVal"],
+    "Case 1: lookup passes includeVal=false (do not filter by obj.val)");
+assertEq($resolvedParent, $call["up"],
+    "Case 1: lookup uses the resolved parent id (scoped uniqueness)");
+assertEq("2026", $call["keyValues"][110]["value"],
+    "Case 1: composite key value 110 propagated from CSV column 1 (post-shift index 1)");
+
+// =============================================================================
+// Case 2: getParent + empty value + composite key + no match -> skip, no delete.
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = false;
+$row = array("", "9999", "Nobody");
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $keyReqsBoth, $resolvedParent);
+assertEq("skipped", $result,
+    "Case 2: empty value under getParent + no match -> skipped (no record to delete)");
+assertEq(null, Issue2524TestHarness::$deletedId,
+    "Case 2: Delete() not called when nothing matches");
+assertEq(1, count(Issue2524TestHarness::$findCalls),
+    "Case 2: FindUniqueRecordDuplicate was still invoked");
+$call = Issue2524TestHarness::$findCalls[0];
+assertEq($resolvedParent, $call["up"],
+    "Case 2: lookup is still scoped under the resolved parent");
+
+// =============================================================================
+// Case 3: getParent + empty value + NO uniqueness reqs -> legacy import path,
+//         no Find/Delete (the fix must not change behavior for non-unique types).
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = array("id" => 7777, "ord" => 0); // unused
+$row = array("", "2026", "Acme");
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $noKeyReqs, $resolvedParent);
+assertEq("skipped", $result,
+    "Case 3: empty value under getParent + no key -> skipped, no delete");
+assertEq(null, Issue2524TestHarness::$deletedId,
+    "Case 3: Delete() not called when uniqueness is not enforced");
+assertEq(0, count(Issue2524TestHarness::$findCalls),
+    "Case 3: FindUniqueRecordDuplicate not called when uniqueness is not enforced");
+
+// =============================================================================
+// Case 4: getParent + empty value + composite key with all empty key cols ->
+//         FindUniqueRecordDuplicate short-circuits to false; no Delete.
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = false; // simulate production short-circuit
+$row = array("", "", "");
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $keyReqsBoth, $resolvedParent);
+assertEq("skipped", $result,
+    "Case 4: empty value + empty key cols under getParent -> no delete");
+assertEq(null, Issue2524TestHarness::$deletedId,
+    "Case 4: Delete() not called when there is nothing to look up");
+$call = Issue2524TestHarness::$findCalls[0];
+assertEq("", $call["keyValues"][110]["value"],
+    "Case 4: composite key value 110 is empty");
+
+// =============================================================================
+// Case 5: getParent + non-empty value (column 1 populated) -> falls through to
+//         the normal import path; the new branch must NOT activate.
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = array("id" => 5555, "ord" => 0); // would match, must not be used
+$row = array("2026", "Acme", "extra"); // post-shift first column non-empty
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $keyReqsBoth, $resolvedParent);
+assertEq("imported", $result,
+    "Case 5: non-empty value under getParent -> normal import (no delete here)");
+assertEq(null, Issue2524TestHarness::$deletedId,
+    "Case 5: Delete() not called when value is present");
+assertEq(0, count(Issue2524TestHarness::$findCalls),
+    "Case 5: FindUniqueRecordDuplicate not called when value is present");
+
+// =============================================================================
+// Case 6: getParent + value-only composite key (no ref reqs) + match -> delete.
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = array("id" => 4444, "ord" => 1);
+$row = array("", "2026", "Anything");
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $keyReqsValueOnly, $resolvedParent);
+assertEq("deleted", $result,
+    "Case 6: value-only composite key under getParent triggers delete on empty value");
+assertEq(4444, Issue2524TestHarness::$deletedId,
+    "Case 6: Delete() called with the matched record id");
+$call = Issue2524TestHarness::$findCalls[0];
+assertTrue(isset($call["keyValues"][110]),
+    "Case 6: key value for req 110 is passed");
+assertEq(false, $call["includeVal"],
+    "Case 6: lookup passes includeVal=false");
+assertEq($resolvedParent, $call["up"],
+    "Case 6: lookup is scoped under the resolved parent");
+
+// =============================================================================
+// Case 7: Root parent (parent=1). The fix should work uniformly: per the issue
+//         description "у корневых записей родитель - 1, но работает всё так же".
+// =============================================================================
+Issue2524TestHarness::reset();
+Issue2524TestHarness::$findResult = array("id" => 3030, "ord" => 1);
+$row = array("", "2026", "Acme");
+$result = Issue2524TestHarness::postShiftRow($row, $localStruct, $typeId, $keyReqsBoth, /*resolvedParent=*/1);
+assertEq("deleted", $result,
+    "Case 7: empty value under getParent + parent=1 (root) -> still deletes");
+assertEq(3030, Issue2524TestHarness::$deletedId,
+    "Case 7: Delete() called with the matched record id under root parent");
+$call = Issue2524TestHarness::$findCalls[0];
+assertEq(1, $call["up"],
+    "Case 7: lookup scoped under parent=1");
+
+echo "\nAll tests passed for issue-2524.\n";

--- a/index.php
+++ b/index.php
@@ -5872,6 +5872,37 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                                 continue;
 						    }
 						    array_shift($object);
+						    // issue #2524: under getParent the type value lives in the second column (now $object[0]
+						    // after the shift). If it was cleared in the source and the type has a composite uniqueness
+						    // key, find the existing record by the key reqs under the resolved parent and delete it —
+						    // mirroring the issue-2522 logic that only handled the first-column case.
+						    if($object[0] === "" && count($keyReqsForDelete)){
+						        $keyValuesForDelete = array();
+						        $ord = 0;
+						        foreach($GLOBALS["local_struct"][$id] as $reqId => $reqName){
+						            if($reqId == 0) continue;
+						            $ord++;
+						            if(!isset($keyReqsForDelete[$reqId])) continue;
+						            $req = $keyReqsForDelete[$reqId];
+						            $rawVal = isset($object[$ord]) ? UnMaskDelimiters($object[$ord]) : "";
+						            $keyValuesForDelete[$reqId] = $req["ref_id"]
+						                ? UniqueKeyNormalizeRefs($req, $rawVal)
+						                : array("kind" => "value", "value" => UniqueKeyNormalizeValue($req["t"], $rawVal));
+						        }
+						        foreach($keyReqsForDelete as $reqId => $req){
+						            if(!isset($keyValuesForDelete[$reqId]))
+						                $keyValuesForDelete[$reqId] = $req["ref_id"]
+						                    ? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
+						                    : array("kind" => "value", "value" => "");
+						        }
+						        if($existingRow = FindUniqueRecordDuplicate($id, 0, $parent, "", $keyValuesForDelete, false)){
+						            trace(" issue-2524: empty value under getParent, deleting existing #".$existingRow["id"]." by composite key (parent=$parent)");
+						            Delete($existingRow["id"]);
+						            $GLOBALS["warning"] .= t9n("[RU]Удалена запись типа $id с пустым значением (строка $count)[EN]Deleted record of type $id with empty value (string #$count)");
+						            $count++;
+						            continue;
+						        }
+						    }
     					}
     					$object[0] = Format_Val($GLOBALS["base"][$id], UnMaskDelimiters($object[0]));
 					    $reqs = Array();


### PR DESCRIPTION
## Проблема

Fixes #2524

В PR #2523 (issue #2522) была добавлена логика: при CSV-импорте в `Get_block_data`, если первая колонка строки пуста и у типа есть составной ключ уникальности (`UniqueKeyReqs`), запись находится по остальным колонкам и удаляется — это означает, что значение было очищено в источнике, и копия в базе тоже должна исчезнуть.

Но та правка явно исключила режим `getParent` (`!$getParent`), потому что в этом режиме первая колонка — не значение, а ссылка на родителя:

```php
if(count($keyReqsForDelete) && !$getParent){ ... }
```

В подчинённых таблицах с `autoParent` также могут быть уникальные записи — проверка уникальности учитывает id родителя (записи уникальны в пределах родителя). У корневых записей родитель — `1`, но работает всё так же. Это означает, что и в `getParent`-режиме нужно удалять запись с очищенным значением — просто значение находится во **второй колонке** файла, а не в первой.

## Решение

В `Get_block_data` сразу после `array_shift($object)` внутри ветки `if($getParent)` добавлен симметричный блок:

1. На этом моменте родитель уже разрешён (либо найден по первой колонке, либо создан через `createParent`), а `$object[0]` теперь содержит собственное значение записи (бывшая вторая колонка).
2. Если оно пустое (`$object[0] === ""`) и у типа есть составной ключ (`$keyReqsForDelete` — переменная уже вычислена выше из #2522), собирается `keyValuesForDelete` из колонок `$object[1..N]` тем же способом, что и в основном пути уникальности.
3. Вызывается `FindUniqueRecordDuplicate($id, 0, $parent, "", $keyValuesForDelete, false)` — параметр `up=$parent` использует уже разрешённый id родителя, что даёт корректную область поиска уникальности; `includeVal=false` отключает фильтр `obj.val='...'`, поскольку основное значение пустое.
4. Если запись найдена — `Delete($existingRow["id"])`, в `$GLOBALS["warning"]` добавляется сообщение об удалении, итератор пропускает остаток цикла через `continue`.

Если значение не пустое или у типа нет ключа уникальности — поведение прежнее. Случай с пустой первой колонкой (без разрешимого родителя) по-прежнему обрабатывается верхней веткой `if($object[0] == "")` и остаётся "пропустить с предупреждением", потому что без родителя нечем ограничить поиск.

## Как воспроизвести

1. Создать тип-родителя (например, "Компания") и подчинённый тип, у которого как минимум один реквизит помечен как часть составного ключа (`attrs.key = true`).
2. Импортировать через CSV с `autoParent` строки вида `ParentName;Value;Req1;Req2` — записи создаются под нужным родителем.
3. До исправления: повторный импорт строки с очищенной второй колонкой (`ParentName;;Req1;Req2`) → запись остаётся в базе, в источнике её уже нет.
4. После исправления: запись находится по составному ключу под разрешённым родителем и удаляется.

## Тест

`experiments/test-issue-2524-getparent-empty-value-delete-by-unique-key.php` — семь сценариев, повторяя пост-`array_shift` логику с моками `Delete` и `FindUniqueRecordDuplicate`:

1. `getParent` + пустое значение + составной ключ + найдено совпадение → `Delete()` вызывается с правильным id, `FindUniqueRecordDuplicate` получает `includeVal=false` и `up=$resolvedParent`.
2. `getParent` + пустое значение + составной ключ + совпадения нет → `Delete` не вызывается, поиск всё равно идёт под разрешённым родителем.
3. `getParent` + пустое значение + нет ключа уникальности → ни поиск, ни удаление не запускаются (старое поведение для не-уникальных типов).
4. `getParent` + пустое значение + все ключевые колонки тоже пусты → `FindUniqueRecordDuplicate` короткозамыкает на `false`, удаления нет.
5. `getParent` + непустое значение → новый блок не активируется, идёт обычный путь импорта.
6. `getParent` + ключ только из value-реквизита (без ref) + совпадение → `Delete()` вызывается.
7. `getParent` + корневой `parent=1` → удаление работает так же, как для дочерних родителей.

```
php experiments/test-issue-2524-getparent-empty-value-delete-by-unique-key.php
# => All tests passed for issue-2524.
```

Существующие смежные тесты по-прежнему проходят:

```
php experiments/test-issue-2522-empty-value-delete-by-unique-key.php           # PASS
php experiments/test-issue-2520-composite-key-without-first-column-unique.php  # PASS
php experiments/test-issue-2510-unique-key-date-format.php                     # PASS
php experiments/test-issue-2490-field-key-attrs.php                            # PASS
php -l index.php                                                               # No syntax errors
```