### PR TITLE
feat(dash): enlarge selection badge and make Σ / N / ⌀ click-to-copy

### DIFF
--- a/css/dash.css
+++ b/css/dash.css
@@ -532,24 +532,39 @@ td:has(.dash-cell-input) {
     z-index: 9998;
     background: #2b6cb0;
     color: #fff;
-    font-size: 0.78rem;
-    line-height: 1.2;
-    padding: 0.3rem 0.7rem;
-    border-radius: 4px;
-    pointer-events: none;
+    font-size: 1rem;
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.25;
+    padding: 0.55rem 1rem;
+    border-radius: 5px;
+    pointer-events: auto;
     white-space: nowrap;
     opacity: 0;
     transition: opacity 0.1s;
     transform: translateX(-100%);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.22);
     top: 0;
     left: 0;
 }
 #dash-selection-sum.visible { opacity: 1; }
 #dash-selection-sum .dash-sel-sep {
     display: inline-block;
-    margin: 0 0.45rem;
+    margin: 0 0.55rem;
     opacity: 0.55;
+}
+#dash-selection-sum .dash-sel-copy {
+    cursor: copy;
+    padding: 0.05rem 0.3rem;
+    margin: 0 -0.05rem;
+    border-radius: 3px;
+    transition: background-color 0.1s;
+}
+#dash-selection-sum .dash-sel-copy:hover {
+    background-color: rgba(255, 255, 255, 0.18);
+}
+#dash-selection-sum .dash-sel-copy.dash-sel-copied {
+    background-color: rgba(255, 255, 255, 0.4);
 }
 /* Panel filter modal */
 #dash-panel-filter-modal {

--- a/js/dash.js
+++ b/js/dash.js
@@ -6459,6 +6459,39 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         return dashFormatNumberText(s);
     }
 
+    function htmlEscape(s) {
+        return String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    }
+
+    function pill(text) {
+        var safe = htmlEscape(text);
+        return '<span class="dash-sel-copy" role="button" tabindex="0" '
+            + 'title="Скопировать в буфер" data-copy="' + safe + '">' + safe + '</span>';
+    }
+
+    function copyToClipboard(text) {
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                return navigator.clipboard.writeText(text);
+            }
+        } catch (e) {}
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'absolute';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        try { document.execCommand('copy'); } catch (e) {}
+        document.body.removeChild(ta);
+    }
+
+    function flashCopied(el) {
+        el.classList.add('dash-sel-copied');
+        setTimeout(function() { el.classList.remove('dash-sel-copied'); }, 700);
+    }
+
     function updateBadge() {
         if (sel.cells.size < 2) {
             badge.classList.remove('visible');
@@ -6484,15 +6517,37 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         var avg = sum / n;
         var sep = '<span class="dash-sel-sep">·</span>';
         badge.innerHTML =
-            'Σ ' + dashFormatNumberText(sum) + sep +
-            'N ' + n + sep +
-            '⌀ ' + formatAvg(avg);
+            'Σ ' + pill(dashFormatNumberText(sum)) + sep +
+            'N ' + pill(String(n)) + sep +
+            '⌀ ' + pill(formatAvg(avg));
         var sy = window.pageYOffset || document.documentElement.scrollTop || 0;
         var sx = window.pageXOffset || document.documentElement.scrollLeft || 0;
         badge.style.top = (rect.bottom + sy + 6) + 'px';
         badge.style.left = (rect.right + sx) + 'px';
         badge.classList.add('visible');
     }
+
+    // Click-to-copy on the badge. The badge lives outside #dash-model, so
+    // these clicks don't reach the dashboard's mousedown/click handlers and
+    // the selection stays put.
+    badge.addEventListener('mousedown', function(e) { e.stopPropagation(); });
+    badge.addEventListener('click', function(e) {
+        var btn = e.target.closest('.dash-sel-copy');
+        if (!btn) return;
+        e.stopPropagation();
+        var text = btn.getAttribute('data-copy') || btn.textContent;
+        copyToClipboard(text);
+        flashCopied(btn);
+    });
+    badge.addEventListener('keydown', function(e) {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        var btn = e.target.closest && e.target.closest('.dash-sel-copy');
+        if (!btn) return;
+        e.preventDefault();
+        var text = btn.getAttribute('data-copy') || btn.textContent;
+        copyToClipboard(text);
+        flashCopied(btn);
+    });
 
     dashModelEl.addEventListener('mousedown', function(e) {
         if (e.button !== 0) return;


### PR DESCRIPTION
## Summary

Follow-up to #2653. Two small UX changes on the cell-selection badge:

1. **Bigger badge** — font 0.78rem → 1rem, padding tightened up, tabular-nums for aligned digits, slightly stronger shadow.
2. **Click-to-copy** — clicking any of Σ, N or ⌀ copies that value to the clipboard. The selection stays active so you can keep copying or compare against another range.

## How it works

- Each value is rendered inside `<span class="dash-sel-copy" role="button" tabindex="0" data-copy="…">`, so it's a focusable, keyboard-activatable button. `Enter` / `Space` also copy.
- A 700 ms `dash-sel-copied` highlight gives visual confirmation.
- Copy uses `navigator.clipboard.writeText` when available, with a hidden-textarea + `document.execCommand('copy')` fallback for older browsers / non-HTTPS contexts.
- The badge lives outside `#dash-model`, so its clicks don't reach the dashboard's mousedown/click handlers — the active selection survives a copy click naturally. `stopPropagation` on the badge's mousedown/click is added defensively.

## Files

- `css/dash.css` — badge sizing + `.dash-sel-copy` hover / `.dash-sel-copied` flash.
- `js/dash.js` — `pill()`, `copyToClipboard()`, `flashCopied()`, badge click / keydown handlers.

## Test plan

- [ ] Make a 2+ cell selection: badge is visibly larger, numbers aligned.
- [ ] Click on Σ value: short white flash, value is in the clipboard, selection is still highlighted.
- [ ] Click on N: count is copied; selection stays.
- [ ] Click on ⌀: average copied; selection stays.
- [ ] Tab to a pill, press Enter or Space: copy fires.
- [ ] Click on the badge's separator dot or empty padding: nothing happens; selection stays.
- [ ] Click outside the badge on any dashboard cell: existing behaviour — selection clears, inline edit / formula modal / readonly tooltip still works.
- [ ] Esc still clears the selection.
- [ ] Resize / scroll keeps badge anchored to the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)