### PR TITLE
feat(dash): use itemSrcName as the data-lookup key when filled (closes #2682)

### DIFF
--- a/experiments/test-issue-2682-item-src-name-lookup.js
+++ b/experiments/test-issue-2682-item-src-name-lookup.js
@@ -1,0 +1,140 @@
+// Test: itemSrcName is used in place of item when looking up data in the
+// query (issue #2682). The visible item-name on the row stays unchanged —
+// only the lookup key flips to the alternative source name.
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+    if (cond) { console.log('  PASS: ' + msg); passed++; }
+    else { console.error('  FAIL: ' + msg); failed++; }
+}
+
+// ─── Minimal stubs mirroring dash.js shape ──────────────────────────────
+
+let dashItems = {};
+let dashValues = {};
+let dashValueItemIds = {};
+
+function dashGetFloat(v) {
+    var f = parseFloat(String(v).replace(',', '.'));
+    return isNaN(f) ? 0 : f;
+}
+function dashNormalizeVal(_item, val) {
+    var v = val || '';
+    if (typeof val === 'object' && val !== null) v = val[0].val;
+    return String(v).replace(/ /g, '').replace(/,/g, '.');
+}
+function dashGetVal(item, fr, to) {
+    var i, acc = 0, valids = false, key = item ? item.toLowerCase() : item;
+    if (!dashValues[key]) return;
+    for (i in dashValues[key]) {
+        if (!fr || (dashValues[key][i].date >= fr && dashValues[key][i].date <= to)) {
+            valids = true;
+            acc += dashGetFloat(dashValues[key][i].val);
+        }
+    }
+    if (valids) return dashNormalizeVal(key, acc);
+}
+
+// ─── The bit under test ─────────────────────────────────────────────────
+// Copy of dashRowLookupName from js/dash.js. The whole point of the
+// helper is to centralise the srcName ?? item-name decision.
+
+function dashRowLookupName(row) {
+    if (!row) return '';
+    var meta = dashItems[row.id];
+    return (meta && meta.srcName) || row.getAttribute('item-name') || '';
+}
+
+// Minimal row shim
+function makeRow(id, itemName) {
+    var attrs = { 'item-name': itemName };
+    return {
+        id: id,
+        getAttribute: function(name) { return attrs[name]; }
+    };
+}
+
+// Simulates what dashGetModel does when ingesting a Дэшборд row.
+function ingestModelRow(itemID, item, itemSrcName) {
+    dashItems[itemID] = {
+        name: item,
+        format: '',
+        mu: '',
+        label: '',
+        srcName: itemSrcName || ''
+    };
+}
+
+// Simulates dashGetSrc storing Дэшборд.ЗначенияЗаПериод rows. Source data
+// is keyed by the source-side `item` field, lowercased.
+function ingestSrcRow(item, value, valueItemID) {
+    var key = (item || '').toLowerCase();
+    dashValues[key] = value;
+    if (valueItemID) dashValueItemIds[key] = valueItemID;
+}
+
+function reset() {
+    dashItems = {};
+    dashValues = {};
+    dashValueItemIds = {};
+}
+
+// =========================================================================
+// Test 1: srcName empty — falls back to the visible item-name (regression).
+// =========================================================================
+console.log('\nTest 1: itemSrcName empty -> use item-name attribute');
+reset();
+ingestModelRow('42', 'Выручка', '');
+ingestSrcRow('Выручка', [{ date: '2024-01-01', val: '1000' }], 'V42');
+var row = makeRow('42', 'Выручка');
+var key = dashRowLookupName(row);
+assert(key === 'Выручка', 'lookup key falls back to item-name: ' + key);
+var v = dashGetVal(key, '2024-01-01', '2024-12-31');
+assert(v === '1000', 'data is found via the fallback key: ' + v);
+assert((dashValueItemIds[(key || '').toLowerCase()] || '') === 'V42',
+    'valueItemId lookup uses the same fallback key');
+
+// =========================================================================
+// Test 2: srcName filled — overrides the visible item-name for lookups.
+// =========================================================================
+console.log('\nTest 2: itemSrcName filled -> lookups use the alternative name');
+reset();
+// Row displays as "Прибыль чистая" but source data is keyed by "Net Profit".
+ingestModelRow('43', 'Прибыль чистая', 'Net Profit');
+ingestSrcRow('Net Profit', [{ date: '2024-06-01', val: '500' }], 'V43');
+// Note: no data is stored under the visible name on purpose.
+ingestSrcRow('Прибыль чистая', [], '');
+row = makeRow('43', 'Прибыль чистая');
+key = dashRowLookupName(row);
+assert(key === 'Net Profit',
+    'lookup key prefers itemSrcName over item-name: ' + key);
+v = dashGetVal(key, '2024-01-01', '2024-12-31');
+assert(v === '500', 'data is found via the alternative key: ' + v);
+assert(row.getAttribute('item-name') === 'Прибыль чистая',
+    'the row\'s visible item-name is untouched (still "Прибыль чистая")');
+assert((dashValueItemIds[(key || '').toLowerCase()] || '') === 'V43',
+    'valueItemId lookup also flips to the alternative key');
+
+// =========================================================================
+// Test 3: row missing from dashItems — degrades to the visible item-name.
+// =========================================================================
+console.log('\nTest 3: dashItems missing entry -> use item-name attribute');
+reset();
+ingestSrcRow('Wage', [{ date: '2024-03-01', val: '7' }]);
+row = makeRow('99', 'Wage');
+key = dashRowLookupName(row);
+assert(key === 'Wage', 'lookup key falls back to item-name when no metadata: ' + key);
+v = dashGetVal(key);
+assert(v === '7', 'data still resolves through the fallback path: ' + v);
+
+// =========================================================================
+// Test 4: null row — returns empty string, no crash.
+// =========================================================================
+console.log('\nTest 4: null row -> empty string');
+assert(dashRowLookupName(null) === '', 'null row returns empty string');
+assert(dashRowLookupName(undefined) === '', 'undefined row returns empty string');
+
+console.log('\n=== Summary ===');
+console.log('Passed: ' + passed);
+console.log('Failed: ' + failed);
+process.exit(failed === 0 ? 0 : 1);

--- a/js/dash.js
+++ b/js/dash.js
@@ -1398,8 +1398,9 @@ function dashGetColValDetails(item, col, dashLabel, panelKey) {
 
 function dashResolveValueCell(rowId, groupName, panelKey) {
     var formula = dashFormulas[rowId] || ''
-        , itemName = dashItems[rowId] ? dashItems[rowId].name : ''
-        , dashLabel = dashItems[rowId] ? (dashItems[rowId].label || '') : ''
+        , itemMeta = dashItems[rowId] || {}
+        , itemName = (itemMeta.srcName || itemMeta.name || '')
+        , dashLabel = itemMeta.label || ''
         , altName = formula.match(itemRegex)
         , valueName = altName ? altName[1] : itemName
         , groupedKey = groupName ? valueName + ':' + groupName : ''
@@ -1708,7 +1709,7 @@ function dashDrawPeriods() {
                             });
                             // Add cells: for each item row, one cell per column group
                             panel.querySelectorAll('.f-item').forEach(function(row) {
-                                var itemName = row.getAttribute('item-name');
+                                var itemName = dashRowLookupName(row);
                                 var s = dashCellSrc(row.id, 'rg');
                                 var valueItemId = dashPanelValues[panelId] ? '' : (dashValueItemIds[(itemName || '').toLowerCase()] || '');
                                 var rgHeadVal = dashModelData[panelId].rgs[rg].head || '';
@@ -1762,7 +1763,7 @@ function dashDrawPeriods() {
                                 headTpl.replace(':head:', p[i].r[0]).replace(':from:', fr).replace(':to:', to));
                             panel.querySelectorAll('.f-item').forEach(function(row) {
                                 var s = dashCellSrc(row.id, 'rg');
-                                var itemName = row.getAttribute('item-name');
+                                var itemName = dashRowLookupName(row);
                                 var valueItemId = dashPanelValues[panelId] ? '' : (dashValueItemIds[(itemName || '').toLowerCase()] || '');
                                 var rgHeadVal = dashModelData[panelId].rgs[rg].head || '';
                                 var rowLabel = (dashItems[row.id] && dashItems[row.id].label) || '';
@@ -1814,7 +1815,7 @@ function dashDrawPeriods() {
                         if (resolved.alias)
                             s = { src: 'value', extra: '' };
                         v = dashNormalizeVal(row.id, resolved.value);
-                        var itemName = row.getAttribute('item-name');
+                        var itemName = dashRowLookupName(row);
                         var valueItemId = dashPanelValues[panelId] ? '' : (dashValueItemIds[(itemName || '').toLowerCase()] || '');
                         var rgHeadVal = groupName;
                         var rowLabel = (dashItems[row.id] && dashItems[row.id].label) || '';
@@ -1897,7 +1898,7 @@ function dashDrawPeriods() {
                                     panel.querySelectorAll('.f-item').forEach(function(row) {
                                         var ready = 0, src = 'report', extra = '', vDetails = '';
                                         var item = dashItems[row.id] || {};
-                                        var itemName = item.name || '';
+                                        var itemName = item.srcName || item.name || '';
                                         var rowLabel = item.label || '';
                                         if (useMatrix) {
                                             var matrixRow = dashFindMatrixValue(itemName, col, rowLabel);
@@ -2236,7 +2237,7 @@ function dashGetModel(json) {
 
     for (i in json) {
         dashPeriods[json[i].period] = 1;
-        dashItems[json[i].itemID] = { name: json[i].item, format: json[i].format, mu: json[i].MU, label: json[i]['Метка'] || '' };
+        dashItems[json[i].itemID] = { name: json[i].item, format: json[i].format, mu: json[i].MU, label: json[i]['Метка'] || '', srcName: json[i].itemSrcName || '' };
         if (json[i].RGsourceID && !dashPeriods[json[i].RGsourceID]) {
             dashRgSourceIds[json[i].RGsourceID] = 1;
             dashPeriods[json[i].RGsourceID] = 1;
@@ -2470,6 +2471,16 @@ function dashPanelGetRows(panelEl) {
 
 function dashPanelGetRowName(row) {
     return row ? (row.getAttribute('item-name') || '') : '';
+}
+
+// Alternative row name used to look up data in the query (issue #2682).
+// When `itemSrcName` is filled on a Дэшборд row, the source data is keyed by
+// that name in ЗначенияЗаПериод / panelQuery — not by the visible row name.
+// Falls back to the visible `item-name` when itemSrcName is empty.
+function dashRowLookupName(row) {
+    if (!row) return '';
+    var meta = dashItems[row.id];
+    return (meta && meta.srcName) || row.getAttribute('item-name') || '';
 }
 
 function dashPanelGetRowKey(row) {


### PR DESCRIPTION
## Summary
- Дэшборд rows now read `itemSrcName` ("alternative row name") and use it instead of the visible item name when looking up ЗначенияЗаПериод / panelQuery / matrix data. Otherwise rows render empty even though the data is present in the query.
- Introduces `dashRowLookupName(row)` (returns `srcName || row[item-name]`) and routes the four data-lookup sites in `dashDrawPeriods` plus `dashResolveValueCell` through it. Visible row names, panel-filter row names, and search-URL building still use the row attribute.
- Adds `experiments/test-issue-2682-item-src-name-lookup.js` (11 assertions, covers empty srcName fallback, filled srcName override, missing dashItems entry, null row).

Closes #2682.

## Test plan
- [x] `node experiments/test-issue-2682-item-src-name-lookup.js` — 11/11 PASS
- [ ] Manual: открыть Дэшборд с строкой, у которой заполнено `itemSrcName` — значения подтягиваются по альтернативному имени; на строках без `itemSrcName` ничего не меняется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)