### PR TITLE
index.php: флаг allowEmptyValue для создания записи с пустым значением (#2584)

### DIFF
--- a/index.php
+++ b/index.php
@@ -5877,7 +5877,7 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 						    // issue #2524/#2530: under getParent the type value lives in the second column (now $object[0]
 						    // after the shift). If it was cleared in the source: if uniqueness is defined, find the
 						    // existing record under the resolved parent and delete it; otherwise skip the record.
-						    if($object[0] === ""){
+						    if($object[0] === "" && empty($_POST["allowEmptyValue"])){
 						        if(count($keyReqsForDelete)){
 						            $keyValuesForDelete = array();
 						            $ord = 0;
@@ -7323,7 +7323,11 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                         {
                             $tableId = preg_replace('/\D+/', '', (string)$configData['integram']['table_id']);
                             if($tableId !== '')
+                            {
                                 $configData['integram']['upload_endpoint'] = "/$z/object/$tableId?JSON&import=1";
+                                if(isset($configData['skip_empty_values']) && !$configData['skip_empty_values'])
+                                    $configData['integram']['upload_endpoint'] .= "&allowEmptyValue=1";
+                            }
                         }
                     }
                     require_once "include/google_sheets_sync.php";


### PR DESCRIPTION
## Summary

**Проблема:** при BKI-импорте с `autoParent`, если значение записи пустое, `array_shift` делает его первым элементом, и строка `if($object[0] === "")` пропускает запись (поведение issue #2524/#2530).

**Изменения:**

- `index.php` строка ~5880: условие `if($object[0] === "")` дополнено проверкой `&& empty($_POST["allowEmptyValue"])`. При `allowEmptyValue=1` пустое значение больше не триггерит ветку удаления/пропуска — запись создаётся как обычно.

- `index.php` строка ~7326 (gssync-роут): если конфиг явно содержит `skip_empty_values: false` (включён чекбокс «Сохранять пустые значения» из #2582), к `upload_endpoint` добавляется `&allowEmptyValue=1`.

## Test plan

- [ ] Конфиг gssync с `skip_empty_values: false` → синхронизировать → пустые ФАКТ-записи создаются в базе
- [ ] Конфиг gssync без `skip_empty_values` (или `true`) → upload_endpoint без `allowEmptyValue` → поведение прежнее
- [ ] Обычный BKI-импорт без `allowEmptyValue` → пустые записи по-прежнему пропускаются (не сломан #2524/#2530)

Closes #2584

🤖 Generated with [Claude Code](https://claude.com/claude-code)