### PR TITLE
export_b3x: выгружать обновлённые лиды и сделки (DATE_MODIFY)

### DIFF
--- a/experiments/test-issue-2689-updates.php
+++ b/experiments/test-issue-2689-updates.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * Test for issue #2689 (updates phase): выгрузка лидов и сделок, обновлённых
+ * после прошлого экспорта. Фильтр >DATE_MODIFY > last_export_time AND <=ID,
+ * чтобы не пересекаться с фазой "новых" (>ID). После полного прогона
+ * (новые + обновлённые) скрипт фиксирует last_export_time.
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+require_once __DIR__ . '/../export_b3x.php';
+
+function updAssert($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+// 1. isUpdatesPhaseComplete: без last_export_time всегда true.
+updAssert(isUpdatesPhaseComplete(getDefaultExportState()) === true,
+    'fresh state: updates phase considered complete (нет фазы обновлений)');
+
+$firstRunDone = normalizeExportState([
+    'last_lead_id' => 100,
+    'last_deal_id' => 50,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'last_export_time' => null,
+]);
+updAssert(isUpdatesPhaseComplete($firstRunDone) === true,
+    'first run done but last_export_time=null: updates phase complete');
+
+$secondRunStart = normalizeExportState([
+    'last_lead_id' => 100,
+    'last_deal_id' => 50,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'last_export_time' => '2026-05-15T10:00:00+03:00',
+    'updates_leads_complete' => false,
+    'updates_deals_complete' => false,
+]);
+updAssert(isUpdatesPhaseComplete($secondRunStart) === false,
+    'second run with last_export_time set: updates phase must run');
+
+$secondRunDone = $secondRunStart;
+$secondRunDone['updates_leads_complete'] = true;
+$secondRunDone['updates_deals_complete'] = true;
+updAssert(isUpdatesPhaseComplete(normalizeExportState($secondRunDone)) === true,
+    'both updates flags set: phase complete');
+
+// 2. prepareResumeAfterComplete: новая логика учитывает обе фазы.
+
+// 2a. Первый полный прогон (last_export_time=null после нашей пометки в коде —
+// сначала пройдёт первый прогон, скрипт поставит last_export_time, и при
+// следующем запуске мы попадём сюда).
+$afterFirstRun = normalizeExportState([
+    'last_lead_id' => 100,
+    'last_deal_id' => 50,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'last_export_time' => '2026-05-15T10:00:00+03:00',
+]);
+[$resumed1, $isResume1] = prepareResumeAfterComplete($afterFirstRun);
+updAssert($isResume1 === true, 'resume after first complete run with last_export_time set');
+updAssert($resumed1['leads_complete'] === false, 'leads_complete cleared');
+updAssert($resumed1['deals_complete'] === false, 'deals_complete cleared');
+updAssert($resumed1['updates_leads_complete'] === false, 'updates_leads_complete cleared too');
+updAssert($resumed1['updates_deals_complete'] === false, 'updates_deals_complete cleared too');
+updAssert($resumed1['updates_lead_last_id'] === 0, 'updates_lead_last_id reset for new pass');
+updAssert($resumed1['updates_deal_last_id'] === 0, 'updates_deal_last_id reset for new pass');
+updAssert($resumed1['last_lead_id'] === 100, 'last_lead_id preserved');
+updAssert($resumed1['last_export_time'] === '2026-05-15T10:00:00+03:00', 'last_export_time preserved');
+
+// 2b. Прерывание во время фазы обновлений — resume НЕ срабатывает, потому что
+// обновления ещё не complete; продолжаем с того места, где остановились.
+$midUpdates = normalizeExportState([
+    'last_lead_id' => 100,
+    'last_deal_id' => 50,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'last_export_time' => '2026-05-15T10:00:00+03:00',
+    'updates_lead_last_id' => 42,
+    'updates_leads_complete' => false,
+    'updates_deals_complete' => false,
+]);
+[$resumed2, $isResume2] = prepareResumeAfterComplete($midUpdates);
+updAssert($isResume2 === false, 'no resume while updates phase in progress');
+updAssert($resumed2['updates_lead_last_id'] === 42, 'mid-updates cursor preserved (no reset)');
+
+// 2c. Полностью завершённый второй прогон → resume снимает всё.
+$fullyDone = normalizeExportState([
+    'last_lead_id' => 100,
+    'last_deal_id' => 50,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'last_export_time' => '2026-05-15T10:00:00+03:00',
+    'updates_lead_last_id' => 99,
+    'updates_deal_last_id' => 49,
+    'updates_leads_complete' => true,
+    'updates_deals_complete' => true,
+]);
+[$resumed3, $isResume3] = prepareResumeAfterComplete($fullyDone);
+updAssert($isResume3 === true, 'resume after fully complete second run');
+updAssert($resumed3['updates_lead_last_id'] === 0, 'updates cursors reset for next pass');
+updAssert($resumed3['updates_deal_last_id'] === 0, 'updates cursors reset for next pass');
+
+// 3. getUpdatedLeadsBatch: фильтр содержит DATE_MODIFY, <=ID и >ID.
+$calls = [];
+$mockApi = function ($webhook, $method, $params) use (&$calls) {
+    $calls[] = ['method' => $method, 'params' => $params];
+    return ['result' => [['ID' => 11, 'TITLE' => 'updated lead']], 'total' => 1];
+};
+$batch = getUpdatedLeadsBatch(
+    'https://example.test/',
+    2026,
+    '2026-05-15T10:00:00+03:00',
+    100,
+    10,
+    50,
+    ['ID', 'TITLE', 'DATE_MODIFY'],
+    $mockApi
+);
+updAssert($calls[0]['method'] === 'crm.lead.list', 'updates leads must call crm.lead.list');
+updAssert($calls[0]['params']['filter']['>DATE_MODIFY'] === '2026-05-15T10:00:00+03:00', 'DATE_MODIFY filter must be present');
+updAssert($calls[0]['params']['filter']['<=ID'] === 100, 'must cap ID at max-id from new phase');
+updAssert($calls[0]['params']['filter']['>ID'] === 10, 'must paginate by >ID for stable order');
+updAssert($calls[0]['params']['order'] === ['ID' => 'ASC'], 'must order by ID ASC');
+updAssert(count($batch['leads']) === 1, 'returns leads array');
+
+// При lastUpdateId=0 фильтр >ID не передаётся.
+$calls = [];
+getUpdatedLeadsBatch('https://example.test/', 2026, '2026-05-15T10:00:00+03:00', 100, 0, 50, ['ID'], $mockApi);
+updAssert(!array_key_exists('>ID', $calls[0]['params']['filter']), 'no >ID when lastUpdateId=0');
+
+// 4. getUpdatedDealsBatch — то же поведение, но для crm.deal.list.
+$calls = [];
+$batchDeals = getUpdatedDealsBatch(
+    'https://example.test/',
+    2026,
+    '2026-05-15T10:00:00+03:00',
+    50,
+    5,
+    50,
+    ['ID', 'TITLE'],
+    $mockApi
+);
+updAssert($calls[0]['method'] === 'crm.deal.list', 'updates deals must call crm.deal.list');
+updAssert($calls[0]['params']['filter']['>DATE_MODIFY'] === '2026-05-15T10:00:00+03:00', 'DATE_MODIFY filter');
+updAssert($calls[0]['params']['filter']['<=ID'] === 50, '<=ID cap');
+updAssert($calls[0]['params']['filter']['>ID'] === 5, 'pagination via >ID');
+
+// 5. normalizeExportState: миграция state_version=2 (после PR #2690) в v3.
+$v2State = [
+    'state_version' => 2,
+    'last_lead_id' => 100,
+    'last_deal_id' => 50,
+    'leads_complete' => true,
+    'deals_complete' => true,
+    'is_complete' => true,
+    'total_leads' => 100,
+    'total_deals' => 50,
+];
+$migrated = normalizeExportState($v2State);
+updAssert($migrated['state_version'] === 3, 'state migrated to v3');
+updAssert($migrated['last_export_time'] === null, 'new field last_export_time defaults to null');
+updAssert($migrated['updates_lead_last_id'] === 0, 'new updates_lead_last_id defaults to 0');
+updAssert($migrated['updates_leads_complete'] === false, 'updates_leads_complete defaults to false');
+updAssert($migrated['total_updated_leads'] === 0, 'total_updated_leads defaults to 0');
+updAssert($migrated['last_lead_id'] === 100, 'existing fields preserved through migration');
+
+// 6. После миграции v2 с is_complete=true фаза updates тоже считается
+// complete (потому что last_export_time = null). На следующем запуске
+// prepareResumeAfterComplete снимет флаги новых, а флаги updates не тронет.
+[$migratedResume, $migratedResumeFlag] = prepareResumeAfterComplete($migrated);
+updAssert($migratedResumeFlag === true, 'v2 fully-complete state resumes on next run');
+updAssert($migratedResume['leads_complete'] === false, 'leads_complete cleared after migration');
+// updates_leads_complete был false и таким остаётся (last_export_time=null).
+updAssert($migratedResume['updates_leads_complete'] === false, 'updates_leads_complete stays false');
+
+echo "PASS: isUpdatesPhaseComplete correctly returns true for first-run states\n";
+echo "PASS: prepareResumeAfterComplete handles both phases and preserves mid-updates cursor\n";
+echo "PASS: getUpdatedLeadsBatch builds DATE_MODIFY + <=ID + >ID filter\n";
+echo "PASS: getUpdatedDealsBatch builds DATE_MODIFY + <=ID + >ID filter\n";
+echo "PASS: normalizeExportState migrates v2 → v3 with safe defaults\n";

--- a/export_b3x.php
+++ b/export_b3x.php
@@ -18,6 +18,8 @@ $batchSize = defined('BATCH_SIZE') ? BATCH_SIZE : 50;
 // ========== НУЖНЫЕ ПОЛЯ И ИХ РУССКИЕ НАЗВАНИЯ ==========
 $leadFieldsMap = [
     'ID' => 'ID',
+    'DATE_CREATE' => 'Дата создания',
+    'DATE_MODIFY' => 'Дата изменения',
     'TITLE' => 'Название',
     'NAME' => 'Имя',
     'SECOND_NAME' => 'Отчество',
@@ -171,6 +173,59 @@ function getLeadsBatch($bitrix24_webhook, $year, $lastId = 0, $limit = 50, $sele
     ];
 }
 
+/**
+ * Issue #2689: тянем лиды, у которых DATE_MODIFY > $sinceTime, но ID
+ * НЕ выше $maxIdInclusive — чтобы не пересекаться с фазой "новые" по >ID.
+ * Пагинация внутри этой выборки — по >ID > $lastUpdateId, ASC.
+ */
+function getUpdatedLeadsBatch($bitrix24_webhook, $year, $sinceTime, $maxIdInclusive, $lastUpdateId = 0, $limit = 50, $selectFields = [], $apiCaller = null) {
+    $filter = [
+        '>=DATE_CREATE' => $year . '-01-01T00:00:00',
+        '<=DATE_CREATE' => $year . '-12-31T23:59:59',
+        '>DATE_MODIFY' => $sinceTime,
+        '<=ID' => $maxIdInclusive,
+    ];
+    if ($lastUpdateId > 0) {
+        $filter['>ID'] = $lastUpdateId;
+    }
+    $params = [
+        'order' => ['ID' => 'ASC'],
+        'filter' => $filter,
+        'select' => $selectFields,
+        'limit' => $limit,
+    ];
+    $apiCaller = $apiCaller ?: 'callBitrix';
+    $result = $apiCaller($bitrix24_webhook, 'crm.lead.list', $params);
+    return [
+        'leads' => $result['result'] ?? [],
+        'total' => $result['total'] ?? 0,
+    ];
+}
+
+function getUpdatedDealsBatch($bitrix24_webhook, $year, $sinceTime, $maxIdInclusive, $lastUpdateId = 0, $limit = 50, $selectFields = [], $apiCaller = null) {
+    $filter = [
+        '>=DATE_CREATE' => $year . '-01-01T00:00:00',
+        '<=DATE_CREATE' => $year . '-12-31T23:59:59',
+        '>DATE_MODIFY' => $sinceTime,
+        '<=ID' => $maxIdInclusive,
+    ];
+    if ($lastUpdateId > 0) {
+        $filter['>ID'] = $lastUpdateId;
+    }
+    $params = [
+        'order' => ['ID' => 'ASC'],
+        'filter' => $filter,
+        'select' => $selectFields,
+        'limit' => $limit,
+    ];
+    $apiCaller = $apiCaller ?: 'callBitrix';
+    $result = $apiCaller($bitrix24_webhook, 'crm.deal.list', $params);
+    return [
+        'deals' => $result['result'] ?? [],
+        'total' => $result['total'] ?? 0,
+    ];
+}
+
 function getDealsBatch($bitrix24_webhook, $year, $lastId = 0, $limit = 50, $selectFields = [], $apiCaller = null) {
     $yearStart = $year . '-01-01T00:00:00';
     $yearEnd = $year . '-12-31T23:59:59';
@@ -205,24 +260,44 @@ function isExportComplete($state) {
 }
 
 /**
+ * Issue #2689: фаза обновлений. На первом прогоне (last_export_time == null)
+ * её нет, считаем завершённой автоматически. На последующих — ждём оба
+ * updates-флага.
+ */
+function isUpdatesPhaseComplete($state) {
+    if (empty($state['last_export_time'])) {
+        return true;
+    }
+    return !empty($state['updates_leads_complete']) && !empty($state['updates_deals_complete']);
+}
+
+/**
  * Issue #2689: при повторном запуске после полной выгрузки снимаем
  * complete-флаги, чтобы догрузить новые лиды/сделки с ID > last_*_id.
- * Возвращает [новый_state, флаг_режим_догрузки].
+ * Если был хотя бы один полный прогон (last_export_time != null) —
+ * также сбрасываем флаги/курсоры фазы обновлений, чтобы заново пройти её.
  */
 function prepareResumeAfterComplete($state) {
-    $isResume = isExportComplete($state)
-        && ((int)($state['last_lead_id'] ?? 0) > 0 || (int)($state['last_deal_id'] ?? 0) > 0);
+    $allComplete = isExportComplete($state) && isUpdatesPhaseComplete($state);
+    $hasData = (int)($state['last_lead_id'] ?? 0) > 0 || (int)($state['last_deal_id'] ?? 0) > 0;
+    $isResume = $allComplete && $hasData;
     if ($isResume) {
         $state['leads_complete'] = false;
         $state['deals_complete'] = false;
         $state['is_complete'] = false;
+        if (!empty($state['last_export_time'])) {
+            $state['updates_leads_complete'] = false;
+            $state['updates_deals_complete'] = false;
+            $state['updates_lead_last_id'] = 0;
+            $state['updates_deal_last_id'] = 0;
+        }
     }
     return [$state, $isResume];
 }
 
 function getDefaultExportState() {
     return [
-        'state_version' => 2,
+        'state_version' => 3,
         'last_id' => 0,
         'last_lead_id' => 0,
         'last_deal_id' => 0,
@@ -230,7 +305,15 @@ function getDefaultExportState() {
         'deals_complete' => false,
         'is_complete' => false,
         'total_leads' => 0,
-        'total_deals' => 0
+        'total_deals' => 0,
+        // Issue #2689: фаза обновлений (DATE_MODIFY > last_export_time).
+        'last_export_time' => null,
+        'updates_lead_last_id' => 0,
+        'updates_deal_last_id' => 0,
+        'updates_leads_complete' => false,
+        'updates_deals_complete' => false,
+        'total_updated_leads' => 0,
+        'total_updated_deals' => 0,
     ];
 }
 
@@ -254,12 +337,23 @@ function normalizeExportState($state) {
     }
 
     $state = array_merge($default, $state);
-    $state['state_version'] = 2;
+    $state['state_version'] = 3;
     $state['last_lead_id'] = (int)$state['last_lead_id'];
     $state['last_deal_id'] = (int)$state['last_deal_id'];
     $state['total_leads'] = (int)$state['total_leads'];
     $state['total_deals'] = (int)$state['total_deals'];
     $state['last_id'] = $state['last_lead_id'];
+    $state['updates_lead_last_id'] = (int)$state['updates_lead_last_id'];
+    $state['updates_deal_last_id'] = (int)$state['updates_deal_last_id'];
+    $state['total_updated_leads'] = (int)$state['total_updated_leads'];
+    $state['total_updated_deals'] = (int)$state['total_updated_deals'];
+    $state['updates_leads_complete'] = (bool)$state['updates_leads_complete'];
+    $state['updates_deals_complete'] = (bool)$state['updates_deals_complete'];
+    if ($state['last_export_time'] !== null && $state['last_export_time'] !== '') {
+        $state['last_export_time'] = (string)$state['last_export_time'];
+    } else {
+        $state['last_export_time'] = null;
+    }
     $state['is_complete'] = isExportComplete($state);
 
     return $state;
@@ -431,10 +525,15 @@ echo "   Последний ID лида: {$lastLeadId}\n";
 echo "   Последний ID сделки: {$lastDealId}\n";
 echo "   Лиды завершены: " . (!empty($state['leads_complete']) ? 'Да' : 'Нет') . "\n";
 echo "   Сделки завершены: " . (!empty($state['deals_complete']) ? 'Да' : 'Нет') . "\n";
-echo "   Выгружено лидов: " . ($state['total_leads'] ?? 0) . "\n";
-echo "   Выгружено сделок: " . ($state['total_deals'] ?? 0) . "\n";
+echo "   Выгружено лидов (новых): " . ($state['total_leads'] ?? 0) . "\n";
+echo "   Выгружено сделок (новых): " . ($state['total_deals'] ?? 0) . "\n";
+echo "   Выгружено обновлённых лидов: " . ($state['total_updated_leads'] ?? 0) . "\n";
+echo "   Выгружено обновлённых сделок: " . ($state['total_updated_deals'] ?? 0) . "\n";
+if (!empty($state['last_export_time'])) {
+    echo "   Прошлый прогон: " . $state['last_export_time'] . "\n";
+}
 if ($isResumeAfterComplete) {
-    echo "   <span class='info'>[ДОГРУЗКА] Ищу новые записи с ID > last_lead_id / last_deal_id</span>\n";
+    echo "   <span class='info'>[ДОГРУЗКА] Сначала новые (ID > last_*_id), затем обновлённые (DATE_MODIFY > last_export_time)</span>\n";
 }
 echo "\n";
 
@@ -556,15 +655,125 @@ try {
         echo "      Пачка {$batchesProcessed}: +{$processedLeads} лидов, +{$processedDeals} сделок | лид ID: {$maxLeadId}, сделка ID: {$maxDealId}\n";
     }
 
+    // Issue #2689: фаза обновлений (DATE_MODIFY > last_export_time).
+    // Запускается только если фаза "новых" завершена и был хоть один полный
+    // прогон в прошлом (last_export_time != null → isUpdatesPhaseComplete = false).
+    if (!$shouldStop && isExportComplete($state) && !isUpdatesPhaseComplete($state)) {
+        $sinceTime = $state['last_export_time'];
+        $updLeadId = (int)$state['updates_lead_last_id'];
+        $updDealId = (int)$state['updates_deal_last_id'];
+        $leadMaxId = (int)$state['last_lead_id'];
+        $dealMaxId = (int)$state['last_deal_id'];
+
+        echo "\n<span class='info'>>>> ФАЗА ОБНОВЛЁННЫХ (DATE_MODIFY > {$sinceTime}) <<<</span>\n";
+
+        while (!isUpdatesPhaseComplete($state) && !$shouldStop) {
+            if (time() - $startTime >= $timeLimit) {
+                echo "\n<span class='info'>[ВРЕМЯ] Лимит ({$timeLimit} сек). Перезагрузка...</span>\n";
+                resetErrorCounter($errorLogFile);
+                $shouldStop = true;
+                break;
+            }
+
+            $procUpdLeads = 0;
+            $procUpdDeals = 0;
+
+            if (empty($state['updates_leads_complete'])) {
+                echo "   Обновлённые лиды (ID > {$updLeadId}, ≤ {$leadMaxId})... ";
+                try {
+                    $batch = getUpdatedLeadsBatch($bitrix24_webhook, $TARGET_YEAR, $sinceTime, $leadMaxId, $updLeadId, $batchSize, $leadFields);
+                    $leads = $batch['leads'];
+                    resetErrorCounter($errorLogFile);
+                } catch (Exception $e) {
+                    incrementErrorCounter($errorLogFile);
+                    checkErrorLimit($errorLogFile, 3);
+                    echo "<span class='error'>Ошибка: " . $e->getMessage() . "</span>\n";
+                    sleep(2);
+                    continue;
+                }
+                $cnt = count($leads);
+                if ($cnt == 0) {
+                    echo "<span class='info'>0 — обновлённые лиды завершены</span>\n";
+                    $state['updates_leads_complete'] = true;
+                } else {
+                    echo "<span class='progress'>+{$cnt}</span>\n";
+                    foreach ($leads as $lead) {
+                        appendCsvRow($leadsCsvFile, prepareRowData($lead, $leadFields));
+                        $procUpdLeads++;
+                        if ((int)$lead['ID'] > $updLeadId) {
+                            $updLeadId = (int)$lead['ID'];
+                        }
+                    }
+                }
+                $state['updates_lead_last_id'] = $updLeadId;
+                $state['total_updated_leads'] = ($state['total_updated_leads'] ?? 0) + $procUpdLeads;
+                saveExportState($stateFile, $state);
+            }
+
+            if (time() - $startTime >= $timeLimit) {
+                echo "\n<span class='info'>[ВРЕМЯ] Лимит ({$timeLimit} сек). Перезагрузка...</span>\n";
+                resetErrorCounter($errorLogFile);
+                $shouldStop = true;
+                break;
+            }
+
+            if (empty($state['updates_deals_complete'])) {
+                echo "   Обновлённые сделки (ID > {$updDealId}, ≤ {$dealMaxId})... ";
+                try {
+                    $batch = getUpdatedDealsBatch($bitrix24_webhook, $TARGET_YEAR, $sinceTime, $dealMaxId, $updDealId, $batchSize, $dealFields);
+                    $deals = $batch['deals'];
+                    resetErrorCounter($errorLogFile);
+                } catch (Exception $e) {
+                    incrementErrorCounter($errorLogFile);
+                    checkErrorLimit($errorLogFile, 3);
+                    echo "<span class='error'>Ошибка: " . $e->getMessage() . "</span>\n";
+                    sleep(2);
+                    continue;
+                }
+                $cnt = count($deals);
+                if ($cnt == 0) {
+                    echo "<span class='info'>0 — обновлённые сделки завершены</span>\n";
+                    $state['updates_deals_complete'] = true;
+                } else {
+                    echo "<span class='progress'>+{$cnt}</span>\n";
+                    foreach ($deals as $deal) {
+                        appendCsvRow($dealsCsvFile, prepareRowData($deal, $dealFields));
+                        $procUpdDeals++;
+                        if ((int)$deal['ID'] > $updDealId) {
+                            $updDealId = (int)$deal['ID'];
+                        }
+                    }
+                }
+                $state['updates_deal_last_id'] = $updDealId;
+                $state['total_updated_deals'] = ($state['total_updated_deals'] ?? 0) + $procUpdDeals;
+                saveExportState($stateFile, $state);
+            }
+
+            $batchesProcessed++;
+            echo "      Пачка {$batchesProcessed}: +{$procUpdLeads} обн. лидов, +{$procUpdDeals} обн. сделок\n";
+        }
+    }
+
+    // Issue #2689: оба прохода завершены — фиксируем момент окончания,
+    // от которого в следующий раз будем тянуть DATE_MODIFY.
+    if (isExportComplete($state) && isUpdatesPhaseComplete($state)) {
+        $state['last_export_time'] = date('c');
+        saveExportState($stateFile, $state);
+    }
+
     $totalLeads = $state['total_leads'] ?? 0;
     $totalDeals = $state['total_deals'] ?? 0;
+    $totalUpdLeads = $state['total_updated_leads'] ?? 0;
+    $totalUpdDeals = $state['total_updated_deals'] ?? 0;
 
     echo "\n<span class='info'>ИТОГИ СЕССИИ:</span>\n";
     echo "   Обработано пачек: {$batchesProcessed}\n";
-    echo "   Всего лидов: {$totalLeads}\n";
-    echo "   Всего сделок: {$totalDeals}\n";
+    echo "   Новых лидов: {$totalLeads}\n";
+    echo "   Новых сделок: {$totalDeals}\n";
+    echo "   Обновлённых лидов: {$totalUpdLeads}\n";
+    echo "   Обновлённых сделок: {$totalUpdDeals}\n";
 
-    if (isExportComplete($state)) {
+    if (isExportComplete($state) && isUpdatesPhaseComplete($state)) {
         echo "\n<span class='success'>[ГОТОВО] ВСЕ ДАННЫЕ ЗА {$TARGET_YEAR} ГОД ВЫГРУЖЕНЫ!</span>\n";
         echo "<hr>\n";
         echo "📁 <a href='" . basename($leadsCsvFile) . "' download>Скачать лидов ({$totalLeads})</a>\n";


### PR DESCRIPTION
Refs #2689 — расширение: тянуть не только новые записи, но и **обновлённые** со времени прошлого экспорта.

## Проблема
До этого `export_b3x.php` догружал только записи с `ID > last_lead_id` / `last_deal_id`. Лиды/сделки из уже выгруженного диапазона, у которых поменялся статус, ответственный, сумма — в CSV не попадали. То есть выгрузка устаревает.

## Решение
Битрикс это позволяет: `crm.lead.list` и `crm.deal.list` поддерживают `>DATE_MODIFY` в фильтре (документация явно перечисляет префиксы `>=`, `>`, `<=`, `<`).

Добавлена **вторая фаза «обновлённые»**, которая запускается после фазы «новых», когда был хотя бы один полный прогон в прошлом (`last_export_time != null`).

**Фильтр обновлений:**
```
>=DATE_CREATE = начало года
<=DATE_CREATE = конец года
>DATE_MODIFY  = last_export_time            ← вот эта строка
<=ID          = last_lead_id / last_deal_id ← чтобы не пересекаться с фазой «новых»
>ID           = updates_*_last_id           ← пагинация внутри фазы
```

Записи **дописываются в конец того же CSV** (append) — пользователь выбрал такой подход, чтобы не перечитывать весь CSV в память. Колонки `DATE_CREATE` / `DATE_MODIFY` добавлены в `$leadFieldsMap` (в `$dealFieldsMap` уже были). В Excel/Power Query можно отфильтровать по последнему `DATE_MODIFY` для дедупликации.

## State (v3)
Расширен `getDefaultExportState`:
- `last_export_time` — момент окончания прошлого полного прогона (ISO 8601 + TZ). Нижняя граница `>DATE_MODIFY` для следующего раза.
- `updates_lead_last_id`, `updates_deal_last_id` — курсоры пагинации внутри фазы обновлений.
- `updates_leads_complete`, `updates_deals_complete` — флаги.
- `total_updated_leads`, `total_updated_deals` — счётчики.

Миграция с v2 (после PR #2690) безопасна: новые поля получают дефолты, `last_export_time=null` → фаза updates сразу считается «завершённой», скрипт ведёт себя как раньше до самого первого полного прогона.

## Изменения в логике
- `isUpdatesPhaseComplete($state)` — новая функция.
- `prepareResumeAfterComplete` обновлена: при полном завершении обеих фаз сбрасывает и updates-флаги/курсоры. Во время фазы updates НЕ трогает курсор (продолжаем с места).
- `getUpdatedLeadsBatch` / `getUpdatedDealsBatch` — новые, строят фильтр выше.
- Основная петля — теперь два цикла: «новые» (как раньше) → «обновлённые» (только при `last_export_time != null`).
- После полного успеха ставим `last_export_time = date('c')`.

## Проверка
- `php experiments/test-issue-2689-updates.php` — 6 групп проверок:
  - `isUpdatesPhaseComplete` корректно отдаёт true для first-run state без `last_export_time`.
  - `prepareResumeAfterComplete` (3 сценария: полное завершение → resume сбрасывает обе фазы; mid-updates → не resume, курсор сохраняется; вторая полная итерация → resume снова).
  - `getUpdatedLeadsBatch` / `getUpdatedDealsBatch` строят фильтр `>DATE_MODIFY + <=ID + >ID`.
  - Миграция state v2 → v3 ставит безопасные дефолты.
- `php -l export_b3x.php`
- Старый `php experiments/test-issue-2689-resume.php` (из PR #2690) продолжает проходить — расширение совместимо.

⚠️ Локально PHP недоступен — линт и тесты прогнать на сервере перед мержем.

## Что НЕ входит в этот PR
`export_b3x_tasks.php` (фаза обновлений по `CHANGED_DATE`) — отдельным PR после мержа [#2693](https://github.com/ideav/crm/pull/2693), чтобы не плодить кросс-зависимости.

## База
Ответвлено от свежего main (содержит уже померженный #2690 — функцию `prepareResumeAfterComplete`).