### PR TITLE
fix(bki-import): refresh first column on composite-key match in plain DATA import

### DIFF
--- a/index.php
+++ b/index.php
@@ -5975,8 +5975,16 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
     					            trace(" not found ".$object[0]);
     					    }
     					}
-    					if(isset($existing))
+    					if(isset($existing)){
         					$new_id = $existing;
+        					// Composite-key uniqueness (the first column itself is not unique) — the existing
+        					// record was matched via UniqueKeyReqs without obj.val in the WHERE clause
+        					// (FindUniqueRecordDuplicate, $includeVal=false), so the first column in the DB may
+        					// differ from the incoming BKI row. Refresh it so re-import overwrites the first
+        					// column on update, not just the secondary requisites.
+        					if(count($keyReqs) && !$isUnique)
+        					    Update_Val($existing, $object[0]);
+    					}
     					else
 							$new_id = Insert($parent, (isset($cur_order) ? $cur_order++ : 1), $id, $object[0], "Plain import #$count");
     					#array_pop($object); 	# Cut off the empty item after the last semi-colon


### PR DESCRIPTION
## Симптом

При повторном BKI-импорте у типа с составным ключом уникальности (`UniqueKeyReqs` непустой) и **неуникальной первой колонкой** значение в первой колонке (`obj.val`) в БД **не перезаписывается** новыми данными. Остальные колонки обновляются корректно — поэтому баг визуально проявляется как «остался старый текст в первой колонке».

Пример BKI-строки:
```
ОПиУ;-65,23%;31.01.2025;Рентабельность чистой прибыли;ФАКТ;202;1778772342;
```

Composite key — `date + row + column` (например, `31.01.2025 + Рентабельность чистой прибыли + ФАКТ`). Первое поле «ОПиУ» уникальным не является — много строк имеют то же самое первое поле, но разный composite key.

## Корень

Путь в `index.php`:

1. **`index.php:5945`** — `FindUniqueRecordDuplicate($id, 0, $parent, $object[0], $keyValues, (bool)$isUnique)`. Если `$isUnique = false` (первая колонка неуникальна, уникальность только через `keyReqs`), параметр `$includeVal` помощника = `false`.
2. **`index.php:8852-8853`** — при `$includeVal=false` условие `obj.val='$val'` **выкидывается** из WHERE. Helper находит существующую запись чисто по composite key.
3. **`index.php:5978-5981`** — найдено → `$new_id = $existing`, дальше идёт цикл по реквизитам (`local_struct`), но `obj.val` (первая колонка) этим циклом **не покрывается**.

Сравнение с веткой простой уникальности (`else`, строки 5955-5976): там SQL включает `obj.val='$val'` — то есть match происходит только при точном совпадении первой колонки, поэтому отсутствие UPDATE на `val` там не заметно.

## Фикс

Один Update_Val после `$new_id = $existing` под флагом «composite-key путь и первая колонка не unique»:

```php
if(isset($existing)){
    $new_id = $existing;
    if(count($keyReqs) && !$isUnique)
        Update_Val($existing, $object[0]);
}
```

Условие `count($keyReqs) && !$isUnique` ограничивает обновление ровно тем случаем, где FindUniqueRecordDuplicate шёл без `obj.val` в WHERE. В простой-уникальной ветке (`$isUnique=true`) val уже совпадал с найденной записью — `Update_Val` стал бы no-op.

## Test plan

- [ ] Тип с composite-key (`date + row + column`) и неуникальным первым столбцом: загрузить BKI с записями, потом залить второй BKI, где у одной записи изменена только первая колонка («ОПиУ» → «ОПиУ-new»). Проверить, что `obj.val` в БД обновился.
- [ ] Регрессия 1: тип с unique первой колонкой (`$isUnique=true`) — повторный импорт не делает лишних апдейтов val (поведение прежнее).
- [ ] Регрессия 2: тип без любой уникальности — `$existing` не выставляется, запись создаётся новая, как раньше.
- [ ] Регрессия 3: добавление новой записи (composite key не находится) — `Insert` отрабатывает с `$object[0]` как раньше.

🤖 Generated with [Claude Code](https://claude.com/claude-code)