### PR TITLE
gssync: принимать один лист как объект и валидный JSON в форме (#2552)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
 # Updated: 2026-05-11T12:29:15.813Z
+# Updated: 2026-05-12T05:25:35.185Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
 # Updated: 2026-05-11T12:29:15.813Z
-# Updated: 2026-05-12T05:25:35.185Z

--- a/experiments/test-issue-2552-gssync-single-sheet.php
+++ b/experiments/test-issue-2552-gssync-single-sheet.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Test for issue #2552:
+ * - User pastes a single sheet config (object) instead of an array of sheets.
+ * - gss_normalize_config() should wrap a single sheet config into a one-element array.
+ * - gss_sync() must NOT throw "Each sheet config must define name or range" for the user's payload.
+ */
+
+require_once __DIR__ . '/../include/google_sheets_sync.php';
+
+// User-supplied config from the issue:
+$userPayload = [
+    'spreadsheet_id' => 'some-id',
+    'sheets' => [
+        'name' => '(План-Факт) (2026)',
+        'rows' => ['Выручка *', 'Поступления *'],
+        'columns' => [
+            ['01.01.202*', '31.01.202*', 'ПЛАН||ФАКТ'],
+            ['01.02.202*', '28.02.202*', 'ПЛАН||ФАКТ'],
+            '2025',
+            '2026',
+        ],
+    ],
+];
+
+$normalized = gss_normalize_config($userPayload, __DIR__);
+assert(is_array($normalized['sheets']), 'sheets must be an array');
+assert(count($normalized['sheets']) === 1, 'single sheet should be wrapped into a 1-element array');
+assert(isset($normalized['sheets'][0]['name']), 'wrapped sheet must keep the "name" field');
+assert($normalized['sheets'][0]['name'] === '(План-Факт) (2026)', 'sheet name preserved');
+
+echo "OK: gss_normalize_config wraps a single sheet object into [sheet]\n";
+
+// Verify the array-of-sheets form still works unchanged.
+$arrayPayload = [
+    'spreadsheet_id' => 'some-id',
+    'sheets' => [
+        [
+            'name' => 'Sheet A',
+            'rows' => ['Row A'],
+            'columns' => [['x', 'y', 'z']],
+        ],
+        [
+            'name' => 'Sheet B',
+            'rows' => ['Row B'],
+            'columns' => [['x', 'y', 'z']],
+        ],
+    ],
+];
+$normalized = gss_normalize_config($arrayPayload, __DIR__);
+assert(count($normalized['sheets']) === 2, 'two-sheet array preserved as-is');
+echo "OK: array-of-sheets form preserved\n";
+
+// Verify empty sheets stays empty (no spurious wrapping).
+$emptyPayload = ['sheets' => []];
+$normalized = gss_normalize_config($emptyPayload, __DIR__);
+assert($normalized['sheets'] === [], 'empty sheets stays empty');
+echo "OK: empty sheets unchanged\n";
+
+// Verify the exact JSON from the issue parses, normalizes, and matches the schema gss_sync() expects.
+$issueRaw = '{
+  "name": "(План-Факт) (2026)",
+  "rows": [
+    "Выручка *",
+    "Поступления *"
+  ],
+  "columns": [
+    ["01.01.202*", "31.01.202*", "ПЛАН||ФАКТ"],
+    ["01.02.202*", "28.02.202*", "ПЛАН||ФАКТ"],
+    ["01.03.202*", "31.03.202*", "ПЛАН||ФАКТ"],
+    ["01.04.202*", "30.04.202*", "ПЛАН||ФАКТ"],
+    ["01.05.202*", "31.05.202*", "ПЛАН||ФАКТ"],
+    ["01.06.202*", "30.06.202*", "ПЛАН||ФАКТ"],
+    ["01.07.202*", "31.07.202*", "ПЛАН||ФАКТ"],
+    ["01.08.202*", "31.08.202*", "ПЛАН||ФАКТ"],
+    ["01.09.202*", "30.09.202*", "ПЛАН||ФАКТ"],
+    ["01.10.202*", "31.10.202*", "ПЛАН||ФАКТ"],
+    ["01.11.202*", "30.11.202*", "ПЛАН||ФАКТ"],
+    ["01.12.202*", "31.12.202*", "ПЛАН||ФАКТ"],
+    "2025",
+    "2026"
+  ]
+}';
+$sheet = json_decode($issueRaw, true);
+assert($sheet !== null, 'issue payload must parse as JSON');
+$saved = ['spreadsheet_id' => 'X', 'sheets' => $sheet];
+$normalized = gss_normalize_config($saved, __DIR__);
+assert(is_array($normalized['sheets']) && count($normalized['sheets']) === 1, 'issue payload wrapped to array of size 1');
+assert($normalized['sheets'][0]['name'] === '(План-Факт) (2026)', 'issue sheet name preserved');
+echo "OK: exact issue payload normalized to array of one sheet\n";
+
+echo "All assertions passed.\n";

--- a/include/google_sheets_sync.php
+++ b/include/google_sheets_sync.php
@@ -89,6 +89,10 @@ function gss_normalize_config($config, $configDir) {
     $config['credentials_path'] = gss_resolve_path($config['credentials_path'], $configDir);
     $config['output_file'] = gss_resolve_path($config['output_file'], $configDir);
 
+    if (is_array($config['sheets']) && (isset($config['sheets']['name']) || isset($config['sheets']['range']))) {
+        $config['sheets'] = [$config['sheets']];
+    }
+
     $integramDefaults = [
         'enabled' => false,
         'base_url' => '',

--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -123,23 +123,24 @@
         <label class="gss-checkbox"><input type="checkbox" id="gss-enabled"> Загрузка включена</label>
 
         <div class="gss-field">
-            <label>JSON-массив листов</label>
-            <textarea id="gss-sheets" rows="14" placeholder="[
+            <label>JSON-массив листов (каждый лист — объект с полями <code>name</code>, <code>rows</code>, <code>columns</code>)</label>
+            <textarea id="gss-sheets" rows="14" placeholder='[
     {
-        'name' => '(План-Факт) (2026)',
-        'rows' => [
-            'Выручка *',
-            'Поступления *',
+        "name": "(План-Факт) (2026)",
+        "rows": [
+            "Выручка *",
+            "Поступления *"
         ],
-        'columns' => [
-            ['01.01.202*', '31.01.202*', &quot;'ПЛАН'||'ФАКТ'&quot;],
-            ['01.02.202*', &quot;'28.02.202*'||'29.02.202*'&quot;, &quot;'ПЛАН'||'ФАКТ'&quot;],
-            ['01.03.202*', '31.03.202*', &quot;'ПЛАН'||'ФАКТ'&quot;],
-            ...
-            ['01.12.202*', '31.12.202*', &quot;'ПЛАН'||'ФАКТ'&quot;],
-        ],
-    },
-]"></textarea>
+        "columns": [
+            ["01.01.202*", "31.01.202*", "ПЛАН||ФАКТ"],
+            ["01.02.202*", "28.02.202*", "ПЛАН||ФАКТ"],
+            ["01.03.202*", "31.03.202*", "ПЛАН||ФАКТ"],
+            ["01.12.202*", "31.12.202*", "ПЛАН||ФАКТ"],
+            "2025",
+            "2026"
+        ]
+    }
+]'></textarea>
         </div>
 
         <div class="gss-form-actions">
@@ -325,6 +326,23 @@
         var sheets;
         try { sheets = sheetsRaw ? JSON.parse(sheetsRaw) : []; }
         catch(e) { showMsg('Ошибка в JSON листов: ' + e.message, false); return; }
+        if (sheets && !Array.isArray(sheets) && typeof sheets === 'object') {
+            sheets = [sheets];
+        }
+        if (!Array.isArray(sheets)) {
+            showMsg('JSON листов должен быть массивом объектов или одним объектом листа', false); return;
+        }
+        for (var i = 0; i < sheets.length; i++) {
+            var s = sheets[i];
+            if (!s || typeof s !== 'object' || Array.isArray(s)) {
+                showMsg('Лист #' + (i + 1) + ' должен быть объектом', false); return;
+            }
+            var hasName = typeof s.name === 'string' && s.name.trim() !== '';
+            var hasRange = typeof s.range === 'string' && s.range.trim() !== '';
+            if (!hasName && !hasRange) {
+                showMsg('Лист #' + (i + 1) + ' должен содержать "name" или "range"', false); return;
+            }
+        }
 
         var cfg = {
             spreadsheet_id: document.getElementById('gss-spreadsheet-id').value.trim(),


### PR DESCRIPTION
## Что не так

В issue #2552 пользователь получил ошибку
`Each sheet config must define "name" or "range".` при сохранении
конфигурации со следующим содержимым в поле "JSON-массив листов":

```json
{
  "name": "(План-Факт) (2026)",
  "rows": ["..."],
  "columns": [...]
}
```

Причина в двух местах в `templates/gssync.html`:

1. **Подсказка (placeholder) была не JSON.** В textarea был
   PHP-подобный синтаксис со стрелками `=>`, одинарными кавычками,
   многоточием `...` и хвостовыми запятыми. Такой текст невозможно
   распарсить через `JSON.parse` — он не пример, а ловушка.
2. **Конфиг ожидает массив листов, а не один лист.** Пользователь
   вставил один объект-лист (без `[ ... ]`). На сервере
   `gss_sync()` берёт `$config['sheets']` как массив листов и для
   каждого требует `name` или `range`. Когда сверху лежит один
   объект, PHP видит ключи `name`, `rows`, `columns` как ключи
   "листа" и ругается, что у листа нет имени.

## Что сделано

- В `templates/gssync.html`:
  - placeholder для `gss-sheets` заменён на **валидный JSON**,
    структура совпадает с примером из справки (`gss-help-box`);
  - перед сохранением: если введён один объект — он автоматически
    оборачивается в массив (`[ ... ]`);
  - перед сохранением проверяется, что каждый лист — объект с
    `name` или `range`. Сообщение показывается до запроса.
- В `include/google_sheets_sync.php`:
  - `gss_normalize_config()` оборачивает один sheet-объект в
    массив, чтобы ранее сохранённые "сломанные" конфиги
    отрабатывали без ручного пересохранения.
- Добавлен тест `experiments/test-issue-2552-gssync-single-sheet.php`,
  который проверяет обе ветки и точный JSON из issue.

## Верный конфиг

```json
{
  "spreadsheet_id": "1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms",
  "sheets": [
    {
      "name": "(План-Факт) (2026)",
      "rows": ["Выручка *", "Поступления *"],
      "columns": [
        ["01.01.202*", "31.01.202*", "ПЛАН||ФАКТ"],
        ["01.02.202*", "28.02.202*", "ПЛАН||ФАКТ"],
        ["01.03.202*", "31.03.202*", "ПЛАН||ФАКТ"],
        ["01.04.202*", "30.04.202*", "ПЛАН||ФАКТ"],
        ["01.05.202*", "31.05.202*", "ПЛАН||ФАКТ"],
        ["01.06.202*", "30.06.202*", "ПЛАН||ФАКТ"],
        ["01.07.202*", "31.07.202*", "ПЛАН||ФАКТ"],
        ["01.08.202*", "31.08.202*", "ПЛАН||ФАКТ"],
        ["01.09.202*", "30.09.202*", "ПЛАН||ФАКТ"],
        ["01.10.202*", "31.10.202*", "ПЛАН||ФАКТ"],
        ["01.11.202*", "30.11.202*", "ПЛАН||ФАКТ"],
        ["01.12.202*", "31.12.202*", "ПЛАН||ФАКТ"],
        "2025",
        "2026"
      ]
    }
  ],
  "integram": {
    "enabled": true,
    "table_id": "<id выбранной таблицы>",
    "token": "<токен>",
    "autoParent": "449960",
    "createParent": "1"
  }
}
```

В поле "JSON-массив листов" в форме нужно вставлять только
содержимое `sheets`, то есть `[ { "name": "...", "rows": [...],
"columns": [...] } ]`. Остальные поля (`spreadsheet_id`,
`integram.*`) задаются отдельными полями формы.

## Проверка

```
php -d assert.exception=1 experiments/test-issue-2552-gssync-single-sheet.php
```

```
OK: gss_normalize_config wraps a single sheet object into [sheet]
OK: array-of-sheets form preserved
OK: empty sheets unchanged
OK: exact issue payload normalized to array of one sheet
All assertions passed.
```

Closes #2552