### PR TITLE
gssync.html: встраивание в main.html вместо standalone (#2539)

### DIFF
--- a/index.php
+++ b/index.php
@@ -10776,11 +10776,6 @@ if(Validate_Token())
     			Make_tree(Get_file("dir_admin.html"), ""); # thus, avoid UI header and styles
     			die(Parse_block(""));
     		}
-    		elseif($a == "gssync")
-    		{
-    			Make_tree(Get_file("gssync.html"), "");
-    			die(Parse_block(""));
-    		}
     		else
     			$text = Get_file("main.html");
 #    		wlog("$user@".$_SERVER["REMOTE_ADDR"], "log");

--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -1,105 +1,47 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>GS Sync</title>
-    <link rel="stylesheet" href="/css/bootstrap.3.3.7.min.css">
-    <link rel="stylesheet" href="/assets/vendor/primeicons/primeicons.css">
-    <link rel="stylesheet" href="/css/styles.css">
-    <style>
-        [data-theme="dark"] body {
-            background-color: var(--bg-primary);
-            color: var(--text-primary);
-        }
-        [data-theme="dark"] .panel {
-            background-color: var(--bg-secondary);
-            border-color: var(--border-color);
-        }
-        [data-theme="dark"] .panel-heading {
-            background-color: var(--bg-secondary);
-            border-color: var(--border-color);
-            color: var(--text-primary);
-        }
-        [data-theme="dark"] .btn-default {
-            background-color: var(--bg-secondary);
-            border-color: var(--border-color);
-            color: var(--text-primary);
-        }
-        [data-theme="dark"] pre {
-            background-color: var(--bg-secondary);
-            border-color: var(--border-color);
-            color: var(--text-primary);
-        }
-    </style>
-    <script src="/js/jquery-3.5.1.slim.min.js"></script>
-</head>
-<body style="font-family:Verdana,Tahoma,sans-serif;line-height:normal;padding:2px">
-<div>
-    <a href="/{_global_.z}"><i class="pi pi-home" style="font-size: 2rem; color: var(--text-primary, #333);"></i></a>
-    &nbsp;
-    <div style="display: inline; margin-top: 7px"><a href="/{_global_.z}">Вернуться в&nbsp;основное меню</a></div>
-</div>
-<br />
-<div class="container" style="margin:1px;">
+<!-- Begin:&Gssync -->
+<div style="padding: 1rem;">
     <h4>Google Sheets Sync</h4>
     <p>Запуск синхронизации данных из Google Sheets в Integram по конфигурационным файлам.</p>
     <p>Файлы конфигурации хранятся в <code>templates/gss/{_global_.z}/</code> (формат JSON).</p>
     <p>Лог-файлы (BKI) сохраняются в <a href="/{_global_.z}/dir_admin/?templates=1&add_path=/logs/{_global_.z}"><code>templates/logs/{_global_.z}/</code></a>.</p>
-<!-- Begin:&Gssync -->
     <div id="config-list" data-db="{DB}">
 <!-- Begin:&Config_item -->
-        <div class="panel panel-default" style="margin-bottom:8px;">
-            <div class="panel-heading">
-                <b>{CONFIG}</b>
-                &nbsp;
-                <button class="btn btn-default btn-sm run-btn" data-config="{CONFIG}">
-                    Запустить синхронизацию
-                </button>
-            </div>
-            <div class="result-box" id="result-{CONFIG}" style="display:none; padding:8px;">
-                <pre style="white-space:pre-wrap; font-size:12px;"></pre>
-            </div>
+        <div style="border: 1px solid var(--border-color); border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 0.5rem; display: flex; align-items: center; gap: 1rem;">
+            <b>{CONFIG}</b>
+            <button class="run-btn" data-config="{CONFIG}" style="margin-left: auto; padding: 0.35rem 0.9rem; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-secondary); color: var(--text-primary); cursor: pointer;">
+                Запустить
+            </button>
+        </div>
+        <div class="result-box" id="result-{CONFIG}" style="display:none; margin-bottom: 0.5rem;">
+            <pre style="white-space:pre-wrap; font-size:12px; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius:4px; padding: 0.75rem;"></pre>
         </div>
 <!-- End:&Config_item -->
     </div>
     <div id="no-configs" style="display:none;">
-        <div class="alert alert-info">
+        <div style="padding: 1rem; border: 1px solid var(--border-color); border-radius: 6px; color: var(--text-secondary);">
             Нет файлов конфигурации. Создайте файл <code>*.json</code> в директории <code>templates/gss/{_global_.z}/</code>.
         </div>
     </div>
-<!-- End:&Gssync -->
 </div>
-<script src="/js/app.js"></script>
-<script src="/js/js.js"></script>
+<!-- End:&Gssync -->
 <script>
-    localize();
-    if ($('#config-list .run-btn').length === 0) {
-        $('#no-configs').show();
+    if (document.querySelectorAll('.run-btn').length === 0) {
+        document.getElementById('no-configs').style.display = '';
     }
-    $(document).on('click', '.run-btn', function() {
-        var btn = $(this);
-        var config = btn.data('config');
-        var db = $('#config-list').data('db');
-        var box = $('#result-' + config);
-        btn.prop('disabled', true).text('Выполняется...');
-        box.show().find('pre').text('Ожидание...');
-        $.ajax({
-            url: '/' + db + '/gssync?JSON&config=' + encodeURIComponent(config),
-            type: 'GET',
-            dataType: 'json',
-            success: function(data) {
-                box.find('pre').text(JSON.stringify(data, null, 2));
-            },
-            error: function(xhr) {
-                box.find('pre').text('Ошибка: ' + xhr.status + ' ' + xhr.responseText);
-            },
-            complete: function() {
-                btn.prop('disabled', false).text('Запустить синхронизацию');
-            }
-        });
+    document.addEventListener('click', function(e) {
+        var btn = e.target.closest('.run-btn');
+        if (!btn) return;
+        var config = btn.dataset.config;
+        var db = document.getElementById('config-list').dataset.db;
+        var box = document.getElementById('result-' + config);
+        btn.disabled = true;
+        btn.textContent = 'Выполняется...';
+        box.style.display = '';
+        box.querySelector('pre').textContent = 'Ожидание...';
+        fetch('/' + db + '/gssync?JSON&config=' + encodeURIComponent(config))
+            .then(function(r) { return r.json(); })
+            .then(function(data) { box.querySelector('pre').textContent = JSON.stringify(data, null, 2); })
+            .catch(function(err) { box.querySelector('pre').textContent = 'Ошибка: ' + err; })
+            .finally(function() { btn.disabled = false; btn.textContent = 'Запустить'; });
     });
 </script>
-</body>
-</html>


### PR DESCRIPTION
## Summary

- `gssync.html` переработан как контентный шаблон (без `<!DOCTYPE html>`, `<head>`, `<body>`) — по аналогии с `dict.html`, `edit_types.html` и другими шаблонами
- Страница встраивается в `main.html` через механизм `<!-- File: a -->` — сохраняет левое меню, верхнюю навигацию и весь стандартный интерфейс
- Убран отдельный роут `elseif($a == "gssync")` из `index.php` — теперь используется стандартный поток через `main.html`
- API-вызов `/{db}/gssync?JSON&config=...` продолжает работать: блок `&gssync` обрабатывается во время `Make_tree`, `api_dump()` завершает выполнение до рендеринга

## Test plan

- [ ] `/{db}/gssync` открывается внутри обычного интерфейса (с меню, navbar)
- [ ] API `/{db}/gssync?JSON&config=test` возвращает JSON
- [ ] Кнопка "Запустить" запускает синхронизацию и показывает результат

Closes #2539

🤖 Generated with [Claude Code](https://claude.com/claude-code)