### PR TITLE
fix: preserve user formatting in #gss-sheets on load (closes #2640)

### DIFF
--- a/templates/gssync.html
+++ b/templates/gssync.html
@@ -443,6 +443,7 @@
             spreadsheet_id: document.getElementById('gss-spreadsheet-id').value.trim(),
             skip_empty_values: !document.getElementById('gss-save-empty').checked,
             sheets: sheets,
+            sheets_raw: sheetsRaw,
             integram: {
                 enabled: document.getElementById('gss-enabled').checked,
                 table_id: tableId,
@@ -507,7 +508,7 @@
         document.getElementById('gss-create-parent').value = ig.createParent !== undefined ? ig.createParent : '1';
         document.getElementById('gss-enabled').checked = !!ig.enabled;
         document.getElementById('gss-save-empty').checked = !data.skip_empty_values;
-        document.getElementById('gss-sheets').value = data.sheets ? JSON.stringify(data.sheets, null, 2) : '';
+        document.getElementById('gss-sheets').value = data.sheets_raw || (data.sheets ? JSON.stringify(data.sheets, null, 2) : '');
         document.getElementById('gss-save-msg').textContent = '';
         resetSecretInitials();
     }


### PR DESCRIPTION
## Problem

When editing an existing config, `fillForm` restored the sheets JSON via:
```js
document.getElementById('gss-sheets').value = data.sheets ? JSON.stringify(data.sheets, null, 2) : '';
```
`data.sheets` is already a parsed object (from `r.json()`), so `JSON.stringify` always reformatted it — destroying the user's intentional line breaks and indentation.

## Fix

**On save** — store the raw textarea text alongside the parsed object:
```js
sheets_raw: sheetsRaw,   // added to cfg
```

**On load** — prefer the raw string if available:
```js
data.sheets_raw || (data.sheets ? JSON.stringify(data.sheets, null, 2) : '')
```

Old configs without `sheets_raw` continue to work via the `JSON.stringify` fallback.

## Test plan

- [ ] Save a config with custom-indented sheets JSON (e.g. mixed compact/expanded lines)
- [ ] Open the config for editing — formatting in `#gss-sheets` is preserved exactly
- [ ] Old config (without `sheets_raw`) still loads correctly via fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)