### PR TITLE
gssync: использовать /metadata?JSON вместо кастомного metadata=tables

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
 # Updated: 2026-05-11T12:29:15.813Z
+# Updated: 2026-05-12T06:00:38.410Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
 # Updated: 2026-05-11T12:29:15.813Z
-# Updated: 2026-05-12T06:00:38.410Z

--- a/index.php
+++ b/index.php
@@ -7264,16 +7264,7 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                 mkdir($gssDir, 0775, true);
             if(isApi())
             {
-                if(isset($_REQUEST["metadata"]) && $_REQUEST["metadata"] === "tables")
-                {
-                    $tables = [];
-                    $sql = "SELECT id, val FROM $z WHERE up=0 AND id!=t AND id>300 ORDER BY val";
-                    $data_set = Exec_sql($sql, "List tables for gssync");
-                    while($row = mysqli_fetch_array($data_set))
-                        $tables[] = ["id" => $row["id"], "val" => $row["val"]];
-                    api_dump(json_encode(["tables" => $tables], JSON_UNESCAPED_UNICODE));
-                }
-                elseif(isset($_REQUEST["config"]))
+                if(isset($_REQUEST["config"]))
                 {
                     $configName = trim($_REQUEST["config"]);
                     if(!preg_match(FILE_MASK, $configName))

--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -185,18 +185,24 @@
 
     function loadTables() {
         if (tablesLoaded) return tablesLoaded;
-        tablesLoaded = fetch('/' + db + '/gssync?JSON&metadata=tables')
+        tablesLoaded = fetch('/' + db + '/metadata?JSON')
             .then(function(r) { return r.json(); })
             .then(function(d) {
                 var sel = document.getElementById('gss-table-id');
                 sel.innerHTML = '<option value="">— выберите таблицу —</option>';
-                (d.tables || []).forEach(function(t) {
+                var tables = (Array.isArray(d) ? d : []).filter(function(t) {
+                    return t && t.id && t.val;
+                });
+                tables.sort(function(a, b) {
+                    return String(a.val).localeCompare(String(b.val), 'ru');
+                });
+                tables.forEach(function(t) {
                     var opt = document.createElement('option');
                     opt.value = t.id;
                     opt.textContent = t.val + ' (id=' + t.id + ')';
                     sel.appendChild(opt);
                 });
-                return d.tables || [];
+                return tables;
             })
             .catch(function(err) {
                 var sel = document.getElementById('gss-table-id');


### PR DESCRIPTION
## Summary

Issue #2554: запрос `/gssync?JSON&metadata=tables`, добавленный в #2549, возвращает мусор. Удаляем его и переходим на уже существующий стандартный эндпоинт `/{db}/metadata?JSON`, который применяется и в других формах (`templates/forms.html`, `js/migr.js`) и отдаёт корректный список типов с учётом прав доступа.

## Changes

- **`index.php`** — удалён ad-hoc обработчик `metadata=tables` в ветке `&gssync` (запрос `SELECT id, val FROM $z WHERE up=0 AND id!=t AND id>300`).
- **`templates/gssync.html`** — `loadTables()` теперь обращается к `/{db}/metadata?JSON`. Ответ-массив фильтруется по наличию `id`/`val` и сортируется по `val` (через `localeCompare`, ru).

## Backward compatibility

Формат опций в выпадающем списке (`<option value="{id}">{val} (id={id})</option>`) не меняется, поэтому сохранение/загрузка конфигов и логика выбора `table_id` остаются прежними.

## Test plan

- [ ] Открыть форму `gssync`, нажать «Новая конфигурация» → выпадающий список «Таблица для загрузки» заполнен из `/{db}/metadata?JSON` (с учётом грантов пользователя).
- [ ] Открыть существующий конфиг → корректно подставляется ранее выбранная таблица.
- [ ] В DevTools → Network: запрос `gssync?JSON&metadata=tables` больше не отправляется; вместо него идёт `metadata?JSON`, возвращающий валидный JSON-массив.
- [ ] Сохранение и запуск синка работают как раньше.

Fixes #2554

🤖 Generated with [Claude Code](https://claude.com/claude-code)