### PR TITLE
fix: strip subordinate row-number from parent value in form title (closes #2642)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -12412,8 +12412,11 @@ class IntegramTable{
                 if (clickedRow) {
                     const firstCell = clickedRow.querySelector('td:first-child');
                     if (firstCell) {
-                        // Get the text content from the first cell (parent record value)
-                        const cellText = firstCell.textContent.trim();
+                        // Strip the subordinate row-number span so its digits don't leak
+                        // into the header title (issue #2642).
+                        const cellClone = firstCell.cloneNode(true);
+                        cellClone.querySelectorAll('.subordinate-row-number').forEach(n => n.remove());
+                        const cellText = cellClone.textContent.trim();
                         // Remove any leading index/ID prefix and icon markup
                         parentRecordValue = cellText.replace(/^\d+\s*/, '').replace(/<[^>]*>/g, '').trim();
                     }

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -981,8 +981,11 @@
                 if (clickedRow) {
                     const firstCell = clickedRow.querySelector('td:first-child');
                     if (firstCell) {
-                        // Get the text content from the first cell (parent record value)
-                        const cellText = firstCell.textContent.trim();
+                        // Strip the subordinate row-number span so its digits don't leak
+                        // into the header title (issue #2642).
+                        const cellClone = firstCell.cloneNode(true);
+                        cellClone.querySelectorAll('.subordinate-row-number').forEach(n => n.remove());
+                        const cellText = cellClone.textContent.trim();
                         // Remove any leading index/ID prefix and icon markup
                         parentRecordValue = cellText.replace(/^\d+\s*/, '').replace(/<[^>]*>/g, '').trim();
                     }


### PR DESCRIPTION
## Summary
- Fixes #2642 — parent row index (e.g. `11`) leaked into the subordinate-table form header title.
- In subordinate-table views (`dataSource='table'`), `renderCell` appends a `<span class="subordinate-row-number">` after the value of the first column. `openSubordinateTableFromCell` was reading `firstCell.textContent`, so the trailing row index landed in `parentRecordValue` and the header rendered as `"ValueName11 / TypeName"`.
- Clone the cell and remove `.subordinate-row-number` nodes before reading `textContent`, so only the actual parent value remains.

## Test plan
- [ ] Open a subordinate table with `dataSource='table'` and a parent of more than one row.
- [ ] Click a `(count)` link in a row whose index would otherwise be appended (e.g. row 11).
- [ ] Verify the modal header reads `ParentValue / TypeName` with no trailing digits.
- [ ] Verify the no-parent-value fallback path (`typeName` only) still works when the first cell is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)