### PR TITLE
gssync: логи BKI в templates/logs/{db}/, создание папки (#2535)

### DIFF
--- a/include/google_sheets_sync.php
+++ b/include/google_sheets_sync.php
@@ -76,7 +76,7 @@ function gss_normalize_config($config, $configDir) {
     $defaults = [
         'credentials_path' => __DIR__ . '/credentials.json',
         'spreadsheet_id' => '',
-        'output_file' => __DIR__ . '/../logs/google_sheets_sync.bki',
+        'output_file' => 'google_sheets_sync.bki',
         'skip_empty_values' => false,
         'debug' => false,
         'http_timeout' => 60,

--- a/index.php
+++ b/index.php
@@ -7273,6 +7273,11 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                 $configData = json_decode(file_get_contents($configFile), true);
                 if(!is_array($configData))
                     my_error(t9n("[RU]Ошибка разбора конфигурации[EN]Config parse error"), "400");
+                $logsDir = "templates/logs/$z";
+                if(!file_exists($logsDir))
+                    mkdir($logsDir, 0775, true);
+                if(!isset($configData['output_file']))
+                    $configData['output_file'] = "$logsDir/google_sheets_sync.bki";
                 require_once "include/google_sheets_sync.php";
                 $configData = gss_normalize_config($configData, realpath($gssDir));
                 try {

--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -46,6 +46,7 @@
     <h4>Google Sheets Sync</h4>
     <p>Запуск синхронизации данных из Google Sheets в Integram по конфигурационным файлам.</p>
     <p>Файлы конфигурации хранятся в <code>templates/gss/{_global_.z}/</code> (формат JSON).</p>
+    <p>Лог-файлы (BKI) сохраняются в <a href="/{_global_.z}/dir_admin/?templates=1&add_path=/logs/{_global_.z}"><code>templates/logs/{_global_.z}/</code></a>.</p>
 <!-- Begin:&Gssync -->
     <div id="config-list" data-db="{DB}">
 <!-- Begin:&Config_item -->


### PR DESCRIPTION
## Summary

- Путь для BKI-файла изменён с `logs/google_sheets_sync.bki` на `templates/logs/{db}/google_sheets_sync.bki`
- Папка `templates/logs/{db}/` создаётся автоматически при запуске синхронизации (если не существует)
- `gss_normalize_config`: дефолтный `output_file` теперь `google_sheets_sync.bki` (относительный, резолвится в `$configDir`) — не ломает CLI
- `gssync.html`: добавлена ссылка на папку с логами через файловый менеджер (`dir_admin`)

## Test plan

- [ ] Запустить синхронизацию через `/{db}/gssync?JSON&config=...` — в `templates/logs/{db}/` должен появиться BKI-файл
- [ ] Если папка `templates/logs/{db}/` не существует — создаётся автоматически
- [ ] Ссылка на логи в `gssync.html` ведёт в правильную директорию файлового менеджера
- [ ] CLI-запуск `php include/google_sheets_sync.php config.php` — `output_file` резолвится относительно директории конфига

Closes #2535

🤖 Generated with [Claude Code](https://claude.com/claude-code)