### PR TITLE
fix(index.php): batch INSERTs in Execute UPDATEs section (closes #2748)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
+# Updated: 2026-05-20T21:07:45.991Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
-# Updated: 2026-05-20T21:07:45.991Z

--- a/experiments/execute_updates_batching.php
+++ b/experiments/execute_updates_batching.php
@@ -1,0 +1,116 @@
+<?php
+// Standalone simulation of the Execute UPDATEs batching logic from index.php.
+// Verifies:
+//  - new records without "ID needed" are sent through Insert_batch
+//  - new records with "ID needed" trigger a batch flush then Insert (so mysqli_insert_id is correct)
+//  - UPDATE / DELETE flush any pending batch first
+//  - Calc_Order is consulted once per (up,t); subsequent rows in the batch use the cached next ord
+
+$logged = array();
+function out($s){ global $logged; $logged[] = $s; echo $s, "\n"; }
+
+// Stubs that record the SQL the real functions would issue.
+$nextId = 1000;
+function Insert($up, $ord, $t, $val, $msg){
+    global $nextId;
+    out("Insert: ($up,$ord,$t,'$val') -- $msg");
+    return $nextId++;
+}
+function Insert_batch($up, $ord, $t, $val, $msg){
+    if($up === "" && isset($GLOBALS["SQLbatch"])){
+        out("Flush: ".$GLOBALS["SQLbatch"]." -- $msg");
+        unset($GLOBALS["SQLbatch"]);
+        return;
+    }
+    $tuple = "($up,$ord,$t,'$val')";
+    if(isset($GLOBALS["SQLbatch"]))
+        $GLOBALS["SQLbatch"] .= ",$tuple";
+    else
+        $GLOBALS["SQLbatch"] = $tuple;
+    if(strlen($GLOBALS["SQLbatch"]) > 31000){
+        out("Auto-flush (length): ".$GLOBALS["SQLbatch"]." -- $msg");
+        unset($GLOBALS["SQLbatch"]);
+    }
+}
+function Exec_sql($sql, $msg){ out("SQL: $sql -- $msg"); }
+function Delete($id){ out("Delete: id=$id"); }
+function Update_Val($id, $v){ out("Update_Val: id=$id v=$v"); }
+function Calc_Order($up, $t){
+    static $seq = array();
+    // Returns the next ord for (up,t) from the simulated DB. Without batching,
+    // repeated calls inside one transaction would all see the same MAX.
+    $k = "$up:$t";
+    if(!isset($seq[$k])) $seq[$k] = 1;
+    return $seq[$k]; // intentionally not incremented — caller would have to insert to bump it
+}
+
+// --- Re-implementation of the relevant block, in isolation ---
+function exec_updates_block(array $updates){
+    unset($GLOBALS["SQLbatch"]);
+    $new_id_needed = array();
+    foreach($updates as $u){
+        if(!empty($u["needs_id"]))
+            $new_id_needed[$u["new_id_key"]] = "<placeholder>";
+    }
+
+    $ordCache = array();
+    foreach($updates as $u){
+        if(isset($u["ord"])){
+            $up = $u["up"]; $t = $u["t"]; $val = $u["val"];
+            if($u["ord"] == 0){
+                $ordKey = "$up:$t";
+                if(!isset($ordCache[$ordKey]))
+                    $ordCache[$ordKey] = Calc_Order($up, $t);
+                $ordToUse = $ordCache[$ordKey]++;
+            } else $ordToUse = $u["ord"];
+
+            if(isset($new_id_needed[$u["new_id_key"] ?? ""])){
+                if(isset($GLOBALS["SQLbatch"]))
+                    Insert_batch("", "", "", "", "Flush before INSERT with ID");
+                $new_id_needed[$u["new_id_key"]] = Insert($up, $ordToUse, $t, $val, "new rec, get ID");
+            } else
+                Insert_batch($up, $ordToUse, $t, $val, "new rec");
+        } elseif($u["op"] === "ord_update"){
+            if(isset($GLOBALS["SQLbatch"]))
+                Insert_batch("", "", "", "", "Flush before UPDATE Ord");
+            Exec_sql("UPDATE z SET ord={$u["val"]} WHERE id={$u["id"]}", "UPDATE Ord");
+        } elseif($u["op"] === "delete"){
+            if(isset($GLOBALS["SQLbatch"]))
+                Insert_batch("", "", "", "", "Flush before DELETE");
+            Delete($u["id"]);
+        } elseif($u["op"] === "val_update"){
+            if(isset($GLOBALS["SQLbatch"]))
+                Insert_batch("", "", "", "", "Flush before Update_Val");
+            Update_Val($u["id"], $u["val"]);
+        }
+    }
+    if(isset($GLOBALS["SQLbatch"]))
+        Insert_batch("", "", "", "", "Final flush Execute UPDATEs");
+}
+
+echo "=== Case 1: three batchable new records, same (up,t), ord=0 ===\n";
+exec_updates_block(array(
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"A"),
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"B"),
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"C"),
+));
+
+echo "\n=== Case 2: batchable new rec, then update, then batchable new rec ===\n";
+exec_updates_block(array(
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"A"),
+    array("op"=>"val_update", "id"=>42, "val"=>"changed"),
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"B"),
+));
+
+echo "\n=== Case 3: new rec needing ID forces flush of prior batch ===\n";
+exec_updates_block(array(
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"A"),
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"B", "needs_id"=>true, "new_id_key"=>"k1"),
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"C"),
+));
+
+echo "\n=== Case 4: delete before any batched insert (must not flush nothing) ===\n";
+exec_updates_block(array(
+    array("op"=>"delete", "id"=>100),
+    array("ord"=>0, "up"=>5, "t"=>3, "val"=>"A"),
+));

--- a/index.php
+++ b/index.php
@@ -3996,6 +3996,10 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
                     || isset($GLOBALS["STORED_REPS"][$id]["rep_params"]["EXECUTE"]))){
 		if(!isset($GLOBALS["STORED_REPS"][$id]["rep_params"]["EXECUTE"]))
 		    check();
+		# Batch INSERTs of new records similarly to import: collect into Insert_batch,
+		# flush automatically by length and before any UPDATE/DELETE/INSERT-with-ID so
+		# subsequent ops see the just-inserted rows.
+		$ordCache = array();	# Next ord per "up:t" — Calc_Order can't see unflushed batched rows
 		foreach($blocks["_update"] as $key => $value){
     	    trace(" Execute ".count($value["id"]));
 			foreach($value["id"] as $i => $n){
@@ -4011,12 +4015,23 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
 				    trace("A new record under ".$value["up"][$n]);
 					if(isset($new_id_needed[$value["up"][$n]])) # Fetch the new ID of our parent
 						$value["up"][$n] = $new_id_needed[$value["up"][$n]];
-					if(isset($new_id_needed[$key."_".$value["new_id"][$n]]))	# Save the new ID in case some Reqs need to know it
-						$new_id_needed[$key."_".$value["new_id"][$n]] = Insert($value["up"][$n]
-												, $value["ord"][$n] == 0 ? Calc_Order($value["up"][$n], $value["t"][$n]) : $value["ord"][$n]
-												, $value["t"][$n], $value["val"][$n], "INSERT new rec, get ID");
+					if($value["ord"][$n] == 0){
+						$ordKey = $value["up"][$n].":".$value["t"][$n];
+						if(!isset($ordCache[$ordKey]))
+							$ordCache[$ordKey] = Calc_Order($value["up"][$n], $value["t"][$n]);
+						$ordToUse = $ordCache[$ordKey]++;
+					}
 					else
-						Insert($value["up"][$n], $value["ord"][$n] == 0 ? Calc_Order($value["up"][$n], $value["t"][$n]) : $value["ord"][$n]
+						$ordToUse = $value["ord"][$n];
+					if(isset($new_id_needed[$key."_".$value["new_id"][$n]])){	# Save the new ID in case some Reqs need to know it
+						if(isset($GLOBALS["SQLbatch"]))	# Flush pending batch so mysqli_insert_id reflects this Insert only
+							Insert_batch("", "", "", "", "Flush before INSERT with ID");
+						$new_id_needed[$key."_".$value["new_id"][$n]] = Insert($value["up"][$n]
+												, $ordToUse
+												, $value["t"][$n], $value["val"][$n], "INSERT new rec, get ID");
+					}
+					else
+						Insert_batch($value["up"][$n], $ordToUse
 									, $value["t"][$n], $value["val"][$n], "INSERT new rec ($n)");
 				    trace("  ref ".$GLOBALS["STORED_REPS"][$id]["ref_typ"][$value["val"][$n]]);
     				if(isset($GLOBALS["STORED_REPS"][$id]["ref_typ"][$value["val"][$n]])){
@@ -4024,15 +4039,22 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
                         $blocks["_data_col"][$id][$names[$key]][$n] = $dsRefs[$value["t"][$n]];
     				}
 				}
-				elseif(substr($fields[$key],-4)===".ord")
+				elseif(substr($fields[$key],-4)===".ord"){
+					if(isset($GLOBALS["SQLbatch"]))	# Apply pending INSERTs so UPDATE sees them
+						Insert_batch("", "", "", "", "Flush before UPDATE Ord");
 					Exec_sql("UPDATE $z SET ord=".(int)$value["val"][$n]." WHERE id=$i", "UPDATE Ord");
+				}
 				elseif(isset($value["delete"][$n])){
                     $blocks["_data_col"][$id][$names[$key]][$n] = "";
+					if(isset($GLOBALS["SQLbatch"]))	# Apply pending INSERTs so DELETE sees them
+						Insert_batch("", "", "", "", "Flush before DELETE");
 					Delete($i);
 				}
 				elseif(!isset($value["val"][$n])){
 				    if(($blocks["_data_col"][$id][$names[$key]][$n] !== $dsRefs[$value["t"][$n]]) || isset($curLineOld[$key])){
                         $blocks["_data_col"][$id][$names[$key]][$n] = $dsRefs[$value["t"][$n]];
+						if(isset($GLOBALS["SQLbatch"]))	# Apply pending INSERTs so UPDATE sees them
+							Insert_batch("", "", "", "", "Flush before UPDATE Ref");
     					Exec_sql("UPDATE $z SET t=".$value["t"][$n]." WHERE id=$i", "UPDATE Ref");
 				    }
 				}
@@ -4041,12 +4063,16 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
                         $blocks["_data_col"][$id][$names[$key]][$n] = "<a target=\"$key\" href=\"/$z/edit_obj/$i\">".$value["val"][$n]."</a>";
                     else
                         $blocks["_data_col"][$id][$names[$key]][$n] = $value["val"][$n];
+					if(isset($GLOBALS["SQLbatch"]))	# Apply pending INSERTs so Update_Val sees them
+						Insert_batch("", "", "", "", "Flush before Update_Val");
                     Update_Val($i, Format_Val($GLOBALS["BT"][$GLOBALS["STORED_REPS"][$id]["base_out"][$key]], $value["val"][$n]));
 				}
 			    else
 			        trace(" value not changed: ".$dsRefs[$value["val"][$n]]);
     		}
 		}
+		if(isset($GLOBALS["SQLbatch"]))	# Apply remaining batched INSERTs
+			Insert_batch("", "", "", "", "Final flush Execute UPDATEs");
 		unset($blocks["_update"]);
 	}
 # Format the Totals values according to their type


### PR DESCRIPTION
Fixes #2748.

## Summary
The `Execute UPDATEs` section in `index.php` was issuing one `INSERT` per new record. This PR mirrors the import flow and sends those INSERTs through `Insert_batch`, which accumulates a single multi-row `INSERT … VALUES (…),(…),…` and auto-flushes when the SQL string exceeds 31000 characters — the same limit the import code uses.

## Changes
- `index.php`, `Compile_Report` / `# Execute UPDATEs` block:
  - New records whose ID is **not** needed downstream now go through `Insert_batch` instead of `Insert`.
  - New records whose ID **is** needed (tracked in `$new_id_needed`) still use `Insert`, but the pending batch is flushed first so `mysqli_insert_id` reflects only that single row.
  - `UPDATE` (ord / ref / value) and `Delete` paths now flush any pending batch before running, so they see the just-inserted rows.
  - Added an `$ordCache` keyed by `"up:t"` for the new-record path: `Calc_Order` is consulted once per `(up, t)`, then the cached next-ord is incremented per inserted row. Without this, multiple batched rows under the same parent would all receive the same `ord` because `Calc_Order` queries the DB for `MAX(ord)+1` and can't see unflushed inserts.
  - Final `Insert_batch("", …)` flush after the loop to drain any leftover batch.
- `experiments/execute_updates_batching.php`: standalone harness that stubs `Insert`, `Insert_batch`, `Exec_sql`, `Delete`, `Update_Val`, `Calc_Order` and replays the four interesting interleavings (batchable inserts only; batch + update + batch; batch + INSERT-with-ID + batch; delete before any batch) so the flush/order logic can be verified without a real DB.

## Test plan
- [x] `php -l index.php` — no syntax errors.
- [x] `php experiments/execute_updates_batching.php` produces expected output:
  - Three same-parent batchable inserts collapse into one `(5,1,3,'A'),(5,2,3,'B'),(5,3,3,'C')` flush — distinct cached `ord` values.
  - An interleaved `Update_Val` triggers a flush of the prior batch; the next insert starts a fresh batch.
  - An `Insert`-with-ID flushes the prior batch first so `mysqli_insert_id` is accurate.
  - A leading `Delete` does not produce a spurious empty flush.
- [ ] Manual smoke test in CRM: confirm the report editor still applies new rows, updates, and deletes through a confirmed `_update`.