### PR TITLE
index.php: gssync — авторизованный запуск Google Sheets синхронизации (#2533)

### DIFF
--- a/include/google_sheets_sync.php
+++ b/include/google_sheets_sync.php
@@ -74,9 +74,9 @@ function gss_load_config($configPath) {
 
 function gss_normalize_config($config, $configDir) {
     $defaults = [
-        'credentials_path' => __DIR__ . '/include/credentials.json',
+        'credentials_path' => __DIR__ . '/credentials.json',
         'spreadsheet_id' => '',
-        'output_file' => __DIR__ . '/logs/google_sheets_sync.bki',
+        'output_file' => __DIR__ . '/../logs/google_sheets_sync.bki',
         'skip_empty_values' => false,
         'debug' => false,
         'http_timeout' => 60,

--- a/index.php
+++ b/index.php
@@ -4355,6 +4355,8 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 			{
 				$blocks[$block]["top_menu"][] = t9n("[RU]Файлы[EN]Files");
 				$blocks[$block]["top_menu_href"][] = "dir_admin";
+				$blocks[$block]["top_menu"][] = "GS Sync";
+				$blocks[$block]["top_menu_href"][] = "gssync";
 			}
 			#$blocks[$block]["top_menu"][] = t9n("[RU]Выход[EN]Exit");
 			#$blocks[$block]["top_menu_href"][] = "exit";
@@ -7252,6 +7254,50 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 			}
 			break;
 			
+		case "&gssync":
+		{
+            $grant = RepoGrant();
+            if($grant == "BARRED")
+            	die(t9n("[RU]Недостаточно прав для доступа к этому рабочему месту[EN]Insufficient permissions to access this workplace"));
+            $gssDir = "templates/gss/$z";
+            if(!file_exists($gssDir))
+                mkdir($gssDir, 0775, true);
+            if(isApi())
+            {
+                $configName = isset($_REQUEST["config"]) ? trim($_REQUEST["config"]) : "";
+                if(!preg_match(FILE_MASK, $configName))
+                    my_error(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
+                $configFile = "$gssDir/$configName.json";
+                if(!file_exists($configFile))
+                    my_error(t9n("[RU]Файл конфигурации не найден[EN]Config file not found"), "404");
+                $configData = json_decode(file_get_contents($configFile), true);
+                if(!is_array($configData))
+                    my_error(t9n("[RU]Ошибка разбора конфигурации[EN]Config parse error"), "400");
+                require_once "include/google_sheets_sync.php";
+                $configData = gss_normalize_config($configData, realpath($gssDir));
+                try {
+                    $summary = gss_sync($configData);
+                    api_dump(json_encode($summary, JSON_UNESCAPED_UNICODE));
+                } catch (Throwable $e) {
+                    my_error($e->getMessage(), "500");
+                }
+            }
+            # Populate config list for HTML rendering
+            $GLOBALS["gss_configs"] = [];
+            if(is_dir($gssDir))
+            {
+                foreach(scandir($gssDir) as $f)
+                    if(substr($f, -5) === ".json")
+                        $GLOBALS["gss_configs"][] = substr($f, 0, -5);
+            }
+            $blocks[$block]["db"][] = $z;
+			break;
+		}
+
+		case "&config_item":
+			$blocks[$block]["config"] = $GLOBALS["gss_configs"];
+			break;
+
 		case "&pattern":
 			$add_path = "";
 			foreach(explode("/", substr($blocks[$blocks[$block]["PARENT"]]["CUR_VARS"]["add_path"], 1)) as $val)
@@ -10723,6 +10769,11 @@ if(Validate_Token())
     		elseif($a == "dir_admin") # Admin should be able to fix the files anyway,
     		{
     			Make_tree(Get_file("dir_admin.html"), ""); # thus, avoid UI header and styles
+    			die(Parse_block(""));
+    		}
+    		elseif($a == "gssync")
+    		{
+    			Make_tree(Get_file("gssync.html"), "");
     			die(Parse_block(""));
     		}
     		else

--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>GS Sync</title>
+    <link rel="stylesheet" href="/css/bootstrap.3.3.7.min.css">
+    <link rel="stylesheet" href="/assets/vendor/primeicons/primeicons.css">
+    <link rel="stylesheet" href="/css/styles.css">
+    <style>
+        [data-theme="dark"] body {
+            background-color: var(--bg-primary);
+            color: var(--text-primary);
+        }
+        [data-theme="dark"] .panel {
+            background-color: var(--bg-secondary);
+            border-color: var(--border-color);
+        }
+        [data-theme="dark"] .panel-heading {
+            background-color: var(--bg-secondary);
+            border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        [data-theme="dark"] .btn-default {
+            background-color: var(--bg-secondary);
+            border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        [data-theme="dark"] pre {
+            background-color: var(--bg-secondary);
+            border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+    </style>
+    <script src="/js/jquery-3.5.1.slim.min.js"></script>
+</head>
+<body style="font-family:Verdana,Tahoma,sans-serif;line-height:normal;padding:2px">
+<div>
+    <a href="/{_global_.z}"><i class="pi pi-home" style="font-size: 2rem; color: var(--text-primary, #333);"></i></a>
+    &nbsp;
+    <div style="display: inline; margin-top: 7px"><a href="/{_global_.z}">Вернуться в&nbsp;основное меню</a></div>
+</div>
+<br />
+<div class="container" style="margin:1px;">
+    <h4>Google Sheets Sync</h4>
+    <p>Запуск синхронизации данных из Google Sheets в Integram по конфигурационным файлам.</p>
+    <p>Файлы конфигурации хранятся в <code>templates/gss/{_global_.z}/</code> (формат JSON).</p>
+<!-- Begin:&Gssync -->
+    <div id="config-list" data-db="{DB}">
+<!-- Begin:&Config_item -->
+        <div class="panel panel-default" style="margin-bottom:8px;">
+            <div class="panel-heading">
+                <b>{CONFIG}</b>
+                &nbsp;
+                <button class="btn btn-default btn-sm run-btn" data-config="{CONFIG}">
+                    Запустить синхронизацию
+                </button>
+            </div>
+            <div class="result-box" id="result-{CONFIG}" style="display:none; padding:8px;">
+                <pre style="white-space:pre-wrap; font-size:12px;"></pre>
+            </div>
+        </div>
+<!-- End:&Config_item -->
+    </div>
+    <div id="no-configs" style="display:none;">
+        <div class="alert alert-info">
+            Нет файлов конфигурации. Создайте файл <code>*.json</code> в директории <code>templates/gss/{_global_.z}/</code>.
+        </div>
+    </div>
+<!-- End:&Gssync -->
+</div>
+<script src="/js/app.js"></script>
+<script src="/js/js.js"></script>
+<script>
+    localize();
+    if ($('#config-list .run-btn').length === 0) {
+        $('#no-configs').show();
+    }
+    $(document).on('click', '.run-btn', function() {
+        var btn = $(this);
+        var config = btn.data('config');
+        var db = $('#config-list').data('db');
+        var box = $('#result-' + config);
+        btn.prop('disabled', true).text('Выполняется...');
+        box.show().find('pre').text('Ожидание...');
+        $.ajax({
+            url: '/' + db + '/gssync?JSON&config=' + encodeURIComponent(config),
+            type: 'GET',
+            dataType: 'json',
+            success: function(data) {
+                box.find('pre').text(JSON.stringify(data, null, 2));
+            },
+            error: function(xhr) {
+                box.find('pre').text('Ошибка: ' + xhr.status + ' ' + xhr.responseText);
+            },
+            complete: function() {
+                btn.prop('disabled', false).text('Запустить синхронизацию');
+            }
+        });
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `google_sheets_sync.php` перемещён в `include/` — теперь недоступен для прямого вызова извне
- Исправлены пути `__DIR__` в `gss_normalize_config` (credentials.json, output log) после перемещения
- Добавлен route `/{db}/gssync` (HTML-страница) и `/{db}/gssync?JSON&config={name}` (API)
- Авторизация: токен проверяется через `Validate_Token()`, доступ — через `RepoGrant() != "BARRED"`
- JSON-конфиги хранятся в `templates/gss/{db}/*.json`
- Новый файл `templates/gssync.html`: страница управления синхронизацией с кнопками запуска по конфигу
- Ссылка "GS Sync" добавлена в верхнее меню (только для авторизованных)

## Test plan

- [ ] Прямой вызов `include/google_sheets_sync.php` из браузера — должен вернуть пустой ответ (не выполняться как скрипт)
- [ ] `/{db}/gssync` без авторизации — редирект на страницу входа
- [ ] `/{db}/gssync` с авторизацией — открывается страница с меню конфигов
- [ ] `/{db}/gssync?JSON&config=test` — запускает синхронизацию, возвращает JSON с summary
- [ ] `/{db}/gssync?JSON&config=../etc` — отклоняется (FILE_MASK)
- [ ] `/{db}/gssync?JSON&config=nonexistent` — 404 JSON ошибка
- [ ] Страница GS Sync появляется в верхнем меню при наличии прав

Closes #2533

🤖 Generated with [Claude Code](https://claude.com/claude-code)