### PR TITLE
gssync: исправлен fatal my_error() is undefined (#2548)

### DIFF
--- a/index.php
+++ b/index.php
@@ -7277,13 +7277,13 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                 {
                     $configName = trim($_REQUEST["config"]);
                     if(!preg_match(FILE_MASK, $configName))
-                        my_error(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
+                        my_die(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
                     $configFile = "$gssDir/$configName.json";
                     if(!file_exists($configFile))
-                        my_error(t9n("[RU]Файл конфигурации не найден[EN]Config file not found"), "404");
+                        my_die(t9n("[RU]Файл конфигурации не найден[EN]Config file not found"), "404");
                     $configData = json_decode(file_get_contents($configFile), true);
                     if(!is_array($configData))
-                        my_error(t9n("[RU]Ошибка разбора конфигурации[EN]Config parse error"), "400");
+                        my_die(t9n("[RU]Ошибка разбора конфигурации[EN]Config parse error"), "400");
                     $logsDir = "templates/logs/$z";
                     if(!file_exists($logsDir))
                         mkdir($logsDir, 0775, true);
@@ -7307,17 +7307,17 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                         $summary = gss_sync($configData);
                         api_dump(json_encode($summary, JSON_UNESCAPED_UNICODE));
                     } catch (Throwable $e) {
-                        my_error($e->getMessage(), "500");
+                        my_die($e->getMessage(), "500");
                     }
                 }
                 elseif(isset($_REQUEST["load"]))
                 {
                     $configName = trim($_REQUEST["load"]);
                     if(!preg_match(FILE_MASK, $configName))
-                        my_error(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
+                        my_die(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
                     $configFile = "$gssDir/$configName.json";
                     if(!file_exists($configFile))
-                        my_error(t9n("[RU]Файл конфигурации не найден[EN]Config file not found"), "404");
+                        my_die(t9n("[RU]Файл конфигурации не найден[EN]Config file not found"), "404");
                     api_dump(file_get_contents($configFile));
                 }
                 elseif(isset($_REQUEST["save"]))
@@ -7325,11 +7325,11 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                     check();
                     $configName = trim($_REQUEST["save"]);
                     if(!preg_match(FILE_MASK, $configName))
-                        my_error(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
+                        my_die(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
                     $json = isset($_POST["config"]) ? $_POST["config"] : "";
                     $data = json_decode($json, true);
                     if(!is_array($data))
-                        my_error(t9n("[RU]Ошибка разбора JSON[EN]Invalid JSON"), "400");
+                        my_die(t9n("[RU]Ошибка разбора JSON[EN]Invalid JSON"), "400");
                     # Strip client-supplied site / DB and persist only table_id; URL is built from current $z at sync time
                     if(isset($data['integram']) && is_array($data['integram']))
                     {
@@ -7348,14 +7348,14 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                     check();
                     $configName = trim($_REQUEST["delete"]);
                     if(!preg_match(FILE_MASK, $configName))
-                        my_error(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
+                        my_die(t9n("[RU]Неверное имя файла конфигурации[EN]Invalid config file name"), "400");
                     $configFile = "$gssDir/$configName.json";
                     if(file_exists($configFile))
                         unlink($configFile);
                     api_dump(json_encode(["ok" => true], JSON_UNESCAPED_UNICODE));
                 }
                 else
-                    my_error(t9n("[RU]Не указано действие[EN]No action specified"), "400");
+                    my_die(t9n("[RU]Не указано действие[EN]No action specified"), "400");
             }
             # Populate config list for HTML rendering
             $GLOBALS["gss_configs"] = [];


### PR DESCRIPTION
## Summary

В handler-е `case \"&gssync\":` (`index.php`) использовался несуществующий хелпер `my_error()` для ответа ошибками 400/404/500. В этом коде канонический хелпер — `my_die(\$msg, \$code)` (`index.php:1243`), сигнатура та же. Из-за чего любой запрос с невалидным/непереданным параметром (`?JSON&save=…`, `&load=…`, `&config=…`, `&delete=…` без аргумента, или вообще без действия) валился с

\`\`\`
PHP Fatal error: Uncaught Error: Call to undefined function my_error()
\`\`\`

Имя `my_error` приехало вместе с PR #2545 и сохранилось в #2549 — обе мердж-проверки не вызывают эти пути, поэтому регрессия не была поймана.

## Change

Замена `my_error(` → `my_die(` во всех 10 местах внутри `case \"&gssync\":`. Сигнатура `my_die(\$msg, \$code=\"\")` совпадает с использованной — позиционные аргументы (сообщение, HTTP-код) передаются без изменений.

\`my_die\` устанавливает HTTP-код, и для API (\`isApi()\`) отвечает \`api_dump(json_encode([[\"error\" => …]]))\` — поведение, ожидаемое клиентом формы (\`gssync.html\` парсит \`r.json()\`).

## Test plan

- [ ] \`POST /<db>/gssync?JSON&save=../etc\` → 400 + JSON, не Fatal
- [ ] \`GET  /<db>/gssync?JSON&load=nonexistent\` → 404 + JSON, не Fatal
- [ ] \`GET  /<db>/gssync?JSON&config=nonexistent\` → 404 + JSON, не Fatal
- [ ] \`POST /<db>/gssync?JSON\` (без действия) → 400 + JSON «Не указано действие»
- [ ] Сохранение валидного конфига через форму — продолжает работать (200 ok).

Closes #2548

🤖 Generated with [Claude Code](https://claude.com/claude-code)