### PR TITLE
main.html: имя пользователя и роль первым пунктом в мобильном меню (#2537)

### DIFF
--- a/css/main-app.css
+++ b/css/main-app.css
@@ -162,6 +162,25 @@
     background-color: rgba(220, 53, 69, 0.2);
 }
 
+/* User info header in dropdown — visible only on mobile (issue #2537) */
+.user-menu-userinfo {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .user-menu-userinfo {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.875rem 1rem;
+        color: var(--text-primary);
+        font-size: 0.9rem;
+        font-weight: 600;
+        pointer-events: none;
+        cursor: default;
+    }
+}
+
 /* Application Layout */
 .app-layout {
     display: flex;

--- a/templates/main.html
+++ b/templates/main.html
@@ -182,6 +182,11 @@
                     <i class="user-menu-arrow pi pi-chevron-down"></i>
                 </button>
                 <div id="user-menu-dropdown" class="user-menu-dropdown" style="display: none;">
+                    <div class="user-menu-userinfo">
+                        <i class="user-menu-icon pi pi-user"></i>
+                        <span>{_global_.user} / {_global_.role}</span>
+                    </div>
+                    <div class="user-menu-divider user-menu-userinfo"></div>
                     <!-- Begin: showCabinet --><!--{_global_.z}-->
                     <a href="/my" target="my" class="user-menu-item">
                         <i class="user-menu-icon pi pi-user"></i>


### PR DESCRIPTION
## Summary

На мобильных устройствах (≤768px) `account-email` скрыт через CSS. При открытии пользовательского меню пользователь не видел своё имя и роль.

- Добавлен блок `.user-menu-userinfo` как первый элемент в `#user-menu-dropdown`
- Показывает `{_global_.user} / {_global_.role}` с иконкой пользователя
- На десктопе скрыт (`display: none`) — блок виден только на мобильных (≤768px)
- После блока идёт разделитель, также скрытый на десктопе

## Test plan

- [ ] Мобильный браузер (или DevTools ≤768px): открыть меню пользователя — первым пунктом должны быть имя и роль
- [ ] Десктоп: открыть меню пользователя — блок с именем/ролью не виден (только в navbar)
- [ ] Разделитель под блоком тоже скрыт на десктопе

Closes #2537

🤖 Generated with [Claude Code](https://claude.com/claude-code)