### PR TITLE
fix(dash): use panelQuery data for matching row formulas

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-18T19:55:24.624Z for PR creation at branch issue-2718-b4d9b1fa09d4 for issue https://github.com/ideav/crm/issues/2718

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-18T19:55:24.624Z for PR creation at branch issue-2718-b4d9b1fa09d4 for issue https://github.com/ideav/crm/issues/2718

--- a/experiments/test-issue-2166-dashboard-panel-filter.js
+++ b/experiments/test-issue-2166-dashboard-panel-filter.js
@@ -46,6 +46,8 @@ function dashDrawPeriods() {}
 function dashFilterReportRowsForPanel(rows) { return rows || []; }
 
 ${extractFunctionMaybe('dashNormalizePanelFilter')}
+${extractFunctionMaybe('dashReportRefId')}
+${extractFunctionMaybe('dashCleanReportRef')}
 ${extractFunctionMaybe('dashReportKey')}
 ${extractFunctionMaybe('dashReportUrl')}
 ${extractFunction('dashNormalizeNumberText')}

--- a/experiments/test-issue-2232-dashboard-report-groups.js
+++ b/experiments/test-issue-2232-dashboard-report-groups.js
@@ -81,6 +81,8 @@ ${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashFormatNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
+${extractFunctionMaybe('dashReportRefId')}
+${extractFunctionMaybe('dashCleanReportRef')}
 ${extractFunctionMaybe('dashParseReportFormula')}
 ${extractFunctionMaybe('dashReportFieldName')}
 ${extractFunctionMaybe('dashReportHasField')}

--- a/experiments/test-issue-2235-dashboard-duplicate-report-rows.js
+++ b/experiments/test-issue-2235-dashboard-duplicate-report-rows.js
@@ -74,6 +74,8 @@ ${extractFunction('dashFormatNumberText')}
 ${extractFunction('dashGetFloat')}
 ${extractFunction('dashNormalizeVal')}
 ${extractFunctionMaybe('dashNormalizePanelFilter')}
+${extractFunctionMaybe('dashReportRefId')}
+${extractFunctionMaybe('dashCleanReportRef')}
 ${extractFunctionMaybe('dashReportKey')}
 ${extractFunctionMaybe('dashParseReportFormula')}
 ${extractFunctionMaybe('dashReportFieldName')}

--- a/experiments/test-issue-2300-dashboard-viz-report-source.js
+++ b/experiments/test-issue-2300-dashboard-viz-report-source.js
@@ -33,8 +33,11 @@ function dashPanelTableCellPassesFilters() { return true; }
 
 ${extractFunction('dashNormalizeNumberText')}
 ${extractFunction('dashGetFloat')}
+${extractFunction('dashChartMeasureValue')}
 ${extractFunction('dashAttr')}
 ${extractFunction('dashNormalizePanelFilter')}
+${extractFunction('dashReportRefId')}
+${extractFunction('dashCleanReportRef')}
 ${extractFunction('dashResolvePanelVizReportId')}
 ${extractFunction('dashVizReportKey')}
 ${extractFunction('dashVizReportUrl')}

--- a/experiments/test-issue-2352-dashboard-local-panel-filter.js
+++ b/experiments/test-issue-2352-dashboard-local-panel-filter.js
@@ -28,6 +28,8 @@ const urlCtx = {};
 vm.createContext(urlCtx);
 vm.runInContext(`
 ${extractFunction('dashNormalizePanelFilter')}
+${extractFunction('dashReportRefId')}
+${extractFunction('dashCleanReportRef')}
 ${extractFunction('dashReportKey')}
 ${extractFunction('dashReportUrl')}
 ${extractFunction('dashVizReportKey')}
@@ -142,6 +144,8 @@ ${extractFunction('dashPanelLocalFilterState')}
 ${extractFunction('dashMergePanelFilterState')}
 ${extractFunction('dashPanelFiltersFor')}
 ${extractFunction('dashNormalizePanelFilter')}
+${extractFunction('dashReportRefId')}
+${extractFunction('dashCleanReportRef')}
 ${extractFunction('dashReportKey')}
 ${extractFunction('dashParseReportFormula')}
 ${extractFunction('dashReportFieldName')}

--- a/experiments/test-issue-2718-panel-query-formula-source.js
+++ b/experiments/test-issue-2718-panel-query-formula-source.js
@@ -1,0 +1,224 @@
+'use strict';
+
+// Issue #2718: when a dashboard row formula references the same query as the
+// panelQuery, formula cells must use the already loaded panel JSON report after
+// panelFilter, even when the panel query is configured by ID and the formula
+// names the report by its JSON `header`.
+
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+
+const source = fs.readFileSync('js/dash.js', 'utf8');
+
+function extractFunction(name) {
+    const marker = 'function ' + name + '(';
+    const start = source.indexOf(marker);
+    if (start === -1) throw new Error('Missing function ' + name);
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let i = braceStart; i < source.length; i++) {
+        if (source[i] === '{') depth++;
+        if (source[i] === '}') depth--;
+        if (depth === 0) return source.slice(start, i + 1);
+    }
+    throw new Error('Unclosed function ' + name);
+}
+
+assert(
+    source.includes('dashUsePanelReportForFormula(panelKey'),
+    'dashGetModel must route matching row formulas through the panel query report'
+);
+
+const ctx = { require, console };
+vm.createContext(ctx);
+vm.runInContext(`
+const repRegex = /^\\[([^\\].]+)(\\.[^\\].]+)(\\.[^\\].]+)?\\]$/;
+
+var calls = [];
+var dashReports = {};
+var dashReportNames = {};
+var dashReportKeys = {};
+var dashReportSources = {};
+var dashFormulas = {};
+var dashModelData = {};
+var dashPanelFilters = {};
+var dashVizReports = {};
+var dashPanelReportFormulas = {};
+var dashAjaxes = 0;
+
+function newApi(method, url, callback, vars, ctx) {
+    calls.push({ method, url, callback, vars, ctx });
+}
+function dashDrawPeriods() {}
+
+${extractFunction('dashNormalizeNumberText')}
+${extractFunction('dashFormatNumberText')}
+${extractFunction('dashGetFloat')}
+${extractFunction('dashNormalizeVal')}
+${extractFunction('dashReportRefId')}
+${extractFunction('dashCleanReportRef')}
+${extractFunction('dashNormalizeReportRef')}
+${extractFunction('dashReportRefIsNumeric')}
+${extractFunction('dashSameReportRef')}
+${extractFunction('dashPanelDateValue')}
+${extractFunction('dashPanelMonthValue')}
+${extractFunction('dashPanelFilterValueKey')}
+${extractFunction('dashPanelFilterIsActive')}
+${extractFunction('dashPanelReportRowPassesFilter')}
+${extractFunction('dashFilterReportRowsForPanel')}
+${extractFunction('dashPanelFilterPartIsLocal')}
+${extractFunction('dashPanelFilterParts')}
+${extractFunction('dashDecodePanelFilterPart')}
+${extractFunction('dashPanelLocalFilterState')}
+${extractFunction('dashMergePanelFilterState')}
+${extractFunction('dashPanelFiltersFor')}
+${extractFunction('dashNormalizePanelFilter')}
+${extractFunction('dashReportKey')}
+${extractFunction('dashReportUrl')}
+${extractFunction('dashVizReportKey')}
+${extractFunction('dashVizReportUrl')}
+${extractFunction('dashNormalizeReportJson')}
+${extractFunction('dashParseReportFormula')}
+${extractFunction('dashReportFieldName')}
+${extractFunction('dashReportHasField')}
+${extractFunction('dashReportSumField')}
+${extractFunction('dashNormalizeGroupName')}
+${extractFunction('dashSameGroupName')}
+${extractFunction('dashReportGroupMatches')}
+${extractFunction('dashCellRgColumn')}
+${extractFunction('dashCellReportGroup')}
+${extractFunction('dashCollectReportGroups')}
+${extractFunction('dashResolveReportCellValue')}
+${extractFunction('dashBindPanelReportFormulaRows')}
+${extractFunction('dashQueuePanelReportFormula')}
+${extractFunction('dashFlushPanelReportFormulas')}
+${extractFunction('dashUsePanelReportForFormula')}
+${extractFunction('dashGetRepVals')}
+${extractFunction('dashGetRepDone')}
+${extractFunction('dashGetRep')}
+${extractFunction('dashGetVizReportDone')}
+${extractFunction('dashGetVizReport')}
+`, ctx);
+
+function makeFormulaCell(panel, range) {
+    return {
+        innerHTML: '',
+        attrs: { range: range || '20260101-20261231' },
+        dataset: {},
+        getAttribute(name) { return this.attrs[name]; },
+        setAttribute(name, value) { this.attrs[name] = value; },
+        closest(selector) { return selector === '.f-panel' ? panel : null; }
+    };
+}
+
+function installFormulaRow(ctx, rowId, formula, reportKey, cell) {
+    ctx.dashFormulas[rowId] = formula;
+    ctx.dashReportKeys[rowId] = reportKey;
+    ctx.dashReportSources[rowId] = [{ formula, reportKey }];
+    ctx.document = {
+        getElementById(id) {
+            if (id !== rowId) return null;
+            return {
+                querySelectorAll(selector) {
+                    return selector === '.f-rg-cell[data-src="report"],.f-values[data-src="report"]' ? [cell] : [];
+                }
+            };
+        }
+    };
+}
+
+const panel = { id: 'fp1' };
+const panelFilter = 'Лист GS:ОПиУ';
+const panelReportKey = ctx.dashVizReportKey('155675', panelFilter);
+const formula = '[Операционные результаты.В работе]';
+const parsed = ctx.dashParseReportFormula(formula);
+const formulaReportKey = ctx.dashReportKey(parsed.report, panelFilter);
+
+ctx.dashModelData.fp1 = {
+    vizReportId: '155675',
+    vizReportKey: panelReportKey,
+    panelFilters: ctx.dashPanelLocalFilterState(panelFilter)
+};
+
+const reportKeyFromGet = ctx.dashGetVizReport('155675', '01.01.2026', '31.12.2026', panelFilter);
+assert.strictEqual(reportKeyFromGet, panelReportKey, 'panel JSON report key is stable');
+assert.deepStrictEqual(
+    Array.from(ctx.calls).map(call => call.url),
+    ['report/155675?JSON&FR_Date=01.01.2026&TO_Date=31.12.2026'],
+    'panel JSON request strips local panelFilter and is the only request so far'
+);
+
+assert.strictEqual(
+    ctx.dashUsePanelReportForFormula('fp1', parsed.report, formulaReportKey, '01.01.2026', '31.12.2026', panelFilter),
+    true,
+    'formula with report name should wait for panel JSON header when panelQuery is an ID'
+);
+assert.strictEqual(
+    ctx.calls.some(call => call.url.indexOf('JSON_KV') !== -1),
+    false,
+    'matching formula must not start a separate JSON_KV report request'
+);
+
+ctx.dashGetVizReportDone({
+    header: 'Операционные результаты',
+    columns: [
+        { id: 'date', name: 'Date', format: 'DATE' },
+        { id: 'work', name: 'В работе', format: 'NUMBER' },
+        { id: 'sheet', name: 'Лист GS', format: 'SHORT' }
+    ],
+    data: [
+        ['20260110', '5', 'ОПиУ'],
+        ['20260110', '9', 'ДДС']
+    ]
+}, { key: panelReportKey });
+
+assert.ok(Array.isArray(ctx.dashReports[formulaReportKey]), 'panel JSON rows must be cached as formula report rows');
+assert.strictEqual(ctx.dashReportNames[formulaReportKey], 'Операционные результаты', 'formula report name comes from JSON header');
+
+const idFormulaReportKey = ctx.dashReportKey('155675', panelFilter);
+assert.strictEqual(
+    ctx.dashUsePanelReportForFormula('fp1', '155675', idFormulaReportKey, '01.01.2026', '31.12.2026', panelFilter),
+    true,
+    'formula with report ID should directly reuse the loaded panel JSON report'
+);
+assert.ok(Array.isArray(ctx.dashReports[idFormulaReportKey]), 'ID-based formula report uses panel JSON rows');
+
+const cell = makeFormulaCell(panel);
+installFormulaRow(ctx, 'item1', formula, formulaReportKey, cell);
+ctx.dashGetRepVals();
+assert.strictEqual(cell.innerHTML, '5', 'formula cell uses panel JSON rows after local panelFilter');
+assert.strictEqual(cell.attrs.ready, '1', 'formula cell is marked ready after resolving panel JSON data');
+
+ctx.calls = [];
+const mismatchPanelKey = ctx.dashVizReportKey('200', '');
+const mismatchFormulaKey = ctx.dashReportKey('Другой запрос', '');
+ctx.dashModelData.fp2 = {
+    vizReportId: '200',
+    vizReportKey: mismatchPanelKey,
+    panelFilters: {}
+};
+ctx.dashGetVizReport('200', '01.01.2026', '31.12.2026', '');
+assert.strictEqual(
+    ctx.dashUsePanelReportForFormula('fp2', 'Другой запрос', mismatchFormulaKey, '01.01.2026', '31.12.2026', ''),
+    true,
+    'non-ID formula names are delayed until the panel JSON header is known'
+);
+ctx.dashGetVizReportDone({
+    header: 'Операционные результаты',
+    columns: [{ id: 'date', name: 'Date', format: 'DATE' }],
+    data: [['20260110']]
+}, { key: mismatchPanelKey });
+assert.ok(
+    ctx.calls.some(call => call.url === 'report/Другой запрос?JSON_KV&FR_Date=01.01.2026&TO_Date=31.12.2026'),
+    'header mismatch falls back to the normal formula JSON_KV request'
+);
+
+assert.strictEqual(
+    JSON.stringify(ctx.dashParseReportFormula('[155675.В работе]')),
+    JSON.stringify({ report: '155675', field: 'В работе', group: '', fullField: 'В работе' }),
+    'formula parser accepts query IDs in the report position'
+);
+
+console.log('issue-2718 panelQuery formula source: ok');

--- a/js/dash.js
+++ b/js/dash.js
@@ -1,6 +1,6 @@
 (function(){
 
-const repRegex  = /^\[([A-Za-яЁё][A-Za-яЁё0-9 ]*)(\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)(\.[A-Za-яЁё][A-Za-яЁё0-9 ]*)?\]$/
+const repRegex  = /^\[([^\].]+)(\.[^\].]+)(\.[^\].]+)?\]$/
     , itemRegex = /^\[([A-Za-яЁё][ A-Za-яЁё0-9\(\)-]*)\]$/
     , exprRegex = /(СУММА)\(\[(.*?)\]:\[(.*?)\]\)/g
     , itemIdRegex = /\[\d+\]/g;
@@ -84,7 +84,7 @@ const sheetTabTpl = '<li class="nav-item"><a id=":id:" class="nav-link dash-shee
         + ':name:'
     , cellTpl     = '<td range=":from:-:to:" ready=":ready:" class="f-cell :classes:" align="right" title=":title:" data-src=":src:" data-item-id=":item-id:":extra:>:val:';
 
-let dashModelData = {}, dashPeriodData = {}, dashPeriods = {}, dashValues = {}, dashValueErrors = {}, dashFormulas = {}, dashItems = {}, dashReports = {}, dashReportNames = {}, dashReportKeys = {}, dashReportSources = {}, dashVizReports = {}, dashPanelValues = {}, dashPanelValueErrors = {}, dashPanelFilters = {}, dashAjaxes = 0;
+let dashModelData = {}, dashPeriodData = {}, dashPeriods = {}, dashValues = {}, dashValueErrors = {}, dashFormulas = {}, dashItems = {}, dashReports = {}, dashReportNames = {}, dashReportKeys = {}, dashReportSources = {}, dashVizReports = {}, dashPanelValues = {}, dashPanelValueErrors = {}, dashPanelFilters = {}, dashPanelReportFormulas = {}, dashAjaxes = 0;
 let dashValueItemIds = {}; // item name -> valueItemID from ЗначенияЗаПериод
 let dashMatrixValues = [], dashMatrixValuesRequested = false, dashRgSourceIds = {};
 
@@ -531,12 +531,36 @@ function dashMergePanelFilterState(target, incoming) {
     return target;
 }
 
+function dashReportRefId(ref) {
+    var match = String(ref || '').trim().match(/^(\d+)(?::|$)/);
+    return match ? match[1] : '';
+}
+
+function dashCleanReportRef(ref) {
+    ref = String(ref || '').trim();
+    return dashReportRefId(ref) || ref;
+}
+
+function dashNormalizeReportRef(ref) {
+    return dashCleanReportRef(ref).replace(/\s+/g, ' ').toLowerCase();
+}
+
+function dashReportRefIsNumeric(ref) {
+    return /^\d+$/.test(dashCleanReportRef(ref));
+}
+
+function dashSameReportRef(a, b) {
+    var left = dashNormalizeReportRef(a)
+        , right = dashNormalizeReportRef(b);
+    return !!left && !!right && left === right;
+}
+
 function dashReportKey(rep, panelFilter) {
-    return JSON.stringify([String(rep || ''), dashNormalizePanelFilter(panelFilter)]);
+    return JSON.stringify([dashCleanReportRef(rep), dashNormalizePanelFilter(panelFilter)]);
 }
 
 function dashReportUrl(rep, fr, to, panelFilter) {
-    var url = 'report/' + rep + '?JSON_KV&FR_Date=' + fr + '&TO_Date=' + to
+    var url = 'report/' + dashCleanReportRef(rep) + '?JSON_KV&FR_Date=' + fr + '&TO_Date=' + to
         , filter = dashNormalizePanelFilter(panelFilter);
     if (filter) url += '&' + filter;
     return url;
@@ -564,18 +588,17 @@ function dashResolvePanelVizReportId(row) {
         if (value === null || value === undefined) continue;
         value = String(value).trim();
         if (!value || value === '0') continue;
-        match = value.match(/^\s*(\d+)(?::|$)/);
-        return match ? match[1] : value;
+        return dashCleanReportRef(value);
     }
     return '';
 }
 
 function dashVizReportKey(reportId, panelFilter) {
-    return JSON.stringify(['viz', String(reportId || ''), dashNormalizePanelFilter(panelFilter)]);
+    return JSON.stringify(['viz', dashCleanReportRef(reportId), dashNormalizePanelFilter(panelFilter)]);
 }
 
 function dashVizReportUrl(reportId, fr, to, panelFilter) {
-    var url = 'report/' + reportId + '?JSON&FR_Date=' + fr + '&TO_Date=' + to
+    var url = 'report/' + dashCleanReportRef(reportId) + '?JSON&FR_Date=' + fr + '&TO_Date=' + to
         , filter = dashNormalizePanelFilter(panelFilter);
     if (filter) url += '&' + filter;
     return url;
@@ -1170,10 +1193,10 @@ function dashCollectReportVizData(report, vizConfig) {
 function dashParseReportFormula(formula) {
     var rep = (formula || '').match(repRegex);
     if (!rep) return null;
-    var field = rep[2].substr(1)
-        , group = rep[3] ? rep[3].substr(1) : '';
+    var field = rep[2].substr(1).trim()
+        , group = rep[3] ? rep[3].substr(1).trim() : '';
     return {
-        report: rep[1],
+        report: dashCleanReportRef(rep[1]),
         field: field,
         group: group,
         fullField: group ? field + '.' + group : field
@@ -2072,16 +2095,76 @@ function dashGetRepDone(json, ctx) {
 
 function dashGetRep(rep, fr, to, panelFilter) {
     var key = dashReportKey(rep, panelFilter);
-    dashReports[key] = {};
-    dashReportNames[key] = rep;
+    dashReports[key] = { loading: 'report' };
+    dashReportNames[key] = dashCleanReportRef(rep);
     dashAjaxes++;
     newApi('GET', dashReportUrl(rep, fr, to, panelFilter), 'dashGetRepDone', '', { key: key });
     return key;
 }
 
+function dashBindPanelReportFormulaRows(reportKey, reportRef, report) {
+    dashReports[reportKey] = report && Array.isArray(report.rows) ? report.rows : [];
+    dashReportNames[reportKey] = (report && report.header) || dashCleanReportRef(reportRef);
+}
+
+function dashQueuePanelReportFormula(panelReportKey, reportRef, reportKey, fr, to, panelFilter, directMatch) {
+    var queue = dashPanelReportFormulas[panelReportKey] || (dashPanelReportFormulas[panelReportKey] = [])
+        , i;
+    for (i = 0; i < queue.length; i++)
+        if (queue[i].reportKey === reportKey) return;
+    if (!Array.isArray(dashReports[reportKey]))
+        dashReports[reportKey] = { loading: 'panel-query' };
+    dashReportNames[reportKey] = dashCleanReportRef(reportRef);
+    queue.push({
+        reportRef: dashCleanReportRef(reportRef),
+        reportKey: reportKey,
+        fr: fr,
+        to: to,
+        panelFilter: panelFilter,
+        directMatch: !!directMatch
+    });
+}
+
+function dashFlushPanelReportFormulas(panelReportKey) {
+    var report = dashVizReports[panelReportKey]
+        , queue = dashPanelReportFormulas[panelReportKey] || [];
+    if (!queue.length) return;
+    delete dashPanelReportFormulas[panelReportKey];
+    queue.forEach(function(source) {
+        if (source.directMatch || dashSameReportRef(source.reportRef, report && report.header)) {
+            dashBindPanelReportFormulaRows(source.reportKey, source.reportRef, report);
+            return;
+        }
+        if (Array.isArray(dashReports[source.reportKey])) return;
+        if (dashReports[source.reportKey] && dashReports[source.reportKey].loading === 'report') return;
+        dashGetRep(source.reportRef, source.fr, source.to, source.panelFilter);
+    });
+}
+
+function dashUsePanelReportForFormula(panelKey, reportRef, reportKey, fr, to, panelFilter) {
+    var data = dashModelData[panelKey]
+        , report, directMatch, canMatchHeader;
+    if (!data || !data.vizReportId || !data.vizReportKey || !reportRef || !reportKey) return false;
+    if (Array.isArray(dashReports[reportKey])) return true;
+    directMatch = dashSameReportRef(reportRef, data.vizReportId);
+    canMatchHeader = !directMatch && dashReportRefIsNumeric(data.vizReportId) && !dashReportRefIsNumeric(reportRef);
+    if (!directMatch && !canMatchHeader) return false;
+    report = dashVizReports[data.vizReportKey];
+    if (report && !report.loading) {
+        if (directMatch || dashSameReportRef(reportRef, report.header)) {
+            dashBindPanelReportFormulaRows(reportKey, reportRef, report);
+            return true;
+        }
+        return false;
+    }
+    dashQueuePanelReportFormula(data.vizReportKey, reportRef, reportKey, fr, to, panelFilter, directMatch);
+    return true;
+}
+
 function dashGetVizReportDone(json, ctx) {
     var key = ctx && typeof ctx === 'object' ? ctx.key : ctx;
     dashVizReports[key] = dashNormalizeReportJson(json || {});
+    dashFlushPanelReportFormulas(key);
     dashAjaxes--;
     dashDrawPeriods();
 }
@@ -2365,17 +2448,18 @@ function dashGetModel(json) {
             dashValues[itemTargetId] = dashNormalizeVal(itemTargetId, json[i].value);
         // Formulas
         if (json[i].formulas.length > 0) {
+            var parsedFormulaReport = dashParseReportFormula(json[i].formulas);
             rep = json[i].formulas.match(repRegex);
             if (!dashFormulas[itemTargetId] || (rep && dashFormulas[itemTargetId] === '[]'))
                 dashFormulas[itemTargetId] = json[i].formulas;
-            if (rep) {
-                var reportKey = dashReportKey(rep[1], panelFilter);
+            if (parsedFormulaReport) {
+                var reportKey = dashReportKey(parsedFormulaReport.report, panelFilter);
                 if (!dashReportKeys[itemTargetId])
                     dashReportKeys[itemTargetId] = reportKey;
                 dashRememberReportSource(itemTargetId, json[i].formulas, reportKey);
-                dashReportNames[reportKey] = rep[1];
-                if (!dashReports[reportKey])
-                    dashGetRep(rep[1], fr, to, panelFilter);
+                dashReportNames[reportKey] = parsedFormulaReport.report;
+                if (!dashReports[reportKey] && !dashUsePanelReportForFormula(panelKey, parsedFormulaReport.report, reportKey, fr, to, panelFilter))
+                    dashGetRep(parsedFormulaReport.report, fr, to, panelFilter);
             }
         }
     }
@@ -5887,7 +5971,7 @@ document.addEventListener('click', function(e) {
 
 function dashReset() {
     dashModelData = {}; dashPeriodData = {}; dashPeriods = {}; dashValues = {}; dashValueErrors = {};
-    dashFormulas = {}; dashItems = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashReportSources = {}; dashVizReports = {}; dashPanelValues = {}; dashPanelValueErrors = {}; dashPanelFilters = {}; dashAjaxes = 0; dashValueItemIds = {};
+    dashFormulas = {}; dashItems = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashReportSources = {}; dashVizReports = {}; dashPanelValues = {}; dashPanelValueErrors = {}; dashPanelFilters = {}; dashPanelReportFormulas = {}; dashAjaxes = 0; dashValueItemIds = {};
     dashPanelFilterModalCtx = null;
     dashMatrixValues = []; dashMatrixValuesRequested = false; dashRgSourceIds = {};
     var model = document.getElementById('dash-model');
@@ -5931,7 +6015,7 @@ window.dashApplyFilter = function(sheetEl) {
         p.remove();
     });
     dashUpdateSheetSizeResetIcon(sheetEl);
-    dashPeriodData = {}; dashPeriods = {}; dashValues = {}; dashValueErrors = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashReportSources = {}; dashVizReports = {}; dashAjaxes = 0; dashValueItemIds = {}; dashRgSourceIds = {};
+    dashPeriodData = {}; dashPeriods = {}; dashValues = {}; dashValueErrors = {}; dashReports = {}; dashReportNames = {}; dashReportKeys = {}; dashReportSources = {}; dashVizReports = {}; dashPanelReportFormulas = {}; dashAjaxes = 0; dashValueItemIds = {}; dashRgSourceIds = {};
 
     // Re-fetch model for this sheet only — skip get_record, use cached dashRecordId
     dashSetStatus('Загрузка данных...');


### PR DESCRIPTION
## Summary

Fixes #2718. Dashboard row formulas that reference the same query as the panel `panelQuery` now reuse the already loaded panel JSON report instead of starting a separate `JSON_KV` report request.

This covers both direct query ID formulas such as `[155675.В работе]` and the issue case where the panel query is configured by ID while the row formula names the report by the JSON `header`, for example `[Операционные результаты.В работе]`.

## Fix

- Normalize report references so `123`, `123:Name`, and formula query IDs resolve to the same report key.
- Queue row formulas that may match the panel query while the panel JSON is loading.
- When the panel JSON arrives, bind matching formula report rows from that filtered panel response; if the JSON `header` does not match, fall back to the normal `JSON_KV` formula request.
- Keep local `panelFilter` behavior intact by reusing the existing filtered report-row path used by formula cells.

## Tests

- [x] `node experiments/test-issue-2718-panel-query-formula-source.js`
- [x] `node experiments/test-issue-2679-panel-query-local-filter.js`
- [x] `node experiments/test-issue-2352-dashboard-local-panel-filter.js`
- [x] `node experiments/test-issue-2166-dashboard-panel-filter.js`
- [x] `node experiments/test-issue-2300-dashboard-viz-report-source.js`
- [x] `node experiments/test-issue-2235-dashboard-duplicate-report-rows.js`
- [x] `node experiments/test-issue-2232-dashboard-report-groups.js`
- [x] `node --check js/dash.js`
- [x] `node --check experiments/test-issue-2718-panel-query-formula-source.js`

No screenshots: this is dashboard data-source logic, covered by the reproducing experiment.