### PR TITLE
main.html: убрана иконка-дубликат и толстая серая полоса в мобильном меню (#2541)

### DIFF
--- a/css/main-app.css
+++ b/css/main-app.css
@@ -167,17 +167,24 @@
     display: none;
 }
 
+.user-menu-divider-mobile {
+    display: none;
+}
+
 @media (max-width: 768px) {
     .user-menu-userinfo {
         display: flex;
         align-items: center;
-        gap: 0.75rem;
         padding: 0.875rem 1rem;
         color: var(--text-primary);
         font-size: 0.9rem;
         font-weight: 600;
         pointer-events: none;
         cursor: default;
+    }
+
+    .user-menu-divider-mobile {
+        display: block;
     }
 }
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -183,10 +183,9 @@
                 </button>
                 <div id="user-menu-dropdown" class="user-menu-dropdown" style="display: none;">
                     <div class="user-menu-userinfo">
-                        <i class="user-menu-icon pi pi-user"></i>
                         <span>{_global_.user} / {_global_.role}</span>
                     </div>
-                    <div class="user-menu-divider user-menu-userinfo"></div>
+                    <div class="user-menu-divider user-menu-divider-mobile"></div>
                     <!-- Begin: showCabinet --><!--{_global_.z}-->
                     <a href="/my" target="my" class="user-menu-item">
                         <i class="user-menu-icon pi pi-user"></i>


### PR DESCRIPTION
## Summary

Два визуальных дефекта в мобильном меню пользователя (введены в #2537):

1. **Толстая серая полоса** — разделитель после блока имени пользователя имел класс `user-menu-userinfo`, из-за чего наследовал `display: flex` и `padding: 0.875rem 1rem` вместо обычного `height: 1px`. Исправлено: разделитель получил отдельный класс `user-menu-divider-mobile` с корректным `display: block` на мобильных.

2. **Две одинаковые иконки** — блок `user-menu-userinfo` содержал `pi pi-user`, которая дублировала иконку строки «Личный кабинет» прямо под ней. Исправлено: иконка убрана, остался только текст с именем/ролью.

## Test plan

- [ ] Мобильный (≤768px): открыть меню пользователя — первым пунктом имя/роль без иконки, под ним тонкий разделитель, затем «Личный кабинет» со своей иконкой
- [ ] Десктоп: блок имени/роли и разделитель не видны

Closes #2541

🤖 Generated with [Claude Code](https://claude.com/claude-code)