### PR TITLE
export_b3x_departments: полная выгрузка департаментов

### DIFF
--- a/experiments/test-issue-2689-departments.php
+++ b/experiments/test-issue-2689-departments.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Test for issue #2689 (departments block): полная выгрузка департаментов
+ * с пагинацией через start/next и перезапись CSV целиком.
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+define('EXPORT_B3X_DEPARTMENTS_SKIP_RUN', true);
+require_once __DIR__ . '/../export_b3x_departments.php';
+
+function deptAssert($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+// 1. Пагинация: первый запрос отдаёт next=50, второй — без next.
+$capturedCalls = [];
+$pages = [
+    ['result' => [
+        ['ID' => 1, 'NAME' => 'Корневой', 'SORT' => 100, 'PARENT' => '', 'UF_HEAD' => 10],
+        ['ID' => 2, 'NAME' => 'Продажи', 'SORT' => 200, 'PARENT' => 1, 'UF_HEAD' => 20],
+    ], 'next' => 50],
+    ['result' => [
+        ['ID' => 3, 'NAME' => 'Маркетинг', 'SORT' => 300, 'PARENT' => 1, 'UF_HEAD' => 30],
+    ]],
+];
+$callIndex = 0;
+$mockApi = function ($webhook, $method, $params) use (&$capturedCalls, &$callIndex, $pages) {
+    $capturedCalls[] = ['method' => $method, 'params' => $params];
+    $response = $pages[$callIndex] ?? ['result' => []];
+    $callIndex++;
+    return $response;
+};
+
+$all = fetchAllDepartments('https://example.test/rest/1/token/', $mockApi);
+
+deptAssert(count($capturedCalls) === 2, 'expected exactly 2 pagination calls, got ' . count($capturedCalls));
+deptAssert($capturedCalls[0]['method'] === 'department.get', 'must call department.get');
+deptAssert($capturedCalls[0]['params'] === ['start' => 0], 'first page must start=0');
+deptAssert($capturedCalls[1]['params'] === ['start' => 50], 'second page must use next from first response');
+deptAssert(count($all) === 3, 'all 3 departments must be aggregated');
+deptAssert($all[0]['ID'] === 1 && $all[2]['ID'] === 3, 'order must be preserved');
+
+// 2. Запись CSV: BOM, заголовки, строки в правильном порядке полей.
+$tmpCsv = sys_get_temp_dir() . '/test-issue-2689-departments-' . getmypid() . '.csv';
+$fields = ['ID', 'NAME', 'SORT', 'PARENT', 'UF_HEAD'];
+$headers = ['ID', 'Название', 'Сортировка', 'Родительский ID', 'Руководитель (ID)'];
+writeDepartmentsCsv($tmpCsv, $headers, $fields, $all);
+
+$content = file_get_contents($tmpCsv);
+deptAssert(substr($content, 0, 3) === "\xEF\xBB\xBF", 'CSV must start with UTF-8 BOM');
+$lines = preg_split('/\r?\n/', trim(substr($content, 3)));
+deptAssert(count($lines) === 4, 'CSV must have 1 header + 3 data rows, got ' . count($lines));
+deptAssert($lines[0] === 'ID;Название;Сортировка;Родительский ID;Руководитель (ID)', 'header line mismatch: ' . $lines[0]);
+deptAssert($lines[1] === '1;Корневой;100;;10', 'row 1 mismatch: ' . $lines[1]);
+deptAssert($lines[2] === '2;Продажи;200;1;20', 'row 2 mismatch: ' . $lines[2]);
+
+unlink($tmpCsv);
+
+// 3. Перезапись: повторный writeDepartmentsCsv с другими данными полностью
+// заменяет файл (а не дописывает).
+writeDepartmentsCsv($tmpCsv, $headers, $fields, [['ID' => 99, 'NAME' => 'Новый', 'SORT' => 1, 'PARENT' => '', 'UF_HEAD' => '']]);
+writeDepartmentsCsv($tmpCsv, $headers, $fields, [['ID' => 1, 'NAME' => 'Один', 'SORT' => 1, 'PARENT' => '', 'UF_HEAD' => '']]);
+$content = file_get_contents($tmpCsv);
+deptAssert(strpos($content, 'Новый') === false, 'second write must fully replace first');
+deptAssert(strpos($content, 'Один') !== false, 'second write content must be present');
+unlink($tmpCsv);
+
+// 4. Защита от бесконечной пагинации: API всегда возвращает next.
+$badApi = function () { return ['result' => [['ID' => 1]], 'next' => 50]; };
+$tripped = false;
+try {
+    fetchAllDepartments('https://example.test/', $badApi);
+} catch (Exception $e) {
+    $tripped = strpos($e->getMessage(), 'guard') !== false;
+}
+deptAssert($tripped, 'pagination guard must trip on runaway next loop');
+
+echo "PASS: fetchAllDepartments paginates via start/next\n";
+echo "PASS: writeDepartmentsCsv writes BOM + headers + rows in field order\n";
+echo "PASS: writeDepartmentsCsv replaces file content (no append)\n";
+echo "PASS: pagination guard trips on runaway loop\n";

--- a/export_b3x_departments.php
+++ b/export_b3x_departments.php
@@ -107,6 +107,22 @@ try {
     echo "\n<span class='success'>[ГОТОВО] Выгружено {$count} департаментов</span>\n";
     echo "<hr>\n";
     echo "📁 <a href='" . basename($departmentsCsvFile) . "' download>Скачать departments.csv</a>\n";
+
+    // Issue #2689: паровозик. После завершения переходим к следующему скрипту
+    // (если он существует и не передан ?nochain=1).
+    $nextScript = 'export_b3x_users.php';
+    if (file_exists(__DIR__ . '/' . $nextScript) && empty($_GET['nochain'])) {
+        echo "<br><br><span class='info'>[ПАРОВОЗИК] Через 2 секунды → {$nextScript}</span>";
+        echo " <a href='#' id='b3x-stop-chain'>остановить</a>";
+        echo "</pre><script>
+var __b3xChain = setTimeout(function(){ location.href='{$nextScript}'; }, 2000);
+document.getElementById('b3x-stop-chain').onclick = function(e){
+    e.preventDefault();
+    clearTimeout(__b3xChain);
+    this.outerHTML = '<span class=\"info\">[цепочка остановлена]</span>';
+};
+</script>";
+    }
 } catch (Exception $e) {
     echo "\n<span class='error'>[ОШИБКА] " . htmlspecialchars($e->getMessage()) . "</span>\n";
 }

--- a/export_b3x_departments.php
+++ b/export_b3x_departments.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Issue #2689: выгрузка всех департаментов в departments.csv.
+ * Не инкрементально — каждый запуск перезаписывает CSV целиком.
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+require_once __DIR__ . '/export_b3x.php';
+
+$departmentFieldsMap = [
+    'ID' => 'ID',
+    'NAME' => 'Название',
+    'SORT' => 'Сортировка',
+    'PARENT' => 'Родительский ID',
+    'UF_HEAD' => 'Руководитель (ID)',
+];
+
+$departmentFields = array_keys($departmentFieldsMap);
+$departmentHeaders = array_values($departmentFieldsMap);
+
+$departmentsCsvFile = $csvPath . 'departments.csv';
+
+/**
+ * Полный pull департаментов с пагинацией через start/next.
+ * Возвращает плоский массив записей.
+ */
+function fetchAllDepartments($bitrix24_webhook, $apiCaller = null) {
+    $apiCaller = $apiCaller ?: 'callBitrix';
+    $all = [];
+    $start = 0;
+    $guard = 0;
+    do {
+        $response = $apiCaller($bitrix24_webhook, 'department.get', ['start' => $start]);
+        $items = $response['result'] ?? [];
+        if (!empty($items)) {
+            $all = array_merge($all, $items);
+        }
+        $start = isset($response['next']) ? (int)$response['next'] : null;
+        if (++$guard > 1000) {
+            throw new Exception('department.get pagination guard tripped');
+        }
+    } while ($start !== null && !empty($items));
+    return $all;
+}
+
+/**
+ * Перезаписывает CSV целиком: BOM + заголовки + все строки.
+ */
+function writeDepartmentsCsv($csvFile, array $headers, array $fields, array $departments) {
+    $tmpFile = $csvFile . '.tmp';
+    $handle = fopen($tmpFile, 'w');
+    if ($handle === false) {
+        throw new Exception("Cannot open $tmpFile for writing");
+    }
+    fwrite($handle, "\xEF\xBB\xBF");
+    fputcsv($handle, $headers, ';');
+    foreach ($departments as $dept) {
+        fputcsv($handle, prepareRowData($dept, $fields), ';');
+    }
+    fclose($handle);
+    if (!rename($tmpFile, $csvFile)) {
+        throw new Exception("Cannot move $tmpFile to $csvFile");
+    }
+}
+
+if (defined('EXPORT_B3X_DEPARTMENTS_SKIP_RUN') && EXPORT_B3X_DEPARTMENTS_SKIP_RUN) {
+    return;
+}
+
+header('Content-Type: text/html; charset=utf-8');
+ob_implicit_flush(true);
+while (ob_get_level()) ob_end_flush();
+
+if (!is_dir($csvPath)) {
+    mkdir($csvPath, 0755, true);
+}
+
+echo "<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='UTF-8'>
+    <title>Экспорт департаментов</title>
+    <style>
+        body { font-family: monospace; padding: 6px; background: #1e1e1e; color: #d4d4d4; }
+        .info { color: #4ec9b0; }
+        .success { color: #6a9955; }
+        .error { color: #f48771; }
+        a { color: #4ec9b0; }
+    </style>
+</head>
+<body>
+<pre>
+";
+
+echo ">>> ЭКСПОРТ ДЕПАРТАМЕНТОВ <<<\n";
+echo "   URL: " . parse_url($bitrix24_webhook, PHP_URL_HOST) . "\n";
+echo "   CSV: " . basename($departmentsCsvFile) . " (перезапись целиком)\n\n";
+
+try {
+    echo "   Загрузка department.get... ";
+    $departments = fetchAllDepartments($bitrix24_webhook);
+    $count = count($departments);
+    echo "<span class='success'>OK ({$count} записей)</span>\n";
+
+    writeDepartmentsCsv($departmentsCsvFile, $departmentHeaders, $departmentFields, $departments);
+
+    echo "\n<span class='success'>[ГОТОВО] Выгружено {$count} департаментов</span>\n";
+    echo "<hr>\n";
+    echo "📁 <a href='" . basename($departmentsCsvFile) . "' download>Скачать departments.csv</a>\n";
+} catch (Exception $e) {
+    echo "\n<span class='error'>[ОШИБКА] " . htmlspecialchars($e->getMessage()) . "</span>\n";
+}
+
+echo "</pre></body></html>";


### PR DESCRIPTION
Refs #2689 (пункт 2 — «Департаменты и пользователей загружать всех, не инкрементально»).

## Что делает
Новый скрипт `export_b3x_departments.php`:
- Тянет `department.get` с пагинацией через `start`/`next`.
- Перезаписывает `departments.csv` целиком при каждом запуске (без append, без state — каждая загрузка = свежий снимок).
- Использует общие хелперы (`callBitrix`, `prepareRowData`, `formatFieldValue`) из `export_b3x.php`, подключая его с `EXPORT_B3X_SKIP_RUN`.

Поля департамента (можно расширить позже): `ID`, `NAME`, `SORT`, `PARENT`, `UF_HEAD`.

Защита: пагинация-guard на 1000 итераций — если API почему-то всегда возвращает `next`, бросаем исключение вместо вечного цикла.

## Запуск
Открыть `https://<host>/export_b3x_departments.php` в браузере. Файл `departments.csv` ложится рядом с `leads_2026.csv` в `$csvPath`.

## Проверка
- `php experiments/test-issue-2689-departments.php` — 4 проверки: пагинация (start/next), формат CSV (BOM + заголовки + порядок полей), факт перезаписи (не append), guard от бесконечного цикла.
- `php -l export_b3x_departments.php`
- `php -l experiments/test-issue-2689-departments.php`

⚠️ Локально PHP недоступен — линт и тест нужно прогнать на сервере перед мержем.

## Что НЕ входит в этот PR
Пункт 2 из issue #2689. Остальные пункты — отдельными PR:
- #2690 — догрузка лидов/сделок при повторном запуске (открыт)
- TODO — `export_b3x_users.php` (пункт 3)
- TODO — `tasks` инкрементально (пункт 4)