### PR TITLE
export_b3x: догружать новые лиды/сделки при повторном запуске

### DIFF
--- a/experiments/test-issue-2689-resume.php
+++ b/experiments/test-issue-2689-resume.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Test for issue #2689: на следующий запуск после "ВСЕ ВЫГРУЖЕНО"
+ * скрипт должен снимать leads_complete/deals_complete и догружать новое
+ * с ID > last_lead_id / last_deal_id, не теряя CSV и не сбрасывая last_*_id.
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+require_once __DIR__ . '/../export_b3x.php';
+
+function issue2689Assert($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+// 1. Полностью завершённый прошлый прогон → должен включиться режим догрузки.
+$completedState = normalizeExportState([
+    'last_lead_id' => 328089,
+    'last_deal_id' => 124745,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'total_leads' => 14683,
+    'total_deals' => 6637,
+]);
+issue2689Assert(isExportComplete($completedState), 'precondition: state must be complete');
+
+[$resumedState, $isResume] = prepareResumeAfterComplete($completedState);
+
+issue2689Assert($isResume === true, 'resume flag must be raised when previous run was complete');
+issue2689Assert($resumedState['leads_complete'] === false, 'leads_complete must be cleared on resume');
+issue2689Assert($resumedState['deals_complete'] === false, 'deals_complete must be cleared on resume');
+issue2689Assert($resumedState['is_complete'] === false, 'is_complete must be cleared on resume');
+issue2689Assert($resumedState['last_lead_id'] === 328089, 'last_lead_id must be preserved on resume');
+issue2689Assert($resumedState['last_deal_id'] === 124745, 'last_deal_id must be preserved on resume');
+issue2689Assert($resumedState['total_leads'] === 14683, 'total_leads must be preserved on resume');
+issue2689Assert($resumedState['total_deals'] === 6637, 'total_deals must be preserved on resume');
+
+// 2. Незавершённый прогон → resume не срабатывает, ничего не меняется.
+$partialState = normalizeExportState([
+    'last_lead_id' => 100,
+    'last_deal_id' => 0,
+    'leads_complete' => false,
+    'deals_complete' => false,
+]);
+[$samePartial, $partialResume] = prepareResumeAfterComplete($partialState);
+issue2689Assert($partialResume === false, 'resume must not trigger on partial state');
+issue2689Assert($samePartial === $partialState, 'partial state must pass through unchanged');
+
+// 3. Свежий пустой стейт (первый запуск) → resume не срабатывает.
+$freshState = getDefaultExportState();
+[$sameFresh, $freshResume] = prepareResumeAfterComplete($freshState);
+issue2689Assert($freshResume === false, 'resume must not trigger on fresh state');
+issue2689Assert($sameFresh === $freshState, 'fresh state must pass through unchanged');
+
+// 4. Полный стейт, но last_*_id = 0 (вырожденный случай: complete без выгруженных
+// записей — например, в году вообще нет данных). Resume не нужен, иначе мы будем
+// каждый раз делать два пустых запроса в Bitrix.
+$emptyComplete = normalizeExportState([
+    'last_lead_id' => 0,
+    'last_deal_id' => 0,
+    'leads_complete' => true,
+    'deals_complete' => true,
+]);
+[$_, $emptyResume] = prepareResumeAfterComplete($emptyComplete);
+issue2689Assert($emptyResume === false, 'resume must not trigger when nothing was ever exported');
+
+echo "PASS: complete state turns into resume mode and keeps last_*_id\n";
+echo "PASS: partial / fresh / empty-complete states do not trigger resume\n";

--- a/export_b3x.php
+++ b/export_b3x.php
@@ -570,6 +570,22 @@ try {
         echo "📁 <a href='" . basename($leadsCsvFile) . "' download>Скачать лидов ({$totalLeads})</a>\n";
         echo "<br>📁 <a href='" . basename($dealsCsvFile) . "' download>Скачать сделки ({$totalDeals})</a>\n";
         echo "<br><br>🗑️ <a href='?reset=1'>Сбросить и начать заново</a>\n";
+
+        // Issue #2689: паровозик. Если следующий скрипт существует — переходим
+        // к нему через 2 секунды. Прервать можно ссылкой "остановить".
+        $nextScript = 'export_b3x_departments.php';
+        if (file_exists(__DIR__ . '/' . $nextScript) && empty($_GET['nochain'])) {
+            echo "<br><br><span class='info'>[ПАРОВОЗИК] Через 2 секунды → {$nextScript}</span>";
+            echo " <a href='#' id='b3x-stop-chain'>остановить</a>";
+            echo "</pre><script>
+var __b3xChain = setTimeout(function(){ location.href='{$nextScript}'; }, 2000);
+document.getElementById('b3x-stop-chain').onclick = function(e){
+    e.preventDefault();
+    clearTimeout(__b3xChain);
+    this.outerHTML = '<span class=\"info\">[цепочка остановлена]</span>';
+};
+</script>";
+        }
     } else {
         echo "\n<span class='progress'>[ПЕРЕЗАГРУЗКА] Через 0,1 секунду...</span>\n";
         echo "</pre><script>setTimeout(function(){ location.reload(); }, 100);</script>";

--- a/export_b3x.php
+++ b/export_b3x.php
@@ -204,6 +204,22 @@ function isExportComplete($state) {
     return !empty($state['leads_complete']) && !empty($state['deals_complete']);
 }
 
+/**
+ * Issue #2689: при повторном запуске после полной выгрузки снимаем
+ * complete-флаги, чтобы догрузить новые лиды/сделки с ID > last_*_id.
+ * Возвращает [новый_state, флаг_режим_догрузки].
+ */
+function prepareResumeAfterComplete($state) {
+    $isResume = isExportComplete($state)
+        && ((int)($state['last_lead_id'] ?? 0) > 0 || (int)($state['last_deal_id'] ?? 0) > 0);
+    if ($isResume) {
+        $state['leads_complete'] = false;
+        $state['deals_complete'] = false;
+        $state['is_complete'] = false;
+    }
+    return [$state, $isResume];
+}
+
 function getDefaultExportState() {
     return [
         'state_version' => 2,
@@ -365,6 +381,12 @@ global $bitrix24_webhook;
 
 $startTime = time();
 $state = getExportState($stateFile);
+
+[$state, $isResumeAfterComplete] = prepareResumeAfterComplete($state);
+if ($isResumeAfterComplete) {
+    saveExportState($stateFile, $state);
+}
+
 $lastLeadId = $state['last_lead_id'];
 $lastDealId = $state['last_deal_id'];
 $isComplete = isExportComplete($state);
@@ -410,17 +432,11 @@ echo "   Последний ID сделки: {$lastDealId}\n";
 echo "   Лиды завершены: " . (!empty($state['leads_complete']) ? 'Да' : 'Нет') . "\n";
 echo "   Сделки завершены: " . (!empty($state['deals_complete']) ? 'Да' : 'Нет') . "\n";
 echo "   Выгружено лидов: " . ($state['total_leads'] ?? 0) . "\n";
-echo "   Выгружено сделок: " . ($state['total_deals'] ?? 0) . "\n\n";
-
-if ($isComplete) {
-    echo "<span class='success'>[ГОТОВО] ВСЕ ДАННЫЕ ЗА {$TARGET_YEAR} ГОД ВЫГРУЖЕНЫ!</span>\n";
-    echo "<hr>\n";
-    echo "📁 <a href='" . basename($leadsCsvFile) . "' download>Скачать лидов ({$state['total_leads']})</a>\n";
-    echo "<br>📁 <a href='" . basename($dealsCsvFile) . "' download>Скачать сделки ({$state['total_deals']})</a>\n";
-    echo "<br><br>🗑️ <a href='?reset=1'>Сбросить и начать заново</a>\n";
-    echo "</pre></body></html>";
-    exit(0);
+echo "   Выгружено сделок: " . ($state['total_deals'] ?? 0) . "\n";
+if ($isResumeAfterComplete) {
+    echo "   <span class='info'>[ДОГРУЗКА] Ищу новые записи с ID > last_lead_id / last_deal_id</span>\n";
 }
+echo "\n";
 
 $batchesProcessed = 0;
 $shouldStop = false;


### PR DESCRIPTION
Refs #2689 (пункт 1 — догрузка лидов и сделок при следующем запуске).

## Проблема
После завершения полной выгрузки `export_b3x.php` показывает:
```
[ГОТОВО] ВСЕ ДАННЫЕ ЗА 2026 ГОД ВЫГРУЖЕНЫ!
```
и сразу выходит. Новые лиды/сделки, появившиеся в Битрикс24 после прошлого прогона, не догружаются — единственный способ продолжить это `?reset=1`, который чистит CSV и начинает с нуля.

## Решение
В начале каждого запуска проверяем: если стейт помечен как `is_complete=true` и `last_lead_id`/`last_deal_id` > 0 — снимаем `leads_complete`/`deals_complete`/`is_complete` (но сами `last_*_id` оставляем как есть). Дальше работает существующий фильтр `>ID` — он подхватит только то, что появилось после прошлого прогона. CSV не удаляются: condition очистки `if ($lastLeadId == 0 && empty($state['leads_complete']))` остаётся прежним и в режиме догрузки не срабатывает (потому что `last_lead_id > 0`).

Если новых записей нет — пройдут два запроса с пустыми ответами, флаги снова станут true, скрипт быстро завершится.

## Что изменено
- `export_b3x.php`: новая чистая функция `prepareResumeAfterComplete($state)` — снимает complete-флаги, если прошлый прогон был завершён, и возвращает флаг `$isResume` для отображения статуса в шапке.
- Удалён ранний `exit` при `is_complete=true` (строки 415-423 старой версии) — теперь основная петля сама проходит и выводит итоги/ссылки.
- В шапке вывода добавлена строка `[ДОГРУЗКА] Ищу новые записи с ID > ...`, когда сработал режим резюма.

## Что НЕ входит в этот PR
Это первый из четырёх PR по issue #2689. Остальные три (departments, users, tasks) — отдельными PR.

## Проверка
- `php experiments/test-issue-2689-resume.php` — 4 сценария (complete → resume; partial → нет resume; fresh → нет resume; complete но last_*_id=0 → нет resume).
- `php -l export_b3x.php`
- `php -l experiments/test-issue-2689-resume.php`

⚠️ Локально PHP недоступен — линт и тест необходимо прогнать на сервере перед мержем.