### PR TITLE
fix(integram-table): delete referencing requisite before deleting the table (closes #2746)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
+# Updated: 2026-05-20T16:00:49.504Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
-# Updated: 2026-05-20T16:35:19.215Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
+# Updated: 2026-05-20T16:35:19.215Z

--- a/experiments/test-issue-2746-delete-table-references.js
+++ b/experiments/test-issue-2746-delete-table-references.js
@@ -1,0 +1,344 @@
+/*
+ * Test for issue #2746: js/integram-table.js
+ * "При удалении таблицы проверить, нет ли ссылки на неё, и, если есть,
+ * вначале удалить ссылку"
+ *
+ * When deleting a table whose metadata exposes a "referenced" id, the client
+ * must first delete that referenced requisite via _d_del/{referenced} and
+ * only then delete the table itself. On failure the FULL server error must
+ * be surfaced (issue text: "Не забывай вывести сообщение об ошибке целиком!").
+ *
+ * This test exercises deleteTable / deleteTableReferences / deleteReferenceRequisite
+ * from js/integram-table/11-column-settings.js against a mocked server.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+// --- Load the deleteTable* methods straight from the source module ----------
+
+const moduleSource = fs.readFileSync(
+    path.join(__dirname, '..', 'js', 'integram-table', '11-column-settings.js'),
+    'utf8'
+);
+
+function extractMethod(name) {
+    // Match either `async name(` or `name(` followed by the method body, where the
+    // method is indented 8 spaces (the class is wrapped in an IIFE with 4-space
+    // indent, plus 4 spaces for the class body).
+    const re = new RegExp(`(?:^|\\n)        (async\\s+)?${name}\\s*\\([^)]*\\)\\s*\\{`);
+    const match = moduleSource.match(re);
+    if (!match) throw new Error(`Could not find method ${name} in module source`);
+    const start = match.index + match[0].length - 1; // position of the opening {
+    let depth = 0;
+    for (let i = start; i < moduleSource.length; i++) {
+        const ch = moduleSource[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                // include the closing brace
+                return moduleSource.slice(match.index + 1, i + 1);
+            }
+        }
+    }
+    throw new Error(`Could not find matching closing brace for ${name}`);
+}
+
+const methodSources = [
+    extractMethod('deleteTable'),
+    extractMethod('deleteTableReferences'),
+    extractMethod('deleteReferenceRequisite'),
+].join('\n');
+
+// Build a small class that hosts those exact methods so we can call them with
+// `this` bound to a controllable mock. Evaluate it in the current context so
+// its objects share the same prototype chain as the assertion helpers
+// (deepStrictEqual is reference-aware).
+const Host = new Function('fetchRef', `
+    const fetch = (...args) => fetchRef(...args);
+    class Host {
+        constructor(opts) { Object.assign(this, opts); }
+        getApiBase() { return this._apiBase; }
+        getServerError(result) {
+            if (Array.isArray(result)) return (result[0] && result[0].error) || null;
+            return result && result.error ? result.error : null;
+        }
+        ${methodSources}
+    }
+    return Host;
+`)((...args) => global.fetch(...args));
+
+// --- Mock fetch helpers -----------------------------------------------------
+
+function makeFetch(routes) {
+    return async function fetch(url, init) {
+        for (const route of routes) {
+            const match = route.match(url, init);
+            if (match) {
+                route.calls.push({ url, init });
+                return route.respond(match);
+            }
+        }
+        throw new Error(`Unexpected fetch to ${url}`);
+    };
+}
+
+function jsonResponse(status, body) {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'Error',
+        async text() { return text; },
+        async json() { return JSON.parse(text); },
+    };
+}
+
+function textResponse(status, text) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: status === 200 ? 'OK' : 'Error',
+        async text() { return text; },
+        async json() { throw new Error('not json'); },
+    };
+}
+
+// --- Tests ------------------------------------------------------------------
+
+const API = 'https://example.test/db';
+
+async function testDeletesReferencedFirstThenTable() {
+    // Metadata returns referenced first, then no referenced after the
+    // requisite has been deleted (server-side state mutates between calls).
+    let metadataCalls = 0;
+    const routes = [
+        {
+            calls: [],
+            match: (url) => url === `${API}/metadata/865427` && (metadataCalls++, true),
+            respond: () => {
+                const referenced = metadataCalls === 1 ? '865428' : null;
+                return jsonResponse(200, {
+                    id: '865427', up: '0', type: '3', val: 'Стадия',
+                    unique: '0', granted: 'WRITE',
+                    referenced,
+                    export: '1', delete: '1', reqs: [],
+                });
+            },
+        },
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865428?JSON`,
+            respond: () => jsonResponse(200, { id: '865428', obj: 'requisite' }),
+        },
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865427?JSON`,
+            respond: () => jsonResponse(200, { id: '865427', obj: 'table' }),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({ _apiBase: API });
+    const result = await tbl.deleteTable('865427');
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.strictEqual(routes[1].calls.length, 1,
+        'reference requisite must be deleted exactly once');
+    assert.strictEqual(routes[2].calls.length, 1,
+        'table must be deleted exactly once');
+    // Ordering: reference deletion came before table deletion
+    // (verified via call counts above + metadata being queried first).
+    console.log('PASS deletes referenced requisite first, then the table itself');
+}
+
+async function testFailsAndShowsFullErrorWhenReferenceDeletionFails() {
+    // Mirrors the issue text: server returns a rich error message we must
+    // surface verbatim. Uses HTTP 400 with a JSON error payload.
+    const richError = 'Эта ссылка используется в <a href="/db/object/22/?F_28=865428">отчётах</a>!';
+    const routes = [
+        {
+            calls: [],
+            match: (url) => url === `${API}/metadata/865427`,
+            respond: () => jsonResponse(200, {
+                id: '865427', val: 'Стадия', referenced: '865428', reqs: [],
+            }),
+        },
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865428?JSON`,
+            respond: () => jsonResponse(400, [{ error: richError }]),
+        },
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865427?JSON`,
+            respond: () => { throw new Error('table delete must NOT be attempted'); },
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({ _apiBase: API });
+    const result = await tbl.deleteTable('865427');
+
+    assert.strictEqual(result.success, false, 'overall delete should fail');
+    assert.ok(result.error.includes(richError),
+        `error should include full server message, got: ${result.error}`);
+    assert.ok(result.error.includes('865428'),
+        'error should mention which reference id failed');
+    assert.strictEqual(routes[2].calls.length, 0,
+        'table _d_del must not be attempted when reference deletion fails');
+    console.log('PASS surfaces full server error and aborts table deletion');
+}
+
+async function testDeletesMultipleReferencesUntilNoneRemain() {
+    // Server reports references one at a time: 865428, then 865429, then none.
+    const refsRemaining = ['865428', '865429'];
+    const routes = [
+        {
+            calls: [],
+            match: (url) => url === `${API}/metadata/865427`,
+            respond: () => jsonResponse(200, {
+                id: '865427', val: 'Стадия',
+                referenced: refsRemaining[0] || null,
+                reqs: [],
+            }),
+        },
+        {
+            calls: [],
+            match: (url) => url.startsWith(`${API}/_d_del/`) && url.endsWith('?JSON'),
+            respond: ({ id }) => {
+                const idx = refsRemaining.indexOf(id);
+                if (idx !== -1) refsRemaining.splice(idx, 1);
+                return jsonResponse(200, { id });
+            },
+        },
+    ];
+    // augment match to also extract id
+    routes[1].match = (url) => {
+        const m = url.match(new RegExp(`^${API.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}/_d_del/(\\d+)\\?JSON$`));
+        return m ? { id: m[1] } : null;
+    };
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({ _apiBase: API });
+    const result = await tbl.deleteTable('865427');
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.strictEqual(routes[1].calls.length, 3,
+        'should call _d_del for 865428, 865429, and finally 865427');
+    const deletedIds = routes[1].calls.map(c => c.url.match(/_d_del\/(\d+)/)[1]);
+    assert.deepStrictEqual(deletedIds, ['865428', '865429', '865427'],
+        'references must be deleted before the table itself');
+    console.log('PASS handles multiple references and deletes them all before the table');
+}
+
+async function testSkipsReferenceCheckWhenMetadataUnavailable() {
+    // If we can't fetch metadata, fall back to a plain table delete so the
+    // user still gets the server-side error, not a silent failure.
+    const routes = [
+        {
+            calls: [],
+            match: (url) => url === `${API}/metadata/865427`,
+            respond: () => textResponse(500, 'boom'),
+        },
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865427?JSON`,
+            respond: () => jsonResponse(200, { id: '865427' }),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({ _apiBase: API });
+    const result = await tbl.deleteTable('865427');
+
+    assert.deepStrictEqual(result, { success: true });
+    assert.strictEqual(routes[1].calls.length, 1);
+    console.log('PASS falls back to direct table delete when metadata is unavailable');
+}
+
+async function testSurfacesFullTableDeleteError() {
+    // No reference; table delete itself fails — make sure the full body is
+    // surfaced (issue #2402 regression guard plus issue #2746 requirement).
+    const richError = 'Невозможно удалить таблицу: <a href="/db/object/42/?F_116=865427">используется в роли</a>';
+    const routes = [
+        {
+            calls: [],
+            match: (url) => url === `${API}/metadata/865427`,
+            respond: () => jsonResponse(200, {
+                id: '865427', val: 'Стадия', referenced: null, reqs: [],
+            }),
+        },
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865427?JSON`,
+            respond: () => jsonResponse(400, [{ error: richError }]),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({ _apiBase: API });
+    const result = await tbl.deleteTable('865427');
+
+    assert.strictEqual(result.success, false);
+    assert.ok(result.error.includes(richError),
+        `error should include full server message, got: ${result.error}`);
+    console.log('PASS surfaces full table-delete error when no reference exists');
+}
+
+async function testReproducesIssueBeforeFix() {
+    // Re-implement the pre-fix deleteTable to demonstrate the bug from #2746:
+    // when the server refuses with "referenced", the old code did not first
+    // attempt to delete the reference, so the table delete failed outright.
+    async function oldDeleteTable(tableId) {
+        const apiBase = this.getApiBase();
+        const params = new URLSearchParams();
+        const resp = await fetch(`${apiBase}/_d_del/${tableId}?JSON`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+        });
+        const responseText = await resp.text();
+        let result = null;
+        try { result = JSON.parse(responseText); } catch (_) { /* not JSON */ }
+        if (!resp.ok) {
+            const serverError = result ? this.getServerError(result) : null;
+            return { success: false, error: serverError || responseText || `HTTP ${resp.status}` };
+        }
+        if (result && result.id) return { success: true };
+        return { success: false, error: (result && this.getServerError(result)) || 'Неизвестная ошибка' };
+    }
+
+    const refError = 'Таблица "Стадия" имеет ссылку, удалите её сначала';
+    const routes = [
+        {
+            calls: [],
+            match: (url) => url === `${API}/_d_del/865427?JSON`,
+            respond: () => jsonResponse(400, [{ error: refError }]),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({ _apiBase: API });
+    const result = await oldDeleteTable.call(tbl, '865427');
+    assert.strictEqual(result.success, false);
+    assert.strictEqual(result.error, refError,
+        'pre-fix code fails because it never deletes the reference first');
+    console.log('PASS reproduces the pre-fix behaviour from issue #2746');
+}
+
+(async function run() {
+    await testReproducesIssueBeforeFix();
+    await testDeletesReferencedFirstThenTable();
+    await testFailsAndShowsFullErrorWhenReferenceDeletionFails();
+    await testDeletesMultipleReferencesUntilNoneRemain();
+    await testSkipsReferenceCheckWhenMetadataUnavailable();
+    await testSurfacesFullTableDeleteError();
+    console.log('\nAll issue #2746 tests passed.');
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -8110,11 +8110,26 @@ class IntegramTable{
         /**
          * Delete a table via API (issue #1932).
          * Uses _d_del/{tableId}?JSON. On success returns {id, obj, next_act, args, warnings}.
+         *
+         * Issue #2746: if the table is referenced by another column (metadata
+         * exposes a "referenced" id), the server refuses to delete it. Fetch
+         * fresh metadata, delete each reference first via _d_del/{referenced},
+         * then delete the table itself. Surface the full server error on
+         * failure (no truncation, no generic "HTTP 400").
+         *
          * @returns {Promise<{success: boolean, error?: string}>}
          */
         async deleteTable(tableId) {
             const apiBase = this.getApiBase();
             try {
+                // Issue #2746: remove any reference columns pointing to this table
+                // before deleting the table itself. Bypass the cache so we see
+                // the current server-side state.
+                const refResult = await this.deleteTableReferences(tableId);
+                if (!refResult.success) {
+                    return refResult;
+                }
+
                 const params = new URLSearchParams();
                 if (typeof xsrf !== 'undefined') params.append('_xsrf', xsrf);
 
@@ -8133,8 +8148,106 @@ class IntegramTable{
                     return { success: false, error: serverError || responseText || `HTTP ${resp.status}` };
                 }
                 if (result && result.id) return { success: true };
-                const err = (result && this.getServerError(result)) || 'Неизвестная ошибка';
+                // Issue #2746: surface the raw response body when the JSON shape
+                // is unexpected, so the user sees the whole server message
+                // rather than the generic "Неизвестная ошибка".
+                const err = (result && this.getServerError(result)) || responseText || 'Неизвестная ошибка';
                 return { success: false, error: err };
+            } catch (err) {
+                return { success: false, error: err.message };
+            }
+        }
+
+        /**
+         * Delete every column that references the given table (issue #2746).
+         * The server marks such tables in metadata with a "referenced" field
+         * holding the requisite id; deleting that requisite removes the link.
+         * Repeats until metadata reports no more references or the request
+         * fails. Returns the full server error on failure.
+         *
+         * @returns {Promise<{success: boolean, error?: string}>}
+         */
+        async deleteTableReferences(tableId) {
+            const apiBase = this.getApiBase();
+            const seen = new Set();
+            // Cap iterations to avoid a runaway loop if the server keeps
+            // returning the same referenced id (it would also be caught by
+            // `seen`, but the cap is a defensive backstop).
+            for (let i = 0; i < 32; i++) {
+                let metadata;
+                try {
+                    const resp = await fetch(`${apiBase}/metadata/${tableId}`);
+                    if (!resp.ok) {
+                        // Can't inspect references; let the table-delete call
+                        // surface whatever error the server returns.
+                        return { success: true };
+                    }
+                    const text = await resp.text();
+                    try { metadata = JSON.parse(text); } catch (_) { return { success: true }; }
+                } catch (_) {
+                    return { success: true };
+                }
+                if (Array.isArray(metadata)) metadata = metadata[0];
+                if (!metadata) return { success: true };
+                const referenced = metadata.referenced;
+                if (!referenced) return { success: true };
+
+                const refIds = Array.isArray(referenced) ? referenced : [referenced];
+                let removedAny = false;
+                for (const rawRefId of refIds) {
+                    const refId = String(rawRefId || '').trim();
+                    if (!refId || seen.has(refId)) continue;
+                    seen.add(refId);
+                    const delResult = await this.deleteReferenceRequisite(refId);
+                    if (!delResult.success) {
+                        return {
+                            success: false,
+                            error: `Не удалось удалить ссылку ${refId}: ${delResult.error}`,
+                        };
+                    }
+                    removedAny = true;
+                }
+                if (!removedAny) {
+                    // Nothing new to remove this iteration; either we already
+                    // processed every reference or the metadata still reports
+                    // ones we cannot resolve. Stop and let the table-delete
+                    // call surface the underlying error.
+                    return { success: true };
+                }
+            }
+            return { success: true };
+        }
+
+        /**
+         * Delete a reference requisite via _d_del/{id} (issue #2746).
+         * Returns the full server error on failure.
+         *
+         * @returns {Promise<{success: boolean, error?: string}>}
+         */
+        async deleteReferenceRequisite(refId) {
+            const apiBase = this.getApiBase();
+            try {
+                const params = new URLSearchParams();
+                if (typeof xsrf !== 'undefined') params.append('_xsrf', xsrf);
+
+                const resp = await fetch(`${apiBase}/_d_del/${refId}?JSON`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: params.toString()
+                });
+                const responseText = await resp.text();
+                let result = null;
+                try { result = JSON.parse(responseText); } catch (_) { /* not JSON */ }
+                if (!resp.ok) {
+                    const serverError = result ? this.getServerError(result) : null;
+                    return { success: false, error: serverError || responseText || `HTTP ${resp.status}` };
+                }
+                const serverError = result ? this.getServerError(result) : null;
+                if (serverError) {
+                    return { success: false, error: serverError };
+                }
+                if (result && result.id) return { success: true };
+                return { success: false, error: responseText || 'Неизвестная ошибка' };
             } catch (err) {
                 return { success: false, error: err.message };
             }

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -780,11 +780,26 @@
         /**
          * Delete a table via API (issue #1932).
          * Uses _d_del/{tableId}?JSON. On success returns {id, obj, next_act, args, warnings}.
+         *
+         * Issue #2746: if the table is referenced by another column (metadata
+         * exposes a "referenced" id), the server refuses to delete it. Fetch
+         * fresh metadata, delete each reference first via _d_del/{referenced},
+         * then delete the table itself. Surface the full server error on
+         * failure (no truncation, no generic "HTTP 400").
+         *
          * @returns {Promise<{success: boolean, error?: string}>}
          */
         async deleteTable(tableId) {
             const apiBase = this.getApiBase();
             try {
+                // Issue #2746: remove any reference columns pointing to this table
+                // before deleting the table itself. Bypass the cache so we see
+                // the current server-side state.
+                const refResult = await this.deleteTableReferences(tableId);
+                if (!refResult.success) {
+                    return refResult;
+                }
+
                 const params = new URLSearchParams();
                 if (typeof xsrf !== 'undefined') params.append('_xsrf', xsrf);
 
@@ -803,8 +818,106 @@
                     return { success: false, error: serverError || responseText || `HTTP ${resp.status}` };
                 }
                 if (result && result.id) return { success: true };
-                const err = (result && this.getServerError(result)) || 'Неизвестная ошибка';
+                // Issue #2746: surface the raw response body when the JSON shape
+                // is unexpected, so the user sees the whole server message
+                // rather than the generic "Неизвестная ошибка".
+                const err = (result && this.getServerError(result)) || responseText || 'Неизвестная ошибка';
                 return { success: false, error: err };
+            } catch (err) {
+                return { success: false, error: err.message };
+            }
+        }
+
+        /**
+         * Delete every column that references the given table (issue #2746).
+         * The server marks such tables in metadata with a "referenced" field
+         * holding the requisite id; deleting that requisite removes the link.
+         * Repeats until metadata reports no more references or the request
+         * fails. Returns the full server error on failure.
+         *
+         * @returns {Promise<{success: boolean, error?: string}>}
+         */
+        async deleteTableReferences(tableId) {
+            const apiBase = this.getApiBase();
+            const seen = new Set();
+            // Cap iterations to avoid a runaway loop if the server keeps
+            // returning the same referenced id (it would also be caught by
+            // `seen`, but the cap is a defensive backstop).
+            for (let i = 0; i < 32; i++) {
+                let metadata;
+                try {
+                    const resp = await fetch(`${apiBase}/metadata/${tableId}`);
+                    if (!resp.ok) {
+                        // Can't inspect references; let the table-delete call
+                        // surface whatever error the server returns.
+                        return { success: true };
+                    }
+                    const text = await resp.text();
+                    try { metadata = JSON.parse(text); } catch (_) { return { success: true }; }
+                } catch (_) {
+                    return { success: true };
+                }
+                if (Array.isArray(metadata)) metadata = metadata[0];
+                if (!metadata) return { success: true };
+                const referenced = metadata.referenced;
+                if (!referenced) return { success: true };
+
+                const refIds = Array.isArray(referenced) ? referenced : [referenced];
+                let removedAny = false;
+                for (const rawRefId of refIds) {
+                    const refId = String(rawRefId || '').trim();
+                    if (!refId || seen.has(refId)) continue;
+                    seen.add(refId);
+                    const delResult = await this.deleteReferenceRequisite(refId);
+                    if (!delResult.success) {
+                        return {
+                            success: false,
+                            error: `Не удалось удалить ссылку ${refId}: ${delResult.error}`,
+                        };
+                    }
+                    removedAny = true;
+                }
+                if (!removedAny) {
+                    // Nothing new to remove this iteration; either we already
+                    // processed every reference or the metadata still reports
+                    // ones we cannot resolve. Stop and let the table-delete
+                    // call surface the underlying error.
+                    return { success: true };
+                }
+            }
+            return { success: true };
+        }
+
+        /**
+         * Delete a reference requisite via _d_del/{id} (issue #2746).
+         * Returns the full server error on failure.
+         *
+         * @returns {Promise<{success: boolean, error?: string}>}
+         */
+        async deleteReferenceRequisite(refId) {
+            const apiBase = this.getApiBase();
+            try {
+                const params = new URLSearchParams();
+                if (typeof xsrf !== 'undefined') params.append('_xsrf', xsrf);
+
+                const resp = await fetch(`${apiBase}/_d_del/${refId}?JSON`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: params.toString()
+                });
+                const responseText = await resp.text();
+                let result = null;
+                try { result = JSON.parse(responseText); } catch (_) { /* not JSON */ }
+                if (!resp.ok) {
+                    const serverError = result ? this.getServerError(result) : null;
+                    return { success: false, error: serverError || responseText || `HTTP ${resp.status}` };
+                }
+                const serverError = result ? this.getServerError(result) : null;
+                if (serverError) {
+                    return { success: false, error: serverError };
+                }
+                if (result && result.id) return { success: true };
+                return { success: false, error: responseText || 'Неизвестная ошибка' };
             } catch (err) {
                 return { success: false, error: err.message };
             }


### PR DESCRIPTION
## Summary

Fixes #2746.

When deleting a table whose metadata exposes a `referenced` id (i.e. another column references this table), the server refuses to delete it until the referencing requisite is removed. The client now performs the two-step deletion automatically:

1. Fetch fresh metadata for the table.
2. If `metadata.referenced` is set, call `_d_del/{referenced}` to remove the referencing requisite.
3. Re-check metadata and repeat until no `referenced` remains (capped at 32 iterations + a `seen` set to guard against runaway loops).
4. Then call `_d_del/{tableId}` to delete the table itself.

Surfaces the **full** server error on every failure path (issue text: *"Не забывай вывести сообщение об ошибке целиком!"*). The previous `"Неизвестная ошибка"` fallback in the unexpected-JSON branch now falls back to the raw response body instead.

## Root cause

`js/integram-table/11-column-settings.js` → `deleteTable(tableId)` called `_d_del/{tableId}?JSON` directly. When the table was the target of a reference column, the server returned an error and the table was never deleted. The UI surfaced the error but offered no way to recover other than manually finding and deleting every reference.

The fix adds two helpers next to `deleteTable`:

- `deleteTableReferences(tableId)` — loops over the server-reported `referenced` ids and removes each via `_d_del/{refId}?JSON`.
- `deleteReferenceRequisite(refId)` — performs the actual `_d_del/{refId}` call and parses the response, returning the full server error string on failure.

`deleteTable` calls `deleteTableReferences` first and only proceeds to delete the table when references are cleared. If any reference deletion fails, it returns `{ success: false, error: "Не удалось удалить ссылку {refId}: {server error}" }` and the table deletion is skipped.

## How to reproduce

1. Open a table that another table references (metadata returns `"referenced": "<refId>"`).
2. Open the first column's edit modal and click "Delete".
3. Before the fix: server responds with a "referenced" error and the table is not deleted.
4. After the fix: the referencing requisite is removed automatically, then the table is deleted and the user is redirected to `/{db}/tables`.

## Test

`experiments/test-issue-2746-delete-table-references.js` covers:

- ✅ pre-fix code reproduces the bug (table delete fails outright)
- ✅ post-fix code deletes the reference, then the table
- ✅ multiple references are handled in sequence
- ✅ falls back to a direct table delete when `/metadata/{id}` is unavailable
- ✅ surfaces the **full** server error (including HTML link payloads) when reference deletion fails
- ✅ surfaces the **full** server error when the table deletion itself fails

```
$ node experiments/test-issue-2746-delete-table-references.js
PASS reproduces the pre-fix behaviour from issue #2746
PASS deletes referenced requisite first, then the table itself
PASS surfaces full server error and aborts table deletion
PASS handles multiple references and deletes them all before the table
PASS falls back to direct table delete when metadata is unavailable
PASS surfaces full table-delete error when no reference exists
```

The existing `experiments/test-issue-2402-delete-column-error.js` regression suite still passes (no behaviour change for the `deleteColumn` path).

## Files changed

- `js/integram-table/11-column-settings.js` — implementation
- `js/integram-table.js` — auto-generated bundle (rebuilt via `bash build.sh`)
- `experiments/test-issue-2746-delete-table-references.js` — new test