### PR TITLE
fix(dash): resolve formula refs in the same Plan/Fact sub-column (closes #2652)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -1408,6 +1408,7 @@ function dashCalcCells() {
                 for (i in refs) {
                     // Try exact range match first; if not found and range="-", accept any range (issue #1877)
                     var rangeVal = el.getAttribute('range');
+                    var rgColVal = el.getAttribute('data-rg-col');
                     // Use getElementById to avoid invalid CSS selectors when IDs start with digits (issue #2074)
                     var refEl = document.getElementById(refs[i]);
                     var cells = refEl ? refEl.querySelectorAll('.f-rg-cell[range="' + rangeVal + '"],.f-col-cell[range="' + rangeVal + '"]') : [];
@@ -1417,10 +1418,21 @@ function dashCalcCells() {
                         cells = refEl ? refEl.querySelectorAll('.f-rg-cell,.f-col-cell') : [];
                         fallbackUsed = true;
                     }
+                    // Plan/Fact sub-columns share the same range="from-to", so the selector
+                    // above returns both; the non-global replace below would always pick the
+                    // first (План), leaking Plan values into Факт cells. Restrict to the
+                    // target cell's sub-column (issue #2652).
+                    if (rgColVal !== null && cells.length > 1) {
+                        var rgFilteredCells = Array.prototype.filter.call(cells, function(c) {
+                            return c.getAttribute('data-rg-col') === rgColVal;
+                        });
+                        if (rgFilteredCells.length > 0) cells = rgFilteredCells;
+                    }
                     dashTrace('formula-ref-lookup', {
                         itemId: itemId,
                         refId: refs[i],
                         range: rangeVal,
+                        rgCol: rgColVal,
                         matches: cells.length,
                         fallbackUsed: fallbackUsed,
                         formulaBeforeReplace: f


### PR DESCRIPTION
## Summary
- Fixes #2652 — formulas like `[ДДЛ]+[ддо (b2b)]+[ддо (b2g)]+[доп]` on a row split by RGcolumns (e.g. План/Факт) returned the same value in both sub-columns.
- Root cause: in `dashCalcCells` (`js/dash.js`), the ref-lookup selected `.f-rg-cell[range="from-to"]` and that range is shared by every sub-column of the same period header, so the query returned both План and Факт cells. The non-global `f.replace()` that followed always substituted the first match — `План` due to DOM order from the `rgCols.forEach` render loop.
- Fix: when the cell being computed has a `data-rg-col` (i.e. lives in an RGcolumns panel) and the selector returned more than one cell, filter to cells whose `data-rg-col` matches the target. The filter only narrows; if no referenced cell shares the sub-column the original list is kept, so panels without sub-columns (single cell per range) and cross-panel references are unaffected.
- This is the natural follow-up to #2651: that PR enabled formula evaluation in RGcolumns panels; this PR makes the result correct when those panels use Plan/Fact sub-columns.

## Test plan
- [ ] On a dashboard panel with RGcolumns `План,Факт`, set a row formula referencing other rows (e.g. `[ДДЛ]+[ддо (b2b)]+[ддо (b2g)]+[доп]`). Confirm the План cell sums the План values of the referenced rows and the Факт cell sums the Факт values.
- [ ] Verify single-column (no-RGcolumns) panels and report-source (`.f-col-cell`) cells still compute as before.
- [ ] Verify formulas referencing rows that themselves have no sub-columns still resolve via the existing range-only fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)