### PR TITLE
feat(dash): TSV copy of full selection on Ctrl/Cmd+C; strip thousands spaces

### DIFF
--- a/css/dash.css
+++ b/css/dash.css
@@ -522,6 +522,10 @@ td:has(.dash-cell-input) {
     background-color: rgba(43, 108, 176, 0.18);
     box-shadow: inset 0 0 0 1px rgba(43, 108, 176, 0.55);
 }
+#dash-model td.f-cell.dash-cell-copied {
+    background-color: rgba(43, 108, 176, 0.4);
+    transition: background-color 0.2s;
+}
 #dash-model.dash-selecting,
 #dash-model.dash-selecting td.f-cell {
     user-select: none;

--- a/js/dash.js
+++ b/js/dash.js
@@ -6464,10 +6464,18 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
             .replace(/</g, '&lt;').replace(/>/g, '&gt;');
     }
 
+    function stripSpaces(text) {
+        // Drop every whitespace char (regular space used as thousands
+        // separator, NBSP, narrow NBSP, tabs etc.) — keep digits, decimal
+        // comma/period, sign, percent.
+        return String(text).replace(/\s+/g, '');
+    }
+
     function pill(text) {
-        var safe = htmlEscape(text);
+        var display = htmlEscape(text);
+        var copy = htmlEscape(stripSpaces(text));
         return '<span class="dash-sel-copy" role="button" tabindex="0" '
-            + 'title="Скопировать в буфер" data-copy="' + safe + '">' + safe + '</span>';
+            + 'title="Скопировать в буфер" data-copy="' + copy + '">' + display + '</span>';
     }
 
     function copyToClipboard(text) {
@@ -6490,6 +6498,35 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
     function flashCopied(el) {
         el.classList.add('dash-sel-copied');
         setTimeout(function() { el.classList.remove('dash-sel-copied'); }, 700);
+    }
+
+    function flashSelection() {
+        var cells = [];
+        sel.cells.forEach(function(c) { cells.push(c); });
+        cells.forEach(function(c) { c.classList.add('dash-cell-copied'); });
+        setTimeout(function() {
+            cells.forEach(function(c) { c.classList.remove('dash-cell-copied'); });
+        }, 700);
+    }
+
+    // Build a TSV blob from the current selection, walking the DOM in row
+    // order. Each `<tr>` that has any selected cell becomes a line; selected
+    // cells inside the row are joined with TAB in DOM (column) order. This
+    // makes a rectangular range paste as a matching grid in Excel/Google
+    // Sheets, while disjoint Ctrl-selections still produce a sensible
+    // row-per-line layout.
+    function buildSelectionTsv() {
+        var trs = dashModelEl.querySelectorAll('tr');
+        var rows = [];
+        trs.forEach(function(tr) {
+            var rowCells = [];
+            for (var i = 0; i < tr.children.length; i++) {
+                var td = tr.children[i];
+                if (sel.cells.has(td)) rowCells.push(stripSpaces(dashCellText(td)));
+            }
+            if (rowCells.length > 0) rows.push(rowCells.join('\t'));
+        });
+        return rows.join('\n');
     }
 
     function updateBadge() {
@@ -6547,6 +6584,27 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         var text = btn.getAttribute('data-copy') || btn.textContent;
         copyToClipboard(text);
         flashCopied(btn);
+    });
+
+    // Ctrl+C / Cmd+C (and the OS «Copy» menu) over an active selection
+    // copies a TSV of every selected cell. We listen for the `copy` event so
+    // the user's data goes through `clipboardData.setData` directly — no
+    // permission prompt, no clipboard API quirks.
+    document.addEventListener('copy', function(e) {
+        if (sel.cells.size === 0) return;
+        var ae = document.activeElement;
+        if (ae && /^(INPUT|TEXTAREA)$/.test(ae.tagName)) return;
+        if (ae && ae.isContentEditable) return;
+        var text = buildSelectionTsv();
+        if (!text) return;
+        if (e.clipboardData) {
+            e.clipboardData.setData('text/plain', text);
+            e.preventDefault();
+        } else {
+            // Old IE / fallback
+            copyToClipboard(text);
+        }
+        flashSelection();
     });
 
     dashModelEl.addEventListener('mousedown', function(e) {


### PR DESCRIPTION
## Summary

Follow-up to #2655.

1. **Pills strip thousands spaces.** Clicking Σ / N / ⌀ on the badge now copies `1234,56` instead of `1 234,56` — the pill still *displays* the formatted version for readability, only the `data-copy` payload is stripped.

2. **Whole-selection copy on Ctrl/Cmd+C.** With an active selection, pressing Ctrl+C or ⌘+C (or picking «Copy» from the OS menu) now copies the entire selection as a TSV blob:
   - Each \`<tr>\` with any selected cell becomes one line.
   - Cells inside a row are TAB-joined in DOM (column) order.
   - Spaces stripped from each value, same as for pills.

   So a rectangular drag-selection pastes as a matching grid in Excel / Google Sheets, and disjoint Ctrl-click selections still produce a sensible row-per-line layout.

## How it works

- A document-level \`copy\` event listener intercepts the keystroke (and the OS «Copy» menu). When a dashboard selection is active and focus is not in an \`<input>\` / \`<textarea>\` / contenteditable, it calls \`e.clipboardData.setData('text/plain', tsv)\` and \`e.preventDefault()\`. No permission prompt, no Clipboard API quirks.
- \`buildSelectionTsv()\` walks \`#dash-model\` in DOM order: for each \`<tr>\`, collects its selected cells in column order, joins with TAB, then joins rows with \`\\n\`. Works for rectangular **and** disjoint selections, and across multiple panels (Ctrl-click can build a selection spanning tables).
- A short \`dash-cell-copied\` flash on every selected cell confirms the copy visually.

## Files

- \`css/dash.css\` — \`.dash-cell-copied\` flash (200 ms transition, 700 ms total).
- \`js/dash.js\` — \`stripSpaces()\`, \`buildSelectionTsv()\`, \`flashSelection()\`, and the \`document\` \`copy\` listener.

## Test plan

- [ ] Drag-select a 3×2 rectangle of numbers, Ctrl+C, paste into Excel / Google Sheets — lands as a matching grid, no thousands-separator spaces.
- [ ] Same on macOS with ⌘+C.
- [ ] Ctrl-click 4 disjoint cells across 2 rows (some in row A, some in row B), Ctrl+C, paste into a text editor — each row on its own line, cells TAB-separated.
- [ ] Ctrl-click cells in two different panels (selection spans tables), Ctrl+C, paste — each \`<tr>\` is its own line; ordering follows DOM order.
- [ ] Click on a Σ / N / ⌀ pill — copied value has no thousands spaces (e.g. \`12345,67\`).
- [ ] Focus an inline edit input on a cell, type, then Ctrl+C — native input copy still works (no dashboard interception).
- [ ] Esc clears the selection; Ctrl+C afterwards copies whatever native text selection exists (no dashboard interception).
- [ ] Visual: every selected cell briefly flashes when Ctrl+C fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)