### PR TITLE
main-app.css: имя и роль по центру в мобильном меню (#2544)

### DIFF
--- a/css/main-app.css
+++ b/css/main-app.css
@@ -175,6 +175,7 @@
     .user-menu-userinfo {
         display: flex;
         align-items: center;
+        justify-content: center;
         padding: 0.875rem 1rem;
         color: var(--text-primary);
         font-size: 0.9rem;


### PR DESCRIPTION
## Summary

Добавлен `justify-content: center` в `.user-menu-userinfo` — имя пользователя и роль теперь выровнены по центру при открытии мобильного меню.

Closes #2544

🤖 Generated with [Claude Code](https://claude.com/claude-code)