### PR TITLE
google_sheets_sync.php: добавить имя листа google sheets в BKI-формат и подчинить ему строки

### DIFF
--- a/experiments/test-issue-2450-google-sheets-sync.php
+++ b/experiments/test-issue-2450-google-sheets-sync.php
@@ -42,10 +42,10 @@ assertSameValue(['2025'], $records[1]['columns'], 'matches scalar column matcher
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;4;1773328460;\r\n"
-    . "89;;Выручка (ддо - b2b);2025;4;1773328460;\r\n";
+    . "Выручка (ддо - b2b);123\\:45\\;6\\,7;31.01.2026;Выручка (ддо - b2b);ПЛАН;4;1773328460;\r\n"
+    . "Выручка (ддо - b2b);89;;Выручка (ддо - b2b);2025;4;1773328460;\r\n";
 
-assertSameValue($expected, $content, 'builds DATA-prefixed BKI content in value/date/row/column/sheet_row_number/timestamp format and escapes delimiters');
+assertSameValue($expected, $content, 'builds DATA-prefixed BKI content in sheet/value/date/row/column/sheet_row_number/timestamp format and escapes delimiters');
 assertTrueValue(gss_pattern_matches('*.2026', '31.01.2026'), 'asterisk mask matches arbitrary leading text');
 assertTrueValue(gss_pattern_matches('ПЛ*', 'ПЛАН'), 'asterisk mask matches arbitrary trailing text');
 assertTrueValue(!gss_pattern_matches('2026', '2025'), 'exact matcher does not match different value');

--- a/experiments/test-issue-2456-google-sheets-sync-rules.php
+++ b/experiments/test-issue-2456-google-sheets-sync-rules.php
@@ -54,12 +54,12 @@ assertSameIssue2456('13', $records[4]['value'], 'captures the value under the ne
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "10;;Metric A;PLAN;4;1773328460;\r\n"
-    . "20;;Metric B;PLAN;5;1773328460;\r\n"
-    . "11;;Metric A;PLAN;6;1773328460;\r\n"
-    . "12;;Metric A;PLAN;10;1773328460;\r\n"
-    . "13;;Metric A;PLAN;10;1773328460;\r\n";
+    . "Rules;10;;Metric A;PLAN;4;1773328460;\r\n"
+    . "Rules;20;;Metric B;PLAN;5;1773328460;\r\n"
+    . "Rules;11;;Metric A;PLAN;6;1773328460;\r\n"
+    . "Rules;12;;Metric A;PLAN;10;1773328460;\r\n"
+    . "Rules;13;;Metric A;PLAN;10;1773328460;\r\n";
 
-assertSameIssue2456($expected, $content, 'builds BKI content with value/date/row/column/sheet_row_number/timestamp fields');
+assertSameIssue2456($expected, $content, 'builds BKI content with sheet/value/date/row/column/sheet_row_number/timestamp fields');
 
 echo "PASS issue 2456 Google Sheets sync row rules\n";

--- a/experiments/test-issue-2469-google-sheets-sync-format.php
+++ b/experiments/test-issue-2469-google-sheets-sync-format.php
@@ -34,8 +34,8 @@ assertSameIssue2469('ПЛАН', $records[0]['column'], 'uses the lowest matched 
 
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "900;01.01.2026;Region West;ПЛАН;4;1773328460;\r\n";
+    . "NewFormat;900;01.01.2026;Region West;ПЛАН;4;1773328460;\r\n";
 
-assertSameIssue2469($expected, $content, 'builds value/date/row/column/sheet_row_number/timestamp import lines');
+assertSameIssue2469($expected, $content, 'builds sheet/value/date/row/column/sheet_row_number/timestamp import lines');
 
 echo "PASS issue 2469 Google Sheets sync output format\n";

--- a/experiments/test-issue-2512-bki-trailing-semicolon.php
+++ b/experiments/test-issue-2512-bki-trailing-semicolon.php
@@ -67,13 +67,14 @@ if (count($object) <= $typesCount) {
 
 ok($line0ExtraReads === 0, "Record 0 reads 0 extra lines (got $line0ExtraReads)");
 
-// The Обновлено field (object[4]) must be the clean timestamp, not contaminated by record 1
-$obnovleno = isset($object[4]) ? rtrim($object[4], "\t\n\r\0\x0B") : '';
+// The Обновлено field (object[6]) must be the clean timestamp, not contaminated by record 1
+// Format: sheet(0);value(1);date(2);row(3);column(4);sheet_row_number(5);timestamp(6);
+$obnovleno = isset($object[6]) ? rtrim($object[6], "\t\n\r\0\x0B") : '';
 ok($obnovleno === '1774970163', "Record 0: Обновлено = '1774970163' (got '$obnovleno')");
 
-$contaminated = $line0ExtraReads > 0 && isset($object[4]) && strpos($object[4], "\r\n") !== false;
+$contaminated = $line0ExtraReads > 0 && isset($object[6]) && strpos($object[6], "\r\n") !== false;
 if ($contaminated) {
-    fwrite(STDERR, "  BUG: Record 0's Обновлено field contains next record's data: " . json_encode($object[4]) . "\n");
+    fwrite(STDERR, "  BUG: Record 0's Обновлено field contains next record's data: " . json_encode($object[6]) . "\n");
 }
 
 echo "\n=== Results: $passed passed, $failed failed ===\n\n";

--- a/experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
+++ b/experiments/test-issue-2514-google-sheets-sync-trailing-semicolon.php
@@ -22,9 +22,9 @@ $records = [
 
 $content = gss_build_bki_content($records, 1000000000);
 
-// Each data line must end with a semicolon: value;date;row;column;sheet_row_number;timestamp;
+// Each data line must end with a semicolon: sheet;value;date;row;column;sheet_row_number;timestamp;
 $expected = "DATA\r\n"
-    . "TestValue;01.01.2026;Row A;Col B;;1000000000;\r\n";
+    . ";TestValue;01.01.2026;Row A;Col B;;1000000000;\r\n";
 
 assertSameIssue2514($expected, $content, 'each BKI data line ends with a trailing semicolon');
 

--- a/experiments/test-issue-2518-google-sheets-row-number.php
+++ b/experiments/test-issue-2518-google-sheets-row-number.php
@@ -49,22 +49,22 @@ $records2 = gss_extract_sheet_records(
 assertSameIssue2518(1, count($records2), 'extracts 1 record with range offset');
 assertSameIssue2518(6, $records2[0]['sheet_row_number'], 'sheet_row_number is 6 when rangeStartRow=4 and rowIndex=1');
 
-// Test 3: BKI output includes sheet_row_number between column and timestamp
+// Test 3: BKI output includes sheet name as first column and sheet_row_number between column and timestamp
 $content = gss_build_bki_content($records, 1773328460);
 $expected = "DATA\r\n"
-    . "123;31.01.2026;Выручка;ПЛАН;4;1773328460;\r\n"
-    . "89;;Выручка;2025;4;1773328460;\r\n";
+    . "TestSheet;123;31.01.2026;Выручка;ПЛАН;4;1773328460;\r\n"
+    . "TestSheet;89;;Выручка;2025;4;1773328460;\r\n";
 
-assertSameIssue2518($expected, $content, 'BKI output includes sheet_row_number as {value};{date};{row};{column};{sheet_row_number};{timestamp};');
+assertSameIssue2518($expected, $content, 'BKI output includes sheet name as {sheet};{value};{date};{row};{column};{sheet_row_number};{timestamp};');
 
 // Test 4: BKI output with range offset
 $content2 = gss_build_bki_content($records2, 1773328460);
 $expected2 = "DATA\r\n"
-    . "89;;Выручка;2025;6;1773328460;\r\n";
+    . "TestSheet;89;;Выручка;2025;6;1773328460;\r\n";
 
 assertSameIssue2518($expected2, $content2, 'BKI output uses correct sheet_row_number with range offset');
 
-// Test 5: record without sheet_row_number (backward compat) produces empty field
+// Test 5: record without sheet or sheet_row_number (backward compat) produces empty fields
 $manualRecord = [
     'value' => 'Val',
     'date' => '01.01.2026',
@@ -75,8 +75,8 @@ $manualRecord = [
 ];
 $content3 = gss_build_bki_content([$manualRecord], 12345);
 $expected3 = "DATA\r\n"
-    . "Val;01.01.2026;Row;Col;;12345;\r\n";
+    . ";Val;01.01.2026;Row;Col;;12345;\r\n";
 
-assertSameIssue2518($expected3, $content3, 'record without sheet_row_number produces empty field in BKI');
+assertSameIssue2518($expected3, $content3, 'record without sheet or sheet_row_number produces empty fields in BKI');
 
 echo "PASS issue 2518 Google Sheets row number in BKI format\n";

--- a/experiments/test-issue-2528-google-sheets-sheet-name.php
+++ b/experiments/test-issue-2528-google-sheets-sheet-name.php
@@ -1,0 +1,119 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2528($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+// Test 1: BKI output includes sheet name as first column
+$values = [
+    ['Период', '01.01.2026', '2025'],
+    ['', '31.01.2026', ''],
+    ['', 'ПЛАН', ''],
+    ['Выручка', '123', '89'],
+];
+
+$records = gss_extract_sheet_records(
+    'Лист1',
+    $values,
+    ['Выручка'],
+    [
+        ['*.2026', '*.2026', 'ПЛАН'],
+        '2025',
+    ]
+);
+
+assertSameIssue2528(2, count($records), 'extracts 2 records');
+assertSameIssue2528('Лист1', $records[0]['sheet'], 'record contains sheet name');
+
+$content = gss_build_bki_content($records, 1773328460);
+$expected = "DATA\r\n"
+    . "Лист1;123;31.01.2026;Выручка;ПЛАН;4;1773328460;\r\n"
+    . "Лист1;89;;Выручка;2025;4;1773328460;\r\n";
+
+assertSameIssue2528($expected, $content, 'BKI output has sheet name as first column: {sheet};{value};{date};{row};{column};{sheet_row_number};{timestamp};');
+
+// Test 2: records from different sheets each carry their own sheet name
+$recordsA = gss_extract_sheet_records(
+    'ШитА',
+    [['X', '2025'], ['Выручка', '10']],
+    ['Выручка'],
+    ['2025']
+);
+$recordsB = gss_extract_sheet_records(
+    'ШитБ',
+    [['X', '2025'], ['Выручка', '20']],
+    ['Выручка'],
+    ['2025']
+);
+
+$combined = gss_build_bki_content(array_merge($recordsA, $recordsB), 1000);
+$expectedCombined = "DATA\r\n"
+    . "ШитА;10;;Выручка;2025;2;1000;\r\n"
+    . "ШитБ;20;;Выручка;2025;2;1000;\r\n";
+
+assertSameIssue2528($expectedCombined, $combined, 'BKI output shows correct sheet name for records from different sheets');
+
+// Test 3: record without sheet key produces empty sheet field (backward compat)
+$manualRecord = [
+    'value' => 'Val',
+    'date' => '01.01.2026',
+    'row' => 'Row',
+    'column' => 'Col',
+    'sheet_row_number' => 5,
+    'rows' => ['Row'],
+    'columns' => ['Col'],
+];
+$content3 = gss_build_bki_content([$manualRecord], 12345);
+$expected3 = "DATA\r\n"
+    . ";Val;01.01.2026;Row;Col;5;12345;\r\n";
+
+assertSameIssue2528($expected3, $content3, 'record without sheet key produces empty sheet field in BKI');
+
+// Test 4: sheet name with special characters is properly escaped
+$recordsSpecial = gss_extract_sheet_records(
+    'Лист;2026',
+    [['Выручка', '2025'], ['100', '']],
+    ['Выручка'],
+    ['2025']
+);
+
+assertSameIssue2528(1, count($recordsSpecial), 'extracts 1 record with special sheet name');
+$contentSpecial = gss_build_bki_content($recordsSpecial, 9999);
+$expectedSpecial = "DATA\r\n"
+    . "Лист\\;2026;100;;Выручка;2025;2;9999;\r\n";
+
+assertSameIssue2528($expectedSpecial, $contentSpecial, 'sheet name with semicolons is escaped in BKI');
+
+// Test 5: gss_normalize_config sets createParent and autoParent defaults
+$config = gss_normalize_config(['sheets' => []], '/tmp');
+assertSameIssue2528('1', $config['integram']['createParent'], 'default createParent is "1"');
+assertSameIssue2528('449960', $config['integram']['autoParent'], 'default autoParent is "449960"');
+
+// Test 6: createParent and autoParent can be overridden via config
+$config2 = gss_normalize_config([
+    'sheets' => [],
+    'integram' => [
+        'createParent' => '0',
+        'autoParent' => '123',
+    ],
+], '/tmp');
+assertSameIssue2528('0', $config2['integram']['createParent'], 'createParent can be overridden');
+assertSameIssue2528('123', $config2['integram']['autoParent'], 'autoParent can be overridden');
+
+// Test 7: createParent and autoParent can be disabled by setting to empty string
+$config3 = gss_normalize_config([
+    'sheets' => [],
+    'integram' => [
+        'createParent' => '',
+        'autoParent' => '',
+    ],
+], '/tmp');
+assertSameIssue2528('', $config3['integram']['createParent'], 'createParent can be set to empty to disable');
+assertSameIssue2528('', $config3['integram']['autoParent'], 'autoParent can be set to empty to disable');
+
+echo "PASS issue 2528 Google Sheets sheet name in BKI format and createParent/autoParent POST params\n";

--- a/google_sheets_sync.php
+++ b/google_sheets_sync.php
@@ -99,6 +99,8 @@ function gss_normalize_config($config, $configDir) {
         'upload_endpoint' => '/object/443296?JSON&import=1',
         'base_url_has_database' => false,
         'url_template' => '',
+        'createParent' => '1',
+        'autoParent' => '449960',
     ];
     $config['integram'] = array_merge($integramDefaults, $config['integram']);
     unset($config['integram']['auth_endpoint'], $config['integram']['xsrf_endpoint']);
@@ -918,8 +920,10 @@ function gss_build_bki_content($records, $timestamp = null) {
             : gss_last_list_value($columns);
 
         $sheetRowNumber = array_key_exists('sheet_row_number', $record) ? $record['sheet_row_number'] : '';
+        $sheet = array_key_exists('sheet', $record) ? $record['sheet'] : '';
 
-        $lines[] = gss_escape_bki_value($record['value'])
+        $lines[] = gss_escape_bki_value($sheet)
+            . ';' . gss_escape_bki_value($record['value'])
             . ';' . gss_escape_bki_value($date)
             . ';' . gss_escape_bki_value($row)
             . ';' . gss_escape_bki_value($column)
@@ -993,12 +997,21 @@ function gss_integram_upload_endpoint($config) {
 function gss_integram_upload_post_fields($filePath, $config) {
     $tokens = gss_integram_tokens($config);
 
-    return [
+    $fields = [
         'token' => $tokens['token'],
         '_xsrf' => $tokens['xsrf'],
         'import' => '1',
         'bki_file' => new CURLFile($filePath, 'application/octet-stream', 'import.bki'),
     ];
+
+    if (isset($config['createParent']) && (string)$config['createParent'] !== '') {
+        $fields['createParent'] = (string)$config['createParent'];
+    }
+    if (isset($config['autoParent']) && (string)$config['autoParent'] !== '') {
+        $fields['autoParent'] = (string)$config['autoParent'];
+    }
+
+    return $fields;
 }
 
 function gss_integram_tokens($config) {


### PR DESCRIPTION
Closes #2528

## Summary

- **Новый BKI-формат**: добавлено имя листа Google Sheets как первое поле: `{имя листа};{значение};{дата};{строка};{колонка};{номер строки};{штамп времени};`
- **POST-параметры**: добавлены `createParent=1` и `autoParent=449960` в запрос к `object/443296` (как значения по умолчанию, настраиваемые через конфиг)

## Изменения

### `google_sheets_sync.php`
- `gss_build_bki_content()`: имя листа (`sheet`) добавлено первым полем в каждую строку BKI
- `gss_normalize_config()`: добавлены значения по умолчанию `createParent='1'` и `autoParent='449960'` в секцию `integram`
- `gss_integram_upload_post_fields()`: передаются `createParent` и `autoParent` из конфига (можно отключить, установив в пустую строку)

## Test plan

- [x] `experiments/test-issue-2528-google-sheets-sheet-name.php` — новые тесты для формата с именем листа и POST-параметров
- [x] Обновлены все существующие тесты (`test-issue-2450`, `2456`, `2469`, `2512`, `2514`, `2518`) под новый формат

🤖 Generated with [Claude Code](https://claude.com/claude-code)