### PR TITLE
fix(procvac): include vacancies whose any date matches the archive month (closes #2644)

### DIFF
--- a/download/sportzania/js/procvac.js
+++ b/download/sportzania/js/procvac.js
@@ -450,18 +450,31 @@
         });
     }
 
-    function getArchiveMonthKey(row) {
-        var rawValue = row && row.rawValues && row.rawValues.startDate;
-        var displayValue = row && row.values && row.values.startDate;
-        return formatMonthKey(parseDate(rawValue || displayValue));
+    var ARCHIVE_MONTH_FIELDS = ['startDate', 'deadline', 'exitDate'];
+
+    function getArchiveMonthKeys(row) {
+        if (!row) return [];
+        var rawValues = row.rawValues || {};
+        var displayValues = row.values || {};
+        var seen = {};
+        var keys = [];
+        ARCHIVE_MONTH_FIELDS.forEach(function(field) {
+            var key = formatMonthKey(parseDate(rawValues[field] || displayValues[field]));
+            if (key && !seen[key]) {
+                seen[key] = true;
+                keys.push(key);
+            }
+        });
+        return keys;
     }
 
     function getArchiveMonthOptions(rows) {
         var months = {};
 
         (rows || []).forEach(function(row) {
-            var key = getArchiveMonthKey(row);
-            if (key) months[key] = true;
+            getArchiveMonthKeys(row).forEach(function(key) {
+                months[key] = true;
+            });
         });
 
         return Object.keys(months).sort(function(a, b) {
@@ -479,7 +492,7 @@
         var selected = String(monthKey || '');
         if (!selected) return (rows || []).slice();
         return (rows || []).filter(function(row) {
-            return getArchiveMonthKey(row) === selected;
+            return getArchiveMonthKeys(row).indexOf(selected) !== -1;
         });
     }
 

--- a/js/procvac.js
+++ b/js/procvac.js
@@ -450,18 +450,31 @@
         });
     }
 
-    function getArchiveMonthKey(row) {
-        var rawValue = row && row.rawValues && row.rawValues.startDate;
-        var displayValue = row && row.values && row.values.startDate;
-        return formatMonthKey(parseDate(rawValue || displayValue));
+    var ARCHIVE_MONTH_FIELDS = ['startDate', 'deadline', 'exitDate'];
+
+    function getArchiveMonthKeys(row) {
+        if (!row) return [];
+        var rawValues = row.rawValues || {};
+        var displayValues = row.values || {};
+        var seen = {};
+        var keys = [];
+        ARCHIVE_MONTH_FIELDS.forEach(function(field) {
+            var key = formatMonthKey(parseDate(rawValues[field] || displayValues[field]));
+            if (key && !seen[key]) {
+                seen[key] = true;
+                keys.push(key);
+            }
+        });
+        return keys;
     }
 
     function getArchiveMonthOptions(rows) {
         var months = {};
 
         (rows || []).forEach(function(row) {
-            var key = getArchiveMonthKey(row);
-            if (key) months[key] = true;
+            getArchiveMonthKeys(row).forEach(function(key) {
+                months[key] = true;
+            });
         });
 
         return Object.keys(months).sort(function(a, b) {
@@ -479,7 +492,7 @@
         var selected = String(monthKey || '');
         if (!selected) return (rows || []).slice();
         return (rows || []).filter(function(row) {
-            return getArchiveMonthKey(row) === selected;
+            return getArchiveMonthKeys(row).indexOf(selected) !== -1;
         });
     }
 


### PR DESCRIPTION
## Summary
- Fixes #2644 — `#procvac-archive-month-filter` only listed/filtered by the «Старт работы» date, so vacancies whose «Дедлайн» or «Выход» fell in the selected month were hidden.
- Replace single-field `getArchiveMonthKey(row)` with `getArchiveMonthKeys(row)`, which returns the deduplicated set of `YYYY-MM` keys from `startDate`, `deadline` and `exitDate`.
- Aggregate dropdown options across all three fields; a row appears under a month if any of its dates falls in that month.
- Kept `js/procvac.js` and `download/sportzania/js/procvac.js` in sync.

## Test plan
- [ ] Archive a vacancy with `Старт` in March, `Дедлайн` in April, `Выход` in May; confirm it appears under each month in the filter.
- [ ] Selecting March / April / May each shows the vacancy; selecting an unrelated month hides it.
- [ ] Clearing the month filter still shows all archived vacancies.
- [ ] A vacancy with only `Старт` filled (and no `Дедлайн`/`Выход`) still appears under its «Старт» month.

🤖 Generated with [Claude Code](https://claude.com/claude-code)