### PR TITLE
funnel: синхронизация фильтров по месяцу и датам

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-11T08:47:40.306Z for PR creation at branch issue-2520-6c5aab1e1d76 for issue https://github.com/ideav/crm/issues/2520
 # Updated: 2026-05-11T09:01:15.332Z
 # Updated: 2026-05-11T12:29:15.813Z
+# Updated: 2026-05-12T06:38:52.141Z

--- a/experiments/test-issue-2556-funnel-month-date.js
+++ b/experiments/test-issue-2556-funnel-month-date.js
@@ -1,0 +1,211 @@
+'use strict';
+
+// Verifies issue #2556 requirements for templates/funnel.html:
+//   1. Changing date-from / date-to resets the month filter to "Все".
+//   2. Month options are rendered in the human-readable form ("янв 2025").
+//   3. Selecting a month sets date-from / date-to to that month's start/end.
+
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('templates/funnel.html', 'utf8');
+
+function assert(condition, message) {
+    if (!condition) throw new Error(message);
+}
+
+function scriptFromTemplate(html) {
+    const match = html.match(/<script>([\s\S]*)<\/script>\s*$/);
+    if (!match) throw new Error('Unable to extract funnel script');
+    return match[1];
+}
+
+function escapeHtml(value) {
+    return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function createElement(tagName) {
+    const element = {
+        tagName: String(tagName || '').toUpperCase(),
+        _textContent: '',
+        _innerHTML: '',
+        value: '',
+        options: [],
+        classList: {
+            toggle: function() {}
+        },
+        appendChild: function(child) {
+            this.options.push(child);
+            return child;
+        },
+        remove: function(index) {
+            this.options.splice(index, 1);
+        },
+        setAttribute: function() {},
+        querySelector: function() {
+            return null;
+        }
+    };
+
+    Object.defineProperty(element, 'textContent', {
+        get: function() { return this._textContent; },
+        set: function(value) { this._textContent = String(value || ''); }
+    });
+    Object.defineProperty(element, 'innerHTML', {
+        get: function() {
+            return this._innerHTML || escapeHtml(this._textContent);
+        },
+        set: function(value) { this._innerHTML = String(value || ''); }
+    });
+
+    return element;
+}
+
+function createSelect() {
+    const select = createElement('select');
+    select.options.push({ value: '', textContent: '— Все —' });
+    return select;
+}
+
+const elements = {
+    'funnel-content': createElement('div'),
+    'funnel-filter-vacancy': createSelect(),
+    'funnel-filter-name': createSelect(),
+    'funnel-filter-month': createSelect(),
+    'funnel-filter-hire-type': createSelect(),
+    'funnel-filter-date-from': createElement('input'),
+    'funnel-filter-date-to': createElement('input'),
+    'funnel-view-chart': createElement('button'),
+    'funnel-view-table': createElement('button'),
+    'funnel-container': createElement('div')
+};
+
+const rows = [
+    {
+        'Вакансия': 'Менеджер',
+        'Имя': 'Алина',
+        'Месяц': '202501',
+        'Дата': '05.01.2025',
+        'Тип найма': 'Штат',
+        'Первый контакт': 10,
+        'Оффер': 2
+    },
+    {
+        'Вакансия': 'Менеджер',
+        'Имя': 'Борис',
+        'Месяц': '202501',
+        'Дата': '20.01.2025',
+        'Тип найма': 'Штат',
+        'Первый контакт': 20,
+        'Оффер': 5
+    },
+    {
+        'Вакансия': 'Менеджер',
+        'Имя': 'Вера',
+        'Месяц': '202502',
+        'Дата': '2025-02-03',
+        'Тип найма': 'Штат',
+        'Первый контакт': 30,
+        'Оффер': 8
+    }
+];
+
+function FakeXHR() {}
+FakeXHR.prototype.open = function() {};
+FakeXHR.prototype.send = function() {
+    this.responseText = JSON.stringify(rows);
+    this.onload();
+};
+
+const context = {
+    console: console,
+    db: 'crm',
+    XMLHttpRequest: FakeXHR,
+    document: {
+        getElementById: function(id) {
+            if (!elements[id]) throw new Error('Missing fake element #' + id);
+            return elements[id];
+        },
+        createElement: createElement,
+        addEventListener: function() {},
+        querySelector: function() {
+            return null;
+        }
+    },
+    window: {}
+};
+context.window = context;
+
+// The template's filter handlers must call the new functions.
+assert(/onchange="funnelMonthChanged\(\)"/.test(source), 'month filter must call funnelMonthChanged');
+assert(/onchange="funnelDateChanged\(\)"/.test(source), 'date filters must call funnelDateChanged');
+
+vm.runInNewContext(scriptFromTemplate(source), context);
+context.funnelLoad();
+
+// Requirement 2: month options are rendered in human-readable form.
+const monthSelect = elements['funnel-filter-month'];
+const monthOptions = monthSelect.options
+    .filter(function(opt) { return opt.value; })
+    .map(function(opt) { return opt.textContent; });
+assert(monthOptions.indexOf('янв 2025') !== -1, 'month option for 202501 must read "янв 2025"');
+assert(monthOptions.indexOf('фев 2025') !== -1, 'month option for 202502 must read "фев 2025"');
+
+// Requirement 3: picking a month sets date-from / date-to to that month's bounds.
+elements['funnel-filter-month'].value = '202501';
+context.funnelMonthChanged();
+assert(
+    elements['funnel-filter-date-from'].value === '2025-01-01',
+    'date-from must equal first day of selected month, got ' + elements['funnel-filter-date-from'].value
+);
+assert(
+    elements['funnel-filter-date-to'].value === '2025-01-31',
+    'date-to must equal last day of selected month, got ' + elements['funnel-filter-date-to'].value
+);
+let html = elements['funnel-content'].innerHTML;
+assert(html.includes('2 записей'), 'month picker must narrow data to January rows, got: ' + html.slice(0, 200));
+
+// Requirement 1: changing date-from resets month filter to "Все".
+elements['funnel-filter-date-from'].value = '2025-01-15';
+context.funnelDateChanged();
+assert(
+    elements['funnel-filter-month'].value === '',
+    'changing date-from must reset month filter, got "' + elements['funnel-filter-month'].value + '"'
+);
+html = elements['funnel-content'].innerHTML;
+assert(html.includes('1 записей'), 'date-from must narrow to one row in mid-January');
+
+// And changing date-to with an empty date-from also resets the month filter.
+elements['funnel-filter-month'].value = '202502';
+elements['funnel-filter-date-from'].value = '';
+elements['funnel-filter-date-to'].value = '2025-02-28';
+context.funnelDateChanged();
+assert(
+    elements['funnel-filter-month'].value === '',
+    'changing date-to must reset month filter, got "' + elements['funnel-filter-month'].value + '"'
+);
+
+// Picking the empty "— Все —" month must not overwrite manually entered dates.
+elements['funnel-filter-date-from'].value = '2025-03-01';
+elements['funnel-filter-date-to'].value = '2025-03-31';
+elements['funnel-filter-month'].value = '';
+context.funnelMonthChanged();
+assert(
+    elements['funnel-filter-date-from'].value === '2025-03-01'
+        && elements['funnel-filter-date-to'].value === '2025-03-31',
+    'choosing "— Все —" month must not overwrite manually entered dates'
+);
+
+// February (non-31-day month) must compute the correct last day.
+elements['funnel-filter-month'].value = '202502';
+context.funnelMonthChanged();
+assert(
+    elements['funnel-filter-date-to'].value === '2025-02-28',
+    'February 2025 last day must be 28, got ' + elements['funnel-filter-date-to'].value
+);
+
+console.log('issue-2556 funnel month/date sync: ok');

--- a/templates/funnel.html
+++ b/templates/funnel.html
@@ -642,17 +642,17 @@
         </div>
         <div class="funnel-filter-group">
             <div class="funnel-filter-label">Месяц</div>
-            <select id="funnel-filter-month" class="funnel-filter-select" onchange="funnelApplyFilters()">
+            <select id="funnel-filter-month" class="funnel-filter-select" onchange="funnelMonthChanged()">
                 <option value="">— Все —</option>
             </select>
         </div>
         <div class="funnel-filter-group">
             <div class="funnel-filter-label">Дата с</div>
-            <input type="date" id="funnel-filter-date-from" class="funnel-filter-date" onchange="funnelApplyFilters()">
+            <input type="date" id="funnel-filter-date-from" class="funnel-filter-date" onchange="funnelDateChanged()">
         </div>
         <div class="funnel-filter-group">
             <div class="funnel-filter-label">Дата по</div>
-            <input type="date" id="funnel-filter-date-to" class="funnel-filter-date" onchange="funnelApplyFilters()">
+            <input type="date" id="funnel-filter-date-to" class="funnel-filter-date" onchange="funnelDateChanged()">
         </div>
         <div class="funnel-filter-group">
             <div class="funnel-filter-label">Тип найма</div>
@@ -803,15 +803,39 @@
         return STAGE_PALETTE[i % STAGE_PALETTE.length];
     }
 
-    function funnelFormatMonth(val) {
+    function funnelMonthParts(val) {
         var s = String(val || '').trim();
-        var match = s.match(/^(\d{4})(\d{2})(?:\d{2})?$/) || s.match(/^(\d{4})-(\d{1,2})/);
-        if (!match) return val;
+        var match = s.match(/^(\d{4})(\d{2})(?:\d{2})?$/)
+            || s.match(/^(\d{4})-(\d{1,2})/)
+            || s.match(/^(\d{4})\/(\d{1,2})/);
+        if (match) return { year: match[1], month: parseInt(match[2], 10) };
+        match = s.match(/^(\d{1,2})[.\/-](\d{4})$/);
+        if (match) return { year: match[2], month: parseInt(match[1], 10) };
+        return null;
+    }
+
+    function funnelFormatMonth(val) {
+        var parts = funnelMonthParts(val);
+        if (!parts) return val;
         var months = ['янв', 'фев', 'мар', 'апр', 'май', 'июн',
                       'июл', 'авг', 'сен', 'окт', 'ноя', 'дек'];
-        var y = match[1];
-        var m = parseInt(match[2], 10);
-        return months[m - 1] ? months[m - 1] + ' ' + y : val;
+        return months[parts.month - 1] ? months[parts.month - 1] + ' ' + parts.year : val;
+    }
+
+    function funnelPad2(n) {
+        return (n < 10 ? '0' : '') + n;
+    }
+
+    function funnelMonthDateRange(val) {
+        var parts = funnelMonthParts(val);
+        if (!parts || parts.month < 1 || parts.month > 12) return null;
+        var y = parseInt(parts.year, 10);
+        var m = parts.month;
+        var lastDay = new Date(y, m, 0).getDate();
+        return {
+            from: parts.year + '-' + funnelPad2(m) + '-01',
+            to: parts.year + '-' + funnelPad2(m) + '-' + funnelPad2(lastDay)
+        };
     }
 
     function funnelFormatDate(val) {
@@ -1019,6 +1043,25 @@
 
     window.funnelApplyFilters = function() {
         funnelRender(funnelGetFiltered());
+    };
+
+    window.funnelMonthChanged = function() {
+        var month = document.getElementById('funnel-filter-month').value;
+        var range = month ? funnelMonthDateRange(month) : null;
+        if (range) {
+            document.getElementById('funnel-filter-date-from').value = range.from;
+            document.getElementById('funnel-filter-date-to').value = range.to;
+        }
+        funnelApplyFilters();
+    };
+
+    window.funnelDateChanged = function() {
+        var from = document.getElementById('funnel-filter-date-from').value;
+        var to = document.getElementById('funnel-filter-date-to').value;
+        if (from || to) {
+            document.getElementById('funnel-filter-month').value = '';
+        }
+        funnelApplyFilters();
     };
 
     window.funnelResetFilters = function() {


### PR DESCRIPTION
Fixes #2556.

## Что сделано в `templates/funnel.html`

1. **Сброс месяца при изменении дат.** Изменение `Дата с` или `Дата по`
   очищает фильтр `Месяц` на «Все» — раньше комбинация дат и месяца
   могла дать пустой результат, потому что они применялись по И.
2. **Месяцы в человеческом виде.** Опции селекта `Месяц` отрисовываются
   как `янв 2025`. Парсер расширен на форматы `YYYYMM`, `YYYY-MM`,
   `YYYY/MM` и `MM.YYYY`, поэтому отображение работает независимо от
   того, как поле приходит из отчёта.
3. **Авто-подстановка дат при выборе месяца.** Выбор месяца ставит
   `Дата с` в 1-е число и `Дата по` в последний день этого месяца
   (включая корректный расчёт для февраля).

Логика разнесена на новые `funnelMonthChanged()` и `funnelDateChanged()`,
которые потом вызывают существующий `funnelApplyFilters()` — без
дублирования логики фильтрации и рендера.

## Тесты

`experiments/test-issue-2556-funnel-month-date.js` — отдельный
node-сценарий, который выполняет скрипт шаблона в `vm` с мок-DOM и
проверяет все три требования (включая, что `— Все —` не затирает
вручную введённые даты и что февраль корректно ограничивается 28-м
числом).

```
$ node experiments/test-issue-2556-funnel-month-date.js
issue-2556 funnel month/date sync: ok

$ node experiments/funnel-logic.test.js
PASS — middle zero-stage is hidden, conversion uses previous visible stage
PASS — trailing zero stages remain visible
PASS — counts are raw sums, not cumulative
PASS — multiple middle zero stages all hidden

$ node experiments/test-issue-2477-funnel-date-range.js
issue-2477 funnel date range: ok
```

## Test plan

- [x] Открыть HR-воронку, выбрать месяц → `Дата с`/`Дата по` подставляются.
- [x] Открыть HR-воронку, поменять `Дата с` или `Дата по` → фильтр
      `Месяц` сбрасывается на «Все».
- [x] Опции селекта `Месяц` показываются как «янв 2025», «фев 2025» и т.д.
- [x] Регрессионные тесты `funnel-logic.test.js` и `test-issue-2477-funnel-date-range.js` проходят.