### PR TITLE
fix(integram-table): preserve horizontal scroll across paginated re-renders (closes #2744)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
+# Updated: 2026-05-20T14:55:12.627Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
-# Updated: 2026-05-20T14:55:12.627Z

--- a/experiments/test-issue-2744-horizontal-scroll-preservation.js
+++ b/experiments/test-issue-2744-horizontal-scroll-preservation.js
@@ -1,0 +1,273 @@
+/**
+ * Test for issue #2744: after auto-scroll triggers a paginated load, the
+ * horizontal scroll position of a wide .integram-table-container must NOT
+ * snap back to 0.
+ *
+ * The synchronous scrollLeft restore was already in place from issue #2129,
+ * but three follow-up problems still allowed the table to drift back to 0:
+ *
+ *   1. The sticky scrollbar element is re-created by innerHTML on every render
+ *      and starts at scrollLeft=0. The next time it fired a scroll event it
+ *      would snap the table back to scrollLeft=0 via syncFromSticky.
+ *   2. Layout shifts that fire AFTER restoreScrollState (ResizeObserver, font/
+ *      image load, etc.) could clamp scrollLeft back to 0 if they happened
+ *      before the new <tbody> rows had been laid out.
+ *   3. loadGlobalMetadata() and loadParentInfo() both call render() asynchronously
+ *      without any scroll preservation at all.
+ *
+ * This test exercises all three paths against the real integram-table.js code.
+ */
+
+const assert = require('assert');
+const IntegramTable = require('../js/integram-table.js');
+
+function createScrollContainer(scrollTop, scrollLeft, scrollWidth = 2400, clientWidth = 800) {
+    return {
+        scrollTop,
+        scrollLeft,
+        clientHeight: 320,
+        scrollHeight: 1200,
+        scrollWidth,
+        clientWidth,
+        getBoundingClientRect: () => ({ bottom: 500 })
+    };
+}
+
+function createStickyScrollbar() {
+    return { scrollLeft: 0 };
+}
+
+function setupGlobals(stickyScrollbar) {
+    global.window = {
+        scrollY: 0,
+        scrollX: 0,
+        innerHeight: 800,
+        scrollTo: () => {
+            throw new Error('window scroll should not be used when table container exists');
+        },
+        requestAnimationFrame: (cb) => { queueMicrotask(cb); },
+        INTEGRAM_DEBUG: false
+    };
+    global.document = {
+        documentElement: { scrollHeight: 1200 },
+        querySelector: () => null,
+        getElementById: (id) => {
+            if (id === 'test-table-sticky-scrollbar') return stickyScrollbar;
+            return null;
+        }
+    };
+}
+
+function buildTable(scrollContainer) {
+    const table = Object.create(IntegramTable.prototype);
+    table._scrollContainer = scrollContainer;
+    table.container = {
+        id: 'test-table',
+        querySelector: (selector) => {
+            if (selector === '.integram-table-container') return table._scrollContainer;
+            return null;
+        }
+    };
+    return table;
+}
+
+async function testAppendPathPreservesScroll() {
+    const sticky = createStickyScrollbar();
+    setupGlobals(sticky);
+
+    const table = buildTable(createScrollContainer(420, 853));
+    table.isLoading = false;
+    table.hasMore = true;
+    table.pendingNewRow = null;
+    table.data = [[1], [2], [3]];
+    table.rawObjectData = [];
+    table.loadedRecords = 3;
+    table.totalRows = null;
+    table.options = { pageSize: 3, onDataLoad: null };
+    table.columns = [{ id: 'name' }];
+    table.columnOrder = ['name'];
+    table.visibleColumns = ['name'];
+    table.idColumns = new Set();
+    table.urlFilters = {};
+    table.groupingEnabled = false;
+    table.groupingColumns = [];
+    table.getDataSourceType = () => 'report';
+    table.loadDataFromReport = async () => ({
+        rows: [[4], [5]],
+        rawData: [],
+        columns: [{ id: 'name' }]
+    });
+    table.processColumnVisibility = () => {};
+    table.parseUrlFiltersFromParams = () => {};
+    table.checkAndLoadMore = () => {};
+
+    let renderCount = 0;
+    table.render = () => {
+        renderCount += 1;
+        // Each render creates a fresh container + sticky scrollbar with scrollLeft=0,
+        // mirroring what innerHTML replacement does in the production code.
+        table._scrollContainer = createScrollContainer(0, 0);
+        sticky.scrollLeft = 0;
+    };
+
+    await table.loadData(true);
+    // Let the rAF re-restore (queued via microtask in this test) fire.
+    await new Promise((resolve) => queueMicrotask(resolve));
+
+    assert.strictEqual(renderCount, 1, 'append load should render exactly once');
+    assert.strictEqual(table.loadedRecords, 5, 'append load should add new rows');
+    assert.strictEqual(table._scrollContainer.scrollTop, 420,
+        'vertical scroll offset should survive append render');
+    assert.strictEqual(table._scrollContainer.scrollLeft, 853,
+        'horizontal scroll offset should survive append render (issue #2744)');
+    assert.strictEqual(sticky.scrollLeft, 853,
+        'sticky scrollbar should be synced to the restored horizontal scroll');
+    console.log('ok - append render preserves horizontal scroll and syncs sticky scrollbar');
+}
+
+async function testRestoreSurvivesLateLayoutShift() {
+    const sticky = createStickyScrollbar();
+    setupGlobals(sticky);
+
+    // Pretend a late ResizeObserver fires between the synchronous restore and
+    // the rAF re-restore, resetting scrollLeft to 0.
+    let rafCallback = null;
+    global.window.requestAnimationFrame = (cb) => { rafCallback = cb; };
+
+    const table = buildTable(createScrollContainer(420, 853));
+    table.isLoading = false;
+    table.hasMore = true;
+    table.pendingNewRow = null;
+    table.data = [[1]];
+    table.rawObjectData = [];
+    table.loadedRecords = 1;
+    table.totalRows = null;
+    table.options = { pageSize: 3, onDataLoad: null };
+    table.columns = [{ id: 'name' }];
+    table.columnOrder = ['name'];
+    table.visibleColumns = ['name'];
+    table.idColumns = new Set();
+    table.urlFilters = {};
+    table.groupingEnabled = false;
+    table.groupingColumns = [];
+    table.getDataSourceType = () => 'report';
+    table.loadDataFromReport = async () => ({
+        rows: [[2]],
+        rawData: [],
+        columns: [{ id: 'name' }]
+    });
+    table.processColumnVisibility = () => {};
+    table.parseUrlFiltersFromParams = () => {};
+    table.checkAndLoadMore = () => {};
+    table.render = () => {
+        table._scrollContainer = createScrollContainer(0, 0);
+        sticky.scrollLeft = 0;
+    };
+
+    await table.loadData(true);
+
+    // Synchronous restore happened — scrollLeft should be 853.
+    assert.strictEqual(table._scrollContainer.scrollLeft, 853,
+        'synchronous restore should set scrollLeft to 853');
+
+    // Simulate a late layout shift that resets scroll position.
+    table._scrollContainer.scrollLeft = 0;
+    sticky.scrollLeft = 0;
+
+    // Fire the rAF re-restore.
+    assert.strictEqual(typeof rafCallback, 'function',
+        'append path should schedule a requestAnimationFrame re-restore');
+    rafCallback();
+
+    assert.strictEqual(table._scrollContainer.scrollLeft, 853,
+        'rAF re-restore should defeat late layout shifts (issue #2744)');
+    assert.strictEqual(sticky.scrollLeft, 853,
+        'rAF re-restore should also re-sync the sticky scrollbar');
+    console.log('ok - rAF re-restore defeats late layout shifts');
+}
+
+function testRenderPreservingScrollHelper() {
+    const sticky = createStickyScrollbar();
+    setupGlobals(sticky);
+
+    const table = buildTable(createScrollContainer(120, 600));
+
+    let rafCallback = null;
+    global.window.requestAnimationFrame = (cb) => { rafCallback = cb; };
+
+    let renderCount = 0;
+    table.render = () => {
+        renderCount += 1;
+        table._scrollContainer = createScrollContainer(0, 0);
+        sticky.scrollLeft = 0;
+    };
+
+    table.renderPreservingScroll(() => table.render());
+
+    assert.strictEqual(renderCount, 1, 'helper should invoke the render callback exactly once');
+    assert.strictEqual(table._scrollContainer.scrollLeft, 600,
+        'helper should restore horizontal scroll synchronously');
+    assert.strictEqual(table._scrollContainer.scrollTop, 120,
+        'helper should restore vertical scroll synchronously');
+    assert.strictEqual(sticky.scrollLeft, 600,
+        'helper should sync the sticky scrollbar to the restored scroll');
+
+    table._scrollContainer.scrollLeft = 0;
+    sticky.scrollLeft = 0;
+    assert.strictEqual(typeof rafCallback, 'function',
+        'helper should schedule a requestAnimationFrame re-restore');
+    rafCallback();
+    assert.strictEqual(table._scrollContainer.scrollLeft, 600,
+        'helper rAF re-restore should defeat late layout shifts');
+    console.log('ok - renderPreservingScroll helper restores horizontal scroll twice');
+}
+
+function testLoadGlobalMetadataPreservesScroll() {
+    const sticky = createStickyScrollbar();
+    setupGlobals(sticky);
+
+    let rafCalls = 0;
+    global.window.requestAnimationFrame = () => { rafCalls += 1; };
+
+    const table = buildTable(createScrollContainer(50, 410));
+    table.columns = [{ id: 'name' }];
+    table.globalMetadataPromise = null;
+    table.globalMetadata = null;
+    table.options = { apiUrl: 'http://test/report/1' };
+    table.getApiBase = () => 'http://test';
+
+    global.fetch = async () => ({
+        ok: true,
+        json: async () => ({ id: 1 })
+    });
+
+    let renderCount = 0;
+    table.render = () => {
+        renderCount += 1;
+        table._scrollContainer = createScrollContainer(0, 0);
+        sticky.scrollLeft = 0;
+    };
+
+    return table.loadGlobalMetadata().then(() => {
+        assert.strictEqual(renderCount, 1, 'metadata path should render exactly once');
+        assert.strictEqual(table._scrollContainer.scrollLeft, 410,
+            'loadGlobalMetadata render must preserve horizontal scroll (issue #2744)');
+        assert.strictEqual(sticky.scrollLeft, 410,
+            'loadGlobalMetadata must keep the sticky scrollbar in sync');
+        assert.ok(rafCalls >= 1, 'renderPreservingScroll should schedule a rAF re-restore');
+        console.log('ok - loadGlobalMetadata preserves horizontal scroll');
+    });
+}
+
+async function run() {
+    await testAppendPathPreservesScroll();
+    await testRestoreSurvivesLateLayoutShift();
+    testRenderPreservingScrollHelper();
+    await testLoadGlobalMetadataPreservesScroll();
+    console.log('all issue #2744 horizontal-scroll-preservation tests passed');
+}
+
+run().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -304,9 +304,11 @@ class IntegramTable{
                 const metadata = await response.json();
                 this.globalMetadata = metadata;
                 // Re-render if data is already loaded, so column-add-btn visibility
-                // can be recalculated based on the metadata ids
+                // can be recalculated based on the metadata ids.
+                // Preserve scroll position since this resolves asynchronously and may
+                // fire after the user has scrolled the table (issue #2744).
                 if (this.columns.length > 0) {
-                    this.render();
+                    this.renderPreservingScroll(() => this.render());
                 }
             } catch (error) {
                 console.error('Error loading global metadata:', error);
@@ -341,9 +343,10 @@ class IntegramTable{
                         up: data.up,
                         type: data.type
                     };
-                    // Re-render if data is already loaded, so the title updates
+                    // Re-render if data is already loaded, so the title updates.
+                    // Preserve scroll position since this resolves asynchronously (issue #2744).
                     if (this.columns.length > 0) {
-                        this.render();
+                        this.renderPreservingScroll(() => this.render());
                     }
                 }
             } catch (error) {
@@ -572,6 +575,12 @@ class IntegramTable{
                 const appendScrollState = append ? this.captureScrollState() : null;
                 this.render();
                 this.restoreScrollState(appendScrollState);
+                // Re-apply the scroll state after the browser has settled the new layout,
+                // so late-firing layout shifts (ResizeObserver, font/image load, sticky-
+                // scrollbar sync) can't snap the table back to scrollLeft=0 (issue #2744).
+                if (appendScrollState && typeof window.requestAnimationFrame === 'function') {
+                    window.requestAnimationFrame(() => this.restoreScrollState(appendScrollState));
+                }
             } catch (error) {
                 console.error('Error loading data:', error);
                 if (!append && this.container) {
@@ -1706,11 +1715,15 @@ class IntegramTable{
                 this.loadRefFilterOptions();
             }
 
-            // Restore focus state after re-rendering
+            // Restore focus state after re-rendering.
+            // preventScroll: true keeps the browser from auto-scrolling the filter input
+            // into view, which would otherwise reset the table's horizontal scroll
+            // position when a filter input lives outside the visible scroll viewport
+            // (issue #2744).
             if (focusState) {
                 const newInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${focusState.columnId}"]`);
                 if (newInput) {
-                    newInput.focus();
+                    newInput.focus({ preventScroll: true });
                     // Restore cursor position (only for text inputs, not date pickers)
                     if (focusState.selectionStart !== null && focusState.selectionEnd !== null &&
                         newInput.type === 'text') {
@@ -6722,6 +6735,38 @@ class IntegramTable{
 
             scrollContainer.scrollTop = scrollState.scrollTop;
             scrollContainer.scrollLeft = scrollState.scrollLeft;
+
+            // After re-render the sticky scrollbar element is a fresh node at scrollLeft=0.
+            // Without this sync it stays at 0 while the table is at scrollState.scrollLeft;
+            // any later interaction with the sticky bar would then snap the table back to 0
+            // (issue #2744).
+            if (this.container && typeof document !== 'undefined'
+                && typeof document.getElementById === 'function') {
+                const stickyScrollbar = document.getElementById(
+                    `${this.container.id}-sticky-scrollbar`
+                );
+                if (stickyScrollbar) {
+                    this.isSyncingScroll = true;
+                    stickyScrollbar.scrollLeft = scrollState.scrollLeft;
+                    this.isSyncingScroll = false;
+                }
+            }
+        }
+
+        /**
+         * Capture the current scroll state, run the supplied render callback, then restore
+         * the scroll state both synchronously and on the next animation frame. The extra
+         * rAF-deferred restoration defeats late layout shifts (ResizeObserver callbacks,
+         * focus-triggered auto-scroll, sticky-scrollbar sync) that can otherwise reset
+         * .integram-table-container.scrollLeft after the synchronous restore (issue #2744).
+         */
+        renderPreservingScroll(renderFn) {
+            const state = this.captureScrollState();
+            renderFn();
+            this.restoreScrollState(state);
+            if (state && typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(() => this.restoreScrollState(state));
+            }
         }
 
         /**

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -287,9 +287,11 @@
                 const metadata = await response.json();
                 this.globalMetadata = metadata;
                 // Re-render if data is already loaded, so column-add-btn visibility
-                // can be recalculated based on the metadata ids
+                // can be recalculated based on the metadata ids.
+                // Preserve scroll position since this resolves asynchronously and may
+                // fire after the user has scrolled the table (issue #2744).
                 if (this.columns.length > 0) {
-                    this.render();
+                    this.renderPreservingScroll(() => this.render());
                 }
             } catch (error) {
                 console.error('Error loading global metadata:', error);
@@ -324,9 +326,10 @@
                         up: data.up,
                         type: data.type
                     };
-                    // Re-render if data is already loaded, so the title updates
+                    // Re-render if data is already loaded, so the title updates.
+                    // Preserve scroll position since this resolves asynchronously (issue #2744).
                     if (this.columns.length > 0) {
-                        this.render();
+                        this.renderPreservingScroll(() => this.render());
                     }
                 }
             } catch (error) {
@@ -555,6 +558,12 @@
                 const appendScrollState = append ? this.captureScrollState() : null;
                 this.render();
                 this.restoreScrollState(appendScrollState);
+                // Re-apply the scroll state after the browser has settled the new layout,
+                // so late-firing layout shifts (ResizeObserver, font/image load, sticky-
+                // scrollbar sync) can't snap the table back to scrollLeft=0 (issue #2744).
+                if (appendScrollState && typeof window.requestAnimationFrame === 'function') {
+                    window.requestAnimationFrame(() => this.restoreScrollState(appendScrollState));
+                }
             } catch (error) {
                 console.error('Error loading data:', error);
                 if (!append && this.container) {

--- a/js/integram-table/04-render-table.js
+++ b/js/integram-table/04-render-table.js
@@ -240,11 +240,15 @@
                 this.loadRefFilterOptions();
             }
 
-            // Restore focus state after re-rendering
+            // Restore focus state after re-rendering.
+            // preventScroll: true keeps the browser from auto-scrolling the filter input
+            // into view, which would otherwise reset the table's horizontal scroll
+            // position when a filter input lives outside the visible scroll viewport
+            // (issue #2744).
             if (focusState) {
                 const newInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${focusState.columnId}"]`);
                 if (newInput) {
-                    newInput.focus();
+                    newInput.focus({ preventScroll: true });
                     // Restore cursor position (only for text inputs, not date pickers)
                     if (focusState.selectionStart !== null && focusState.selectionEnd !== null &&
                         newInput.type === 'text') {

--- a/js/integram-table/09-scroll-layout.js
+++ b/js/integram-table/09-scroll-layout.js
@@ -40,6 +40,38 @@
 
             scrollContainer.scrollTop = scrollState.scrollTop;
             scrollContainer.scrollLeft = scrollState.scrollLeft;
+
+            // After re-render the sticky scrollbar element is a fresh node at scrollLeft=0.
+            // Without this sync it stays at 0 while the table is at scrollState.scrollLeft;
+            // any later interaction with the sticky bar would then snap the table back to 0
+            // (issue #2744).
+            if (this.container && typeof document !== 'undefined'
+                && typeof document.getElementById === 'function') {
+                const stickyScrollbar = document.getElementById(
+                    `${this.container.id}-sticky-scrollbar`
+                );
+                if (stickyScrollbar) {
+                    this.isSyncingScroll = true;
+                    stickyScrollbar.scrollLeft = scrollState.scrollLeft;
+                    this.isSyncingScroll = false;
+                }
+            }
+        }
+
+        /**
+         * Capture the current scroll state, run the supplied render callback, then restore
+         * the scroll state both synchronously and on the next animation frame. The extra
+         * rAF-deferred restoration defeats late layout shifts (ResizeObserver callbacks,
+         * focus-triggered auto-scroll, sticky-scrollbar sync) that can otherwise reset
+         * .integram-table-container.scrollLeft after the synchronous restore (issue #2744).
+         */
+        renderPreservingScroll(renderFn) {
+            const state = this.captureScrollState();
+            renderFn();
+            this.restoreScrollState(state);
+            if (state && typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(() => this.restoreScrollState(state));
+            }
         }
 
         /**


### PR DESCRIPTION
## Summary

Fixes #2744 — when a wide table that does not fit on screen triggers an infinite-scroll load via vertical scrolling, the table no longer snaps back to `scrollLeft=0`. The user keeps looking at the columns they had scrolled to.

## Root cause

The synchronous `scrollLeft` restore from issue #2129 was already in place but three follow-up paths still reset horizontal scroll after each paginated load:

1. **Sticky scrollbar desync** — `.integram-table-sticky-scrollbar` is recreated by `innerHTML` on every render and starts at `scrollLeft=0`. The next time it fired a scroll event it would snap the table back to `0` via `syncFromSticky`.
2. **Late layout shifts** — `ResizeObserver` callbacks, font/image load, etc. that fired AFTER the synchronous `restoreScrollState` could clamp `scrollLeft` back to `0` before the new `<tbody>` rows were laid out.
3. **Async `render()` callsites without scroll preservation** — `loadGlobalMetadata()` and `loadParentInfo()` both `render()` asynchronously; either can resolve after the user has scrolled horizontally and reset the position.
4. **`focus()` auto-scroll** — `newInput.focus()` during filter focus restoration could auto-scroll the table to bring the filter input into view.

## Fix

- `restoreScrollState` now also syncs the sticky scrollbar to the restored `scrollLeft` so both elements stay consistent.
- `loadData` append path re-applies `restoreScrollState` on the next animation frame to defeat late layout shifts.
- New `renderPreservingScroll()` helper used by `loadGlobalMetadata` and `loadParentInfo` so their async `render()` calls also preserve scroll.
- Filter-input `focus()` now passes `preventScroll: true`.

## Test plan

- [x] `node experiments/test-issue-2744-horizontal-scroll-preservation.js` — new test covering append path, late layout shift recovery, `renderPreservingScroll` helper, and `loadGlobalMetadata`.
- [x] `node experiments/test-issue-2129-append-scroll-preservation.js` — existing scroll preservation test still passes.
- [x] Other scroll/sticky tests (`#2079`, `#2083`, `#2085`, `#1946`, `#1959`, `#2348`, `#2432`, `#2370`) all still pass.
- [x] `bash build.sh` regenerates `js/integram-table.js` cleanly.

## How to reproduce manually

1. Open any wide integram-table report (more columns than fit on screen).
2. Scroll horizontally all the way to the right.
3. Scroll vertically near the bottom so infinite-scroll pagination fires.
4. Without this fix, the table snaps back to `scrollLeft=0` on each page load. With the fix, the horizontal position is preserved.