### PR TITLE
gssync.html: правки формы (current site/DB, выбор таблицы, авто-имя) (#2547)

### DIFF
--- a/index.php
+++ b/index.php
@@ -7264,7 +7264,16 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                 mkdir($gssDir, 0775, true);
             if(isApi())
             {
-                if(isset($_REQUEST["config"]))
+                if(isset($_REQUEST["metadata"]) && $_REQUEST["metadata"] === "tables")
+                {
+                    $tables = [];
+                    $sql = "SELECT id, val FROM $z WHERE up=0 AND id!=t AND id>300 ORDER BY val";
+                    $data_set = Exec_sql($sql, "List tables for gssync");
+                    while($row = mysqli_fetch_array($data_set))
+                        $tables[] = ["id" => $row["id"], "val" => $row["val"]];
+                    api_dump(json_encode(["tables" => $tables], JSON_UNESCAPED_UNICODE));
+                }
+                elseif(isset($_REQUEST["config"]))
                 {
                     $configName = trim($_REQUEST["config"]);
                     if(!preg_match(FILE_MASK, $configName))
@@ -7280,6 +7289,18 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                         mkdir($logsDir, 0775, true);
                     if(!isset($configData['output_file']))
                         $configData['output_file'] = "$logsDir/google_sheets_sync.bki";
+                    # Force current site / current DB at sync time
+                    if(isset($configData['integram']) && is_array($configData['integram']))
+                    {
+                        $configData['integram']['base_url'] = '';
+                        $configData['integram']['database'] = '';
+                        if(!empty($configData['integram']['table_id']))
+                        {
+                            $tableId = preg_replace('/\D+/', '', (string)$configData['integram']['table_id']);
+                            if($tableId !== '')
+                                $configData['integram']['upload_endpoint'] = "/$z/object/$tableId?JSON&import=1";
+                        }
+                    }
                     require_once "include/google_sheets_sync.php";
                     $configData = gss_normalize_config($configData, realpath($gssDir));
                     try {
@@ -7309,6 +7330,16 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                     $data = json_decode($json, true);
                     if(!is_array($data))
                         my_error(t9n("[RU]Ошибка разбора JSON[EN]Invalid JSON"), "400");
+                    # Strip client-supplied site / DB and persist only table_id; URL is built from current $z at sync time
+                    if(isset($data['integram']) && is_array($data['integram']))
+                    {
+                        unset($data['integram']['base_url'], $data['integram']['database'], $data['integram']['upload_endpoint']);
+                        if(isset($data['integram']['table_id']))
+                        {
+                            $tableId = preg_replace('/\D+/', '', (string)$data['integram']['table_id']);
+                            $data['integram']['table_id'] = $tableId;
+                        }
+                    }
                     file_put_contents("$gssDir/$configName.json", json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
                     api_dump(json_encode(["ok" => true], JSON_UNESCAPED_UNICODE));
                 }

--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -23,12 +23,13 @@
 .gss-result pre { white-space: pre-wrap; font-size: 0.8rem; background: var(--bg-secondary); border: 1px solid var(--border-color); border-radius: 4px; padding: 0.75rem; margin: 0; color: var(--text-primary); }
 .gss-form-box { border: 1px solid var(--border-color); border-radius: 8px; padding: 1.25rem; margin-top: 1rem; background: var(--card-bg, var(--bg-primary)); }
 .gss-form-box h5 { margin: 0 0 1rem; color: var(--text-primary); font-size: 1rem; }
-.gss-section-label { font-size: 0.75rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-secondary); margin: 1rem 0 0.5rem; border-bottom: 1px solid var(--border-color); padding-bottom: 0.25rem; }
 .gss-field { margin-bottom: 0.75rem; }
 .gss-field label { display: block; font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 0.2rem; }
-.gss-field input[type=text], .gss-field textarea { width: 100%; box-sizing: border-box; padding: 0.45rem 0.6rem; border: 1px solid var(--border-color); border-radius: 4px; background: var(--input-bg, var(--bg-secondary)); color: var(--text-primary); font-size: 0.9rem; font-family: inherit; }
+.gss-field input[type=text], .gss-field select, .gss-field textarea { width: 100%; box-sizing: border-box; padding: 0.45rem 0.6rem; border: 1px solid var(--border-color); border-radius: 4px; background: var(--input-bg, var(--bg-secondary)); color: var(--text-primary); font-size: 0.9rem; font-family: inherit; }
 .gss-field textarea { font-family: monospace; resize: vertical; }
-.gss-field input[type=text]:focus, .gss-field textarea:focus { outline: none; border-color: var(--color-primary, #1283da); }
+.gss-field input[type=text]:focus, .gss-field select:focus, .gss-field textarea:focus { outline: none; border-color: var(--color-primary, #1283da); }
+#service-acc { cursor: pointer; }
+#service-acc:hover { background: var(--bg-primary); }
 .gss-row { display: flex; gap: 1rem; }
 .gss-row .gss-field { flex: 1; }
 .gss-checkbox { display: flex; align-items: center; gap: 0.5rem; font-size: 0.9rem; color: var(--text-primary); cursor: pointer; margin-bottom: 0.5rem; }
@@ -49,8 +50,20 @@
         <h5>Как пользоваться</h5>
         <p><b>1. credentials.json</b> — сервисный аккаунт Google (скачивается в <a target="googel" href="https://console.cloud.google.com/apis/credentials?project=ideavpro">Google Cloud Console</a>). Если путь не указан, используется <code>include/credentials.json</code> на сервере. Дайте аккаунту доступ к таблице.</p>
         <p><b>2. Spreadsheet ID</b> — из ссылки Google Sheets: <code>docs.google.com/spreadsheets/d/<b>ИДЕНТИФИКАТОР</b>/edit</code></p>
-        <p><b>3. Sheets</b> — JSON-массив листов. Пример: <code>[{"name":"Лист1","rows":["Метрика"],"columns":[["01.**.202*","31.**.202*","'ПЛАН'||'ФАКТ'"]]}]</code></p>
-        <p><b>4. Integram</b> — укажите URL базы, endpoint и токен авторизации. autoParent — ID родительского типа.</p>
+        <p><b>3. Sheets</b> — JSON-массив листов. Каждый лист задает имя, список строк (метрик) и колонки в формате <code>[from, to, label]</code>. Пример:</p>
+        <pre style="white-space:pre-wrap;font-size:0.78rem;background:var(--bg-primary);padding:0.5rem;border-radius:4px;margin:0.25rem 0;">[
+    {
+        "name": "(План-Факт) (2026)",
+        "rows": ["Выручка *", "Поступления *"],
+        "columns": [
+            ["01.01.202*", "31.01.202*", "'ПЛАН'||'ФАКТ'"],
+            ["01.02.202*", "'28.02.202*'||'29.02.202*'", "'ПЛАН'||'ФАКТ'"],
+            ["01.03.202*", "31.03.202*", "'ПЛАН'||'ФАКТ'"],
+            ["01.12.202*", "31.12.202*", "'ПЛАН'||'ФАКТ'"]
+        ]
+    }
+]</pre>
+        <p><b>4. Integram</b> — выберите таблицу для загрузки (выпадающий список), укажите токен авторизации. autoParent — ID родительского типа. URL сервера и БД подставляются автоматически (текущий сайт/БД).</p>
         <p><b>5. Логи</b> (BKI-файлы) сохраняются в <a href="/{_global_.z}/dir_admin/?templates=1&add_path=/logs/{_global_.z}"><code>templates/logs/{_global_.z}/</code></a>.</p>
         <p>Конфигурации хранятся в <code>templates/gss/{_global_.z}/</code>.</p>
     </div>
@@ -76,7 +89,6 @@
     <div class="gss-form-box" id="gss-form" style="display:none">
         <h5 id="gss-form-title">Новая конфигурация</h5>
 
-        <div class="gss-section-label">Основные</div>
         <div class="gss-field">
             <label>Имя конфигурации (латиница, цифры, дефис, точка) *</label>
             <input type="text" id="gss-name" placeholder="my_config">
@@ -86,21 +98,13 @@
             <input type="text" id="gss-spreadsheet-id" placeholder="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms">
         </div>
         <div class="gss-field">
-            <label>Путь к credentials.json (можно оставить пустым и запросить доступ для <code id="service-acc">ideav-430@ideavpro.iam.gserviceaccount.com</code>)</label>
+            <label>Путь к credentials.json (можно оставить пустым и запросить доступ для <code id="service-acc" title="Скопировать">ideav-430@ideavpro.iam.gserviceaccount.com</code>)</label>
             <input type="text" id="gss-credentials" placeholder="">
         </div>
-        <label class="gss-checkbox"><input type="checkbox" id="gss-skip-empty"> Пропускать пустые значения</label>
 
-        <div class="gss-section-label">Integram</div>
-        <div class="gss-row">
-            <div class="gss-field">
-                <label>Base URL *</label>
-                <input type="text" id="gss-base-url" placeholder="https://ideav.ru">
-            </div>
-            <div class="gss-field">
-                <label>Upload endpoint *</label>
-                <input type="text" id="gss-endpoint" placeholder="/object/443296?JSON&import=1">
-            </div>
+        <div class="gss-field">
+            <label>Таблица для загрузки *</label>
+            <select id="gss-table-id"><option value="">— загрузка списка —</option></select>
         </div>
         <div class="gss-field">
             <label>Токен авторизации</label>
@@ -116,12 +120,26 @@
                 <input type="text" id="gss-create-parent" placeholder="1">
             </div>
         </div>
-        <label class="gss-checkbox"><input type="checkbox" id="gss-enabled"> Включить загрузку в Integram</label>
+        <label class="gss-checkbox"><input type="checkbox" id="gss-enabled"> Загрузка включена</label>
 
-        <div class="gss-section-label">Листы (sheets)</div>
         <div class="gss-field">
             <label>JSON-массив листов</label>
-            <textarea id="gss-sheets" rows="8" placeholder='[{"name":"Лист1","rows":["Метрика A"],"columns":[["01.**.202*","31.**.202*","'"'"'ПЛАН'"'"'||'"'"'ФАКТ'"'"'"]]}]'></textarea>
+            <textarea id="gss-sheets" rows="14" placeholder="[
+    {
+        'name' => '(План-Факт) (2026)',
+        'rows' => [
+            'Выручка *',
+            'Поступления *',
+        ],
+        'columns' => [
+            ['01.01.202*', '31.01.202*', &quot;'ПЛАН'||'ФАКТ'&quot;],
+            ['01.02.202*', &quot;'28.02.202*'||'29.02.202*'&quot;, &quot;'ПЛАН'||'ФАКТ'&quot;],
+            ['01.03.202*', '31.03.202*', &quot;'ПЛАН'||'ФАКТ'&quot;],
+            ...
+            ['01.12.202*', '31.12.202*', &quot;'ПЛАН'||'ФАКТ'&quot;],
+        ],
+    },
+]"></textarea>
         </div>
 
         <div class="gss-form-actions">
@@ -136,12 +154,56 @@
 (function() {
     var db = document.getElementById('gss-list').dataset.db;
     var editingConfig = null;
+    var tablesLoaded = null; // Promise
 
     function updateEmpty() {
         var hasCards = document.querySelectorAll('.gss-card').length > 0;
         document.getElementById('gss-empty').style.display = hasCards ? 'none' : '';
     }
     updateEmpty();
+
+    function existingConfigNames() {
+        var names = [];
+        document.querySelectorAll('.gss-card').forEach(function(c) {
+            var id = c.id || '';
+            if (id.indexOf('card-') === 0) names.push(id.substring(5));
+        });
+        return names;
+    }
+
+    function nextDefaultConfigName() {
+        var used = {};
+        existingConfigNames().forEach(function(n) {
+            var m = /^my_config(\d+)$/.exec(n);
+            if (m) used[parseInt(m[1], 10)] = true;
+        });
+        var n = 1;
+        while (used[n]) n++;
+        return 'my_config' + n;
+    }
+
+    function loadTables() {
+        if (tablesLoaded) return tablesLoaded;
+        tablesLoaded = fetch('/' + db + '/gssync?JSON&metadata=tables')
+            .then(function(r) { return r.json(); })
+            .then(function(d) {
+                var sel = document.getElementById('gss-table-id');
+                sel.innerHTML = '<option value="">— выберите таблицу —</option>';
+                (d.tables || []).forEach(function(t) {
+                    var opt = document.createElement('option');
+                    opt.value = t.id;
+                    opt.textContent = t.val + ' (id=' + t.id + ')';
+                    sel.appendChild(opt);
+                });
+                return d.tables || [];
+            })
+            .catch(function(err) {
+                var sel = document.getElementById('gss-table-id');
+                sel.innerHTML = '<option value="">Ошибка загрузки списка</option>';
+                throw err;
+            });
+        return tablesLoaded;
+    }
 
     document.getElementById('gss-help-btn').addEventListener('click', function() {
         var h = document.getElementById('gss-help');
@@ -153,6 +215,8 @@
         document.getElementById('gss-form-title').textContent = 'Новая конфигурация';
         document.getElementById('gss-name').disabled = false;
         clearForm();
+        document.getElementById('gss-name').value = nextDefaultConfigName();
+        loadTables();
         document.getElementById('gss-form').style.display = '';
         document.getElementById('gss-form').scrollIntoView({behavior:'smooth', block:'nearest'});
     });
@@ -171,15 +235,48 @@
         document.getElementById('gss-name').value = config;
         document.getElementById('gss-name').disabled = true;
         document.getElementById('gss-save-msg').textContent = '';
-        fetch('/' + db + '/gssync?JSON&load=' + encodeURIComponent(config))
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                fillForm(data);
-                document.getElementById('gss-form').style.display = '';
-                document.getElementById('gss-form').scrollIntoView({behavior:'smooth', block:'nearest'});
-            })
-            .catch(function(err) { alert('Ошибка загрузки: ' + err); });
+        Promise.all([
+            loadTables(),
+            fetch('/' + db + '/gssync?JSON&load=' + encodeURIComponent(config)).then(function(r) { return r.json(); })
+        ]).then(function(res) {
+            fillForm(res[1]);
+            document.getElementById('gss-form').style.display = '';
+            document.getElementById('gss-form').scrollIntoView({behavior:'smooth', block:'nearest'});
+        }).catch(function(err) { alert('Ошибка загрузки: ' + err); });
     });
+
+    document.getElementById('service-acc').addEventListener('click', function(e) {
+        e.preventDefault();
+        var text = this.textContent;
+        var done = function() {
+            var msg = document.getElementById('gss-save-msg');
+            msg.textContent = 'Адрес скопирован в буфер обмена';
+            msg.className = 'gss-msg ok';
+            setTimeout(function() {
+                if (msg.textContent === 'Адрес скопирован в буфер обмена') {
+                    msg.textContent = '';
+                    msg.className = 'gss-msg';
+                }
+            }, 2500);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done).catch(function() { fallbackCopy(text); done(); });
+        } else {
+            fallbackCopy(text);
+            done();
+        }
+    });
+
+    function fallbackCopy(text) {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); } catch(e) {}
+        document.body.removeChild(ta);
+    }
 
     document.addEventListener('click', function(e) {
         var btn = e.target.closest('.gss-run-btn');
@@ -222,6 +319,8 @@
     document.getElementById('gss-save-btn').addEventListener('click', function() {
         var name = document.getElementById('gss-name').value.trim();
         if (!name) { showMsg('Укажите имя конфигурации', false); return; }
+        var tableId = document.getElementById('gss-table-id').value.trim();
+        if (!tableId) { showMsg('Выберите таблицу для загрузки', false); return; }
         var sheetsRaw = document.getElementById('gss-sheets').value.trim();
         var sheets;
         try { sheets = sheetsRaw ? JSON.parse(sheetsRaw) : []; }
@@ -230,11 +329,9 @@
         var cfg = {
             spreadsheet_id: document.getElementById('gss-spreadsheet-id').value.trim(),
             sheets: sheets,
-            skip_empty_values: document.getElementById('gss-skip-empty').checked,
             integram: {
                 enabled: document.getElementById('gss-enabled').checked,
-                base_url: document.getElementById('gss-base-url').value.trim(),
-                upload_endpoint: document.getElementById('gss-endpoint').value.trim(),
+                table_id: tableId,
                 token: document.getElementById('gss-token').value.trim(),
                 autoParent: document.getElementById('gss-auto-parent').value.trim() || '449960',
                 createParent: document.getElementById('gss-create-parent').value.trim() || '1'
@@ -266,12 +363,12 @@
     }
 
     function clearForm() {
-        ['gss-name','gss-spreadsheet-id','gss-credentials','gss-base-url','gss-endpoint','gss-token'].forEach(function(id) {
+        ['gss-name','gss-spreadsheet-id','gss-credentials','gss-token'].forEach(function(id) {
             document.getElementById(id).value = '';
         });
+        document.getElementById('gss-table-id').value = '';
         document.getElementById('gss-auto-parent').value = '449960';
         document.getElementById('gss-create-parent').value = '1';
-        document.getElementById('gss-skip-empty').checked = false;
         document.getElementById('gss-enabled').checked = false;
         document.getElementById('gss-sheets').value = '';
         document.getElementById('gss-save-msg').textContent = '';
@@ -280,10 +377,13 @@
     function fillForm(data) {
         document.getElementById('gss-spreadsheet-id').value = data.spreadsheet_id || '';
         document.getElementById('gss-credentials').value = data.credentials_path || '';
-        document.getElementById('gss-skip-empty').checked = !!data.skip_empty_values;
         var ig = data.integram || {};
-        document.getElementById('gss-base-url').value = ig.base_url || '';
-        document.getElementById('gss-endpoint').value = ig.upload_endpoint || '';
+        var tableId = ig.table_id || '';
+        if (!tableId && ig.upload_endpoint) {
+            var m = /\/object\/(\d+)/.exec(ig.upload_endpoint);
+            if (m) tableId = m[1];
+        }
+        document.getElementById('gss-table-id').value = tableId;
         document.getElementById('gss-token').value = ig.token || '';
         document.getElementById('gss-auto-parent').value = ig.autoParent !== undefined ? ig.autoParent : '449960';
         document.getElementById('gss-create-parent').value = ig.createParent !== undefined ? ig.createParent : '1';


### PR DESCRIPTION
## Summary

Правки формы конфигурации `gssync` по списку из #2547:

- **Base URL убран** — URL сервера всегда подставляется автоматически (текущий сайт). При сохранении клиентское `base_url` игнорируется, при запуске синка он принудительно очищается.
- **Upload endpoint → выпадающий список таблиц.** Новый endpoint `gssync?JSON&metadata=tables` отдаёт типы, где `up=0 AND id!=t AND id>300`. На сохранении хранится только `integram.table_id`; финальный URL `/<db>/object/<table_id>?JSON&import=1` строится сервером (текущая БД) при запуске.
- **Имя конфигурации по умолчанию** — `my_config{N}`, где N — наименьший свободный порядковый номер среди существующих имён вида `my_config\d+`.
- **`#service-acc` копируется в буфер** по клику, в области сообщений формы появляется «Адрес скопирован в буфер обмена» (исчезает через 2.5 с). Используется `navigator.clipboard.writeText` с fallback на `document.execCommand('copy')`.
- **Удалены** `.gss-section-label` и чекбокс `#gss-skip-empty` (с сохранением — больше не передаётся).
- **Переименовано** «Включить загрузку в Integram» → «Загрузка включена».
- **Подсказка/placeholder** для «JSON-массив листов» обновлены: в справке (`#gss-help`) — корректный JSON-пример с (План-Факт) (2026), в `placeholder` textarea — PHP-array образец из тела issue.

## Backward compatibility

Конфиги, сохранённые до этого PR (с `base_url`/`upload_endpoint`), продолжают работать: при загрузке формы из `upload_endpoint` парсится `/object/(\d+)` и выставляется в дропдаун. При следующем сохранении конфиг мигрирует к новой схеме (`table_id` вместо `upload_endpoint`).

## Test plan

- [ ] Открыть `gssync`, нажать «Новая конфигурация» → имя предзаполнено `my_config1` (или ближайшим свободным).
- [ ] Список «Таблица для загрузки» загружается, в нём только типы с `id>300`.
- [ ] Сохранить новый конфиг → файл в `templates/gss/<db>/<name>.json` содержит `integram.table_id` и не содержит `base_url`/`upload_endpoint`.
- [ ] Нажать «Запустить» → в логе/ответе видно, что запрос ушёл на `/<db>/object/<table_id>?JSON&import=1` на текущий хост.
- [ ] Открыть старый конфиг (с `upload_endpoint`) → в дропдауне выбран соответствующий `table_id`.
- [ ] Клик по адресу `ideav-430@...` копирует его в буфер, появляется зелёное сообщение «Адрес скопирован в буфер обмена».
- [ ] Чекбокс «Загрузка включена» сохраняется/восстанавливается.
- [ ] Сохранение без выбранной таблицы → красная ошибка «Выберите таблицу для загрузки».

Closes #2547

🤖 Generated with [Claude Code](https://claude.com/claude-code)