### PR TITLE
fix(import): flush plain import batch before lookups

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-18T20:09:19.556Z for PR creation at branch issue-2720-66c63ab9a959 for issue https://github.com/ideav/crm/issues/2720

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-18T20:09:19.556Z for PR creation at branch issue-2720-66c63ab9a959 for issue https://github.com/ideav/crm/issues/2720

--- a/experiments/test-issue-2712-plain-import-ref-replace.php
+++ b/experiments/test-issue-2712-plain-import-ref-replace.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * Issue #2712 plain DATA import reference replacement checks.
+ *
+ * The production bug was in the cached reference path: when an existing
+ * single-select ref had Accepted and the incoming row resolved Done from cache,
+ * the old branch inserted Done instead of updating the Accepted row.
+ */
+
+function assert_eq($expected, $actual, $message){
+    if($expected !== $actual){
+        fwrite(STDERR, "FAIL: $message\nExpected: ".var_export($expected, true)."\nActual:   ".var_export($actual, true)."\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+function extract_function($source, $name){
+    $start = strpos($source, "function ".$name."(");
+    if($start === false)
+        throw new RuntimeException("Function $name not found");
+    $brace = strpos($source, "{", $start);
+    $depth = 0;
+    $len = strlen($source);
+    for($i = $brace; $i < $len; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+    throw new RuntimeException("Function $name body not closed");
+}
+
+$index = file_get_contents(__DIR__."/../index.php");
+eval(extract_function($index, "HideDelimiters"));
+eval(extract_function($index, "UnHideDelimiters"));
+eval(extract_function($index, "PlainImportReferenceValues"));
+
+assert_eq(array("8925"), PlainImportReferenceValues("8925,9002:Done,Accepted", false),
+    "single-select id:value import keeps only the first ref id");
+assert_eq(array("8925", "9002"), PlainImportReferenceValues("8925,9002:Done,Accepted", true),
+    "multi-select id:value import keeps the incoming id set");
+assert_eq(array("Done"), PlainImportReferenceValues("Done,Accepted", false),
+    "single-select display-name import keeps only the first value");
+assert_eq(array("Done", "Accepted"), PlainImportReferenceValues("Done,Accepted", true),
+    "multi-select display-name import keeps all values");
+
+function old_cached_single_actions($reqs, $refObjID){
+    $actions = array();
+    if(!isset($reqs[$refObjID]))
+        $actions[] = array("insert", $refObjID);
+    return $actions;
+}
+
+function fixed_single_actions($currentRefs, $refObjID){
+    $actions = array();
+    if(count($currentRefs)){
+        if(isset($currentRefs[$refObjID]) && count($currentRefs[$refObjID]))
+            $keepId = array_shift($currentRefs[$refObjID]);
+        else{
+            reset($currentRefs);
+            $curRefObjID = key($currentRefs);
+            $keepId = array_shift($currentRefs[$curRefObjID]);
+            if((int)$curRefObjID !== $refObjID)
+                $actions[] = array("update_typ", $keepId, $refObjID);
+        }
+        foreach($currentRefs as $staleIDs)
+            foreach($staleIDs as $staleID)
+                $actions[] = array("delete", $staleID);
+        return $actions;
+    }
+    return array(array("insert", $refObjID));
+}
+
+function fixed_multi_actions($currentRefs, $incomingRefs){
+    $actions = array();
+    $seen = array();
+    $ord = 1;
+    foreach($incomingRefs as $refObjID){
+        $targetOrd = $ord++;
+        if(isset($seen[$refObjID]))
+            continue;
+        $seen[$refObjID] = true;
+        if(isset($currentRefs[$refObjID]) && count($currentRefs[$refObjID])){
+            $keepId = array_shift($currentRefs[$refObjID]);
+            $actions[] = array("order", $keepId, $targetOrd);
+            foreach($currentRefs[$refObjID] as $staleID)
+                $actions[] = array("delete", $staleID);
+            unset($currentRefs[$refObjID]);
+            continue;
+        }
+        $actions[] = array("insert", $refObjID, $targetOrd);
+    }
+    foreach($currentRefs as $staleIDs)
+        foreach($staleIDs as $staleID)
+            $actions[] = array("delete", $staleID);
+    return $actions;
+}
+
+$statusReq = 8907;
+$done = 8925;
+$accepted = 9002;
+$acceptedRow = 43190;
+$doneRow = 393908;
+
+assert_eq(array(array("insert", $done)), old_cached_single_actions(array($accepted => $statusReq), $done),
+    "old cached path reproduces the bug by inserting the new status");
+assert_eq(array(array("update_typ", $acceptedRow, $done)), fixed_single_actions(array($accepted => array($acceptedRow)), $done),
+    "single-select import updates the existing status row instead of inserting a second one");
+assert_eq(array(array("delete", $acceptedRow)), fixed_single_actions(array($done => array($doneRow), $accepted => array($acceptedRow)), $done),
+    "single-select import removes stale duplicate statuses when the desired one already exists");
+assert_eq(
+    array(array("order", $acceptedRow, 1), array("insert", 7777, 2), array("delete", $doneRow)),
+    fixed_multi_actions(array($done => array($doneRow), $accepted => array($acceptedRow)), array($accepted, 7777)),
+    "multi-select import replaces the current ref set with the incoming set"
+);
+
+echo "\nAll issue-2712 plain import reference checks passed.\n";

--- a/experiments/test-issue-2720-plain-import-ref-batch-flush.php
+++ b/experiments/test-issue-2720-plain-import-ref-batch-flush.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Issue #2720 plain import batch visibility checks.
+ *
+ * PR #2715 fixed replacement of plain DATA reference values, but the import
+ * code batches requisite/reference inserts. A later row for the same record
+ * cannot see those rows in SELECT queries until the insert batch is flushed.
+ */
+
+function assert_eq($expected, $actual, $message){
+    if($expected !== $actual){
+        fwrite(STDERR, "FAIL: $message\nExpected: ".var_export($expected, true)."\nActual:   ".var_export($actual, true)."\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+function assert_contains($needle, $haystack, $message){
+    if(strpos($haystack, $needle) === false){
+        fwrite(STDERR, "FAIL: $message\nMissing: $needle\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+function extract_function($source, $name){
+    $start = strpos($source, "function ".$name."(");
+    if($start === false)
+        throw new RuntimeException("Function $name not found");
+    $brace = strpos($source, "{", $start);
+    $depth = 0;
+    $len = strlen($source);
+    for($i = $brace; $i < $len; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+    throw new RuntimeException("Function $name body not closed");
+}
+
+class Issue2720BatchHarness {
+    public $committedRefs = array();
+    public $batchRefs = array();
+    public $nextReqId = 1000;
+    public $flushes = 0;
+
+    public function currentRefs($recordId, $reqId){
+        if(isset($this->committedRefs[$recordId]) && isset($this->committedRefs[$recordId][$reqId]))
+            return $this->committedRefs[$recordId][$reqId];
+        return array();
+    }
+
+    public function insertBatch($recordId, $reqId, $refObjId){
+        $this->batchRefs[] = array("recordId" => $recordId, "reqId" => $reqId, "refObjId" => $refObjId);
+    }
+
+    public function flushBatch(){
+        if(!count($this->batchRefs))
+            return;
+        $this->flushes++;
+        foreach($this->batchRefs as $row){
+            $recordId = $row["recordId"];
+            $reqId = $row["reqId"];
+            $refObjId = $row["refObjId"];
+            if(!isset($this->committedRefs[$recordId]))
+                $this->committedRefs[$recordId] = array();
+            if(!isset($this->committedRefs[$recordId][$reqId]))
+                $this->committedRefs[$recordId][$reqId] = array();
+            if(!isset($this->committedRefs[$recordId][$reqId][$refObjId]))
+                $this->committedRefs[$recordId][$reqId][$refObjId] = array();
+            $this->committedRefs[$recordId][$reqId][$refObjId][] = $this->nextReqId++;
+        }
+        $this->batchRefs = array();
+    }
+
+    public function importSingleRefWithoutLookupFlush($recordId, $reqId, $refObjId){
+        $currentRefs = $this->currentRefs($recordId, $reqId);
+        if(count($currentRefs))
+            return "kept";
+        $this->insertBatch($recordId, $reqId, $refObjId);
+        return "inserted";
+    }
+
+    public function importSingleRefWithLookupFlush($recordId, $reqId, $refObjId){
+        $this->flushBatch();
+        return $this->importSingleRefWithoutLookupFlush($recordId, $reqId, $refObjId);
+    }
+
+    public function committedRefCount($recordId, $reqId, $refObjId){
+        return count($this->committedRefs[$recordId][$reqId][$refObjId]);
+    }
+}
+
+$recordId = 43072;
+$statusReq = 8907;
+$done = 8925;
+
+$old = new Issue2720BatchHarness();
+assert_eq("inserted", $old->importSingleRefWithoutLookupFlush($recordId, $statusReq, $done),
+    "old path queues the first missing single-select ref");
+assert_eq("inserted", $old->importSingleRefWithoutLookupFlush($recordId, $statusReq, $done),
+    "old path cannot see the pending batch row and queues a duplicate");
+$old->flushBatch();
+assert_eq(2, $old->committedRefCount($recordId, $statusReq, $done),
+    "old path reproduces duplicate refs after final batch flush");
+
+$fixed = new Issue2720BatchHarness();
+assert_eq("inserted", $fixed->importSingleRefWithLookupFlush($recordId, $statusReq, $done),
+    "fixed path queues the first missing single-select ref");
+assert_eq("kept", $fixed->importSingleRefWithLookupFlush($recordId, $statusReq, $done),
+    "fixed path flushes before lookup and sees the existing ref");
+$fixed->flushBatch();
+assert_eq(1, $fixed->committedRefCount($recordId, $statusReq, $done),
+    "fixed path keeps only one ref after final batch flush");
+
+$index = file_get_contents(__DIR__."/../index.php");
+assert_contains("function FlushInsertBatch(", $index,
+    "production code exposes an explicit insert-batch flush helper");
+assert_contains("FlushInsertBatch(\"Before plain import lookup\")", $index,
+    "plain DATA import flushes pending inserts before DB-backed lookups");
+
+$executedSql = array();
+$z = "issue2720_tmp";
+function exec_sql($sql, $message){
+    global $executedSql;
+    $executedSql[] = array($sql, $message);
+}
+eval(extract_function($index, "FlushInsertBatch"));
+eval(extract_function($index, "Insert_batch"));
+
+unset($GLOBALS["SQLbatch"]);
+Insert_batch("", "", "", "", "Empty close");
+assert_eq(0, count($executedSql),
+    "closing an empty insert batch does not execute malformed SQL");
+
+Insert_batch(1, 1, 2, "Done", "Queue ref");
+assert_eq(0, count($executedSql),
+    "queued insert remains pending before an explicit flush");
+assert_eq("(1,1,2,'Done')", $GLOBALS["SQLbatch"],
+    "queued insert is stored in SQLbatch");
+assert_eq(TRUE, FlushInsertBatch("Before lookup"),
+    "explicit flush reports that a pending batch was closed");
+assert_eq(array("INSERT INTO issue2720_tmp (up, ord, t, val) VALUES (1,1,2,'Done')", "Close batch: Before lookup"), $executedSql[0],
+    "explicit flush writes the pending batch with the requested trace message");
+assert_eq(FALSE, isset($GLOBALS["SQLbatch"]),
+    "explicit flush clears SQLbatch");
+
+echo "\nAll issue-2720 plain import batch flush checks passed.\n";

--- a/index.php
+++ b/index.php
@@ -5812,6 +5812,7 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
     					if(strlen($buffer)==0)
     						continue;
     					$object = UnHideDelimiters(explode(";", HideDelimiters($buffer)));	# Get fields array
+						FlushInsertBatch("Before plain import lookup");
                         if($object[0] == ""){
                             // issue #2522: if the Type has uniqueness defined by composite key reqs, an emptied
                             // first column means the source row was cleared — find the existing record by the
@@ -7726,13 +7727,21 @@ function Salt($u, $val){
 	# $u = strtoupper($u);
 	return SALT."$z$val";
 }
+# Flushes the pending insert batch so later SELECT/UPDATE/DELETE queries can see it
+function FlushInsertBatch($message, $prefix="Close batch"){
+	global $z;
+	if(!isset($GLOBALS["SQLbatch"]) || $GLOBALS["SQLbatch"] === "")
+		return FALSE;
+	exec_sql("INSERT INTO $z (up, ord, t, val) VALUES ".$GLOBALS["SQLbatch"], "$prefix: $message");
+	unset($GLOBALS["SQLbatch"]);
+	return TRUE;
+}
 # Inserts new values in a batch
 function Insert_batch($up, $ord, $t, $val, $message){
 	global $connection, $z;
-	if(($up === "") && isset($GLOBALS["SQLbatch"])) // Close the batch
+	if($up === "") // Close the batch
 	{
-    	exec_sql("INSERT INTO $z (up, ord, t, val) VALUES ".$GLOBALS["SQLbatch"], "Close batch: $message");
-    	unset($GLOBALS["SQLbatch"]);
+		FlushInsertBatch($message);
     	return;
 	}
 	if(isset($GLOBALS["SQLbatch"]))
@@ -7741,10 +7750,7 @@ function Insert_batch($up, $ord, $t, $val, $message){
         $GLOBALS["SQLbatch"] = "($up,$ord,$t,'".addslashes($val)."')";
 #    trace("GLOBAL[SQLbatch] = ".$GLOBALS["SQLbatch"]);
 	if(strlen($GLOBALS["SQLbatch"]) > 31000)
-	{
-    	exec_sql("INSERT INTO $z (up, ord, t, val) VALUES ".$GLOBALS["SQLbatch"], "Flush batch: $message");
-    	unset($GLOBALS["SQLbatch"]);
-	}
+		FlushInsertBatch($message, "Flush batch");
 }
 # Inserts a new value and returns the ID it got
 function Insert($up, $ord, $t, $val, $message)

--- a/index.php
+++ b/index.php
@@ -1924,6 +1924,20 @@ function UnHideDelimiters($v)
 {
     return str_replace("%2C", "\,", str_replace("%3B", "\;", str_replace("%3A", "\:", str_replace("%5C", "\\\\", $v))));
 }
+function PlainImportReferenceValues($value, $multi)
+{
+	$value = (string)$value;
+	$colonPos = strpos($value, ":");
+	if($colonPos !== FALSE){
+		$ids = substr($value, 0, $colonPos);
+		if(preg_match("/^[0-9]+(,[0-9]+)*$/", $ids))
+			$value = $ids;
+	}
+	$refs = UnHideDelimiters(explode(",", HideDelimiters($value)));
+	if(!$multi && count($refs) > 1)
+		$refs = array($refs[0]);
+	return $refs;
+}
 function constructHeader($id, $parent=0){
 	global $z;
 	if(!isset($GLOBALS["local_struct"][$id])){
@@ -6008,45 +6022,86 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
                         				while($row = mysqli_fetch_array($data_set))
                 						    Delete($row["id"]);
             						}
-            						else{
-        						        if(isset($GLOBALS["MULTI"][$key]))
-        						            $multies = UnHideDelimiters(explode(",", HideDelimiters($object[$order])));	# Get multiselect items set
-        						        else
-        						            $multies = array($object[$order]);
-        					            $ord = 1;
-                    					foreach($multies as $ref){
-                    					    $ref = trim($ref);
-            							    if(isset($GLOBALS["refs"][$refType]))
-                							    if(isset($GLOBALS["refs"][$refType][$ref])){
-                							        // if(!isset($existing) // It is a ref of a new rec
-                							                // || (isset($GLOBALS["MULTI"][$key]) && !isset($reqs[$GLOBALS["refs"][$refType][$ref]]))) // or multiple ref yet not on the list
-                							        if(!isset($reqs[$GLOBALS["refs"][$refType][$ref]])) // ref yet not on the list
-                        							    // Insert($new_id, 1, $GLOBALS["refs"][$refType][$ref], $key, "Import cached plain ref");
-                        							    Insert_batch($new_id, 1, $GLOBALS["refs"][$refType][$ref], $key, "Import cached plain ref");
-                    							    continue;
-                    						    }
-            								if($row = mysqli_fetch_array(Exec_sql("SELECT id FROM $z WHERE t=$refType AND val='".addslashes($ref)."'", "Check plain ref Obj Value")))
-            								    $refObjID = $row["id"];
-            								else
-            								    $refObjID = Insert(1, 1, $refType, $ref, "Import plain ref Object");
-            								if(!isset($GLOBALS["MULTI"][$key])){
-                            				    trace("    Check existing ref $key $refType");
-                    						    foreach($reqs as $rid => $req){
-                                				    trace("    rid $rid => req $req ($req === $key)");
-                    						        if($req == $key){
-                                    				    trace("    req $req === key $key, rid $rid === refObjID $refObjID");
-                    						            if($refObjID !== $rid)
-                                							UpdateTyp($ids[$rid], $refObjID);
-                    						            continue 2;
-                    						        }
-                    						    }
-            								}
-            								if(!isset($reqs[$refObjID]))
-                    						// Insert($new_id, $ord++, $refObjID, $key, "Import plain ref");
-                							Insert_batch($new_id, $ord++, $refObjID, $key, "Import plain ref");
-                							$GLOBALS["refs"][$refType][$ref] = $refObjID;
-                    					}
-            						}
+								else{
+									$multiRef = isset($GLOBALS["MULTI"][$key]);
+									$multies = PlainImportReferenceValues($object[$order], $multiRef);	# Get reference items set
+									$currentRefs = Array();
+									if(isset($existing)){
+										$data_set = Exec_sql("SELECT req.id, req.t, req.ord FROM $z req, $z ref"
+														."   WHERE req.up=$new_id AND req.val='$key' AND ref.id=req.t AND (ref.t=$refType OR $refType=1)"
+														."   ORDER BY req.ord, req.id"
+														, "Get current plain refs for import");
+										while($row = mysqli_fetch_array($data_set)){
+											$currentRef = (int)$row["t"];
+											if(!isset($currentRefs[$currentRef]))
+												$currentRefs[$currentRef] = Array();
+											$currentRefs[$currentRef][] = (int)$row["id"];
+										}
+									}
+									$incomingRefs = Array();
+									$ord = 1;
+									foreach($multies as $ref){
+										$ref = trim($ref);
+										if($ref === "")
+											continue;
+										$targetOrd = $ord++;
+										$refObjID = 0;
+										if(is_numeric($ref) && ((int)$ref > 0)){
+											$refID = (int)$ref;
+											if($row = mysqli_fetch_array(Exec_sql("SELECT id FROM $z WHERE id=$refID AND (t=$refType OR $refType=1)", "Check plain ref Obj ID")))
+												$refObjID = (int)$row["id"];
+										}
+										if(!$refObjID && isset($GLOBALS["plain_refs"][$refType]) && isset($GLOBALS["plain_refs"][$refType][$ref]))
+											$refObjID = (int)$GLOBALS["plain_refs"][$refType][$ref];
+										if(!$refObjID){
+											if($row = mysqli_fetch_array(Exec_sql("SELECT id FROM $z WHERE t=$refType AND val='".addslashes($ref)."'", "Check plain ref Obj Value")))
+												$refObjID = (int)$row["id"];
+											else
+												$refObjID = Insert(1, 1, $refType, $ref, "Import plain ref Object");
+											if(!isset($GLOBALS["plain_refs"][$refType]))
+												$GLOBALS["plain_refs"][$refType] = Array();
+											$GLOBALS["plain_refs"][$refType][$ref] = $refObjID;
+										}
+										if(!$multiRef){
+											trace("    Check existing ref $key $refType");
+											if(count($currentRefs)){
+												if(isset($currentRefs[$refObjID]) && count($currentRefs[$refObjID]))
+													$keepId = array_shift($currentRefs[$refObjID]);
+												else{
+													reset($currentRefs);
+													$curRefObjID = key($currentRefs);
+													$keepId = array_shift($currentRefs[$curRefObjID]);
+													if((int)$curRefObjID !== $refObjID)
+														UpdateTyp($keepId, $refObjID);
+												}
+												Exec_sql("UPDATE $z SET ord=1 WHERE id=$keepId AND ord!=1", "Update plain ref order");
+												foreach($currentRefs as $staleIDs)
+													foreach($staleIDs as $staleID)
+														Delete($staleID);
+												continue 2;
+											}
+											Insert_batch($new_id, 1, $refObjID, $key, "Import plain ref");
+											continue;
+										}
+										if(isset($incomingRefs[$refObjID]))
+											continue;
+										$incomingRefs[$refObjID] = TRUE;
+										if(isset($currentRefs[$refObjID]) && count($currentRefs[$refObjID])){
+											$keepId = array_shift($currentRefs[$refObjID]);
+											Exec_sql("UPDATE $z SET ord=$targetOrd WHERE id=$keepId AND ord!=$targetOrd", "Update plain multi ref order");
+											foreach($currentRefs[$refObjID] as $staleID)
+												Delete($staleID);
+											unset($currentRefs[$refObjID]);
+											continue;
+										}
+										// Insert($new_id, $targetOrd, $refObjID, $key, "Import plain ref");
+										Insert_batch($new_id, $targetOrd, $refObjID, $key, "Import plain ref");
+									}
+									if($multiRef)
+										foreach($currentRefs as $staleIDs)
+											foreach($staleIDs as $staleID)
+												Delete($staleID);
+								}
     						    }
     						    elseif(isset($existing) && isset($reqs[$key])){
     						         # Drop false BOOLEAN: -1 or FALSE


### PR DESCRIPTION
## Summary

Fixes #2720.

Builds on #2715 and makes plain DATA import account for batched inserts before DB-backed lookups:
- reference fields still replace current values instead of appending duplicate single-select refs;
- pending `Insert_batch` rows are flushed before the next plain import row performs uniqueness/current-ref lookups, so the DB sees refs/reqs inserted by the previous row;
- batch closing is centralized in `FlushInsertBatch`, and closing an empty batch is a no-op instead of creating malformed pending SQL.

## Reproduction

The new issue #2720 experiment models two consecutive imports for the same existing record. Without a pre-lookup flush, the second import cannot see the first row's pending single-select reference insert and queues a duplicate. With the flush, the second import sees the committed ref and keeps one row.

## Tests

- `php -l index.php`
- `php -l experiments/test-issue-2712-plain-import-ref-replace.php`
- `php -l experiments/test-issue-2720-plain-import-ref-batch-flush.php`
- `php experiments/test-issue-2712-plain-import-ref-replace.php`
- `php experiments/test-issue-2720-plain-import-ref-batch-flush.php`
- `php experiments/test-issue-2520-composite-key-without-first-column-unique.php`
- `php experiments/test-issue-2522-empty-value-delete-by-unique-key.php`
- `php experiments/test-issue-2524-getparent-empty-value-delete-by-unique-key.php`
- `git diff --check HEAD~2..HEAD`
