### PR TITLE
fix(dash): show empty cells instead of N/A when formulas have no operands (closes #2660)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -1383,7 +1383,10 @@ function dashEvalFormula(el, f) {
         val = parseFloat(eval(f)); // eslint-disable-line no-eval
         if (isNaN(val)) return false;
     } catch (e) {
-        val = 'N/A';
+        // Missing operands turn the substituted formula into invalid JS
+        // (`+++` etc.) and eval throws — show an empty cell instead of N/A
+        // so dashboards read as "no data" rather than "broken" (issue #2660).
+        val = '';
         console.log(e + ': ' + f);
     }
     el.innerHTML = dashFormatNumberText(val);
@@ -1523,7 +1526,10 @@ function dashCalcRGFormulas() {
             try {
                 val = eval(expr); // eslint-disable-line no-eval
             } catch (e) {
-                val = 'N/A';
+                // Empty operands turn the expression into invalid JS — show an
+                // empty cell rather than N/A so missing data reads as "no data"
+                // instead of "broken" (issue #2660).
+                val = '';
                 console.log('RGformula eval error: ' + e + ' in: ' + expr);
             }
             var valStr = val !== null && val !== undefined ? String(val) : '';


### PR DESCRIPTION
## Summary
- Closes #2660 — cells like the «Кол-во exit-интервью» row in the screenshot showed `N/A` where the user expects an empty cell because the underlying report simply has no data for that period.
- Root cause: `dashEvalFormula` (`js/dash.js:1380`) and `dashCalcRGFormulas` (`js/dash.js:1525`) both set `val = 'N/A'` in their `eval()` catch block. That block fires when referenced cells contributed nothing, leaving the substituted expression as invalid JS (`+++`, trailing operator, empty parens) — i.e. the "no data" case, not a real formula error.
- Fix: render `''` in both catch blocks. `dashFormatNumberText('')` already returns `''`, so the cell renders empty. `console.log` and the `title` attribute with the original formula are kept, so a broken formula is still observable to admins via DevTools / hover.

## Test plan
- [ ] On a panel where a row formula references cells without values for a period, confirm the cell now renders empty instead of `N/A`.
- [ ] On the same panel where data IS present, confirm the formula still evaluates and shows the number (no regression).
- [ ] Check that `f-rg-formula-cell` cells (RG-formula path, `dashCalcRGFormulas`) follow the same behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)