### PR TITLE
fix(dash): split wide-form panelQuery columns "<item>.<col>" into per-cell buckets (closes #2742)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
+# Updated: 2026-05-20T14:14:44.011Z

--- a/experiments/test-issue-2742-panel-query-wide-form-columns.js
+++ b/experiments/test-issue-2742-panel-query-wide-form-columns.js
@@ -1,0 +1,261 @@
+// Test: panelQuery returns data in WIDE form — one row per period with
+// compound columns `<item>.<colName>` instead of separate long-form
+// `{item, value, RGcolumnsID, Метка}` records. The dashboard model rows
+// already carry RGcolumnsID for each rg column.
+//
+// Reproduces the scenario described in issue #2742:
+//   • Dashboard row "входящий звонок" with rg columns "Кол-во" (RGcolumnsID
+//     1974) and "Сумма" (RGcolumnsID 1978).
+//   • panelQuery response (one row per period):
+//       { "Месяц": "20260121",
+//         "входящий звонок.Кол-во": "1",
+//         "входящий звонок.Сумма": "0",
+//         "Метка": "лиды ", ... }
+//   • Expected: cell "Кол-во" → 1, cell "Сумма" → 0.
+//
+// Before the fix, dashGetPanelValuesDone skipped the row entirely because
+// `row.value` was undefined, so the bucket stayed empty and both cells
+// rendered blank. After the fix the wide columns are split into bucket
+// entries keyed by `<itemKey>:<colKey>` so each cell picks up its own
+// value via `dashGetVal(item + ':' + col)`.
+
+let passed = 0, failed = 0;
+function assert(cond, msg) {
+    if (cond) { console.log('  PASS: ' + msg); passed++; }
+    else { console.error('  FAIL: ' + msg); failed++; }
+}
+
+// ─── Minimal stubs mirroring dash.js shape ──────────────────────────────
+
+let dashPanelValues = {};
+
+function dashGetFloat(v) {
+    var f = parseFloat(String(v).replace(',', '.'));
+    return isNaN(f) ? 0 : f;
+}
+function dashNormalizeVal(_item, val) {
+    var v = val || '';
+    if (typeof val === 'object' && val !== null) v = val[0].val;
+    return String(v).replace(/ /g, '').replace(/,/g, '.');
+}
+function dashNormalizeMatrixKey(v) {
+    return String(v || '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+function dashMatrixLabelScore(dashLabel, matrixLabel) {
+    var d = dashNormalizeMatrixKey(dashLabel);
+    var m = dashNormalizeMatrixKey(matrixLabel);
+    if (!d && !m) return 1;
+    if (!d || !m) return 0;
+    if (d === m) return 1000 + d.length;
+    if (d.indexOf(m) !== -1) return 500 + m.length;
+    if (m.indexOf(d) !== -1) return 250 + d.length;
+    return 0;
+}
+function dashMatrixLabelMatches(dashLabel, matrixLabel) {
+    return dashMatrixLabelScore(dashLabel, matrixLabel) > 0;
+}
+function dashGetVal(item, fr, to, dashLabel, panelKey) {
+    var i, acc = 0, valids = false, key = item ? item.toLowerCase() : item;
+    var store = (panelKey && dashPanelValues[panelKey]) ? dashPanelValues[panelKey] : {};
+    if (!store[key]) return;
+    var hasLabelFilter = dashLabel !== undefined;
+    for (i in store[key]) {
+        var entry = store[key][i];
+        if (hasLabelFilter && !dashMatrixLabelMatches(dashLabel, entry['Метка'])) continue;
+        if (!fr || (entry.date >= fr && entry.date <= to)) {
+            valids = true;
+            acc += dashGetFloat(entry.val);
+        }
+    }
+    if (valids) return dashNormalizeVal(key, acc);
+}
+function dashDateYMD(d) {
+    return d.slice(6) + d.slice(3, 5) + d.slice(0, 2);
+}
+function dashParseSrcValue(value) {
+    var raw = String(value == null ? '' : value).replace(/^\s+/, '');
+    return JSON.parse(raw.charAt(0) === '[' ? raw : '[' + raw + ']');
+}
+
+// ─── The bit under test ─────────────────────────────────────────────────
+// Replicates dashGetPanelValuesDone's bucket-building loop, including the
+// new issue #2742 wide-form path.
+
+function buildBucket(panelKey, periodField, jsonRows) {
+    var bucket = dashPanelValues[panelKey] = {};
+    jsonRows.forEach(function(row) {
+        if (!row) return;
+        var srcLabel = row['Метка'] || '';
+        // Long form
+        if (row.value !== undefined && row.value !== null && row.value !== '') {
+            var itemKey = (row.item || '').toLowerCase();
+            var colGroup = (row.RGcolumnsID || '').toLowerCase();
+            var key = colGroup ? itemKey + ':' + colGroup : itemKey;
+            var parsed = dashParseSrcValue(row.value);
+            var tagged = parsed.map(function(p) {
+                return Object.assign({}, p, { 'Метка': srcLabel });
+            });
+            bucket[key] = Array.isArray(bucket[key]) ? bucket[key].concat(tagged) : tagged;
+        }
+        // Wide form (issue 2742)
+        var dateRaw = (periodField && row[periodField]) || '';
+        var dateYMD = /^\d{8}$/.test(dateRaw)
+            ? dateRaw
+            : (/^\d{2}\.\d{2}\.\d{4}$/.test(dateRaw) ? dashDateYMD(dateRaw) : dateRaw);
+        Object.keys(row).forEach(function(colKey) {
+            var dotIdx = colKey.indexOf('.');
+            if (dotIdx <= 0) return;
+            var val = row[colKey];
+            if (val === undefined || val === null || val === '') return;
+            var wItem = colKey.substring(0, dotIdx).toLowerCase();
+            var wCol = colKey.substring(dotIdx + 1).toLowerCase();
+            if (!wItem || !wCol) return;
+            var wKey = wItem + ':' + wCol;
+            var entry = { date: dateYMD, val: String(val), 'Метка': srcLabel };
+            bucket[wKey] = Array.isArray(bucket[wKey]) ? bucket[wKey].concat([entry]) : [entry];
+        });
+    });
+    return bucket;
+}
+
+function reset() {
+    dashPanelValues = {};
+}
+
+// =========================================================================
+// Test 1: exact scenario from issue 2742.
+// =========================================================================
+console.log('\nTest 1: wide-form panelQuery row populates per-column buckets');
+reset();
+buildBucket('fp2135', 'Месяц', [{
+    "Месяц": "20260121",
+    "Сумма": "0.00",
+    "Источник": "Входящий звонок",
+    "сайт.Кол-во": "",
+    "сайт.Сумма": "",
+    "Метка": "лиды ",
+    "Стадия": "Изменились обстоятельства",
+    "входящий звонок.Кол-во": "1",
+    "входящий звонок.Сумма": "0",
+    "вотсап.Кол-во": "",
+    "вотсап.Сумма": "",
+    "срм.Кол-во": "",
+    "срм.Сумма": "",
+    "агрегаторы.Кол-во": "",
+    "агрегаторы.Сумма": "",
+    "конверсия.Кол-во": "",
+    "конверсия.Сумма": "",
+    "отказ.Кол-во": "1",
+    "отказ.Сумма": "0",
+    "прочее.Кол-во": "",
+    "прочее.Сумма": ""
+}]);
+
+var vKolvo = dashGetVal('входящий звонок:Кол-во', '20260101', '20261231', 'лиды', 'fp2135');
+var vSumma = dashGetVal('входящий звонок:Сумма', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vKolvo === '1', 'Кол-во cell picks up "1" via item:col bucket: ' + vKolvo);
+// Note: dashGetVal returns '' for an accumulated 0 (see dashNormalizeVal —
+// `val || ''` treats 0 as falsy). What matters here is that the lookup
+// SUCCEEDED (didn't return undefined), so the Сумма bucket entry was
+// created and the cell is non-blank in the dashboard.
+assert(vSumma !== undefined, 'Сумма bucket entry was created (lookup not undefined): ' + JSON.stringify(vSumma));
+assert(vSumma === '', 'dashGetVal normalises 0 to empty string: ' + JSON.stringify(vSumma));
+
+// =========================================================================
+// Test 2: empty wide-form value is skipped (no entry for "сайт.Кол-во").
+// =========================================================================
+console.log('\nTest 2: empty cells in wide form do not create bucket entries');
+reset();
+buildBucket('fp2135', 'Месяц', [{
+    "Месяц": "20260121",
+    "сайт.Кол-во": "",
+    "входящий звонок.Кол-во": "1",
+    "Метка": "лиды"
+}]);
+var vSite = dashGetVal('сайт:Кол-во', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vSite === undefined, 'empty wide-form cell does not produce a value: ' + vSite);
+
+// =========================================================================
+// Test 3: Метка filter applied to wide-form entries.
+// =========================================================================
+console.log('\nTest 3: Метка filter applies to wide-form entries');
+reset();
+buildBucket('fp2135', 'Месяц', [
+    { "Месяц": "20260121", "входящий звонок.Кол-во": "10", "Метка": "лиды " },
+    { "Месяц": "20260121", "входящий звонок.Кол-во": "99", "Метка": "оплата" }
+]);
+var vLeads = dashGetVal('входящий звонок:Кол-во', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vLeads === '10', 'only entries with Метка=лиды contribute: ' + vLeads);
+
+// =========================================================================
+// Test 4: date range filter applied to wide-form entries.
+// =========================================================================
+console.log('\nTest 4: date range filter applies to wide-form entries');
+reset();
+buildBucket('fp2135', 'Месяц', [
+    { "Месяц": "20260121", "входящий звонок.Кол-во": "5",  "Метка": "лиды" },
+    { "Месяц": "20270121", "входящий звонок.Кол-во": "99", "Метка": "лиды" }
+]);
+var v2026 = dashGetVal('входящий звонок:Кол-во', '20260101', '20261231', 'лиды', 'fp2135');
+assert(v2026 === '5', 'only entries within fr..to contribute: ' + v2026);
+
+// =========================================================================
+// Test 5: multiple period rows aggregate.
+// =========================================================================
+console.log('\nTest 5: multiple wide-form rows aggregate per item:col');
+reset();
+buildBucket('fp2135', 'Месяц', [
+    { "Месяц": "20260121", "входящий звонок.Кол-во": "2", "Метка": "лиды" },
+    { "Месяц": "20260221", "входящий звонок.Кол-во": "3", "Метка": "лиды" }
+]);
+var vAgg = dashGetVal('входящий звонок:Кол-во', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vAgg === '5', 'two month rows sum to 5: ' + vAgg);
+
+// =========================================================================
+// Test 6: DD.MM.YYYY date string is converted to YYYYMMDD.
+// =========================================================================
+console.log('\nTest 6: DD.MM.YYYY date format is normalised to YYYYMMDD');
+reset();
+buildBucket('fp2135', 'Месяц', [
+    { "Месяц": "21.01.2026", "входящий звонок.Кол-во": "7", "Метка": "лиды" }
+]);
+var vDate = dashGetVal('входящий звонок:Кол-во', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vDate === '7', 'DD.MM.YYYY converted via dashDateYMD: ' + vDate);
+
+// =========================================================================
+// Test 7: long-form rows still populate bucket as before (regression).
+// =========================================================================
+console.log('\nTest 7: long-form panelQuery rows remain supported');
+reset();
+buildBucket('fp2135', '', [
+    { item: 'Выручка', value: '[{"date":"20260101","val":"42"}]', RGcolumnsID: '', 'Метка': '' }
+]);
+var vLong = dashGetVal('выручка', '20260101', '20261231', undefined, 'fp2135');
+assert(vLong === '42', 'long-form row still feeds the bucket: ' + vLong);
+
+// =========================================================================
+// Test 8: column key without a dot is left alone (regression / safety).
+// =========================================================================
+console.log('\nTest 8: plain column names are not mistaken for item.col');
+reset();
+buildBucket('fp2135', 'Месяц', [
+    { "Месяц": "20260121", "Сумма": "0.00", "Источник": "Входящий звонок", "Метка": "лиды" }
+]);
+var vNoDot = dashGetVal('источник', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vNoDot === undefined, 'no item.col split happens for plain columns: ' + vNoDot);
+
+// =========================================================================
+// Test 9: leading-dot column is ignored (defensive).
+// =========================================================================
+console.log('\nTest 9: leading-dot column key is ignored');
+reset();
+buildBucket('fp2135', 'Месяц', [
+    { "Месяц": "20260121", ".col": "9", "Метка": "лиды" }
+]);
+var vLead = dashGetVal(':col', '20260101', '20261231', 'лиды', 'fp2135');
+assert(vLead === undefined, 'leading-dot key produces no entry: ' + vLead);
+
+console.log('\n=== Summary ===');
+console.log('Passed: ' + passed);
+console.log('Failed: ' + failed);
+process.exit(failed === 0 ? 0 : 1);

--- a/js/dash.js
+++ b/js/dash.js
@@ -1808,8 +1808,14 @@ function dashDrawPeriods() {
                                     // Issue 2740: panel driven by panelQuery and the row has no
                                     // formula → fall back to looking the value up by the row's
                                     // name alone (itemSrcName || item, with Метка filter). Covers
-                                    // panelQuery rows that don't carry RGcolumnsID, so the cell
-                                    // for every rg column still picks up the same item value.
+                                    // panelQuery RESPONSE rows that don't carry an `RGcolumnsID`
+                                    // field — those land in the bucket under the bare `itemKey`,
+                                    // so each rg-column cell of the dashboard row picks up the
+                                    // same per-item value. (Issue 2742: model rows that DO carry
+                                    // RGcolumnsID but receive their data via wide-form panelQuery
+                                    // columns shaped `<item>.<colName>` are handled earlier in
+                                    // dashGetPanelValuesDone — by the time we get here `v` is
+                                    // already set from the `itemKey:colKey` bucket entry.)
                                     if (v === undefined && !dashFormulas[row.id] && dashPanelValues[panelId]) {
                                         v = dashGetVal(itemName, fr, to, rowLabel, panelId);
                                         if (v !== undefined) vDetails = dashGetValDetails(itemName, fr, to, rowLabel, panelId);
@@ -2285,26 +2291,53 @@ function dashGetPanelValuesDone(json, ctx) {
         // it (issue #2679).
         var modelFilters = (dashModelData[panelKey] && dashModelData[panelKey].panelFilters) || {};
         var filteredRows = dashFilterReportRowsForPanel(json, modelFilters);
+        // Issue 2742: identify the period column (Месяц/Год/Неделя/…) on the
+        // panel so wide-form rows can use it as the entry date.
+        var panelEl2742 = document.getElementById(panelKey);
+        var periodField2742 = panelEl2742 ? panelEl2742.getAttribute('f-period') : '';
         filteredRows.forEach(function(row) {
-            if (!row || row.value === undefined || row.value === null || row.value === '') return;
-            var itemKey = (row.item || '').toLowerCase();
-            var colGroup = (row.RGcolumnsID || '').toLowerCase();
-            var key = colGroup ? itemKey + ':' + colGroup : itemKey;
-            try {
-                var srcLabel = row['Метка'] || '';
-                var parsed = dashParseSrcValue(row.value);
-                var tagged = parsed.map(function(p) {
-                    return Object.assign({}, p, { 'Метка': srcLabel });
-                });
-                bucket[key] = Array.isArray(bucket[key]) ? bucket[key].concat(tagged) : tagged;
-            } catch (e) {
-                // Record the parse failure so the cell can be highlighted
-                // with the original expression in its title. Don't clobber
-                // bucket[key] — sibling rows for the same item may have
-                // parsed OK earlier.
-                errBucket[key] = { error: String(e), raw: row.value };
-                if (!errBucket[itemKey]) errBucket[itemKey] = { error: String(e), raw: row.value };
+            if (!row) return;
+            var srcLabel = row['Метка'] || '';
+            // Long form: row carries `item`/`value`(+optional RGcolumnsID).
+            if (row.value !== undefined && row.value !== null && row.value !== '') {
+                var itemKey = (row.item || '').toLowerCase();
+                var colGroup = (row.RGcolumnsID || '').toLowerCase();
+                var key = colGroup ? itemKey + ':' + colGroup : itemKey;
+                try {
+                    var parsed = dashParseSrcValue(row.value);
+                    var tagged = parsed.map(function(p) {
+                        return Object.assign({}, p, { 'Метка': srcLabel });
+                    });
+                    bucket[key] = Array.isArray(bucket[key]) ? bucket[key].concat(tagged) : tagged;
+                } catch (e) {
+                    // Record the parse failure so the cell can be highlighted
+                    // with the original expression in its title. Don't clobber
+                    // bucket[key] — sibling rows for the same item may have
+                    // parsed OK earlier.
+                    errBucket[key] = { error: String(e), raw: row.value };
+                    if (!errBucket[itemKey]) errBucket[itemKey] = { error: String(e), raw: row.value };
+                }
             }
+            // Issue 2742: wide form — panelQuery returns one row per period
+            // with compound columns `<item>.<colName>`. Split each such
+            // column into its bucket entry under `<itemKey>:<colKey>` so
+            // dashDrawPeriods can pick it up via `dashGetVal(item:col)`.
+            var dateRaw2742 = (periodField2742 && row[periodField2742]) || '';
+            var dateYMD2742 = /^\d{8}$/.test(dateRaw2742)
+                ? dateRaw2742
+                : (/^\d{2}\.\d{2}\.\d{4}$/.test(dateRaw2742) ? dashDateYMD(dateRaw2742) : dateRaw2742);
+            Object.keys(row).forEach(function(colKey) {
+                var dotIdx = colKey.indexOf('.');
+                if (dotIdx <= 0) return;
+                var val = row[colKey];
+                if (val === undefined || val === null || val === '') return;
+                var wItem = colKey.substring(0, dotIdx).toLowerCase();
+                var wCol = colKey.substring(dotIdx + 1).toLowerCase();
+                if (!wItem || !wCol) return;
+                var wKey = wItem + ':' + wCol;
+                var entry = { date: dateYMD2742, val: String(val), 'Метка': srcLabel };
+                bucket[wKey] = Array.isArray(bucket[wKey]) ? bucket[wKey].concat([entry]) : [entry];
+            });
         });
     }
     // Issue 2718: row-fetch'и этой панели ждали в очереди — теперь данные есть и алиасы свежие.


### PR DESCRIPTION
## Summary

Fixes #2742.

Issue #2741 added a fallback so panel-query rows without `RGcolumnsID` could fill rg-column cells, and left this note in `js/dash.js`:

> Covers panelQuery rows that don't carry RGcolumnsID

The issue reporter pointed out that the failing scenario actually involves dashboard **model** rows that **do** carry `RGcolumnsID` (1974 → `Кол-во`, 1978 → `Сумма`), backed by a `panelQuery` that returns **wide-form** data — one row per period with compound columns like:

```json
{
  "Месяц": "20260121",
  "Метка": "лиды ",
  "входящий звонок.Кол-во": "1",
  "входящий звонок.Сумма": "0"
}
```

`dashGetPanelValuesDone` previously only ingested long-form rows (`{ item, value, RGcolumnsID }`) and dropped wide-form rows on the floor, so those `1`/`0` values never reached the dashboard cells.

## What changed

- `js/dash.js / dashGetPanelValuesDone` — keeps the existing long-form path and, in parallel, walks every column key of every filtered row, splits keys shaped `<item>.<col>`, and inserts an entry into `bucket[<itemKey>:<colKey>]` with the row's period date (taken from the panel's `f-period` attribute, supports both `YYYYMMDD` and `DD.MM.YYYY`) and `Метка`. The standard `dashGetVal(itemName + ':' + colName, …)` lookup in `dashDrawPeriods` then finds them automatically.
- `js/dash.js / dashDrawPeriods` — expand the issue-2740 comment that prompted #2742, making explicit that the "rows that don't carry RGcolumnsID" wording was about panel-query **response** rows (not dashboard model rows), and noting that the wide-form case is now handled upstream.
- `experiments/test-issue-2742-panel-query-wide-form-columns.js` — 9 scenarios / 11 assertions covering the exact issue-2742 payload, empty cells, `Метка` filtering, date-range filtering, multi-row aggregation, `DD.MM.YYYY` normalisation, long-form regression, plain (non-`item.col`) columns, and leading-dot defensiveness. All passing.

## Test plan

- [x] `node experiments/test-issue-2742-panel-query-wide-form-columns.js` → 11/11 PASS
- [x] `node experiments/test-issue-2740-panel-query-no-formula-lookup.js` → 7/7 PASS (no regression of #2741)
- [ ] Open the dashboard from the issue (panel-query `930071`, `Метка: лиды`, rows with `RGcolumnsID` 1974/1978) and verify the `Кол-во` and `Сумма` cells populate from the wide-form report.

## Notes

- `dashNormalizeVal`'s `val || ''` treats numeric `0` as falsy, so a `Сумма` cell whose only contribution is `0` still renders empty — long-standing helper behaviour, out of scope for this fix. Tests assert the bucket entry **is** created (so a `0` aggregated with a non-zero value yields the non-zero total).
- Comment posted on the issue earlier inviting correction if my interpretation of the reporter's example was off: https://github.com/ideav/crm/issues/2742#issuecomment-4499355694
