### PR TITLE
fix(gssync): don't escape commas in BKI cell values (closes #2658)

### DIFF
--- a/experiments/test-issue-2658-google-sheets-sync-no-comma-escape.php
+++ b/experiments/test-issue-2658-google-sheets-sync-no-comma-escape.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once __DIR__ . '/../google_sheets_sync.php';
+
+function assertSameIssue2658($expected, $actual, $message) {
+    if ($expected !== $actual) {
+        fwrite(STDERR, "FAIL: {$message}\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+}
+
+// gss_escape_bki_value must only escape BKI row delimiters (`:` and `;`).
+// Commas are not row-level delimiters and must pass through unchanged.
+assertSameIssue2658('1,234.56', gss_escape_bki_value('1,234.56'), 'plain comma is not escaped');
+assertSameIssue2658('A, B, C',  gss_escape_bki_value('A, B, C'),  'commas inside text are not escaped');
+assertSameIssue2658('a\\:b',    gss_escape_bki_value('a:b'),      'colon is still escaped');
+assertSameIssue2658('a\\;b',    gss_escape_bki_value('a;b'),      'semicolon is still escaped');
+assertSameIssue2658('a\\:b\\;c,d', gss_escape_bki_value('a:b;c,d'), 'mixed: only : and ; are escaped');
+
+// And the full BKI row must contain the original commas verbatim.
+$records = [
+    [
+        'value' => '1,234.56',
+        'date' => '01.01.2026',
+        'row' => 'Выручка, факт',
+        'column' => 'Я, Б',
+        'rows' => ['Выручка, факт'],
+        'columns' => ['Я, Б'],
+        'sheet' => 'List, A',
+    ],
+];
+
+$content = gss_build_bki_content($records, 1000000000);
+
+$expected = "DATA\r\n"
+    . "List, A;1,234.56;01.01.2026;Выручка, факт;Я, Б;;1000000000;\r\n";
+
+assertSameIssue2658($expected, $content, 'commas pass through gss_build_bki_content unchanged');
+
+echo "PASS issue 2658 BKI commas are not escaped\n";

--- a/include/google_sheets_sync.php
+++ b/include/google_sheets_sync.php
@@ -955,10 +955,12 @@ function gss_escape_bki_list($values) {
 }
 
 function gss_escape_bki_value($value) {
+    // Only `:` and `;` are structural delimiters in BKI rows. `,` is a separator
+    // only inside multi-select list fields, which gss_build_bki_content never emits,
+    // so escaping it here added noisy backslashes to plain cell values (issue #2658).
     return strtr(gss_cell_to_string($value), [
         ':' => '\\:',
         ';' => '\\;',
-        ',' => '\\,',
     ]);
 }
 


### PR DESCRIPTION
## Summary
- Closes #2658. The bug was visible in `google_sheets_sync.bki`: cell values like `1,234.56` or `Выручка, факт` came out as `1\,234.56` / `Выручка\, факт` with stray backslashes.
- Root cause: `gss_escape_bki_value` (in `include/google_sheets_sync.php`) ran every scalar field through a strtr that escaped `,` alongside `:` and `;`. Inside BKI rows produced by `gss_build_bki_content`, commas are never structural — `;` separates fields, `:` separates type attrs. Comma is only meaningful as a separator inside multi-select list fields, which this code path never emits.
- Fix: drop the `,` rule from `gss_escape_bki_value`. `:` and `;` keep their escapes. The unused helper `gss_escape_bki_list` (no callers anywhere in the repo) is left alone — outside the scope of this fix.

## Test plan
- [x] Adds `experiments/test-issue-2658-google-sheets-sync-no-comma-escape.php` (same style as `test-issue-2514-…trailing-semicolon.php`, `test-issue-2528-…sheet-name.php`): asserts `gss_escape_bki_value` passes plain commas through, still escapes `:` and `;`, and that a full `gss_build_bki_content` row with commas in the sheet name, value, row label and column label comes out verbatim.
- [ ] Manually: run gssync, regenerate `templates/custom/{db}/logs/google_sheets_sync.bki`, confirm cells with commas appear without `\` before the comma. Verify a value containing `:` or `;` still gets the corresponding backslash escape and round-trips cleanly through the BKI importer.
- [ ] Spot-check a downstream import into Интеграм — commas in `value` should not split the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)