### PR TITLE
fix(dash): accept source value already wrapped in [...] in JSON parse

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -2028,6 +2028,20 @@ function dashGetVizReport(reportId, fr, to, panelFilter) {
     return key;
 }
 
+// Parses a source-`value` string into an array of `{date, val, ...}` records.
+// Historically `value` came as a bare list of objects with no outer brackets —
+// `{"date":...},{"date":...}` — so the caller wrapped it in `[...]` before
+// JSON.parse. Newer backends may emit the same payload already wrapped:
+// `[{"date":...},{"date":...}]`. Wrapping that a second time produced a valid
+// JSON array of arrays — JSON.parse succeeded silently but the parsed records
+// were nested one level too deep, so per-record fields (date/val/Метка)
+// stopped being visible and the cells came up empty without any error.
+// Sniff the first non-whitespace char: if it's already `[`, parse as-is.
+function dashParseSrcValue(value) {
+    var raw = String(value == null ? '' : value).replace(/^\s+/, '');
+    return JSON.parse(raw.charAt(0) === '[' ? raw : '[' + raw + ']');
+}
+
 function dashGetSrc(json) {
     for (var i in json || []) {
         if (json[i].valueItemID) dashValueItemIds[(json[i].item || '').toLowerCase()] = json[i].valueItemID;
@@ -2037,7 +2051,7 @@ function dashGetSrc(json) {
                 var itemKey = (json[i].item || '').toLowerCase();
                 var key = colGroup ? itemKey + ':' + colGroup : itemKey;
                 var srcLabel = json[i]['Метка'] || '';
-                var parsed = JSON.parse('[' + json[i].value + ']');
+                var parsed = dashParseSrcValue(json[i].value);
                 var tagged = parsed.map(function(p) {
                     return Object.assign({}, p, { 'Метка': srcLabel });
                 });
@@ -2105,7 +2119,7 @@ function dashGetPanelValuesDone(json, ctx) {
             var key = colGroup ? itemKey + ':' + colGroup : itemKey;
             try {
                 var srcLabel = row['Метка'] || '';
-                var parsed = JSON.parse('[' + row.value + ']');
+                var parsed = dashParseSrcValue(row.value);
                 var tagged = parsed.map(function(p) {
                     return Object.assign({}, p, { 'Метка': srcLabel });
                 });


### PR DESCRIPTION
## Контекст

`dashGetSrc` (`js/dash.js:2040`) и `dashGetPanelValuesDone` (`js/dash.js:2108`) парсили payload одной строки источника:

```js
var parsed = JSON.parse('[' + value + ']');
```

Так исторически было удобно, потому что сервер возвращал per-period данные **без** внешних квадратных скобок:

```
{\"date\":\"20250228\",\"val\":\"-4 075 505\"},{\"date\":\"20250430\",\"val\":\"...\"}
```

## Проблема

Если бекенд (или конкретный `panelQuery`) начнёт отдавать payload **уже с квадратными скобками**:

```json
[{\"date\":\"20250228\",\"val\":\"-4 075 505\"},{\"date\":\"20250430\",\"val\":\"...\"}]
```

то после обёртки `[...]` получается валидный JSON-массив массивов:

```
[[{...},{...}]]
```

`JSON.parse` это **не уронит** — поэтому защита в catch (PR #2662, `dashValueErrors` + `.dash-err`) здесь не сработает. Дальше `parsed.map(p => Object.assign({}, p, {Метка: srcLabel}))` пройдёт ровно один раз; `p` — внутренний массив, а не объект `{date, val}`. `Object.assign({}, [...], {Метка: '...'})` сложит фрейм с числовыми ключами `0/1/2/...` и полем `Метка` на внешнем уровне. В `dashGetVal` `for in` по такому объекту даст entries с `entry.date / entry.val`, но **`Метка` теперь не на entry**, а на родителе — фильтр по `dashLabel` обрезает всё, что не совпало с пустой меткой. Симптом: молча пустые ячейки, ошибки в консоли нет, `.dash-err` не подсвечивается.

## Фикс

Вынес общий хелпер `dashParseSrcValue(value)` (`js/dash.js`, перед `dashGetSrc`). Он смотрит первый не-пробельный символ:

```js
function dashParseSrcValue(value) {
    var raw = String(value == null ? '' : value).replace(/^\\s+/, '');
    return JSON.parse(raw.charAt(0) === '[' ? raw : '[' + raw + ']');
}
```

— если уже `[`, парсит как есть; иначе — оборачивает как раньше. Оба call site (`dashGetSrc`, `dashGetPanelValuesDone`) теперь зовут хелпер. Старый bare-формат продолжает работать; новый bracketed-формат тоже.

Заодно нормализовал `null/undefined → ''`, чтобы хелпер не падал на отсутствующих значениях.

## Проверка

```js
function parse(v){ var raw = String(v==null?'':v).replace(/^\\s+/,''); return JSON.parse(raw.charAt(0)==='[' ? raw : '[' + raw + ']'); }
parse('{\"date\":\"X\",\"val\":\"1\"},{\"date\":\"Y\",\"val\":\"2\"}')
// → [{date:'X', val:'1'}, {date:'Y', val:'2'}]
parse('[{\"date\":\"X\",\"val\":\"1\"},{\"date\":\"Y\",\"val\":\"2\"}]')
// → [{date:'X', val:'1'}, {date:'Y', val:'2'}]
parse('')        // → []
parse(null)      // → []
```

## Test plan

- [ ] Бекенд возвращает старый формат (`{...},{...}`) — панели рендерятся как раньше.
- [ ] Бекенд возвращает новый формат (`[{...},{...}]`) — панели рендерятся теми же значениями.
- [ ] Бекенд возвращает невалидный JSON (например, с `\\,` как в #2660-обсуждении) — старая защита из PR #2662 продолжает работать: ячейка пустая, фон `.dash-err` бледно-розовый, в title видна ошибка и raw expression.
- [ ] Пустой `value` или `null` — не падает, bucket для этой пары `item:colGroup` просто остаётся пустым.

🤖 Generated with [Claude Code](https://claude.com/claude-code)