### PR TITLE
export_b3x_tasks: выводить названия статусов задач

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-17T17:27:36.103Z for PR creation at branch issue-2716-48570c4aaed9 for issue https://github.com/ideav/crm/issues/2716

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-17T17:27:36.103Z for PR creation at branch issue-2716-48570c4aaed9 for issue https://github.com/ideav/crm/issues/2716

--- a/experiments/test-issue-2689-tasks.php
+++ b/experiments/test-issue-2689-tasks.php
@@ -6,7 +6,6 @@
  * ответа tasks.task.list (result.tasks, ключи в lowercase), resume-режим.
  */
 
-define('EXPORT_B3X_SKIP_RUN', true);
 define('EXPORT_B3X_TASKS_SKIP_RUN', true);
 require_once __DIR__ . '/../export_b3x_tasks.php';
 

--- a/experiments/test-issue-2696-bki.php
+++ b/experiments/test-issue-2696-bki.php
@@ -39,7 +39,7 @@ bkiAssert(bkiEscape(null) === '', "null → empty string");
 // 5. formatBkiRow: склейка через ";".
 bkiAssert(formatBkiRow(['1', 'John', 'NEW']) === '1;John;NEW', "simple row");
 bkiAssert(formatBkiRow(['1', 'a;b', 'c']) === '1;a\\;b;c', "escape semicolon in value");
-bkiAssert(formatBkiRow(['1', "multi\nline", 'tab\there'])
+bkiAssert(formatBkiRow(['1', "multi\nline", "tab\there"])
     === '1;multi line;tab here', "newlines and tabs in row values");
 bkiAssert(formatBkiRow(['1', '', 'last']) === '1;;last', "empty middle field");
 

--- a/experiments/test-issue-2716-task-status.php
+++ b/experiments/test-issue-2716-task-status.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Test for issue #2716: task export must write readable status names instead
+ * of raw Bitrix task status IDs.
+ */
+
+define('EXPORT_B3X_TASKS_SKIP_RUN', true);
+require_once __DIR__ . '/../export_b3x_tasks.php';
+
+function taskStatusAssert($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+$fields = ['id', 'title', 'status', 'priority'];
+$cases = [
+    ['5', 'Завершена'],
+    ['6', 'Отложена'],
+    ['2', 'Принята'],
+    ['3', 'Выполняется'],
+    ['4', 'Ждёт контроля'],
+];
+
+foreach ($cases as $case) {
+    [$rawStatus, $expectedStatus] = $case;
+    $row = prepareTaskRowData([
+        'id' => 612233,
+        'title' => 'Task',
+        'status' => $rawStatus,
+        'priority' => 1,
+    ], $fields);
+
+    taskStatusAssert(
+        $row === ['612233', 'Task', $expectedStatus, '1'],
+        'status ' . $rawStatus . ' must export as ' . $expectedStatus . ', got: '
+            . json_encode($row, JSON_UNESCAPED_UNICODE)
+    );
+}
+
+$unknownStatusRow = prepareTaskRowData([
+    'id' => 42,
+    'title' => "Line\nBreak",
+    'status' => '999',
+    'priority' => true,
+], $fields);
+taskStatusAssert(
+    $unknownStatusRow === ['42', 'Line Break', '999', 'Да'],
+    'unknown statuses must stay raw while shared field formatting still applies, got: '
+        . json_encode($unknownStatusRow, JSON_UNESCAPED_UNICODE)
+);
+
+$bkiLine = formatBkiRow(prepareTaskRowData([
+    'id' => 612233,
+    'title' => 'Начислить занники',
+    'status' => '5',
+    'priority' => 1,
+], $fields));
+taskStatusAssert(
+    $bkiLine === '612233;Начислить занники;Завершена;1',
+    'BKI rows must also receive translated task statuses, got: ' . $bkiLine
+);
+
+echo "PASS: task status IDs are translated to readable Russian names in CSV/BKI rows\n";
+echo "PASS: unknown task statuses keep their original value\n";

--- a/export_b3x_tasks.php
+++ b/export_b3x_tasks.php
@@ -71,6 +71,30 @@ if (!function_exists('bkiEscape')) {
 }
 
 /**
+ * Bitrix возвращает статус задачи числовым кодом; в экспорт пишем имя.
+ */
+function getTaskStatusName($status) {
+    $status = trim((string)$status);
+    $taskStatuses = [
+        '1' => 'Новая',
+        '2' => 'Принята',
+        '3' => 'Выполняется',
+        '4' => 'Ждёт контроля',
+        '5' => 'Завершена',
+        '6' => 'Отложена',
+        '7' => 'Отклонена',
+    ];
+    return $taskStatuses[$status] ?? $status;
+}
+
+function prepareTaskRowData($task, $fields) {
+    if (array_key_exists('status', $task)) {
+        $task['status'] = getTaskStatusName($task['status']);
+    }
+    return prepareRowData($task, $fields);
+}
+
+/**
  * Один запрос tasks.task.list с фильтром по году создания и >ID.
  */
 function getTasksBatch($bitrix24_webhook, $year, $lastId = 0, $selectFields = [], $apiCaller = null) {
@@ -244,7 +268,7 @@ try {
             echo "<span class='progress'>получено {$tasksCount} задач</span>\n";
 
             foreach ($tasks as $task) {
-                $row = prepareRowData($task, $taskFields);
+                $row = prepareTaskRowData($task, $taskFields);
                 appendCsvRow($tasksCsvFile, $row);
                 appendBkiRow($tasksBkiFile, $row);
                 $processedTasks++;


### PR DESCRIPTION
Fixes #2716

## Что изменено
- В выгрузке задач добавлен перевод Bitrix status ID в читаемые статусы: Завершена, Отложена, Принята, Выполняется, Ждёт контроля и дополнительные стандартные состояния.
- CSV и BKI теперь используют один подготовленный ряд, поэтому статус больше не расходится между файлами.
- Добавлен эксперимент `experiments/test-issue-2716-task-status.php`, который воспроизводит проблему и проверяет CSV/BKI строку.
- Поправлены два соседних экспериментальных теста, чтобы они проходили без предупреждения и с настоящим tab-символом.

## Как воспроизвести
До исправления `prepareRowData()` писал raw `status = 5` в колонку `Статус`. Новый тест проверяет, что такой ряд экспортируется как `Завершена`, а неизвестный код остается исходным значением.

## Проверка
- `php -l export_b3x_tasks.php`
- `php -l experiments/test-issue-2716-task-status.php`
- `php -l experiments/test-issue-2689-tasks.php`
- `php -l experiments/test-issue-2696-bki.php`
- `php experiments/test-issue-2716-task-status.php`
- `php experiments/test-issue-2689-tasks.php`
- `php experiments/test-issue-2696-bki.php`

Скриншоты не требуются: изменение касается серверной выгрузки CSV/BKI.