### PR TITLE
export_b3x_users: полная выгрузка пользователей

### DIFF
--- a/experiments/test-issue-2689-users.php
+++ b/experiments/test-issue-2689-users.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * Test for issue #2689 (users block): полная выгрузка пользователей
+ * с пагинацией для активных и уволенных, дедупликация по ID,
+ * перезапись CSV целиком.
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+define('EXPORT_B3X_USERS_SKIP_RUN', true);
+require_once __DIR__ . '/../export_b3x_users.php';
+
+function usersAssert($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+// 1. Пагинация по двум фильтрам (ACTIVE=true, ACTIVE=false), дедупликация.
+$calls = [];
+$mockApi = function ($webhook, $method, $params) use (&$calls) {
+    $calls[] = ['method' => $method, 'params' => $params];
+    $isActive = !empty($params['FILTER']['ACTIVE']);
+    $start = (int)($params['start'] ?? 0);
+    if ($isActive) {
+        // Двухстраничный ответ для активных.
+        if ($start === 0) {
+            return [
+                'result' => [
+                    ['ID' => 1, 'NAME' => 'Anna', 'LAST_NAME' => 'A', 'ACTIVE' => true],
+                    ['ID' => 2, 'NAME' => 'Boris', 'LAST_NAME' => 'B', 'ACTIVE' => true],
+                ],
+                'next' => 50,
+            ];
+        }
+        return ['result' => [
+            ['ID' => 3, 'NAME' => 'Vera', 'LAST_NAME' => 'V', 'ACTIVE' => true],
+        ]];
+    }
+    // Уволенные: один пользователь, причём ID=2 — дубль активного, проверим dedup.
+    return ['result' => [
+        ['ID' => 2, 'NAME' => 'Boris-duplicate', 'LAST_NAME' => 'B', 'ACTIVE' => false],
+        ['ID' => 99, 'NAME' => 'Old', 'LAST_NAME' => 'O', 'ACTIVE' => false],
+    ]];
+};
+
+$all = fetchAllUsers('https://example.test/rest/1/token/', $mockApi);
+
+usersAssert(count($calls) === 3, 'expected 3 calls (active p1, active p2, inactive p1), got ' . count($calls));
+usersAssert($calls[0]['method'] === 'user.get', 'must call user.get');
+usersAssert($calls[0]['params']['FILTER']['ACTIVE'] === true, 'first pass must filter ACTIVE=true');
+usersAssert($calls[2]['params']['FILTER']['ACTIVE'] === false, 'second pass must filter ACTIVE=false');
+usersAssert(count($all) === 4, 'expected 4 unique users (1,2,3,99), got ' . count($all));
+
+$ids = array_map(function ($u) { return $u['ID']; }, $all);
+usersAssert($ids === [1, 2, 3, 99], 'order must follow fetch order with dedup: ' . implode(',', $ids));
+
+// Дубль ID=2 должен сохраниться от первого прохода (активный Boris), а не быть
+// перезаписан "Boris-duplicate" из неактивных.
+usersAssert($all[1]['NAME'] === 'Boris', 'dedup must keep first occurrence (active), not later inactive duplicate');
+
+// 2. CSV: BOM, заголовки, порядок полей.
+$tmpCsv = sys_get_temp_dir() . '/test-issue-2689-users-' . getmypid() . '.csv';
+$fields = ['ID', 'NAME', 'LAST_NAME', 'ACTIVE'];
+$headers = ['ID', 'Имя', 'Фамилия', 'Активен'];
+writeUsersCsv($tmpCsv, $headers, $fields, [
+    ['ID' => 1, 'NAME' => 'Anna', 'LAST_NAME' => 'A', 'ACTIVE' => true],
+    ['ID' => 99, 'NAME' => 'Old', 'LAST_NAME' => 'O', 'ACTIVE' => false],
+]);
+$content = file_get_contents($tmpCsv);
+usersAssert(substr($content, 0, 3) === "\xEF\xBB\xBF", 'CSV must start with UTF-8 BOM');
+$lines = preg_split('/\r?\n/', trim(substr($content, 3)));
+usersAssert($lines[0] === 'ID;Имя;Фамилия;Активен', 'header line mismatch: ' . $lines[0]);
+usersAssert($lines[1] === '1;Anna;A;Да', 'row 1 mismatch (bool→Да): ' . $lines[1]);
+usersAssert($lines[2] === '99;Old;O;Нет', 'row 2 mismatch (bool→Нет): ' . $lines[2]);
+
+// 3. Перезапись: повторный writeUsersCsv заменяет файл, а не дописывает.
+writeUsersCsv($tmpCsv, $headers, $fields, [['ID' => 7, 'NAME' => 'New', 'LAST_NAME' => 'N', 'ACTIVE' => true]]);
+$content = file_get_contents($tmpCsv);
+usersAssert(strpos($content, 'Anna') === false, 'second write must fully replace first');
+usersAssert(strpos($content, 'New') !== false, 'second write content must be present');
+unlink($tmpCsv);
+
+// 4. Pagination guard.
+$badApi = function () { return ['result' => [['ID' => 1]], 'next' => 50]; };
+$tripped = false;
+try {
+    fetchAllUsers('https://example.test/', $badApi);
+} catch (Exception $e) {
+    $tripped = strpos($e->getMessage(), 'guard') !== false;
+}
+usersAssert($tripped, 'pagination guard must trip on runaway loop');
+
+echo "PASS: fetchAllUsers paginates active + inactive and deduplicates by ID\n";
+echo "PASS: writeUsersCsv writes BOM + headers + rows with correct field order\n";
+echo "PASS: writeUsersCsv replaces file content (no append)\n";
+echo "PASS: pagination guard trips on runaway loop\n";

--- a/export_b3x_users.php
+++ b/export_b3x_users.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Issue #2689: выгрузка всех пользователей в users.csv.
+ * Не инкрементально — каждый запуск перезаписывает CSV целиком.
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+require_once __DIR__ . '/export_b3x.php';
+
+$userFieldsMap = [
+    'ID' => 'ID',
+    'ACTIVE' => 'Активен',
+    'NAME' => 'Имя',
+    'LAST_NAME' => 'Фамилия',
+    'SECOND_NAME' => 'Отчество',
+    'EMAIL' => 'Почта',
+    'WORK_PHONE' => 'Рабочий телефон',
+    'PERSONAL_MOBILE' => 'Мобильный',
+    'WORK_POSITION' => 'Должность',
+    'UF_DEPARTMENT' => 'Департаменты (ID)',
+    'LAST_LOGIN' => 'Последний вход',
+    'DATE_REGISTER' => 'Дата регистрации',
+];
+
+$userFields = array_keys($userFieldsMap);
+$userHeaders = array_values($userFieldsMap);
+
+$usersCsvFile = $csvPath . 'users.csv';
+
+/**
+ * Полный pull пользователей с пагинацией через start/next.
+ * Bitrix user.get отдаёт уволенных, если передать ACTIVE=false в фильтре;
+ * мы делаем два прохода (активные + неактивные) и склеиваем — без фильтра
+ * API возвращает только ACTIVE=true.
+ */
+function fetchAllUsers($bitrix24_webhook, $apiCaller = null) {
+    $apiCaller = $apiCaller ?: 'callBitrix';
+    $all = [];
+    $seen = [];
+
+    foreach ([['ACTIVE' => true], ['ACTIVE' => false]] as $filter) {
+        $start = 0;
+        $guard = 0;
+        do {
+            $response = $apiCaller($bitrix24_webhook, 'user.get', [
+                'FILTER' => $filter,
+                'start' => $start,
+            ]);
+            $items = $response['result'] ?? [];
+            foreach ($items as $user) {
+                $id = $user['ID'] ?? null;
+                if ($id === null || isset($seen[$id])) {
+                    continue;
+                }
+                $seen[$id] = true;
+                $all[] = $user;
+            }
+            $start = isset($response['next']) ? (int)$response['next'] : null;
+            if (++$guard > 1000) {
+                throw new Exception('user.get pagination guard tripped');
+            }
+        } while ($start !== null && !empty($items));
+    }
+
+    return $all;
+}
+
+/**
+ * Перезаписывает CSV целиком: BOM + заголовки + все строки.
+ * Атомарная замена через .tmp + rename.
+ */
+function writeUsersCsv($csvFile, array $headers, array $fields, array $users) {
+    $tmpFile = $csvFile . '.tmp';
+    $handle = fopen($tmpFile, 'w');
+    if ($handle === false) {
+        throw new Exception("Cannot open $tmpFile for writing");
+    }
+    fwrite($handle, "\xEF\xBB\xBF");
+    fputcsv($handle, $headers, ';');
+    foreach ($users as $user) {
+        fputcsv($handle, prepareRowData($user, $fields), ';');
+    }
+    fclose($handle);
+    if (!rename($tmpFile, $csvFile)) {
+        throw new Exception("Cannot move $tmpFile to $csvFile");
+    }
+}
+
+if (defined('EXPORT_B3X_USERS_SKIP_RUN') && EXPORT_B3X_USERS_SKIP_RUN) {
+    return;
+}
+
+header('Content-Type: text/html; charset=utf-8');
+ob_implicit_flush(true);
+while (ob_get_level()) ob_end_flush();
+
+if (!is_dir($csvPath)) {
+    mkdir($csvPath, 0755, true);
+}
+
+echo "<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='UTF-8'>
+    <title>Экспорт пользователей</title>
+    <style>
+        body { font-family: monospace; padding: 6px; background: #1e1e1e; color: #d4d4d4; }
+        .info { color: #4ec9b0; }
+        .success { color: #6a9955; }
+        .error { color: #f48771; }
+        a { color: #4ec9b0; }
+    </style>
+</head>
+<body>
+<pre>
+";
+
+echo ">>> ЭКСПОРТ ПОЛЬЗОВАТЕЛЕЙ <<<\n";
+echo "   URL: " . parse_url($bitrix24_webhook, PHP_URL_HOST) . "\n";
+echo "   CSV: " . basename($usersCsvFile) . " (перезапись целиком, активные + уволенные)\n\n";
+
+try {
+    echo "   Загрузка user.get... ";
+    $users = fetchAllUsers($bitrix24_webhook);
+    $count = count($users);
+    echo "<span class='success'>OK ({$count} записей)</span>\n";
+
+    writeUsersCsv($usersCsvFile, $userHeaders, $userFields, $users);
+
+    echo "\n<span class='success'>[ГОТОВО] Выгружено {$count} пользователей</span>\n";
+    echo "<hr>\n";
+    echo "📁 <a href='" . basename($usersCsvFile) . "' download>Скачать users.csv</a>\n";
+} catch (Exception $e) {
+    echo "\n<span class='error'>[ОШИБКА] " . htmlspecialchars($e->getMessage()) . "</span>\n";
+}
+
+echo "</pre></body></html>";

--- a/export_b3x_users.php
+++ b/export_b3x_users.php
@@ -130,6 +130,22 @@ try {
     echo "\n<span class='success'>[ГОТОВО] Выгружено {$count} пользователей</span>\n";
     echo "<hr>\n";
     echo "📁 <a href='" . basename($usersCsvFile) . "' download>Скачать users.csv</a>\n";
+
+    // Issue #2689: паровозик. После завершения переходим к следующему скрипту
+    // (если он существует и не передан ?nochain=1).
+    $nextScript = 'export_b3x_tasks.php';
+    if (file_exists(__DIR__ . '/' . $nextScript) && empty($_GET['nochain'])) {
+        echo "<br><br><span class='info'>[ПАРОВОЗИК] Через 2 секунды → {$nextScript}</span>";
+        echo " <a href='#' id='b3x-stop-chain'>остановить</a>";
+        echo "</pre><script>
+var __b3xChain = setTimeout(function(){ location.href='{$nextScript}'; }, 2000);
+document.getElementById('b3x-stop-chain').onclick = function(e){
+    e.preventDefault();
+    clearTimeout(__b3xChain);
+    this.outerHTML = '<span class=\"info\">[цепочка остановлена]</span>';
+};
+</script>";
+    }
 } catch (Exception $e) {
     echo "\n<span class='error'>[ОШИБКА] " . htmlspecialchars($e->getMessage()) . "</span>\n";
 }


### PR DESCRIPTION
Refs #2689 (пункт 2 — «Департаменты и пользователей загружать всех, не инкрементально»).

## Что делает
Новый скрипт `export_b3x_users.php`:
- Тянет `user.get` в два прохода: `FILTER=ACTIVE:true`, затем `FILTER=ACTIVE:false` — без явного фильтра Bitrix отдаёт только активных, а нам нужны и уволенные.
- Дедупликация по `ID` между проходами (на случай пересечения).
- Перезаписывает `users.csv` целиком при каждом запуске. Атомарно: пишем в `.tmp`, потом `rename`.
- Хелперы (`callBitrix`, `prepareRowData`) переиспользуем из `export_b3x.php` через `EXPORT_B3X_SKIP_RUN`.

Поля: `ID`, `ACTIVE`, `NAME`, `LAST_NAME`, `SECOND_NAME`, `EMAIL`, `WORK_PHONE`, `PERSONAL_MOBILE`, `WORK_POSITION`, `UF_DEPARTMENT` (массив → склейка через запятую), `LAST_LOGIN`, `DATE_REGISTER`.

Защита: пагинация-guard на 1000 итераций.

## Запуск
Открыть `https://<host>/export_b3x_users.php` в браузере. Файл `users.csv` ложится в `$csvPath`.

## Проверка
- `php experiments/test-issue-2689-users.php` — 4 проверки: пагинация и дедуп активных+уволенных, формат CSV (BOM + заголовки + bool→Да/Нет), перезапись (не append), guard от бесконечного цикла.
- `php -l export_b3x_users.php`

⚠️ Локально PHP недоступен — линт и тест нужно прогнать на сервере перед мержем.

## Связанные PR по issue #2689
- #2690 — догрузка лидов/сделок при повторном запуске
- #2691 — выгрузка департаментов
- этот — выгрузка пользователей
- TODO — задачи (tasks.task.list, инкрементально)