### PR TITLE
feat(dash): selectable header / first column, hover Copy-table icon (closes #2681)

### DIFF
--- a/css/dash.css
+++ b/css/dash.css
@@ -517,17 +517,23 @@ td:has(.dash-cell-input) {
 }
 .dash-readonly-tip.visible { opacity: 1; }
 
-/* Cell multi-selection (sum of selected cells) */
-#dash-model td.f-cell.dash-cell-selected {
+/* Cell multi-selection (sum of selected cells; first column + headers since #2681) */
+#dash-model td.f-cell.dash-cell-selected,
+#dash-model td.f-first-cell.dash-cell-selected,
+#dash-model th.dash-cell-selected {
     background-color: rgba(43, 108, 176, 0.18);
     box-shadow: inset 0 0 0 1px rgba(43, 108, 176, 0.55);
 }
-#dash-model td.f-cell.dash-cell-copied {
+#dash-model td.f-cell.dash-cell-copied,
+#dash-model td.f-first-cell.dash-cell-copied,
+#dash-model th.dash-cell-copied {
     background-color: rgba(43, 108, 176, 0.4);
     transition: background-color 0.2s;
 }
 #dash-model.dash-selecting,
-#dash-model.dash-selecting td.f-cell {
+#dash-model.dash-selecting td.f-cell,
+#dash-model.dash-selecting td.f-first-cell,
+#dash-model.dash-selecting th {
     user-select: none;
     -webkit-user-select: none;
 }
@@ -675,7 +681,8 @@ td:has(.dash-cell-input) {
     flex: 1;
 }
 .f-panel-settings-icon,
-.f-panel-filter-icon {
+.f-panel-filter-icon,
+.f-panel-copy-icon {
     display: none;
     color: var(--text-secondary, #6c757d);
     cursor: pointer;
@@ -687,10 +694,13 @@ td:has(.dash-cell-input) {
 }
 .f-panel-settings-icon:hover,
 .f-panel-filter-icon:hover,
-.f-panel-filter-icon.active { color: var(--text-primary, #212529); background: var(--bg-secondary, #f0f0f0); }
+.f-panel-filter-icon.active,
+.f-panel-copy-icon:hover { color: var(--text-primary, #212529); background: var(--bg-secondary, #f0f0f0); }
 .f-panel:hover .f-panel-settings-icon,
 .f-panel:hover .f-panel-filter-icon,
+.f-panel:hover .f-panel-copy-icon,
 .f-panel-filter-icon.active { display: inline-flex; align-items: center; }
+.f-panel-copy-icon.dash-sel-copied { background: var(--bg-secondary, #f0f0f0); color: var(--text-primary, #212529); }
 /* Visualization type icons in panel header */
 .f-panel-viz-icons {
     display: flex;

--- a/experiments/test-issue-2681-select-headers-and-copy-table.js
+++ b/experiments/test-issue-2681-select-headers-and-copy-table.js
@@ -1,0 +1,274 @@
+// Tests for issue #2681:
+//   1. .f-first-cell and <th> cells participate in the multi-cell selection.
+//   2. Stats badge (Σ / N / ⌀) skips non-data cells so a "2024" period header
+//      doesn't pollute the sum.
+//   3. TSV copy of the whole table walks every row, joining cells with TAB
+//      and rows with newline; numeric cells get spaces stripped, text cells
+//      keep their internal spaces.
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+    if (cond) { console.log('  PASS: ' + msg); passed++; }
+    else { console.error('  FAIL: ' + msg); failed++; }
+}
+
+// ─── Tiny DOM stand-in ──────────────────────────────────────────────────
+// Enough surface for the bits of dash.js under test.
+
+function makeEl(tag, props) {
+    var classes = (props && props.classes) || [];
+    var children = [];
+    var attrs = (props && props.attrs) || {};
+    var text = (props && props.text) || '';
+    return {
+        tagName: tag.toUpperCase(),
+        children: children,
+        classList: {
+            _set: new Set(classes),
+            contains: function(c) { return this._set.has(c); },
+            add: function(c) { this._set.add(c); },
+            remove: function(c) { this._set.delete(c); }
+        },
+        textContent: text,
+        _attrs: attrs,
+        getAttribute: function(name) { return this._attrs[name]; },
+        closest: function(sel) {
+            // Walk up via _parent links until we match a tag selector
+            var node = this;
+            while (node) {
+                if (sel === 'tr' && node.tagName === 'TR') return node;
+                if (sel === 'table' && node.tagName === 'TABLE') return node;
+                if (sel === '.f-panel table'
+                    && node.tagName === 'TABLE'
+                    && node._parent && node._parent.classList && node._parent.classList.contains('f-panel-content')
+                    && node._parent._parent && node._parent._parent.classList && node._parent._parent.classList.contains('f-panel')) {
+                    return node;
+                }
+                node = node._parent;
+            }
+            return null;
+        }
+    };
+}
+
+function appendChild(parent, child) {
+    child._parent = parent;
+    parent.children.push(child);
+    return child;
+}
+
+// Walks .children recursively; mimics querySelectorAll('tr') without caring
+// about thead/tbody nesting.
+function queryAllRows(root) {
+    var out = [];
+    (function walk(node) {
+        if (node.tagName === 'TR') out.push(node);
+        node.children.forEach(walk);
+    })(root);
+    return out;
+}
+
+// ─── Copies of the helpers from js/dash.js (issue #2681) ────────────────
+
+function isSelectableCell(node) {
+    if (!node || !node.classList) return false;
+    if (node.classList.contains('f-cell')) return true;
+    if (node.classList.contains('f-first-cell')) return true;
+    if (node.tagName === 'TH' && node.closest('.f-panel table')) return true;
+    return false;
+}
+
+function isStatsCell(node) {
+    return !!(node && node.classList && node.classList.contains('f-cell'));
+}
+
+function dashCellText(el) {
+    return el && el.textContent !== undefined ? el.textContent : (el ? '' : '');
+}
+
+function stripSpaces(text) {
+    return String(text).replace(/\s+/g, '');
+}
+
+function dashGetFloat(v) {
+    var f = parseFloat(String(v).replace(/\s+/g, '').replace(',', '.'));
+    return isNaN(f) ? NaN : f;
+}
+
+function tsvCellText(cell) {
+    if (!cell) return '';
+    if (isStatsCell(cell)) return stripSpaces(dashCellText(cell));
+    if (cell.classList && cell.classList.contains('f-first-cell')) {
+        var tr = cell.closest('tr');
+        var attr = tr && tr.getAttribute && tr.getAttribute('item-name');
+        if (attr) return String(attr).trim();
+        return (cell.textContent || '').trim();
+    }
+    return (cell.textContent != null ? String(cell.textContent) : '').trim();
+}
+
+function buildTableTsv(table) {
+    if (!table) return '';
+    var rows = [];
+    queryAllRows(table).forEach(function(tr) {
+        var rowCells = [];
+        for (var i = 0; i < tr.children.length; i++) {
+            rowCells.push(tsvCellText(tr.children[i]));
+        }
+        rows.push(rowCells.join('\t'));
+    });
+    return rows.join('\n');
+}
+
+// Badge stats logic — direct port of the updated forEach in updateBadge.
+function statsFor(cells) {
+    var sum = 0, n = 0;
+    cells.forEach(function(td) {
+        if (isStatsCell(td)) {
+            var v = dashGetFloat(dashCellText(td));
+            if (!isNaN(v)) { sum += v; n++; }
+        }
+    });
+    return { sum: sum, n: n };
+}
+
+// ─── Fixture: a tiny dashboard panel ────────────────────────────────────
+// <f-panel>
+//   <f-panel-content>
+//     <table>
+//       <thead>
+//         <tr> <th></th> <th>2024</th> <th>2025</th> </tr>
+//       </thead>
+//       <tbody>
+//         <tr item-name="Total revenue">
+//            <td.f-first-cell>id<br>Total revenue</td>
+//            <td.f-cell>1 000</td>
+//            <td.f-cell>2 500,5</td>
+//         </tr>
+//         <tr item-name="Net profit">
+//            <td.f-first-cell>Net profit</td>
+//            <td.f-cell>300</td>
+//            <td.f-cell>-50</td>
+//         </tr>
+//       </tbody>
+//     </table>
+//   </f-panel-content>
+// </f-panel>
+
+function buildFixture() {
+    var panel = makeEl('div', { classes: ['f-panel'] });
+    var content = makeEl('div', { classes: ['f-panel-content'] });
+    appendChild(panel, content);
+    var table = makeEl('table');
+    appendChild(content, table);
+
+    var thead = makeEl('thead');
+    appendChild(table, thead);
+    var headTr = makeEl('tr', { classes: ['f-head'] });
+    appendChild(thead, headTr);
+    var th0 = appendChild(headTr, makeEl('th', { text: '' }));
+    var th1 = appendChild(headTr, makeEl('th', { text: '2024' }));
+    var th2 = appendChild(headTr, makeEl('th', { text: '2025' }));
+
+    var tbody = makeEl('tbody');
+    appendChild(table, tbody);
+
+    var r1 = appendChild(tbody, makeEl('tr', { classes: ['f-item'], attrs: { 'item-name': 'Total revenue' } }));
+    var r1c0 = appendChild(r1, makeEl('td', {
+        classes: ['dash-first-cell', 'f-first-cell'],
+        text: 'XYZ Total revenue'  // simulates show-id text leaking via textContent
+    }));
+    var r1c1 = appendChild(r1, makeEl('td', { classes: ['f-cell'], text: '1 000' }));
+    var r1c2 = appendChild(r1, makeEl('td', { classes: ['f-cell'], text: '2 500,5' }));
+
+    var r2 = appendChild(tbody, makeEl('tr', { classes: ['f-item'], attrs: { 'item-name': 'Net profit' } }));
+    var r2c0 = appendChild(r2, makeEl('td', { classes: ['dash-first-cell', 'f-first-cell'], text: 'Net profit' }));
+    var r2c1 = appendChild(r2, makeEl('td', { classes: ['f-cell'], text: '300' }));
+    var r2c2 = appendChild(r2, makeEl('td', { classes: ['f-cell'], text: '-50' }));
+
+    return {
+        panel: panel, table: table,
+        headers: [th0, th1, th2],
+        firstCells: [r1c0, r2c0],
+        dataCells: [r1c1, r1c2, r2c1, r2c2]
+    };
+}
+
+// =========================================================================
+// Test 1: isSelectableCell extends to f-first-cell and th.
+// =========================================================================
+console.log('\nTest 1: selection predicate covers headers and first column');
+var fx = buildFixture();
+assert(isSelectableCell(fx.dataCells[0]) === true, 'f-cell is selectable');
+assert(isSelectableCell(fx.firstCells[0]) === true, 'f-first-cell is selectable');
+assert(isSelectableCell(fx.headers[1]) === true, 'th inside a panel table is selectable');
+var loneTh = makeEl('th', { text: 'orphan' }); // not under any panel
+assert(isSelectableCell(loneTh) === false, 'orphan th outside .f-panel is not selectable');
+
+// =========================================================================
+// Test 2: Stats predicate stays narrow — only f-cell counts.
+// =========================================================================
+console.log('\nTest 2: only f-cell contributes to Σ / N');
+assert(isStatsCell(fx.dataCells[0]) === true, 'f-cell is a stats cell');
+assert(isStatsCell(fx.firstCells[0]) === false, 'f-first-cell is NOT a stats cell');
+assert(isStatsCell(fx.headers[1]) === false, '<th> is NOT a stats cell');
+
+// Mixed selection: header "2024", first cell, two data cells.
+// Stats should reflect only the two data cells (1 000 + 2 500,5).
+var mixed = [fx.headers[1], fx.firstCells[0], fx.dataCells[0], fx.dataCells[1]];
+var stats = statsFor(mixed);
+assert(stats.n === 2, 'N excludes header & first-cell: ' + stats.n);
+var expectedSum = 1000 + 2500.5;
+assert(Math.abs(stats.sum - expectedSum) < 1e-9,
+    'Σ excludes header "2024" and label cell (got ' + stats.sum + ', expected ' + expectedSum + ')');
+
+// =========================================================================
+// Test 3: tsvCellText
+//   - numeric f-cell loses its internal thousand-space
+//   - f-first-cell uses item-name (no leaked row-id text)
+//   - <th> keeps its text verbatim
+// =========================================================================
+console.log('\nTest 3: tsvCellText respects cell type');
+assert(tsvCellText(fx.dataCells[0]) === '1000',
+    'numeric f-cell strips spaces: ' + tsvCellText(fx.dataCells[0]));
+assert(tsvCellText(fx.firstCells[0]) === 'Total revenue',
+    'f-first-cell uses item-name even when textContent includes show-id: '
+    + tsvCellText(fx.firstCells[0]));
+assert(tsvCellText(fx.headers[1]) === '2024',
+    '<th> text is preserved verbatim: ' + tsvCellText(fx.headers[1]));
+
+// Text cell with internal spaces stays intact (regression for the bug we'd
+// hit if stripSpaces ran on header text).
+var spacedHeader = makeEl('th', { text: '1 квартал' });
+appendChild(fx.panel.children[0].children[0].children[0], spacedHeader);
+assert(tsvCellText(spacedHeader) === '1 квартал',
+    'header with internal spaces is unmodified: "' + tsvCellText(spacedHeader) + '"');
+
+// =========================================================================
+// Test 4: buildTableTsv — whole-table copy
+//   Expected layout:
+//        \t 2024 \t 2025
+//   Total revenue \t 1000 \t 2500,5
+//   Net profit \t 300 \t -50
+// =========================================================================
+console.log('\nTest 4: buildTableTsv emits the full table as TSV');
+var tsv = buildTableTsv(fx.table);
+var lines = tsv.split('\n');
+assert(lines.length === 3, 'three rows (header + 2 data): ' + lines.length);
+assert(lines[0] === '\t2024\t2025', 'header line: ' + JSON.stringify(lines[0]));
+assert(lines[1] === 'Total revenue\t1000\t2500,5',
+    'first data line uses item-name and strips spaces: ' + JSON.stringify(lines[1]));
+assert(lines[2] === 'Net profit\t300\t-50',
+    'second data line: ' + JSON.stringify(lines[2]));
+
+// =========================================================================
+// Test 5: buildTableTsv on null / missing table is harmless.
+// =========================================================================
+console.log('\nTest 5: buildTableTsv handles a missing table');
+assert(buildTableTsv(null) === '', 'null table -> empty string');
+assert(buildTableTsv(undefined) === '', 'undefined table -> empty string');
+
+console.log('\n=== Summary ===');
+console.log('Passed: ' + passed);
+console.log('Failed: ' + failed);
+process.exit(failed === 0 ? 0 : 1);

--- a/js/dash.js
+++ b/js/dash.js
@@ -66,6 +66,7 @@ const sheetTabTpl = '<li class="nav-item"><a id=":id:" class="nav-link dash-shee
         + '<h4>:name:</h4>'
         + (dashIsAdmin ? '<a class="f-panel-settings-icon" title="Настройки отображения"><i class="pi pi-chart-bar"></i></a>' : '')
         + '<a class="f-panel-filter-icon" title="Фильтр"><i class="pi pi-filter"></i></a>'
+        + '<a class="f-panel-copy-icon" title="Скопировать таблицу"><i class="pi pi-copy"></i></a>'
         + '</div>'
         + '<div class="f-panel-content">'
         + '<div class="f-table-wrap"><table class="table table-sm table-bordered w-auto"><thead><tr class="dash-head f-head"><th>:head:</thead><tbody></tbody></table></div>'
@@ -6540,15 +6541,38 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         suppressNextClick: false
     };
 
+    // Returns true for any cell the user is allowed to drag-select. Header
+    // cells (.f-head / .f-subhead th) and the row-label column (.f-first-cell)
+    // join the data cells (.f-cell) so a drag from the period header down or
+    // from the row name across covers everything, Excel-style (issue #2681).
+    function isSelectableCell(node) {
+        if (!node || !node.classList) return false;
+        if (node.classList.contains('f-cell')) return true;
+        if (node.classList.contains('f-first-cell')) return true;
+        if (node.tagName === 'TH' && node.closest('.f-panel table')) return true;
+        return false;
+    }
+
+    // Cells that contribute numbers to the Σ / N / ⌀ badge. Headers and the
+    // row-label column are part of the selection (for copy) but not the stats.
+    function isStatsCell(node) {
+        return !!(node && node.classList && node.classList.contains('f-cell'));
+    }
+
+    // Row index inside the cell's table (across thead + tbody), so a rectangle
+    // can span a period header at the top down to a data row at the bottom.
     function cellRC(td) {
         var tr = td && td.parentElement;
         if (!tr || tr.tagName !== 'TR') return null;
-        var tbody = tr.parentElement;
-        if (!tbody) return null;
+        var table = tr.closest('table');
+        if (!table) return null;
+        var allRows = table.querySelectorAll('tr');
+        var rowIdx = Array.prototype.indexOf.call(allRows, tr);
+        if (rowIdx < 0) return null;
         return {
-            row: Array.prototype.indexOf.call(tbody.children, tr),
+            row: rowIdx,
             col: Array.prototype.indexOf.call(tr.children, td),
-            tbody: tbody
+            tbody: table  // keep the field name for back-compat — it now scopes the rectangle to the whole table
         };
     }
 
@@ -6576,15 +6600,16 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
     function rectFromCells(a, b) {
         var ra = cellRC(a), rb = cellRC(b);
         if (!ra || !rb || ra.tbody !== rb.tbody) return [];
+        var rows = ra.tbody.querySelectorAll('tr');
         var r1 = Math.min(ra.row, rb.row), r2 = Math.max(ra.row, rb.row);
         var c1 = Math.min(ra.col, rb.col), c2 = Math.max(ra.col, rb.col);
         var out = [];
         for (var r = r1; r <= r2; r++) {
-            var tr = ra.tbody.children[r];
+            var tr = rows[r];
             if (!tr) continue;
             for (var c = c1; c <= c2; c++) {
-                var td = tr.children[c];
-                if (td && td.classList && td.classList.contains('f-cell')) out.push(td);
+                var cell = tr.children[c];
+                if (isSelectableCell(cell)) out.push(cell);
             }
         }
         return out;
@@ -6674,9 +6699,31 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         sel.anchor = td;
         for (var i = 0; i < tr.children.length; i++) {
             var child = tr.children[i];
-            if (child.classList && child.classList.contains('f-cell')) addCell(child);
+            if (isSelectableCell(child)) addCell(child);
         }
         updateBadge();
+    }
+
+    // Text for a single cell in a TSV payload. Strips thousands-separator
+    // spaces from numeric data cells so "1 234,56" pastes as a clean number;
+    // text cells (row labels, period headers) keep their internal spaces so
+    // "Total revenue" doesn't become "Totalrevenue" (issue #2681).
+    function tsvCellText(cell) {
+        if (!cell) return '';
+        if (isStatsCell(cell)) return stripSpaces(dashCellText(cell));
+        // The row-label cell hides .show-id (row id + edit link) via CSS,
+        // but textContent still picks it up. Use item-name as the canonical
+        // row label when available; otherwise fall back to textContent with
+        // any .show-id branch stripped.
+        if (cell.classList && cell.classList.contains('f-first-cell')) {
+            var tr = cell.closest('tr');
+            var attr = tr && tr.getAttribute && tr.getAttribute('item-name');
+            if (attr) return String(attr).trim();
+            var clone = cell.cloneNode(true);
+            clone.querySelectorAll('.show-id').forEach(function(el) { el.remove(); });
+            return (clone.textContent || '').trim();
+        }
+        return (cell.textContent != null ? String(cell.textContent) : '').trim();
     }
 
     // Build a TSV blob from the current selection, walking the DOM in row
@@ -6691,10 +6738,26 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         trs.forEach(function(tr) {
             var rowCells = [];
             for (var i = 0; i < tr.children.length; i++) {
-                var td = tr.children[i];
-                if (sel.cells.has(td)) rowCells.push(stripSpaces(dashCellText(td)));
+                var cell = tr.children[i];
+                if (sel.cells.has(cell)) rowCells.push(tsvCellText(cell));
             }
             if (rowCells.length > 0) rows.push(rowCells.join('\t'));
+        });
+        return rows.join('\n');
+    }
+
+    // Build a TSV blob for a single panel's table — every <tr> (thead + tbody)
+    // joined cell-by-cell. Powers the .f-panel-copy-icon click action; runs
+    // independently of any active selection (issue #2681).
+    function buildTableTsv(table) {
+        if (!table) return '';
+        var rows = [];
+        table.querySelectorAll('tr').forEach(function(tr) {
+            var rowCells = [];
+            for (var i = 0; i < tr.children.length; i++) {
+                rowCells.push(tsvCellText(tr.children[i]));
+            }
+            rows.push(rowCells.join('\t'));
         });
         return rows.join('\n');
     }
@@ -6706,8 +6769,10 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
         }
         var sum = 0, n = 0, rect = null;
         sel.cells.forEach(function(td) {
-            var v = dashGetFloat(dashCellText(td));
-            if (!isNaN(v)) { sum += v; n++; }
+            if (isStatsCell(td)) {
+                var v = dashGetFloat(dashCellText(td));
+                if (!isNaN(v)) { sum += v; n++; }
+            }
             var r = td.getBoundingClientRect();
             if (!rect) rect = { left: r.left, right: r.right, top: r.top, bottom: r.bottom };
             else {
@@ -6779,7 +6844,14 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
 
     dashModelEl.addEventListener('mousedown', function(e) {
         if (e.button !== 0) return;
-        var td = e.target.closest('td.f-cell');
+        // Hover-revealed panel header icons (copy / filter / settings) own
+        // their own click handlers and must leave any active selection
+        // alone — independent of selected cells per #2681.
+        if (e.target.closest('.f-panel-copy-icon, .f-panel-filter-icon, .f-panel-settings-icon')) return;
+        // Restrict the closest() search to a panel table — clicks outside
+        // .f-panel (sheet tabs, status bar, etc.) must still fall through.
+        var hit = e.target.closest('td.f-cell, td.f-first-cell, th');
+        var td = (hit && hit.closest('.f-panel table') && isSelectableCell(hit)) ? hit : null;
 
         // Multi-click handling runs even when the target is inside an inline
         // edit input — that way triple-click still works after a stray first
@@ -6861,7 +6933,8 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
             dashModelEl.classList.add('dash-selecting');
         }
         var node = document.elementFromPoint(e.clientX, e.clientY);
-        var td = node && node.closest ? node.closest('td.f-cell') : null;
+        var hit = node && node.closest ? node.closest('td.f-cell, td.f-first-cell, th') : null;
+        var td = (hit && hit.closest('.f-panel table') && isSelectableCell(hit)) ? hit : null;
         if (!td) return;
         var rc = cellRC(td);
         if (!rc || rc.tbody !== sel.dragTbody) return;
@@ -6916,8 +6989,28 @@ document.getElementById('dash-model').addEventListener('click', function(e) {
             e.preventDefault();
             return;
         }
+        // Don't drop an active selection when the user clicks one of the
+        // hover-revealed panel header icons — they have their own handlers
+        // and the copy icon is explicitly selection-independent (#2681).
+        if (e.target.closest('.f-panel-copy-icon, .f-panel-filter-icon, .f-panel-settings-icon')) return;
         if (sel.cells.size > 0) clearSelection();
     }, true);
+
+    // Hover-revealed Copy icon in the panel header — TSV-copy of the entire
+    // panel table, independent of any selection (issue #2681).
+    dashModelEl.addEventListener('click', function(e) {
+        var icon = e.target.closest('.f-panel-copy-icon');
+        if (!icon) return;
+        e.preventDefault();
+        e.stopPropagation();
+        var panel = icon.closest('.f-panel');
+        var table = panel && panel.querySelector('table');
+        if (!table) return;
+        var text = buildTableTsv(table);
+        if (!text) return;
+        copyToClipboard(text);
+        flashCopied(icon);
+    });
 
     document.addEventListener('keydown', function(e) {
         if (e.key === 'Escape' && sel.cells.size > 0) clearSelection();


### PR DESCRIPTION
## Summary

Two follow-ups to the selection / TSV-copy work landed in #2653–#2657.

1. **Selection covers the first column and headers.** Drag selection now picks up `.f-first-cell` and `<th>` cells alongside `.f-cell`. The rectangle's bounds expand from a single `<tbody>` to the whole `<table>`, so a drag from a period header down through data rows covers everything in between, Excel-style.
   - Stats badge (Σ / N / ⌀) stays narrow: only `.f-cell` contributes, so selecting a `2024` period header doesn't pollute the sum.
   - Header / first-column cells DO land in the TSV that Ctrl+C copies, so a rectangular paste lands as a labelled grid.
   - Text cells keep internal spaces ('1 квартал' stays intact); only numeric `.f-cell` values still get thousand-separator spaces stripped.
   - First-column TSV text comes from `item-name`, so the normally-hidden `.show-id` branch (row id + edit link) doesn't leak into the clipboard.
2. **Hover-revealed `.f-panel-copy-icon`** next to the existing filter / settings icons. Click TSV-copies the entire panel table (thead + tbody) regardless of any active selection. Selection survives the click (mousedown / capture-click handlers skip panel header icons).

Closes #2681.

## Test plan
- [x] `node experiments/test-issue-2681-select-headers-and-copy-table.js` — 19/19 PASS (selection predicate, stats predicate, tsvCellText per cell type, buildTableTsv, null-table no-op)
- [ ] Manual:
  - Drag from a period header (`<th>`) down through several rows — header and first column highlight; Ctrl+C pastes a labelled grid into Excel.
  - Selecting only header + first-column cells doesn't change the Σ / N / ⌀ badge.
  - Hover a panel → Copy icon appears next to the filter icon → click copies the whole table; an existing selection is not cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)