### PR TITLE
export_b3x: писать leads/deals параллельно в .bki для Интеграма

### DIFF
--- a/experiments/test-issue-2696-bki.php
+++ b/experiments/test-issue-2696-bki.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Test for issue #2696: формат .bki для загрузки в Интеграм.
+ * Первая строка "DATA", разделитель ";", переносы строк и табы → пробелы,
+ * ";" в значении экранируется "\;". Первое поле — ID (PK в Интеграме).
+ */
+
+define('EXPORT_B3X_SKIP_RUN', true);
+require_once __DIR__ . '/../export_b3x.php';
+
+function bkiAssert($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+// 1. bkiEscape: переносы (\n, \r, \r\n) и таб → пробел.
+bkiAssert(bkiEscape("a\nb") === 'a b', "\\n must become space");
+bkiAssert(bkiEscape("a\rb") === 'a b', "\\r must become space");
+bkiAssert(bkiEscape("a\r\nb") === 'a b', "\\r\\n must become single space (not two)");
+bkiAssert(bkiEscape("a\tb") === 'a b', "\\t must become space");
+bkiAssert(bkiEscape("line1\nline2\tcol2") === 'line1 line2 col2', "mixed whitespace");
+
+// 2. bkiEscape: ";" → "\;".
+bkiAssert(bkiEscape('a;b') === 'a\\;b', "semicolon must be escaped");
+bkiAssert(bkiEscape('a;b;c') === 'a\\;b\\;c', "multiple semicolons");
+bkiAssert(bkiEscape(';;') === '\\;\\;', "leading/trailing semicolons");
+
+// 3. bkiEscape: обычные строки без изменений.
+bkiAssert(bkiEscape('hello world') === 'hello world', "plain text unchanged");
+bkiAssert(bkiEscape('') === '', "empty stays empty");
+bkiAssert(bkiEscape('Привет!') === 'Привет!', "unicode unchanged");
+
+// 4. bkiEscape: числа и null приводятся к строке.
+bkiAssert(bkiEscape(42) === '42', "int → string");
+bkiAssert(bkiEscape(null) === '', "null → empty string");
+
+// 5. formatBkiRow: склейка через ";".
+bkiAssert(formatBkiRow(['1', 'John', 'NEW']) === '1;John;NEW', "simple row");
+bkiAssert(formatBkiRow(['1', 'a;b', 'c']) === '1;a\\;b;c', "escape semicolon in value");
+bkiAssert(formatBkiRow(['1', "multi\nline", 'tab\there'])
+    === '1;multi line;tab here', "newlines and tabs in row values");
+bkiAssert(formatBkiRow(['1', '', 'last']) === '1;;last', "empty middle field");
+
+// 6. initBkiFile: создаёт файл с одной строкой "DATA" если не существует.
+$tmpFile = sys_get_temp_dir() . '/test-issue-2696-' . getmypid() . '.bki';
+if (file_exists($tmpFile)) unlink($tmpFile);
+initBkiFile($tmpFile);
+bkiAssert(file_exists($tmpFile), "init creates file");
+bkiAssert(file_get_contents($tmpFile) === "DATA\n", "init writes 'DATA\\n'");
+
+// 6a. initBkiFile: на существующий непустой файл не наступает.
+file_put_contents($tmpFile, "DATA\nexisting;row\n");
+initBkiFile($tmpFile);
+bkiAssert(file_get_contents($tmpFile) === "DATA\nexisting;row\n", "init must not touch non-empty file");
+
+// 6b. initBkiFile: пустой файл переинициализируется (filesize==0).
+file_put_contents($tmpFile, '');
+initBkiFile($tmpFile);
+bkiAssert(file_get_contents($tmpFile) === "DATA\n", "init re-creates empty file");
+
+// 7. appendBkiRow: дописывает строку в конец.
+file_put_contents($tmpFile, "DATA\n");
+appendBkiRow($tmpFile, ['1', 'Anna', 'NEW']);
+appendBkiRow($tmpFile, ['2', "Boris\nB", 'IN_WORK']);
+$content = file_get_contents($tmpFile);
+bkiAssert($content === "DATA\n1;Anna;NEW\n2;Boris B;IN_WORK\n",
+    "append produces DATA + escaped rows, got: " . json_encode($content));
+
+// 8. writeBkiFile: атомарная полная перезапись (для departments/users).
+writeBkiFile($tmpFile, [
+    ['1', 'Sales', 'Root'],
+    ['2', 'IT;dept', "multi\nline"],
+]);
+$content = file_get_contents($tmpFile);
+bkiAssert($content === "DATA\n1;Sales;Root\n2;IT\\;dept;multi line\n",
+    "writeBkiFile replaces content with DATA + escaped rows, got: " . json_encode($content));
+
+// 9. ID идёт первым: реальный поток приведения через prepareRowData
+// (формирует массив values в порядке полей; первое поле в leadFieldsMap — 'ID').
+$leadLikePayload = [
+    'ID' => 42,
+    'DATE_CREATE' => '2026-05-16T10:00:00+03:00',
+    'DATE_MODIFY' => '2026-05-16T15:30:00+03:00',
+    'TITLE' => 'Lead with; semicolon',
+    'NAME' => "Anna\nNewline",
+];
+$fields = ['ID', 'DATE_CREATE', 'DATE_MODIFY', 'TITLE', 'NAME'];
+$row = prepareRowData($leadLikePayload, $fields);
+$bkiLine = formatBkiRow($row);
+bkiAssert(strpos($bkiLine, '42;') === 0, "ID must be first field in bki line, got: " . $bkiLine);
+bkiAssert(strpos($bkiLine, 'Lead with\\; semicolon') !== false, "semicolon in title must be escaped, got: " . $bkiLine);
+bkiAssert(strpos($bkiLine, "Anna\n") === false, "no raw newline in bki line, got: " . json_encode($bkiLine));
+
+unlink($tmpFile);
+
+echo "PASS: bkiEscape replaces newlines/tabs with spaces and escapes ';'\n";
+echo "PASS: formatBkiRow joins values with ';' applying escapes\n";
+echo "PASS: initBkiFile writes 'DATA\\n' and respects non-empty existing files\n";
+echo "PASS: appendBkiRow appends escaped row, writeBkiFile replaces atomically\n";
+echo "PASS: prepareRowData + formatBkiRow keeps ID first and escapes special chars\n";

--- a/export_b3x.php
+++ b/export_b3x.php
@@ -81,7 +81,51 @@ $dealHeaders = array_values($dealFieldsMap);
 // ========== ФАЙЛЫ ДЛЯ ЭКСПОРТА ==========
 $leadsCsvFile = $csvPath . 'leads_' . $TARGET_YEAR . '.csv';
 $dealsCsvFile = $csvPath . 'deals_' . $TARGET_YEAR . '.csv';
+// Issue #2696: дополнительная выгрузка в .bki для загрузки в Интеграм.
+$leadsBkiFile = $csvPath . 'leads_' . $TARGET_YEAR . '.bki';
+$dealsBkiFile = $csvPath . 'deals_' . $TARGET_YEAR . '.bki';
 $errorLogFile = $csvPath . 'export_error_counter_' . $TARGET_YEAR . '.json';
+
+// ========== ХЕЛПЕРЫ BKI ==========
+// Формат .bki: первая строка "DATA", далее по строке на запись;
+// поля разделены ";"; переносы/табы заменяются на пробел; ";" в значении
+// экранируется как "\;". Первое поле — ID (используется как PK в Интеграме).
+// function_exists guard на случай, если файл подключён через
+// EXPORT_B3X_SKIP_RUN из другого скрипта, который тоже объявляет хелперы.
+if (!function_exists('bkiEscape')) {
+    function bkiEscape($value) {
+        $value = str_replace(["\r\n", "\r", "\n", "\t"], ' ', (string)$value);
+        return str_replace(';', '\\;', $value);
+    }
+
+    function formatBkiRow(array $values) {
+        return implode(';', array_map('bkiEscape', $values));
+    }
+
+    function initBkiFile($file) {
+        if (!file_exists($file) || filesize($file) == 0) {
+            file_put_contents($file, "DATA\n");
+        }
+    }
+
+    function appendBkiRow($file, array $values) {
+        file_put_contents($file, formatBkiRow($values) . "\n", FILE_APPEND);
+    }
+
+    /**
+     * Атомарная полная перезапись .bki (для departments/users — каждый
+     * запуск свежий снимок).
+     */
+    function writeBkiFile($file, array $rows) {
+        $content = "DATA\n";
+        foreach ($rows as $values) {
+            $content .= formatBkiRow($values) . "\n";
+        }
+        $tmp = $file . '.tmp';
+        file_put_contents($tmp, $content);
+        rename($tmp, $file);
+    }
+}
 
 // ========== ЗАЩИТА ОТ БЕСКОНЕЧНЫХ ПЕРЕЗАГРУЗОК ==========
 function incrementErrorCounter($file) {
@@ -488,14 +532,18 @@ $isComplete = isExportComplete($state);
 // Очищаем файлы при первом запуске
 if ($lastLeadId == 0 && empty($state['leads_complete'])) {
     if (file_exists($leadsCsvFile)) unlink($leadsCsvFile);
+    if (file_exists($leadsBkiFile)) unlink($leadsBkiFile);
 }
 if ($lastDealId == 0 && empty($state['deals_complete'])) {
     if (file_exists($dealsCsvFile)) unlink($dealsCsvFile);
+    if (file_exists($dealsBkiFile)) unlink($dealsBkiFile);
 }
 
 // Инициализируем файлы с заголовками на русском
 initCsvFile($leadsCsvFile, $leadHeaders);
 initCsvFile($dealsCsvFile, $dealHeaders);
+initBkiFile($leadsBkiFile);
+initBkiFile($dealsBkiFile);
 
 echo "<!DOCTYPE html>
 <html>
@@ -585,6 +633,7 @@ try {
                 foreach ($leads as $lead) {
                     $leadRow = prepareRowData($lead, $leadFields);
                     appendCsvRow($leadsCsvFile, $leadRow);
+                    appendBkiRow($leadsBkiFile, $leadRow);
                     $processedLeads++;
 
                     if ($lead['ID'] > $maxLeadId) {
@@ -635,6 +684,7 @@ try {
                 foreach ($deals as $deal) {
                     $dealRow = prepareRowData($deal, $dealFields);
                     appendCsvRow($dealsCsvFile, $dealRow);
+                    appendBkiRow($dealsBkiFile, $dealRow);
                     $processedDeals++;
 
                     if ($deal['ID'] > $maxDealId) {
@@ -698,7 +748,9 @@ try {
                 } else {
                     echo "<span class='progress'>+{$cnt}</span>\n";
                     foreach ($leads as $lead) {
-                        appendCsvRow($leadsCsvFile, prepareRowData($lead, $leadFields));
+                        $row = prepareRowData($lead, $leadFields);
+                        appendCsvRow($leadsCsvFile, $row);
+                        appendBkiRow($leadsBkiFile, $row);
                         $procUpdLeads++;
                         if ((int)$lead['ID'] > $updLeadId) {
                             $updLeadId = (int)$lead['ID'];
@@ -737,7 +789,9 @@ try {
                 } else {
                     echo "<span class='progress'>+{$cnt}</span>\n";
                     foreach ($deals as $deal) {
-                        appendCsvRow($dealsCsvFile, prepareRowData($deal, $dealFields));
+                        $row = prepareRowData($deal, $dealFields);
+                        appendCsvRow($dealsCsvFile, $row);
+                        appendBkiRow($dealsBkiFile, $row);
                         $procUpdDeals++;
                         if ((int)$deal['ID'] > $updDealId) {
                             $updDealId = (int)$deal['ID'];


### PR DESCRIPTION
Refs #2696 (часть 1/4 — лиды и сделки).

## Что делает
Параллельно с `.csv` пишем `.bki` рядом — формат для загрузки в Интеграм.

**Формат .bki:**
```
DATA
1;Anna;NEW
2;Boris B;IN_WORK
3;a\;b;c
```
- Первая строка — литерал `DATA`.
- Дальше по строке на запись, поля через `;`. **Первое поле — ID** (PK для апсерта в Интеграме).
- Переносы строк и табы → пробел.
- `;` в значении экранируется как `\;`.

Никаких BOM, кавычек или заголовков — формат простой, парсится сплитом по `;` с разэскейпом `\;`.

## Хелперы
Объявлены в `export_b3x.php` с `function_exists` guard, чтобы остальные 3 скрипта (departments/users/tasks), которые подключают этот файл через `EXPORT_B3X_SKIP_RUN`, могли независимо использовать те же функции — без конфликта при любом порядке мержа PR.

- `bkiEscape($value)` — пост-обработка строки.
- `formatBkiRow(array $values)` — склейка через `;`.
- `initBkiFile($file)` — создать с одной строкой `DATA`.
- `appendBkiRow($file, $values)` — дописать.
- `writeBkiFile($file, $rows)` — атомарная полная перезапись через `.tmp` + `rename` (для departments/users).

## Интеграция
- `$leadsBkiFile`, `$dealsBkiFile` — рядом с CSV (`leads_2026.bki`, `deals_2026.bki`).
- При первом запуске (last_*_id=0 && !leads_complete) `.bki` удаляется вместе с `.csv` — тот же паттерн.
- `initBkiFile` вызывается рядом с `initCsvFile`.
- В обеих фазах (новые и обновлённые) `appendBkiRow` вызывается **на тех же значениях**, что `appendCsvRow` — `prepareRowData` формирует массив один раз.

## Проверка
- `php experiments/test-issue-2696-bki.php` — 9 групп: escape переносов/табов/`;`, склейка, init на пустом/непустом файле, append, атомарная перезапись `writeBkiFile`, реальный поток `prepareRowData → formatBkiRow` (ID первым, экранирование).
- `php -l export_b3x.php`

⚠️ Локально PHP недоступен — линт и тест прогнать на сервере перед мержем.

## Связанные PR по issue #2696
- этот — leads/deals (содержит хелперы)
- TODO — departments
- TODO — users
- TODO — tasks