### PR TITLE
index.php: не проверять составной ключ при правке неключевой первой колонки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-19T17:24:30.599Z for PR creation at branch issue-2732-775c6cf8ecf6 for issue https://github.com/ideav/crm/issues/2732

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-19T17:24:30.599Z for PR creation at branch issue-2732-775c6cf8ecf6 for issue https://github.com/ideav/crm/issues/2732

--- a/experiments/test-issue-2732-inline-first-column-composite-key.php
+++ b/experiments/test-issue-2732-inline-first-column-composite-key.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Test for issue #2732:
+ * Inline editing the first column of a type whose uniqueness is defined only
+ * by composite-key requisites must not run the duplicate-key check when no
+ * key requisite was submitted.
+ */
+
+function issue2732UniqueKeyRequestHasSubmittedKeyReq($request, $keyReqs){
+	foreach($keyReqs as $reqId => $req)
+		if(array_key_exists("t$reqId", $request) || array_key_exists("NEW_$reqId", $request))
+			return true;
+	return false;
+}
+
+function issue2732ShouldCheckUnique($unique, $request, $keyReqs){
+	if($unique)
+		return true;
+	return issue2732UniqueKeyRequestHasSubmittedKeyReq($request, $keyReqs);
+}
+
+function issue2732OldShouldCheckUnique($unique, $request, $keyReqs){
+	return $unique || count($keyReqs) > 0;
+}
+
+function issue2732AssertSame($expected, $actual, $message){
+	if($expected !== $actual){
+		fwrite(STDERR, "FAIL: $message\nExpected: ".var_export($expected, true)."\nActual:   ".var_export($actual, true)."\n");
+		exit(1);
+	}
+	echo "OK: $message\n";
+}
+
+$typeId = 50;
+$keyReqs = array(
+	100 => array("kind" => "value"),
+	101 => array("kind" => "ref")
+);
+
+$firstColumnOnly = array("t$typeId" => "New display name");
+issue2732AssertSame(true, issue2732OldShouldCheckUnique(false, $firstColumnOnly, $keyReqs),
+	"old _m_save guard reproduced the bug: first-column-only edit still triggered composite duplicate check");
+issue2732AssertSame(false, issue2732ShouldCheckUnique(false, $firstColumnOnly, $keyReqs),
+	"first-column-only edit skips composite duplicate check when first column is not unique");
+
+$keyValueSubmitted = array("t100" => "2026-05-19");
+issue2732AssertSame(true, issue2732ShouldCheckUnique(false, $keyValueSubmitted, $keyReqs),
+	"submitted value key requisite triggers composite duplicate check");
+
+$emptyKeySubmitted = array("t100" => "");
+issue2732AssertSame(true, issue2732ShouldCheckUnique(false, $emptyKeySubmitted, $keyReqs),
+	"clearing a key requisite still triggers composite duplicate check");
+
+$newReferenceSubmitted = array("NEW_101" => "New reference");
+issue2732AssertSame(true, issue2732ShouldCheckUnique(false, $newReferenceSubmitted, $keyReqs),
+	"submitted new reference value for a key requisite triggers composite duplicate check");
+
+issue2732AssertSame(true, issue2732ShouldCheckUnique(true, $firstColumnOnly, $keyReqs),
+	"types with unique first column still validate first-column edits");
+
+issue2732AssertSame(false, issue2732ShouldCheckUnique(false, $firstColumnOnly, array()),
+	"non-unique type without composite key does not run uniqueness check");
+
+echo "\nAll tests passed for issue-2732.\n";

--- a/index.php
+++ b/index.php
@@ -8867,6 +8867,12 @@ function UniqueKeyValuesFromRequest($typ, $recordId, $request, $keyReqs=false){
 	}
 	return $values;
 }
+function UniqueKeyRequestHasSubmittedKeyReq($request, $keyReqs){
+	foreach($keyReqs as $reqId => $req)
+		if(array_key_exists("t$reqId", $request) || array_key_exists("NEW_$reqId", $request))
+			return true;
+	return false;
+}
 function FindUniqueRecordDuplicate($typ, $skipId, $up, $val, $keyValues, $includeVal=true){
 	global $z;
 	// When uniqueness is enforced solely by composite-key reqs (the first column is not marked unique),
@@ -9563,8 +9569,9 @@ if(Validate_Token())
 			Get_Current_Values($id, $typ);
 			$GLOBALS["REQS"][$typ] = $cur_val;
 			if(!$copy){
-				$hasKeyReqs = $unique ? false : (count(UniqueKeyReqs($typ)) > 0);
-				if($unique || $hasKeyReqs){
+				$keyReqs = $unique ? array() : UniqueKeyReqs($typ);
+				$hasSubmittedKeyReqs = $unique ? false : UniqueKeyRequestHasSubmittedKeyReq($_REQUEST, $keyReqs);
+				if($unique || $hasSubmittedKeyReqs){
 					$uniqueVal = $cur_val;
 					if(isset($_REQUEST["t$typ"]) && !(($typ == TOKEN || $typ == XSRF || $typ == PASSWORD) && $_REQUEST["t$typ"] === PASSWORDSTARS))
 						$uniqueVal = UniqueKeyNormalizeValue($typ, $_REQUEST["t$typ"]);


### PR DESCRIPTION
## Проблема

Fixes #2732

При inline-редактировании первой колонки для типа, у которого первая колонка не уникальна, но есть реквизиты составного ключа, `_m_save` запускал проверку уникальности только потому, что у типа есть `UniqueKeyReqs`. В запросе inline-редактирования первой колонки ключевые реквизиты не передаются, поэтому изменение не влияет на составной ключ, но проверка могла найти уже существующую запись с тем же ключом и вернуть ошибку `Запись с таким ключом уже существует`.

## Решение

- Добавлен `UniqueKeyRequestHasSubmittedKeyReq()` для определения, были ли в запросе реально переданы поля составного ключа (`t<reqId>` или `NEW_<reqId>`).
- В `_m_save` для типов без уникальности первой колонки проверка составного ключа запускается только когда в запросе есть хотя бы один реквизит ключа.
- Для типов, где первая колонка сама уникальна, проверка остается прежней.

## Как воспроизвести

1. Создать тип, у которого первая колонка не отмечена уникальной, а один или несколько реквизитов входят в составной ключ.
2. Открыть таблицу и inline-редактировать только значение первой колонки.
3. До исправления `_m_save` мог вернуть `Запись с таким ключом уже существует`, хотя ключевые поля не менялись.
4. После исправления такой first-column-only запрос не запускает composite-only duplicate check.

## Тесты

```
php experiments/test-issue-2732-inline-first-column-composite-key.php
php experiments/test-issue-2520-composite-key-without-first-column-unique.php
php experiments/test-issue-2730-unique-key-ref-comma.php
php -l index.php
php -l experiments/test-issue-2732-inline-first-column-composite-key.php
```

Скриншоты не прикладываю: исправление серверное, без визуального изменения UI.