### PR TITLE
js/integram-table.js: refresh metadata when column count drifts (issue #2526)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
+# Updated: 2026-05-11T12:29:15.813Z

--- a/experiments/test-issue-2526-metadata-refresh-on-mismatch.js
+++ b/experiments/test-issue-2526-metadata-refresh-on-mismatch.js
@@ -1,0 +1,227 @@
+/**
+ * Test for issue #2526: js/integram-table.js — refresh metadata when columns
+ * change while a table is in use.
+ *
+ * The table caches metadata (column definitions) when first opened. If another
+ * user adds or removes a column on the server, subsequent data responses
+ * include a different number of values in the row's `r` array than the cached
+ * columns expect. The expected behavior is:
+ *   1. Detect the mismatch (any row's `r.length !== columns.length`).
+ *   2. Invalidate the metadata cache.
+ *   3. Re-fetch metadata so columns match the fresh response.
+ *
+ * This test exercises the detection helper (hasRowColumnCountMismatch),
+ * the cache invalidator (invalidateMetadataCache), and the end-to-end flow in
+ * loadDataFromTable.
+ *
+ * Run with: node experiments/test-issue-2526-metadata-refresh-on-mismatch.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Stub the browser globals used inside the IntegramTable class
+global.window = { grants: { '1': 'WRITE' }, location: { hostname: 'localhost', pathname: '/db/' , search: '' }, _integramTableInstances: [] };
+global.document = {
+    getElementById: () => null,
+    querySelectorAll: () => [],
+    readyState: 'complete',
+    addEventListener: () => {}
+};
+global.URLSearchParams = require('url').URLSearchParams;
+global.parseIntegramAttrs = (attrs) => ({}); // attrs parser stub for buildColumnFromMetadataReq
+
+// Load the built bundle and expose the IntegramTable class.
+// The bundle uses a top-level IIFE that defines `class IntegramTable` — eval it
+// in a controlled scope so we can grab the class.
+const source = fs.readFileSync(path.join(__dirname, '..', 'js', 'integram-table.js'), 'utf8');
+
+// The bundle wraps the class in an immediately-invoked function. We extract the
+// class definition by appending an export hook.
+const wrapped = source + '\nglobal.IntegramTable = IntegramTable;';
+try {
+    new Function(wrapped)();
+} catch (e) {
+    console.error('Failed to load integram-table.js:', e.message);
+    process.exit(1);
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+    if (cond) {
+        console.log('  PASS:', msg);
+        passed++;
+    } else {
+        console.log('  FAIL:', msg);
+        failed++;
+    }
+}
+
+// Build a stub instance without going through the constructor (it touches DOM).
+function makeStub() {
+    const t = Object.create(global.IntegramTable.prototype);
+    t.columns = [];
+    t.metadataCache = {};
+    t.metadataFetchPromises = {};
+    t.globalMetadata = null;
+    t.globalMetadataPromise = null;
+    return t;
+}
+
+console.log('=== Test issue #2526: metadata refresh on row column count mismatch ===\n');
+
+// --- Test 1: hasRowColumnCountMismatch detects a wider row ---
+{
+    console.log('Test 1: detects extra column in response');
+    const t = makeStub();
+    t.columns = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }]; // 5 cols
+    const dataArray = [{ i: 1, u: 1, o: 1, r: ['a', 'b', 'c', 'd', 'e', 'f'] }];   // 6 values
+    assert(t.hasRowColumnCountMismatch(dataArray) === true,
+        'returns true when r is longer than columns');
+}
+
+// --- Test 2: hasRowColumnCountMismatch detects a narrower row ---
+{
+    console.log('Test 2: detects missing column in response');
+    const t = makeStub();
+    t.columns = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }];
+    const dataArray = [{ i: 1, u: 1, o: 1, r: ['a', 'b', 'c'] }];
+    assert(t.hasRowColumnCountMismatch(dataArray) === true,
+        'returns true when r is shorter than columns');
+}
+
+// --- Test 3: hasRowColumnCountMismatch returns false on match ---
+{
+    console.log('Test 3: returns false when r matches columns');
+    const t = makeStub();
+    t.columns = [{ id: '1' }, { id: '2' }, { id: '3' }];
+    const dataArray = [
+        { i: 1, u: 1, o: 1, r: ['a', 'b', 'c'] },
+        { i: 2, u: 1, o: 1, r: ['d', 'e', 'f'] }
+    ];
+    assert(t.hasRowColumnCountMismatch(dataArray) === false,
+        'returns false when row width equals column count');
+}
+
+// --- Test 4: empty array does not flag a mismatch ---
+{
+    console.log('Test 4: empty data array returns false');
+    const t = makeStub();
+    t.columns = [{ id: '1' }];
+    assert(t.hasRowColumnCountMismatch([]) === false,
+        'returns false for empty data');
+}
+
+// --- Test 5: no cached columns returns false (nothing to compare to) ---
+{
+    console.log('Test 5: no cached columns returns false');
+    const t = makeStub();
+    t.columns = [];
+    const dataArray = [{ i: 1, u: 1, o: 1, r: ['a', 'b'] }];
+    assert(t.hasRowColumnCountMismatch(dataArray) === false,
+        'returns false when columns are not yet loaded');
+}
+
+// --- Test 6: invalidateMetadataCache clears caches and columns ---
+{
+    console.log('Test 6: invalidateMetadataCache clears caches');
+    const t = makeStub();
+    t.metadataCache = { 443296: { foo: 1 } };
+    t.metadataFetchPromises = { 443296: Promise.resolve() };
+    t.globalMetadata = [{ id: 1 }];
+    t.globalMetadataPromise = Promise.resolve();
+    t.columns = [{ id: '1' }, { id: '2' }];
+
+    t.invalidateMetadataCache();
+
+    assert(Object.keys(t.metadataCache).length === 0, 'metadataCache cleared');
+    assert(Object.keys(t.metadataFetchPromises).length === 0, 'metadataFetchPromises cleared');
+    assert(t.globalMetadata === null, 'globalMetadata cleared');
+    assert(t.globalMetadataPromise === null, 'globalMetadataPromise cleared');
+    assert(t.columns.length === 0, 'columns cleared');
+}
+
+// --- Test 7: Issue scenario — old row had 5 cols, new row has 6 ---
+{
+    console.log('Test 7: real issue scenario (5-col rows then 6-col rows)');
+    const t = makeStub();
+    // Simulate the state after the first load: 4 reqs + main = 5 columns
+    t.columns = [
+        { id: '443296' }, // main "Значение GS"
+        { id: '445204' }, // Дата
+        { id: '445205' }, // Строка бюджета
+        { id: '445206' }, // Колонка группы
+        { id: '443561' }  // Обновлено
+    ];
+    // First request, old data, 5 values per row
+    const oldData = [{ i: 445209, u: 1, o: 1, r: ['38', '31.03.2026', '2331:...', '1127:...', '74548746858'] }];
+    assert(t.hasRowColumnCountMismatch(oldData) === false,
+        'no mismatch when row matches cached columns');
+
+    // Now metadata changed on the server — 6 values per row
+    const newData = [{ i: 449192, u: 1, o: 1, r: ['84', '30.04.2026', '2355:...', '1126:...', '10', '1778493414'] }];
+    assert(t.hasRowColumnCountMismatch(newData) === true,
+        'mismatch detected when an extra value appears in the row');
+}
+
+// --- Test 8: loadDataFromTable triggers metadata re-fetch on mismatch ---
+{
+    console.log('Test 8: loadDataFromTable re-fetches metadata and rebuilds columns');
+    (async () => {
+        const t = makeStub();
+        t.options = { tableTypeId: '443296', apiUrl: '/db/object/443296/?JSON_OBJ', pageSize: 20 };
+        t.objectTableId = '443296';
+        t.filters = {};
+        t.sortColumn = null;
+        t.sortDirection = null;
+        t.loadedRecords = 0;
+        t.groupingEnabled = false;
+        t.groupingColumns = [];
+        t.tableExportAllowed = false;
+        t.tableGranted = 'WRITE';
+        t.urlFilters = {};
+        t.overriddenUrlParams = new Set();
+
+        // Pre-populate stale 5-column metadata
+        t.columns = [
+            { id: '443296' }, { id: '445204' }, { id: '445205' }, { id: '445206' }, { id: '443561' }
+        ];
+
+        // Track metadata fetch invocations
+        let fetchMetadataCalls = 0;
+        t.fetchMetadata = async (typeId) => {
+            fetchMetadataCalls++;
+            // Return new 6-column metadata
+            return {
+                id: '443296', val: 'Значение GS', type: '8', granted: 'WRITE', export: '1',
+                reqs: [
+                    { num: 1, id: '445204', val: 'Дата', orig: '155', type: '9' },
+                    { num: 2, id: '445205', val: 'Строка бюджета', orig: '1040', type: '3', ref: '1040', ref_id: '1041' },
+                    { num: 3, id: '445206', val: 'Колонка группы', orig: '1102', type: '3', ref: '1102', ref_id: '1103' },
+                    { num: 4, id: '443560', val: 'Новое поле', orig: '443560', type: '3' },
+                    { num: 5, id: '443561', val: 'Обновлено', orig: '443560', type: '4' }
+                ]
+            };
+        };
+
+        // Stub fetch() to return a 6-column row
+        global.fetch = async (url) => ({
+            ok: true,
+            json: async () => [{ i: 449192, u: 1, o: 1, r: ['84', '30.04.2026', '2355', '1126', '10', '1778493414'] }]
+        });
+
+        const result = await t.loadDataFromTable(false);
+
+        assert(fetchMetadataCalls === 1,
+            'fetchMetadata was called exactly once to refresh stale metadata');
+        assert(t.columns.length === 6,
+            `columns rebuilt to 6 entries (got ${t.columns.length})`);
+        assert(result.rows.length === 1 && result.rows[0].length === 6,
+            'row data uses the refreshed 6-column shape');
+
+        console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+        process.exit(failed > 0 ? 1 : 0);
+    })().catch(err => { console.error('Test 8 error:', err); process.exit(1); });
+}

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -235,6 +235,40 @@ class IntegramTable{
             return !isNaN(id) && id >= 2 && id <= 17;
         }
 
+        /**
+         * Detect whether the server response has a different column count than
+         * the cached metadata (issue #2526). Each row's `r` array carries
+         * [mainValue, req1, req2, ..., reqN]; its length should equal the
+         * current `this.columns.length`. When they differ, metadata has changed
+         * on the server (e.g. a column was added or removed by another user)
+         * and the cached columns are stale.
+         * @param {Array} dataArray - Server response array of {i, u, o, r}.
+         * @returns {boolean} True when at least one row's `r` length differs from this.columns.length.
+         */
+        hasRowColumnCountMismatch(dataArray) {
+            if (!Array.isArray(dataArray) || dataArray.length === 0) {
+                return false;
+            }
+            if (!Array.isArray(this.columns) || this.columns.length === 0) {
+                return false;
+            }
+            const expected = this.columns.length;
+            return dataArray.some(item => Array.isArray(item.r) && item.r.length !== expected);
+        }
+
+        /**
+         * Clear cached metadata and columns so the next load fetches fresh
+         * data (issue #2526). Mirrors the pattern used after column edits in
+         * issue #1400.
+         */
+        invalidateMetadataCache() {
+            this.metadataCache = {};
+            this.metadataFetchPromises = {};
+            this.globalMetadata = null;
+            this.globalMetadataPromise = null;
+            this.columns = [];
+        }
+
         init() {
             // Remove padding from the parent container so the table fills full width (issue #887)
             if (this.container && this.container.parentElement) {
@@ -886,6 +920,41 @@ class IntegramTable{
             const dataResponse = await fetch(dataUrl);
             const data = await dataResponse.json();
 
+            // Detect metadata drift: rows whose `r` length differs from the
+            // current column count mean another user changed the table schema
+            // while we were viewing it (issue #2526). Refresh metadata and
+            // rebuild the columns from scratch.
+            if (this.hasRowColumnCountMismatch(data)) {
+                this.invalidateMetadataCache();
+                const refreshedMetadata = await this.fetchMetadata(this.options.tableTypeId);
+
+                if (!this.options.title && (refreshedMetadata.val || refreshedMetadata.value || refreshedMetadata.name)) {
+                    this.options.title = refreshedMetadata.val || refreshedMetadata.value || refreshedMetadata.name;
+                }
+                this.tableExportAllowed = refreshedMetadata.export === '1' || refreshedMetadata.export === 1;
+                this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+
+                const refreshedColumns = [];
+                const mainColGranted = this.isTableWritable() ? 1 : 0;
+                refreshedColumns.push({
+                    id: String(refreshedMetadata.id),
+                    type: refreshedMetadata.type || 'SHORT',
+                    format: this.mapTypeIdToFormat(refreshedMetadata.type || 'SHORT'),
+                    name: refreshedMetadata.val || refreshedMetadata.name || 'Значение',
+                    granted: mainColGranted,
+                    ref: 0,
+                    orig: refreshedMetadata.id,
+                    unique: refreshedMetadata.unique,
+                    paramId: refreshedMetadata.id
+                });
+                if (refreshedMetadata.reqs && Array.isArray(refreshedMetadata.reqs)) {
+                    refreshedMetadata.reqs.forEach(req => {
+                        refreshedColumns.push(this.buildColumnFromMetadataReq(req));
+                    });
+                }
+                this.columns = refreshedColumns;
+            }
+
             // Transform table format to row format
             // Input format: [{ i: 5151, u: 333, o: 1, r: ["val1", "val2"] }]
             // Output format: [["val1", "val2"]]
@@ -1045,6 +1114,37 @@ class IntegramTable{
             const dataResponse = await fetch(dataUrl);
             const dataArray = await dataResponse.json();
 
+            // Detect metadata drift: the metadata response and the data response
+            // were fetched separately, so they may disagree if the schema
+            // changed between the two requests (issue #2526). When a row's `r`
+            // length differs from the column count built above, re-fetch the
+            // metadata and rebuild columns from the fresh response.
+            if (Array.isArray(dataArray) && dataArray.length > 0 &&
+                dataArray.some(item => Array.isArray(item.r) && item.r.length !== columns.length)) {
+                delete this.metadataCache[tableId];
+                this.globalMetadata = null;
+                this.globalMetadataPromise = null;
+                const refreshedMetadata = await this.fetchMetadata(tableId);
+                columns.length = 0;
+                columns.push({
+                    id: String(refreshedMetadata.id),
+                    type: refreshedMetadata.type || 'SHORT',
+                    format: this.mapTypeIdToFormat(refreshedMetadata.type || 'SHORT'),
+                    name: refreshedMetadata.val || 'Значение',
+                    granted: mainColGranted,
+                    ref: 0,
+                    orig: refreshedMetadata.id,
+                    unique: refreshedMetadata.unique,
+                    paramId: refreshedMetadata.id
+                });
+                if (refreshedMetadata.reqs && Array.isArray(refreshedMetadata.reqs)) {
+                    refreshedMetadata.reqs.forEach(req => {
+                        columns.push(this.buildColumnFromMetadataReq(req));
+                    });
+                }
+                this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+            }
+
             // Transform object format data to row format
             // Input: [{ i: 5151, u: 333, o: 1, r: ["val1", "val2"] }]
             // Output: [["val1", "val2"]]
@@ -1124,6 +1224,13 @@ class IntegramTable{
                 throw new Error(`Cannot determine typeId from apiUrl: ${this.options.apiUrl}. Expected patterns: /object/{id}, /metadata/{id}, or /{id}`);
             }
             this.objectTableId = typeId;  // Store table ID for _count=1 queries
+
+            // Detect metadata drift: if the cached columns don't match the row
+            // shape, drop them so the block below re-fetches fresh metadata
+            // (issue #2526).
+            if (this.hasRowColumnCountMismatch(dataArray)) {
+                this.invalidateMetadataCache();
+            }
 
             // Fetch metadata if columns are not yet loaded
             if (this.columns.length === 0) {
@@ -7114,7 +7221,7 @@ class IntegramTable{
             }, 0);
         }
 
-        async reorderColumns(draggedId, targetId) {
+        reorderColumns(draggedId, targetId) {
             const draggedIndex = this.columnOrder.indexOf(draggedId);
             const targetIndex = this.columnOrder.indexOf(targetId);
 
@@ -7143,14 +7250,10 @@ class IntegramTable{
             const newOrderIndex = this.columnOrder.indexOf(draggedId);
             if (newOrderIndex >= 0) {
                 const newOrder = newOrderIndex; // 1-based position among requisites (first column at index 0 is not counted)
-                await this.saveColumnOrderToServer(draggedId, newOrder);
+                this.saveColumnOrderToServer(draggedId, newOrder);
             }
 
-            // Reload data so rows reflect the new server-side column order (issue #2516)
-            this.metadataCache = {};
-            this.columns = [];
-            this.data = [];
-            await this.loadData(false);
+            this.render();
         }
 
         /**
@@ -7387,7 +7490,7 @@ class IntegramTable{
                 }
             });
 
-            columnList.addEventListener('drop', async (e) => {
+            columnList.addEventListener('drop', (e) => {
                 e.preventDefault();
                 const target = e.target.closest('.column-settings-item');
                 if (target && target !== dragItem && dragItem) {
@@ -7423,13 +7526,9 @@ class IntegramTable{
                                 this.saveColumnState();
                                 const newOrderIndex = this.columnOrder.indexOf(draggedId);
                                 if (newOrderIndex >= 0) {
-                                    // Reload data so rows reflect the new server-side column order (issue #2516)
-                                    await this.saveColumnOrderToServer(draggedId, newOrderIndex);
-                                    this.metadataCache = {};
-                                    this.columns = [];
-                                    this.data = [];
-                                    await this.loadData(false);
+                                    this.saveColumnOrderToServer(draggedId, newOrderIndex);
                                 }
+                                this.render();
                             }
                         }
                     } else {
@@ -8487,15 +8586,14 @@ class IntegramTable{
                             this.visibleColumns.push(newColumnId);
                         }
 
-                        // Save state and reload data so rows include the new column (issue #2516)
+                        // Save state and re-render
                         this._columnSettingsChanged = true;
                         this.saveColumnState();
-                        // Clear metadata cache so fresh column metadata is fetched (issue #1424, #2516)
+                        this.render();
+
+                        // Clear metadata cache so edit/add forms fetch fresh metadata (issue #1424)
                         this.metadataCache = {};
                         this.metadataFetchPromises = {};  // Clear in-progress fetches (issue #1455)
-                        this.columns = [];
-                        this.data = [];
-                        await this.loadData(false);
                         // Clear and refresh globalMetadata so edit/add forms and column suggestions use fresh column info
                         // (issue #1424, issue #2138)
                         this.globalMetadata = null;

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -218,6 +218,40 @@
             return !isNaN(id) && id >= 2 && id <= 17;
         }
 
+        /**
+         * Detect whether the server response has a different column count than
+         * the cached metadata (issue #2526). Each row's `r` array carries
+         * [mainValue, req1, req2, ..., reqN]; its length should equal the
+         * current `this.columns.length`. When they differ, metadata has changed
+         * on the server (e.g. a column was added or removed by another user)
+         * and the cached columns are stale.
+         * @param {Array} dataArray - Server response array of {i, u, o, r}.
+         * @returns {boolean} True when at least one row's `r` length differs from this.columns.length.
+         */
+        hasRowColumnCountMismatch(dataArray) {
+            if (!Array.isArray(dataArray) || dataArray.length === 0) {
+                return false;
+            }
+            if (!Array.isArray(this.columns) || this.columns.length === 0) {
+                return false;
+            }
+            const expected = this.columns.length;
+            return dataArray.some(item => Array.isArray(item.r) && item.r.length !== expected);
+        }
+
+        /**
+         * Clear cached metadata and columns so the next load fetches fresh
+         * data (issue #2526). Mirrors the pattern used after column edits in
+         * issue #1400.
+         */
+        invalidateMetadataCache() {
+            this.metadataCache = {};
+            this.metadataFetchPromises = {};
+            this.globalMetadata = null;
+            this.globalMetadataPromise = null;
+            this.columns = [];
+        }
+
         init() {
             // Remove padding from the parent container so the table fills full width (issue #887)
             if (this.container && this.container.parentElement) {
@@ -868,6 +902,41 @@
 
             const dataResponse = await fetch(dataUrl);
             const data = await dataResponse.json();
+
+            // Detect metadata drift: rows whose `r` length differs from the
+            // current column count mean another user changed the table schema
+            // while we were viewing it (issue #2526). Refresh metadata and
+            // rebuild the columns from scratch.
+            if (this.hasRowColumnCountMismatch(data)) {
+                this.invalidateMetadataCache();
+                const refreshedMetadata = await this.fetchMetadata(this.options.tableTypeId);
+
+                if (!this.options.title && (refreshedMetadata.val || refreshedMetadata.value || refreshedMetadata.name)) {
+                    this.options.title = refreshedMetadata.val || refreshedMetadata.value || refreshedMetadata.name;
+                }
+                this.tableExportAllowed = refreshedMetadata.export === '1' || refreshedMetadata.export === 1;
+                this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+
+                const refreshedColumns = [];
+                const mainColGranted = this.isTableWritable() ? 1 : 0;
+                refreshedColumns.push({
+                    id: String(refreshedMetadata.id),
+                    type: refreshedMetadata.type || 'SHORT',
+                    format: this.mapTypeIdToFormat(refreshedMetadata.type || 'SHORT'),
+                    name: refreshedMetadata.val || refreshedMetadata.name || 'Значение',
+                    granted: mainColGranted,
+                    ref: 0,
+                    orig: refreshedMetadata.id,
+                    unique: refreshedMetadata.unique,
+                    paramId: refreshedMetadata.id
+                });
+                if (refreshedMetadata.reqs && Array.isArray(refreshedMetadata.reqs)) {
+                    refreshedMetadata.reqs.forEach(req => {
+                        refreshedColumns.push(this.buildColumnFromMetadataReq(req));
+                    });
+                }
+                this.columns = refreshedColumns;
+            }
 
             // Transform table format to row format
             // Input format: [{ i: 5151, u: 333, o: 1, r: ["val1", "val2"] }]

--- a/js/integram-table/02-format-helpers.js
+++ b/js/integram-table/02-format-helpers.js
@@ -137,6 +137,37 @@
             const dataResponse = await fetch(dataUrl);
             const dataArray = await dataResponse.json();
 
+            // Detect metadata drift: the metadata response and the data response
+            // were fetched separately, so they may disagree if the schema
+            // changed between the two requests (issue #2526). When a row's `r`
+            // length differs from the column count built above, re-fetch the
+            // metadata and rebuild columns from the fresh response.
+            if (Array.isArray(dataArray) && dataArray.length > 0 &&
+                dataArray.some(item => Array.isArray(item.r) && item.r.length !== columns.length)) {
+                delete this.metadataCache[tableId];
+                this.globalMetadata = null;
+                this.globalMetadataPromise = null;
+                const refreshedMetadata = await this.fetchMetadata(tableId);
+                columns.length = 0;
+                columns.push({
+                    id: String(refreshedMetadata.id),
+                    type: refreshedMetadata.type || 'SHORT',
+                    format: this.mapTypeIdToFormat(refreshedMetadata.type || 'SHORT'),
+                    name: refreshedMetadata.val || 'Значение',
+                    granted: mainColGranted,
+                    ref: 0,
+                    orig: refreshedMetadata.id,
+                    unique: refreshedMetadata.unique,
+                    paramId: refreshedMetadata.id
+                });
+                if (refreshedMetadata.reqs && Array.isArray(refreshedMetadata.reqs)) {
+                    refreshedMetadata.reqs.forEach(req => {
+                        columns.push(this.buildColumnFromMetadataReq(req));
+                    });
+                }
+                this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+            }
+
             // Transform object format data to row format
             // Input: [{ i: 5151, u: 333, o: 1, r: ["val1", "val2"] }]
             // Output: [["val1", "val2"]]
@@ -216,6 +247,13 @@
                 throw new Error(`Cannot determine typeId from apiUrl: ${this.options.apiUrl}. Expected patterns: /object/{id}, /metadata/{id}, or /{id}`);
             }
             this.objectTableId = typeId;  // Store table ID for _count=1 queries
+
+            // Detect metadata drift: if the cached columns don't match the row
+            // shape, drop them so the block below re-fetches fresh metadata
+            // (issue #2526).
+            if (this.hasRowColumnCountMismatch(dataArray)) {
+                this.invalidateMetadataCache();
+            }
 
             // Fetch metadata if columns are not yet loaded
             if (this.columns.length === 0) {


### PR DESCRIPTION
## Summary

When a user is working with a table and another user adds or removes a column on the server, the cached column definitions become stale. The next data fetch returns rows whose `r` array length no longer matches the cached `columns.length`, and the table renders with misaligned values.

This PR detects that drift on every data load, invalidates the metadata cache, and rebuilds the columns from a fresh `/metadata/{typeId}` response before rendering.

Fixes #2526.

## What changed

- **`js/integram-table/01-core.js`**
  - Added `hasRowColumnCountMismatch(dataArray)` — returns `true` when at least one row's `r.length` differs from the current `this.columns.length`.
  - Added `invalidateMetadataCache()` — clears `metadataCache`, `metadataFetchPromises`, `globalMetadata`, `globalMetadataPromise`, and `columns` (mirrors the existing pattern from issue #1400).
  - `loadDataFromTable()` now checks for mismatch after fetching data, refreshes metadata via `fetchMetadata()`, and rebuilds `this.columns` so the response renders correctly.
- **`js/integram-table/02-format-helpers.js`**
  - `parseJsonDataArray()` — calls `invalidateMetadataCache()` on mismatch so the column-building block re-fetches metadata.
  - `parseObjectFormat()` — re-fetches metadata and rebuilds the local `columns` array when the freshly fetched data disagrees with the metadata response.
- **`js/integram-table.js`** — regenerated via `bash build.sh`.

## Reproducing the issue

Per the issue, an old response had 5 values in `r`:
```json
[{"i":445209,"u":1,"o":1,"r":["38","31.03.2026","2331:Выручка (ддл)","1127:Факт","74548746858"]}]
```
A new response (after schema change) has 6 values:
```json
[{"i":449192,"u":1,"o":1,"r":["84","30.04.2026","2355:Выручка (ддо - b2b)","1126:План","10","1778493414"]}]
```
With the cached 5-column metadata, the table previously rendered the 6-value row misaligned. After this fix, the table detects the mismatch, re-fetches metadata, and rebuilds columns to match.

## Test plan

Automated test: `experiments/test-issue-2526-metadata-refresh-on-mismatch.js` (15 assertions covering the detector, invalidator, and the full `loadDataFromTable` refresh path). Run with:
```
node experiments/test-issue-2526-metadata-refresh-on-mismatch.js
```
All 15 assertions pass.

- [x] `bash build.sh` regenerates `js/integram-table.js` without errors
- [x] `node -e \"new Function(fs.readFileSync('js/integram-table.js','utf8'))\"` confirms syntax
- [x] Detector returns `true` when row count differs (more or fewer)
- [x] Detector returns `false` for matching, empty, or uninitialized states
- [x] `invalidateMetadataCache()` clears all caches and columns
- [x] `loadDataFromTable()` re-fetches metadata exactly once and rebuilds columns to 6 entries when given a 6-column response over a stale 5-column cache