### PR TITLE
feat(dash): triple-click selects row; Ctrl/Cmd+drag adds rectangle

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -6374,11 +6374,14 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
 });
 
 // ─── Cell multi-selection (sum of selected cells) ────────────────────────────
-// Drag inside a table to make a rectangular selection. Ctrl/Cmd+click toggles a
-// single cell. Shift+click extends a rectangular selection from the anchor.
-// Plain click on a cell preserves existing behaviour (inline edit / formula
-// modal / readonly tooltip) and clears any previous selection. The floating
-// badge under the selection shows Σ / count / average over numeric cells.
+// Drag inside a table to make a rectangular selection. Ctrl/Cmd+drag adds an
+// additional rectangle to the existing selection. Ctrl/Cmd+click toggles a
+// single cell. Shift+click extends from the anchor. Triple-click selects the
+// whole row. Plain click on a cell preserves existing behaviour (inline edit /
+// formula modal / readonly tooltip) and clears any previous selection. The
+// floating badge under the selection shows Σ / count / average over numeric
+// cells and supports click-to-copy plus Ctrl/Cmd+C TSV copy of everything
+// selected.
 (function() {
     var DRAG_PIXEL_THRESHOLD = 4;
     var dashModelEl = document.getElementById('dash-model');
@@ -6394,6 +6397,9 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         dragOriginY: 0,
         dragArmed: false,
         dragActive: false,
+        dragMode: null,           // 'replace' | 'additive'
+        dragBase: null,           // snapshot for additive merge
+        dragPendingToggle: false, // mouseup applies the Ctrl-click toggle if no drag happened
         suppressNextClick: false
     };
 
@@ -6509,6 +6515,33 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         }, 700);
     }
 
+    // If a stray first click on a triple-click sequence opened the inline
+    // editor, route the cell back through its own Esc handler so the original
+    // value is restored cleanly before we replace the selection.
+    function cancelInlineEdit() {
+        var input = dashModelEl.querySelector('.dash-cell-input');
+        if (!input) return;
+        try {
+            input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        } catch (err) {
+            // KeyboardEvent ctor not available — just blur, the cell will
+            // commit but stay editable through its own logic.
+            input.blur();
+        }
+    }
+
+    function selectRowOf(td) {
+        var tr = td && td.closest && td.closest('tr');
+        if (!tr) return;
+        clearSelection();
+        sel.anchor = td;
+        for (var i = 0; i < tr.children.length; i++) {
+            var child = tr.children[i];
+            if (child.classList && child.classList.contains('f-cell')) addCell(child);
+        }
+        updateBadge();
+    }
+
     // Build a TSV blob from the current selection, walking the DOM in row
     // order. Each `<tr>` that has any selected cell becomes a line; selected
     // cells inside the row are joined with TAB in DOM (column) order. This
@@ -6609,8 +6642,24 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
 
     dashModelEl.addEventListener('mousedown', function(e) {
         if (e.button !== 0) return;
-        if (e.target.closest('input, textarea, select, .dash-cell-input, a, button')) return;
         var td = e.target.closest('td.f-cell');
+
+        // Multi-click handling runs even when the target is inside an inline
+        // edit input — that way triple-click still works after a stray first
+        // click opened the editor.
+        if (td && e.detail >= 2) {
+            e.preventDefault();
+            sel.suppressNextClick = true;
+            if (e.detail === 3) {
+                cancelInlineEdit();
+                selectRowOf(td);
+            }
+            return;
+        }
+
+        // Don't interfere with inputs (inline edit, formula modal textarea, …)
+        if (e.target.closest('input, textarea, select, .dash-cell-input, a, button')) return;
+
         if (!td) {
             if (sel.cells.size > 0) clearSelection();
             return;
@@ -6633,27 +6682,33 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
             return;
         }
         if (e.ctrlKey || e.metaKey) {
-            if (sel.cells.has(td)) {
-                removeCell(td);
-                if (sel.anchor === td) sel.anchor = null;
-            } else {
-                if (!sel.anchor) sel.anchor = td;
-                addCell(td);
-            }
-            updateBadge();
-            sel.suppressNextClick = true;
+            // Defer the toggle until mouseup so Ctrl+drag can grow an additive
+            // rectangle from this cell; a plain Ctrl+click without movement
+            // still toggles, applied in the mouseup handler below.
+            sel.dragStart = td;
+            sel.dragTbody = rc.tbody;
+            sel.dragOriginX = e.clientX;
+            sel.dragOriginY = e.clientY;
+            sel.dragArmed = true;
+            sel.dragActive = false;
+            sel.dragMode = 'additive';
+            sel.dragBase = new Set(sel.cells);
+            sel.dragPendingToggle = true;
             e.preventDefault();
             return;
         }
 
-        // No modifier: arm drag without changing selection yet, so a plain click
-        // still falls through to the existing handler.
+        // No modifier: arm a replace-drag without changing the selection yet,
+        // so a plain click still falls through to the existing handler.
         sel.dragStart = td;
         sel.dragTbody = rc.tbody;
         sel.dragOriginX = e.clientX;
         sel.dragOriginY = e.clientY;
         sel.dragArmed = true;
         sel.dragActive = false;
+        sel.dragMode = 'replace';
+        sel.dragBase = null;
+        sel.dragPendingToggle = false;
     });
 
     document.addEventListener('mousemove', function(e) {
@@ -6663,7 +6718,8 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
             var dy = e.clientY - sel.dragOriginY;
             if (dx * dx + dy * dy < DRAG_PIXEL_THRESHOLD * DRAG_PIXEL_THRESHOLD) return;
             sel.dragActive = true;
-            clearSelection();
+            sel.dragPendingToggle = false;
+            if (sel.dragMode === 'replace') clearSelection();
             sel.anchor = sel.dragStart;
             dashModelEl.classList.add('dash-selecting');
         }
@@ -6673,18 +6729,45 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         var rc = cellRC(td);
         if (!rc || rc.tbody !== sel.dragTbody) return;
         e.preventDefault();
-        replaceWith(rectFromCells(sel.dragStart, td));
+        var rect = rectFromCells(sel.dragStart, td);
+        if (sel.dragMode === 'additive') {
+            var merged = new Set(sel.dragBase);
+            rect.forEach(function(c) { merged.add(c); });
+            replaceWith(merged);
+        } else {
+            replaceWith(rect);
+        }
     });
 
     document.addEventListener('mouseup', function() {
         if (!sel.dragArmed) return;
         var wasDrag = sel.dragActive;
+        var pendingToggle = sel.dragPendingToggle;
+        var dragStart = sel.dragStart;
         sel.dragArmed = false;
         sel.dragActive = false;
+        sel.dragMode = null;
+        sel.dragBase = null;
+        sel.dragPendingToggle = false;
         sel.dragStart = null;
         sel.dragTbody = null;
         dashModelEl.classList.remove('dash-selecting');
-        if (wasDrag) sel.suppressNextClick = true;
+        if (wasDrag) {
+            sel.suppressNextClick = true;
+            return;
+        }
+        if (pendingToggle && dragStart) {
+            // Plain Ctrl/Cmd+click with no drag — apply the deferred toggle now.
+            if (sel.cells.has(dragStart)) {
+                removeCell(dragStart);
+                if (sel.anchor === dragStart) sel.anchor = null;
+            } else {
+                if (!sel.anchor) sel.anchor = dragStart;
+                addCell(dragStart);
+            }
+            updateBadge();
+            sel.suppressNextClick = true;
+        }
     });
 
     // Capture phase: suppress the existing bubble click handler when a


### PR DESCRIPTION
## Summary

Follow-up to #2656. Two selection-ergonomics tweaks on dashboard tables:

1. **Triple-click on a cell → select the whole row.** All `f-cell` cells in the clicked `<tr>` are added; the first item-name column stays excluded.
2. **Ctrl/Cmd+drag → additive rectangle.** Previously Ctrl-mousedown toggled a single cell and never armed a drag, so dragging with Ctrl held did nothing. Now the same gesture grows a second rectangle that joins (doesn't replace) the existing selection. A plain Ctrl-click still toggles, identical to before.

## Behaviour details

### Triple-click
- Detected on `mousedown` with `e.detail === 3` (works the same as in Excel / Google Sheets).
- Browser's native triple-click would otherwise select the cell's text; we `preventDefault` on every `detail >= 2` mousedown to keep the highlight clean.
- If the first click of the sequence already opened the inline editor (its `dashLoadMetadata` callback is async, so the input may or may not be present yet), the input is routed through its own Esc handler before the row selection replaces it. The cell's saved value is therefore restored cleanly — no half-edits.
- Suppresses the click events for clicks #2 and #3 so they don't re-trigger inline edit / readonly tooltip.

### Ctrl/Cmd+drag
- Ctrl mousedown now arms a drag in `additive` mode and snapshots the current selection (`dragBase`).
- A pending toggle flag records that, if no drag happens, the start cell should be toggled on mouseup. So:
  - `Ctrl+click` (no movement) → toggle, same as before.
  - `Ctrl+drag` (past 4 px) → toggle is cancelled, drag activates; on every move, selection becomes `dragBase ∪ rect(dragStart → cursor)`. So you can drag out a second rectangle that adds to the first without clobbering it.
- The single-tbody constraint still applies — an additive drag stays inside the same table; dragging into another panel just stops growing.

## Files

- `js/dash.js` — `cancelInlineEdit()`, `selectRowOf()`, multi-click branch in `mousedown`, `dragMode` / `dragBase` / `dragPendingToggle` state, additive merge in `mousemove`, deferred-toggle path in `mouseup`.

## Test plan

- [ ] Triple-click a cell: only its row's data cells are highlighted (first column excluded), badge shows Σ/N/⌀ for those.
- [ ] Triple-click a cell after a single click already opened inline edit: the editor closes (no save), the row gets selected.
- [ ] Double-click does not leave a native text-selection inside the cell.
- [ ] Plain Ctrl+click on an unselected cell adds it; on a selected cell removes it. Same as before.
- [ ] Drag with Ctrl held from one cell to another: a rectangle is added to the existing selection, nothing previously selected is lost.
- [ ] Drag with Ctrl held into a cell in a different panel: the rectangle stops growing at the source panel's edge, no cross-panel rect.
- [ ] Plain (no-modifier) drag still replaces the selection as before.
- [ ] Shift+click still extends from the anchor.
- [ ] Esc still clears the selection.
- [ ] Ctrl+C over a selection built via Ctrl+drag copies the full TSV (every cell from base + every cell from the new rect).
- [ ] Inline editing of an editable cell via single click still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)