### PR TITLE
export_b3x_departments: писать departments.bki параллельно с .csv

### DIFF
--- a/export_b3x_departments.php
+++ b/export_b3x_departments.php
@@ -19,6 +19,38 @@ $departmentFields = array_keys($departmentFieldsMap);
 $departmentHeaders = array_values($departmentFieldsMap);
 
 $departmentsCsvFile = $csvPath . 'departments.csv';
+// Issue #2696: дополнительная выгрузка в .bki для Интеграма.
+$departmentsBkiFile = $csvPath . 'departments.bki';
+
+// ========== ХЕЛПЕРЫ BKI (Issue #2696) ==========
+// function_exists guard: если export_b3x.php тоже объявил хелперы,
+// этот блок пропускается. Так PR независим от порядка мержа.
+if (!function_exists('bkiEscape')) {
+    function bkiEscape($value) {
+        $value = str_replace(["\r\n", "\r", "\n", "\t"], ' ', (string)$value);
+        return str_replace(';', '\\;', $value);
+    }
+    function formatBkiRow(array $values) {
+        return implode(';', array_map('bkiEscape', $values));
+    }
+    function initBkiFile($file) {
+        if (!file_exists($file) || filesize($file) == 0) {
+            file_put_contents($file, "DATA\n");
+        }
+    }
+    function appendBkiRow($file, array $values) {
+        file_put_contents($file, formatBkiRow($values) . "\n", FILE_APPEND);
+    }
+    function writeBkiFile($file, array $rows) {
+        $content = "DATA\n";
+        foreach ($rows as $values) {
+            $content .= formatBkiRow($values) . "\n";
+        }
+        $tmp = $file . '.tmp';
+        file_put_contents($tmp, $content);
+        rename($tmp, $file);
+    }
+}
 
 /**
  * Полный pull департаментов с пагинацией через start/next.
@@ -104,9 +136,17 @@ try {
 
     writeDepartmentsCsv($departmentsCsvFile, $departmentHeaders, $departmentFields, $departments);
 
+    // Issue #2696: параллельно — снимок в .bki для Интеграма (полная перезапись).
+    $bkiRows = [];
+    foreach ($departments as $dept) {
+        $bkiRows[] = prepareRowData($dept, $departmentFields);
+    }
+    writeBkiFile($departmentsBkiFile, $bkiRows);
+
     echo "\n<span class='success'>[ГОТОВО] Выгружено {$count} департаментов</span>\n";
     echo "<hr>\n";
     echo "📁 <a href='" . basename($departmentsCsvFile) . "' download>Скачать departments.csv</a>\n";
+    echo "<br>📁 <a href='" . basename($departmentsBkiFile) . "' download>Скачать departments.bki</a>\n";
 
     // Issue #2689: паровозик. После завершения переходим к следующему скрипту
     // (если он существует и не передан ?nochain=1).


### PR DESCRIPTION
Refs #2696 (часть 2/4 — departments).

После `writeDepartmentsCsv` делаем атомарную полную перезапись `departments.bki` через `writeBkiFile` — формат для загрузки в Интеграм (`DATA`, разделитель `;`, escape переносов/табов/`;`; ID первым).

Хелперы BKI объявлены под `function_exists` guard — при любом порядке мержа с #2697 (leads/deals, который тоже объявляет хелперы в `export_b3x.php`) конфликта при `require_once` не будет: первый объявит, второй пропустит.

## Что НЕ входит в этот PR
Тест на сами BKI-хелперы — в PR [#2697](https://github.com/ideav/crm/pull/2697) (там 9 групп проверок escape/init/append/write).

Для departments здесь добавлять отдельный unit-тест на полную перезапись `.bki` — избыточно: `writeBkiFile` уже покрыт тестом в #2697, а `prepareRowData` — давно.

⚠️ Локально PHP недоступен — `php -l export_b3x_departments.php` прогнать на сервере перед мержем.

## Связанные PR
- [#2697](https://github.com/ideav/crm/pull/2697) — leads/deals (содержит тест на хелперы)
- этот — departments
- TODO — users
- TODO — tasks