### PR TITLE
fix(integram-table): don't truncate subordinate count to scrolled rows (closes #2663)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -12484,11 +12484,18 @@ class IntegramTable{
 
                 // Close handler
                 const closeModal = () => {
-                    // Update subordinate record count in the parent cell (issue #1839)
-                    if (clickedCountCell) {
-                        const newCount = container.querySelectorAll('table tbody tr').length || 0;
+                    // Update subordinate record count in the parent cell (issue #1839),
+                    // but only when the modal has loaded the full record set. With
+                    // infinite scroll (issue #1640) the DOM only holds the pages the
+                    // user scrolled through, so counting `<tr>` would replace e.g.
+                    // (660) with (40) just because the user didn't scroll to the
+                    // bottom (issue #2663). When more pages remain, keep the link's
+                    // existing text intact rather than writing a wrong number.
+                    if (clickedCountCell
+                        && container._subordinateHasMore === false
+                        && Array.isArray(container._subordinateData)) {
                         const countLink = clickedCountCell.querySelector('.subordinate-count-link');
-                        if (countLink) countLink.textContent = `(${ newCount })`;
+                        if (countLink) countLink.textContent = `(${ container._subordinateData.length })`;
                     }
                     modal.remove();
                     overlay.remove();

--- a/js/integram-table/19-form-edit.js
+++ b/js/integram-table/19-form-edit.js
@@ -1053,11 +1053,18 @@
 
                 // Close handler
                 const closeModal = () => {
-                    // Update subordinate record count in the parent cell (issue #1839)
-                    if (clickedCountCell) {
-                        const newCount = container.querySelectorAll('table tbody tr').length || 0;
+                    // Update subordinate record count in the parent cell (issue #1839),
+                    // but only when the modal has loaded the full record set. With
+                    // infinite scroll (issue #1640) the DOM only holds the pages the
+                    // user scrolled through, so counting `<tr>` would replace e.g.
+                    // (660) with (40) just because the user didn't scroll to the
+                    // bottom (issue #2663). When more pages remain, keep the link's
+                    // existing text intact rather than writing a wrong number.
+                    if (clickedCountCell
+                        && container._subordinateHasMore === false
+                        && Array.isArray(container._subordinateData)) {
                         const countLink = clickedCountCell.querySelector('.subordinate-count-link');
-                        if (countLink) countLink.textContent = `(${ newCount })`;
+                        if (countLink) countLink.textContent = `(${ container._subordinateData.length })`;
                     }
                     modal.remove();
                     overlay.remove();


### PR DESCRIPTION
## Симптом (issue #2663)

Открываешь `.subordinate-count-link` у ячейки, например с (660), закрываешь модаль не доскроллив до конца — число подменяется на (40), сколько успел проскроллить.

## Корень

`closeModal` в потоке cell-opened `.subordinate-modal` (`js/integram-table/19-form-edit.js`, бывшие строки 1054-1066) делал:

```js
const newCount = container.querySelectorAll('table tbody tr').length || 0;
countLink.textContent = `(${ newCount })`;
```

Этот пересчёт верен только если все записи лежат в DOM. Подчинённая таблица использует infinite-scroll из #1640 — страницы догружаются по мере скролла. При закрытии без полной прокрутки в DOM лежат только подгруженные страницы. Изначальное (660) приходит с бэка, а `closeModal` его затирает количеством `<tr>` в виртуальной выдаче.

## Фикс

Обновляем count только когда `_subordinateHasMore === false` — то есть loader дошёл до конца. В этом случае авторитетный источник — `_subordinateData.length` (накопленный массив всех страниц), не DOM: DOM-строки могут быть отфильтрованы текущим `_subordinateSearchTerm`, что дало бы недосчёт в другую сторону.

Если страницы остались — оставляем текст ссылки как есть. Старое значение, проставленное при рендере родительской таблицы, корректное. Лучше слегка устаревшее число (например, при удалении строки в модали оно может на 1 разойтись), чем заведомо неправильное обрезанное.

## Что покрывает

- ✅ Закрыл модаль без скролла до конца → count не меняется (остаётся (660)).
- ✅ Доскроллил всё, закрыл → count = `_subordinateData.length` (правильный total).
- ✅ Активный поиск в модали → count всё равно total, не отфильтрованный.

## Где лежит правка

- Источник: `js/integram-table/19-form-edit.js` (закрытие модали в cell-opened subordinate flow).
- `js/integram-table.js` пересобран через `bash build.sh` согласно правилу `js/CLAUDE.md` («ВАЖНО: integram-table.js генерируется автоматически, никогда не редактировать напрямую»).

## Test plan

- [ ] Открыть строку родителя с большой подчинённой таблицей (`.subordinate-count-link (N)`, N >> pageSize=20).
- [ ] Открыть модаль, проскроллить пару страниц, закрыть — `.subordinate-count-link` остаётся равным исходному (N), не 40.
- [ ] Открыть, доскроллить до конца (спиннер исчезает, hasMore=false), закрыть — число обновилось на актуальное.
- [ ] Открыть, набрать поисковую строку фильтрующую отображаемые строки, закрыть — count не подменяется на отфильтрованную выдачу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)