### PR TITLE
index.php: при импорте в подчинённую таблицу пропускать записи с пустым значением

### DIFF
--- a/index.php
+++ b/index.php
@@ -5872,36 +5872,47 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                                 continue;
 						    }
 						    array_shift($object);
-						    // issue #2524: under getParent the type value lives in the second column (now $object[0]
-						    // after the shift). If it was cleared in the source and the type has a composite uniqueness
-						    // key, find the existing record by the key reqs under the resolved parent and delete it —
-						    // mirroring the issue-2522 logic that only handled the first-column case.
-						    if($object[0] === "" && count($keyReqsForDelete)){
-						        $keyValuesForDelete = array();
-						        $ord = 0;
-						        foreach($GLOBALS["local_struct"][$id] as $reqId => $reqName){
-						            if($reqId == 0) continue;
-						            $ord++;
-						            if(!isset($keyReqsForDelete[$reqId])) continue;
-						            $req = $keyReqsForDelete[$reqId];
-						            $rawVal = isset($object[$ord]) ? UnMaskDelimiters($object[$ord]) : "";
-						            $keyValuesForDelete[$reqId] = $req["ref_id"]
-						                ? UniqueKeyNormalizeRefs($req, $rawVal)
-						                : array("kind" => "value", "value" => UniqueKeyNormalizeValue($req["t"], $rawVal));
-						        }
-						        foreach($keyReqsForDelete as $reqId => $req){
-						            if(!isset($keyValuesForDelete[$reqId]))
+						    // issue #2524/#2530: under getParent the type value lives in the second column (now $object[0]
+						    // after the shift). If it was cleared in the source: if uniqueness is defined, find the
+						    // existing record under the resolved parent and delete it; otherwise skip the record.
+						    if($object[0] === ""){
+						        if(count($keyReqsForDelete)){
+						            $keyValuesForDelete = array();
+						            $ord = 0;
+						            foreach($GLOBALS["local_struct"][$id] as $reqId => $reqName){
+						                if($reqId == 0) continue;
+						                $ord++;
+						                if(!isset($keyReqsForDelete[$reqId])) continue;
+						                $req = $keyReqsForDelete[$reqId];
+						                $rawVal = isset($object[$ord]) ? UnMaskDelimiters($object[$ord]) : "";
 						                $keyValuesForDelete[$reqId] = $req["ref_id"]
-						                    ? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
-						                    : array("kind" => "value", "value" => "");
+						                    ? UniqueKeyNormalizeRefs($req, $rawVal)
+						                    : array("kind" => "value", "value" => UniqueKeyNormalizeValue($req["t"], $rawVal));
+						            }
+						            foreach($keyReqsForDelete as $reqId => $req){
+						                if(!isset($keyValuesForDelete[$reqId]))
+						                    $keyValuesForDelete[$reqId] = $req["ref_id"]
+						                        ? array("kind" => "ref", "ref_id" => (int)$req["ref_id"], "values" => array(), "multi" => $req["multi"], "has_missing_ref" => false)
+						                        : array("kind" => "value", "value" => "");
+						            }
+						            if($existingRow = FindUniqueRecordDuplicate($id, 0, $parent, "", $keyValuesForDelete, false)){
+						                trace(" issue-2524: empty value under getParent, deleting existing #".$existingRow["id"]." by composite key (parent=$parent)");
+						                Delete($existingRow["id"]);
+						                $GLOBALS["warning"] .= t9n("[RU]Удалена запись типа $id с пустым значением (строка $count)[EN]Deleted record of type $id with empty value (string #$count)");
+						                $count++;
+						            }
+						        } elseif($isUnique){
+						            // issue #2530: simple uniqueness — find the existing child record under the resolved parent and delete it
+						            if($existingRow = mysqli_fetch_array(Exec_sql("SELECT id FROM $z WHERE up=$parent AND t=$id LIMIT 1", "Find child for empty-value delete (issue #2530)"))){
+						                trace(" issue-2530: empty value under getParent with simple uniqueness, deleting existing #".$existingRow["id"]." (parent=$parent)");
+						                Delete($existingRow["id"]);
+						                $GLOBALS["warning"] .= t9n("[RU]Удалена запись типа $id с пустым значением (строка $count)[EN]Deleted record of type $id with empty value (string #$count)");
+						                $count++;
+						            }
+						        } else {
+						            $GLOBALS["warning"] .= t9n("[RU]Пропущен пустой объект типа $id (строка $count)[EN]Empty object of type $id skipped (string #$count)");
 						        }
-						        if($existingRow = FindUniqueRecordDuplicate($id, 0, $parent, "", $keyValuesForDelete, false)){
-						            trace(" issue-2524: empty value under getParent, deleting existing #".$existingRow["id"]." by composite key (parent=$parent)");
-						            Delete($existingRow["id"]);
-						            $GLOBALS["warning"] .= t9n("[RU]Удалена запись типа $id с пустым значением (строка $count)[EN]Deleted record of type $id with empty value (string #$count)");
-						            $count++;
-						            continue;
-						        }
+						        continue;
 						    }
     					}
     					$object[0] = Format_Val($GLOBALS["base"][$id], UnMaskDelimiters($object[0]));


### PR DESCRIPTION
Closes #2530

## Summary

При `getParent` (autoParent) в режиме импорта BKI: если значение записи после сдвига первой колонки (имени листа) оказывается пустым, код ранее продолжал выполнение и создавал запись с пустым значением.

Теперь пустое значение обрабатывается по следующей логике:
- **Уникальность по составному ключу** (`$keyReqsForDelete`): найти существующую запись по ключу и удалить её (поведение из #2524, теперь всегда пропускает создание)
- **Простая уникальность** (`$isUnique`): найти любую дочернюю запись типа `$id` под разрешённым родителем и удалить её
- **Уникальность не задана**: пропустить запись с предупреждением (не создавать запись с пустым значением)

## Test plan

- [ ] Импорт BKI с пустыми ячейками без настроенной уникальности → записи с пустым значением не создаются, в предупреждениях появляется сообщение о пропуске
- [ ] Импорт BKI с пустыми ячейками при настроенной простой уникальности → существующая дочерняя запись удаляется
- [ ] Импорт BKI с пустыми ячейками при составном ключе (issue #2524) → поведение не изменилось, удаляется по ключу

🤖 Generated with [Claude Code](https://claude.com/claude-code)