### PR TITLE
fix(dash): evaluate row formulas in panels with RGcolumns (closes #2650)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -1641,10 +1641,13 @@ function dashDrawPeriods() {
                                         + (rowLabel ? ' data-dash-label="' + dashAttr(rowLabel) + '"' : '')
                                         + ' data-rg-col="' + colName.replace(/"/g, '&quot;') + '"'
                                         + dashCellFormatAttribute(row.id);
+                                    var hasValue = v !== undefined && v !== '';
+                                    var rowFormula = dashFormulas[row.id];
+                                    var cellReady = hasValue || rowFormula === '[]' || !rowFormula ? '1' : '0';
                                     row.insertAdjacentHTML('beforeend',
                                         cellTpl.replace(':val:', dashFormatNumberText(v || ''))
-                                            .replace(':ready:', '1')
-                                            .replace(':title:', dashFormatNumberText(v || ''))
+                                            .replace(':ready:', cellReady)
+                                            .replace(':title:', cellReady === '1' ? dashFormatNumberText(v || '') : '')
                                             .replace(':classes:', 'f-rg-cell')
                                             .replace(':src:', s.src)
                                             .replace(':item-id:', row.id)


### PR DESCRIPTION
## Summary

Fixes #2650 — formulas like `[2043]+[2045]+[2047]+[2049]` on a row in a dashboard panel that declares `RGcolumns` were never evaluated. The «Выручка» cell stayed empty even though every referenced row had a value.

**Root cause.** In `js/dash.js` `dashDrawPeriods`, the RGcolumns branch (at the cell template invocation around line 1647) hard-coded `:ready: '1'` on every `.f-rg-cell`. `dashCalcCells` only walks `td[ready="0"]`, so cells with formulas in this branch were skipped entirely. The single-column branch right below already gates `ready` correctly:

```js
.replace(':ready:', v || dashFormulas[row.id] === '[]' || !dashFormulas[row.id] ? '1' : '0')
```

This change mirrors that gate in the per-column path.

## Diff

`js/dash.js` — only the RGcolumns cell template:

- Compute `cellReady` from `(v has value) || formula === '[]' || !formula`.
- Use it for both `:ready:` and the `:title:` (so an unresolved cell gets an empty title that `dashCalcCells` then overwrites with the resolved formula expression, matching the single-column branch).

## Test plan

- [ ] Panel with `RGcolumns` and an item whose `formulas` is `[A]+[B]+...` (multi-ref item formula): cell renders the computed sum, not blank. Tooltip shows the resolved expression.
- [ ] Panel with `RGcolumns` where the item has a value via `panelQuery` / `Дэшборд.ЗначенияЗаПериод`: still renders the value (no regression — `cellReady` is `'1'`).
- [ ] Panel with `RGcolumns` where the item has no formula and no value: cell renders empty with `ready="1"` (no regression).
- [ ] Panel **without** `RGcolumns`: behaviour unchanged (single-column branch was already correct).
- [ ] Same panel, change period: re-render still produces correct sums.

🤖 Generated with [Claude Code](https://claude.com/claude-code)