### PR TITLE
integram-table: overlay-спиннер при обновлении subordinate-таблицы (#2580)

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -2246,6 +2246,29 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     margin: 16px;
 }
 
+/* Refresh overlay: dim existing content, show spinner (issue #2580) */
+.subordinate-refresh-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+.subordinate-refresh-overlay::after {
+    content: '';
+    width: 24px;
+    height: 24px;
+    border: 3px solid var(--color-border, #e0e0e0);
+    border-top-color: var(--color-primary, #1976d2);
+    border-radius: 50%;
+    animation: subordinate-spin 0.7s linear infinite;
+}
+@keyframes subordinate-spin {
+    to { transform: rotate(360deg); }
+}
+
 .subordinate-table-toolbar {
     padding: 0;
     display: flex;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -12145,7 +12145,18 @@ class IntegramTable{
         }
 
         async loadSubordinateTable(container, arrId, parentRecordId, reqId) {
-            container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+            const hasContent = !!container.querySelector('.subordinate-table');
+            if (hasContent) {
+                // Keep existing content visible but dimmed, show spinner overlay (issue #2580)
+                container.style.position = 'relative';
+                const existingOverlay = container.querySelector('.subordinate-refresh-overlay');
+                if (existingOverlay) existingOverlay.remove();
+                const overlay = document.createElement('div');
+                overlay.className = 'subordinate-refresh-overlay';
+                container.appendChild(overlay);
+            } else {
+                container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+            }
 
             try {
                 // Fetch metadata for subordinate table (use cache to avoid redundant requests)
@@ -19434,7 +19445,9 @@ class IntegramCreateFormHelper {
      * Load subordinate table content (issue #837).
      */
     async loadSubordinateTableStandalone(container, arrId, parentRecordId, reqId) {
-        container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+        if (!container.querySelector('.subordinate-table')) {
+            container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+        }
 
         try {
             // Try to use an existing IntegramTable instance for rendering

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -714,7 +714,18 @@
         }
 
         async loadSubordinateTable(container, arrId, parentRecordId, reqId) {
-            container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+            const hasContent = !!container.querySelector('.subordinate-table');
+            if (hasContent) {
+                // Keep existing content visible but dimmed, show spinner overlay (issue #2580)
+                container.style.position = 'relative';
+                const existingOverlay = container.querySelector('.subordinate-refresh-overlay');
+                if (existingOverlay) existingOverlay.remove();
+                const overlay = document.createElement('div');
+                overlay.className = 'subordinate-refresh-overlay';
+                container.appendChild(overlay);
+            } else {
+                container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+            }
 
             try {
                 // Fetch metadata for subordinate table (use cache to avoid redundant requests)

--- a/js/integram-table/25-create-form-helper.js
+++ b/js/integram-table/25-create-form-helper.js
@@ -1481,7 +1481,9 @@ class IntegramCreateFormHelper {
      * Load subordinate table content (issue #837).
      */
     async loadSubordinateTableStandalone(container, arrId, parentRecordId, reqId) {
-        container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+        if (!container.querySelector('.subordinate-table')) {
+            container.innerHTML = '<div class="subordinate-table-loading">Загрузка...</div>';
+        }
 
         try {
             // Try to use an existing IntegramTable instance for rendering


### PR DESCRIPTION
## Summary

- При нажатии `.subordinate-refresh-btn` таблица больше не очищается мгновенно
- Если контент уже отображён (есть `.subordinate-table`), поверх него накладывается полупрозрачный overlay (`rgba(255,255,255,0.55)`) со спиннером
- После получения данных таблица перерисовывается немедленно, overlay исчезает вместе со старым контентом
- При первоначальной загрузке (пустой контейнер) поведение прежнее — показывается «Загрузка...»
- Фикс применён в `19-form-edit.js` (`loadSubordinateTable`) и `25-create-form-helper.js` (`loadSubordinateTableStandalone`)

## Test plan

- [ ] Открыть запись с subordinate-вкладкой, дождаться загрузки таблицы
- [ ] Нажать кнопку обновления — таблица остаётся видимой (полупрозрачной), поверх неё вращается спиннер
- [ ] После загрузки — таблица перерисовывается без схлопывания формы
- [ ] Проверить первоначальную загрузку вкладки — показывается «Загрузка...» как раньше

Closes #2580

🤖 Generated with [Claude Code](https://claude.com/claude-code)