### PR TITLE
fix(dash): cross-panel share row formula fetch via panelQuery index (closes #2727)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -87,6 +87,13 @@ const sheetTabTpl = '<li class="nav-item"><a id=":id:" class="nav-link dash-shee
 let dashModelData = {}, dashPeriodData = {}, dashPeriods = {}, dashValues = {}, dashValueErrors = {}, dashFormulas = {}, dashItems = {}, dashReports = {}, dashReportNames = {}, dashReportIds = {}, dashReportHeaders = {}, dashReportKeys = {}, dashReportSources = {}, dashVizReports = {}, dashPanelValues = {}, dashPanelValueErrors = {}, dashPanelFilters = {}, dashAjaxes = 0;
 // Issue 2718: алиасы запросов id↔name из X-Query-* заголовков; очередь row-fetch'ей, ждущих panel-fetch.
 let dashQueryNameById = {}, dashQueryIdByName = {}, dashPendingPanelRows = {};
+// Issue 2727: индекс panelQuery по id и имени для кросс-панельного шаринга row-fetch'ей.
+// Заполняется pre-pass'ом до основного цикла, чтобы строка из панели B могла найти панель A
+// с подходящим panelQuery даже если A идёт в JSON позже. Server-filter хранится тут же —
+// сравнение dashModelData[candidate].panelFilter не сработало бы, пока главный цикл не дошёл до A.
+// hasItems нужен потому что dashGetPanelValues пропускает панель без .f-item, и данные в
+// dashReports[panelReportKey] не попадут — кросс-панельный шаринг для такой панели бесполезен.
+let dashPanelKeyByRef = {}, dashPanelServerFilterByKey = {}, dashPanelHasItemsByKey = {};
 let dashValueItemIds = {}; // item name -> valueItemID from ЗначенияЗаПериод
 let dashMatrixValues = [], dashMatrixValuesRequested = false, dashRgSourceIds = {};
 
@@ -610,6 +617,26 @@ function dashRefMatchesPanelQuery(rowRef, parts) {
     if (parts.id && s === parts.id) return true;
     if (parts.name && s.toLowerCase() === parts.name.toLowerCase()) return true;
     return false;
+}
+
+// Issue 2727: найти панель, чей panelQuery соответствует row-ref'у, для кросс-панельного шаринга.
+// Шаринг безопасен только если server-side panelFilter совпадает — иначе данные на сервере
+// отфильтрованы по-разному (FR_dept=1 vs FR_dept=2). Локальные ":"-фильтры применяются per-cell
+// в dashGetRepVals и шарингу не мешают.
+function dashFindPanelForRowRef(rowRef, rowPanelFilter, ownPanelKey) {
+    var s = String(rowRef || '').trim();
+    if (!s) return '';
+    var sLower = s.toLowerCase()
+        , rowServerFilter = dashNormalizePanelFilter(rowPanelFilter)
+        , candidate = dashPanelKeyByRef[s] || dashPanelKeyByRef[sLower];
+    if (!candidate || candidate === ownPanelKey) return '';
+    // Сравниваем по индексу, а не по dashModelData[candidate]: целевая панель может ещё
+    // не быть создана в основном цикле (если её строки идут в JSON позже текущей).
+    if (dashPanelServerFilterByKey[candidate] !== rowServerFilter) return '';
+    // dashGetPanelValues пропускает панели без .f-item — без её ответа данные в
+    // dashReports[panelReportKey] не появятся и очередь не разойдётся.
+    if (!dashPanelHasItemsByKey[candidate]) return '';
+    return candidate;
 }
 
 function dashVizReportKey(reportId, panelFilter) {
@@ -2371,6 +2398,23 @@ function dashGetModel(json) {
 
     var model = document.getElementById('dash-model');
 
+    // Issue 2727: pre-pass — индексируем panelQuery каждой панели по id и имени, чтобы
+    // row-формула в любой панели могла найти подходящий panel-fetch до начала основного
+    // цикла. Без этого матч сработал бы только для панелей, обработанных ранее в JSON.
+    var seenPanelsForRefIndex = {};
+    for (i in json) {
+        var indexPid = json[i].panelID;
+        var indexPanelKey = 'fp' + indexPid;
+        if (json[i].itemID) dashPanelHasItemsByKey[indexPanelKey] = true;
+        if (seenPanelsForRefIndex[indexPid]) continue;
+        seenPanelsForRefIndex[indexPid] = true;
+        var indexParts = dashPanelQueryParts(json[i]);
+        if (!indexParts) continue;
+        if (indexParts.id) dashPanelKeyByRef[indexParts.id] = indexPanelKey;
+        if (indexParts.name) dashPanelKeyByRef[indexParts.name.toLowerCase()] = indexPanelKey;
+        dashPanelServerFilterByKey[indexPanelKey] = dashNormalizePanelFilter(json[i].panelFilter || '');
+    }
+
     for (i in json) {
         var panelKey = 'fp' + json[i].panelID
             , previousItem = lastVisibleItemByPanel[panelKey]
@@ -2472,14 +2516,17 @@ function dashGetModel(json) {
             if (!dashFormulas[itemTargetId] || (rep && dashFormulas[itemTargetId] === '[]'))
                 dashFormulas[itemTargetId] = json[i].formulas;
             if (rep) {
-                // Issue 2718: если у панели есть panelQuery — row-fetch встаёт в очередь и
-                // выполнится (или будет переиспользован panel-fetch) после dashGetPanelValuesDone.
-                // Если panelQuery нет — fire'им сразу как раньше.
+                // Issue 2718/2727: row-fetch встаёт в очередь подходящей панели, если такая есть:
+                //   1) собственная панель имеет panelQuery → ждём её panel-fetch'а (issue 2718);
+                //   2) иначе — другая панель имеет panelQuery с тем же ref'ом и тем же
+                //      server-side panelFilter → шарим её panel-fetch (issue 2727).
+                // Иначе — fire'им свой dashGetRep как раньше.
                 var panelData2 = dashModelData[panelKey]
-                    , panelParts2 = panelData2 && panelData2.panelQueryParts;
-                if (panelParts2) {
-                    if (!dashPendingPanelRows[panelKey]) dashPendingPanelRows[panelKey] = [];
-                    dashPendingPanelRows[panelKey].push({
+                    , panelParts2 = panelData2 && panelData2.panelQueryParts
+                    , queueKey = panelParts2 ? panelKey : dashFindPanelForRowRef(rep[1], panelFilter, panelKey);
+                if (queueKey) {
+                    if (!dashPendingPanelRows[queueKey]) dashPendingPanelRows[queueKey] = [];
+                    dashPendingPanelRows[queueKey].push({
                         itemTargetId: itemTargetId, formula: json[i].formulas, rowRef: rep[1],
                         fr: fr, to: to, panelFilter: panelFilter
                     });


### PR DESCRIPTION
## Summary

Closes #2727. Extends PR #2723 cross-panel: when a row's formula references a report that **another** panel has registered via `panelQuery`, the row now attaches to that panel's queue and reuses its panel-fetch instead of firing its own. The row's own `panelFilter` (e.g. `panelFilter=\"Лист:Дашборд для ФО\"`) continues to apply locally per-cell via `dashFilterReportRowsForPanel`.

#2723 only deduplicated rows inside the same panel that declared `panelQuery`. Rows in panels without `panelQuery` always fell through to their own `dashGetRep` call, even when the referenced report was already in flight on a sibling panel.

## Changes (js/dash.js)

- **Pre-pass over the model JSON** (runs before the existing main loop in `dashGetModel`) builds:
  - `dashPanelKeyByRef` — id and lowercase name → panelKey
  - `dashPanelServerFilterByKey` — panelKey → normalized server-side filter
  - `dashPanelHasItemsByKey` — panelKey → whether it has any `.f-item` row
  
  Doing this up front lets a row in an early panel match a panel that appears later in the JSON.

- **New helper `dashFindPanelForRowRef(rowRef, rowPanelFilter, ownPanelKey)`** returns a matched panel key only when all of:
  - ref matches a registered `panelQuery` by id or name,
  - candidate panel is not the row's own panel,
  - server-side (`=`-form) `panelFilter` parts are identical — local (`:`-form) parts are stripped by `dashNormalizePanelFilter` and applied per-cell, so they don't block sharing,
  - target panel has at least one `.f-item` row (otherwise `dashGetPanelValues` would skip it and the queue would never drain).

- **Row-formula handler in `dashGetModel`** now picks a single `queueKey`:
  - own panel if it declares `panelQuery` (existing #2718 behavior),
  - else result of `dashFindPanelForRowRef` (new #2727 cross-panel match),
  - else falls through to the old `dashGetRep` path.
  
  When a `queueKey` exists, the row is pushed into `dashPendingPanelRows[queueKey]`. The existing `dashDrainPendingPanelRows` recognizes the match and reuses the panel's `panelReportKey`.

## Test plan

- [ ] Дашборд из issue ([6.json](https://github.com/user-attachments/files/27987052/6.json)) — три панели с `[Операционные результаты.*]`: панели с локальным `Лист:…` фильтром делают один общий запрос, панель с `FR_dept=…` остаётся отдельной.
- [ ] Панель A с `panelQuery=\"155564\"` и панель B с row-формулой `[Операционные результаты.X]` (по имени) — сетевая вкладка показывает один JSON_KV запрос, ячейка B заполняется данными panel-fetch'а A.
- [ ] Та же связка, но B имеет panelFilter `FR_dept=2`, а A — `FR_dept=1` — два отдельных запроса (сервер-фильтры разные).
- [ ] Панель A без `.f-item` (например, чарт) с `panelQuery` — row из B не цепляется к A, fall-through на свой `dashGetRep`.
- [ ] Локальный `panelFilter` (`Лист:…`) продолжает фильтровать ячейку через `dashFilterReportRowsForPanel`, даже если данные общие.
- [ ] `node --check js/dash.js` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)