### PR TITLE
fix(integram-table): добавить кнопку Удалить по фильтру (closes #2749)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
+# Updated: 2026-05-20T21:07:52.869Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
-# Updated: 2026-05-20T21:07:52.869Z

--- a/experiments/test-issue-2749-delete-by-filter.js
+++ b/experiments/test-issue-2749-delete-by-filter.js
@@ -1,0 +1,357 @@
+/*
+ * Test for issue #2749: js/integram-table.js
+ * "Кнопка «Удалить по фильтру»: добавить кнопку, видимую только пользователям,
+ *  у которых есть метаданное delete:"1", и реализовать удаление через отдельный
+ *  метод (не через _m_del_select)."
+ *
+ * The test exercises bulkDeleteByFilter() and fetchFilterMatchCount() from
+ * js/integram-table/23-bulk-export.js against a mocked server. It verifies:
+ *
+ *   1. fetchFilterMatchCount() hits the JSON_OBJ&_count=1 endpoint with the
+ *      current filters/parent forwarded so the user sees the correct number
+ *      of records before confirming.
+ *   2. bulkDeleteByFilter() loads ALL matching rows (regardless of the current
+ *      pagination window) and POSTs to /_m_del/{id}?JSON for each — i.e. it
+ *      no longer relies on the legacy _m_del_select form endpoint.
+ *   3. Records that the server refuses to delete surface as user-visible
+ *      errors instead of being silently swallowed.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// --- Load just the methods we need straight from the source module ----------
+
+const moduleSource = fs.readFileSync(
+    path.join(__dirname, '..', 'js', 'integram-table', '23-bulk-export.js'),
+    'utf8'
+);
+
+function extractMethod(name) {
+    const re = new RegExp(`(?:^|\\n)        (async\\s+)?${name}\\s*\\([^)]*\\)\\s*\\{`);
+    const match = moduleSource.match(re);
+    if (!match) throw new Error(`Could not find method ${name} in module source`);
+    const start = match.index + match[0].length - 1;
+    let depth = 0;
+    for (let i = start; i < moduleSource.length; i++) {
+        const ch = moduleSource[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                return moduleSource.slice(match.index + 1, i + 1);
+            }
+        }
+    }
+    throw new Error(`Could not find matching closing brace for ${name}`);
+}
+
+const methodSources = [
+    extractMethod('bulkDeleteByFilter'),
+    extractMethod('fetchFilterMatchCount'),
+].join('\n');
+
+// Build a minimal class hosting the methods, with `this` bound to a controllable
+// mock. Stubs for `loadDataFromTableForExport`, `loadData`, `applyFilter`,
+// `appendPageUrlParams`, `escapeHtml`, `sanitizeInlineMessageHtml`, and
+// `showToast` are supplied below; DOM-touching helpers are made into no-ops
+// so the test runs in pure Node without jsdom.
+const Host = new Function('fetchRef', 'documentRef', `
+    const fetch = (...args) => fetchRef(...args);
+    const document = new Proxy({}, {
+        get(_, prop) { return documentRef()[prop]; },
+    });
+    const xsrf = undefined; // typeof xsrf !== 'undefined' will be false
+    class Host {
+        constructor(opts) { Object.assign(this, opts); }
+        getApiBase() { return this._apiBase; }
+        applyFilter(params, column, filter) {
+            // Mirror the FR_/F_/TO_ convention sufficient for these tests
+            if (filter.type === '=') params.set('F_' + column.id, filter.value);
+            else if (filter.type === '^') params.set('FR_' + column.id, filter.value);
+        }
+        appendPageUrlParams() {}
+        escapeHtml(s) { return String(s); }
+        sanitizeInlineMessageHtml(s) { return String(s); }
+        showToast(msg, level) {
+            (this.toasts = this.toasts || []).push({ msg, level });
+        }
+        loadData() {
+            this.reloadCalls = (this.reloadCalls || 0) + 1;
+            return Promise.resolve();
+        }
+        loadDataFromTableForExport(offset, limit) {
+            this.loadCalls = (this.loadCalls || []);
+            this.loadCalls.push({ offset, limit });
+            return Promise.resolve({
+                columns: this.columns,
+                rows: this._rawDataResponse.map(r => r.r),
+                rawData: this._rawDataResponse,
+            });
+        }
+        ${methodSources}
+    }
+    return Host;
+`)(
+    (...args) => global.fetch(...args),
+    () => global.document
+);
+
+// Provide a default document for tests that don't need to introspect DOM writes
+function defaultDocument() {
+    return {
+        body: { insertAdjacentHTML() {} },
+        getElementById() {
+            return {
+                querySelector() { return { style: {}, textContent: '', innerHTML: '', appendChild() {} }; },
+                remove() {},
+            };
+        },
+        createElement() {
+            return { className: '', style: {}, textContent: '', addEventListener() {} };
+        },
+    };
+}
+
+// --- Mock fetch helpers -----------------------------------------------------
+
+function makeFetch(routes) {
+    return async function fetch(url, init) {
+        for (const route of routes) {
+            const match = route.match(url, init);
+            if (match) {
+                route.calls.push({ url, init, match });
+                return route.respond(match);
+            }
+        }
+        throw new Error(`Unexpected fetch to ${url}`);
+    };
+}
+
+function jsonResponse(status, body) {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        async text() { return text; },
+        async json() { return JSON.parse(text); },
+    };
+}
+
+// --- Tests ------------------------------------------------------------------
+
+const API = 'https://example.test/db';
+
+async function testFetchFilterMatchCount() {
+    // The button must show how many records currently match the filter
+    // BEFORE asking for confirmation. The new fetchFilterMatchCount() must
+    // hit /object/{id}/?JSON_OBJ&_count=1 with current filters forwarded.
+    global.document = defaultDocument();
+    const routes = [
+        {
+            calls: [],
+            match: (url) => {
+                const m = url.match(/^https:\/\/example\.test\/db\/object\/3596\/\?JSON_OBJ&(.+)$/);
+                return m ? { qs: new URLSearchParams(m[1]) } : null;
+            },
+            respond: () => jsonResponse(200, { count: 7 }),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: { '3597': { type: '=', value: 'foo' } },
+        options: { parentId: '999' },
+    });
+
+    const count = await tbl.fetchFilterMatchCount();
+    assert.strictEqual(count, 7, 'returned count must match server response');
+    assert.strictEqual(routes[0].calls.length, 1);
+
+    const qs = routes[0].calls[0].match.qs;
+    assert.strictEqual(qs.get('_count'), '1', '_count=1 must be set');
+    assert.strictEqual(qs.get('F_3597'), 'foo', 'current filter must be forwarded');
+    assert.strictEqual(qs.get('F_U'), '999', 'parentId must be forwarded as F_U');
+    console.log('PASS fetchFilterMatchCount forwards filters and parent to the _count endpoint');
+}
+
+async function testBulkDeleteByFilterCallsPerRecordEndpoint() {
+    // After confirming, the new method must fetch ALL matching records via
+    // the existing JSON_OBJ export path (loadDataFromTableForExport) and then
+    // POST /_m_del/{id}?JSON for each one — NOT POST {tableId}/_m_del_select.
+    global.document = defaultDocument();
+    const deleteCalls = [];
+    const routes = [
+        {
+            calls: [],
+            match: (url, init) => {
+                const m = url.match(/^https:\/\/example\.test\/db\/_m_del\/(\d+)\?JSON$/);
+                if (m && init && init.method === 'POST') {
+                    return { id: m[1] };
+                }
+                return null;
+            },
+            respond: ({ id }) => {
+                deleteCalls.push(id);
+                return jsonResponse(200, { id, deleted: true });
+            },
+        },
+        {
+            calls: [],
+            match: (url) => url.includes('/_m_del_select'),
+            respond: () => { throw new Error('legacy _m_del_select must NOT be used'); },
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: {},
+        options: { tableTypeId: '3596' },
+        rawObjectData: [],
+        selectedRows: new Set(),
+        data: [],
+        loadedRecords: 0,
+        hasMore: true,
+        totalRows: null,
+        _rawDataResponse: [
+            { i: 101, u: 1, o: 0, r: ['Alpha'] },
+            { i: 102, u: 1, o: 1, r: ['Beta'] },
+            { i: 103, u: 1, o: 2, r: ['Gamma'] },
+        ],
+    });
+
+    await tbl.bulkDeleteByFilter();
+
+    assert.strictEqual(routes[0].calls.length, 3, 'must POST _m_del once per matching record');
+    assert.deepStrictEqual(deleteCalls.sort(), ['101', '102', '103'],
+        'every matching record id must be deleted');
+    assert.strictEqual(routes[1].calls.length, 0,
+        'legacy _m_del_select endpoint must not be touched');
+    assert.strictEqual(tbl.reloadCalls, 1, 'table must reload after deletion');
+    console.log('PASS bulkDeleteByFilter posts _m_del/{id} for every match and reloads');
+}
+
+async function testBulkDeleteByFilterShowsServerErrors() {
+    // If the server refuses individual records (e.g. reference checks), the
+    // failing IDs must be captured as errors rather than silently dropped.
+    const routes = [
+        {
+            calls: [],
+            match: (url) => {
+                const m = url.match(/^https:\/\/example\.test\/db\/_m_del\/(\d+)\?JSON$/);
+                return m ? { id: m[1] } : null;
+            },
+            respond: ({ id }) => {
+                if (id === '102') {
+                    return jsonResponse(400, [{ error: 'Запись используется как ссылка' }]);
+                }
+                return jsonResponse(200, { id, deleted: true });
+            },
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    // Stub document so we can capture the rendered error HTML
+    const capturedErrors = [];
+    global.document = {
+        body: { insertAdjacentHTML() {} },
+        getElementById() {
+            return {
+                querySelector(sel) {
+                    if (sel === '.bulk-delete-errors') {
+                        return {
+                            style: {},
+                            set innerHTML(v) { capturedErrors.push(v); },
+                            get innerHTML() { return capturedErrors[capturedErrors.length - 1] || ''; },
+                            appendChild() {},
+                        };
+                    }
+                    return {
+                        style: {},
+                        textContent: '',
+                        innerHTML: '',
+                        appendChild() {},
+                    };
+                },
+                remove() {},
+            };
+        },
+        createElement() { return { className: '', style: {}, textContent: '', addEventListener() {} }; },
+    };
+
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: {},
+        options: {},
+        rawObjectData: [],
+        selectedRows: new Set(),
+        data: [],
+        loadedRecords: 0,
+        hasMore: true,
+        totalRows: null,
+        _rawDataResponse: [
+            { i: 101, u: 1, o: 0, r: ['Alpha'] },
+            { i: 102, u: 1, o: 1, r: ['Beta'] },
+            { i: 103, u: 1, o: 2, r: ['Gamma'] },
+        ],
+    });
+
+    await tbl.bulkDeleteByFilter();
+
+    const allErrorHtml = capturedErrors.join('\n');
+    assert.ok(/102/.test(allErrorHtml), 'error report must include failing record id 102');
+    assert.ok(/Запись используется как ссылка/.test(allErrorHtml),
+        'error report must include the server-side error message');
+    console.log('PASS bulkDeleteByFilter surfaces per-record server errors');
+}
+
+async function testReproducesLegacyBehaviourBeforeFix() {
+    // Before the fix, deletion-by-filter was a server-side form POST to
+    // {tableId}/_m_del_select that submitted the page. Re-implement it
+    // locally so we can document the issue and contrast with the new flow.
+    async function legacyDeleteByFilter(tableId, filterParams) {
+        const params = new URLSearchParams(filterParams);
+        params.set('_m_del_select', '1');
+        const resp = await fetch(`${API}/${tableId}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+        });
+        return { ok: resp.ok };
+    }
+
+    let legacyCalled = false;
+    global.fetch = async (url, init) => {
+        if (url === `${API}/3596`
+            && init && init.body && init.body.includes('_m_del_select=1')) {
+            legacyCalled = true;
+            return jsonResponse(200, { ok: true });
+        }
+        throw new Error(`unexpected ${url}`);
+    };
+
+    await legacyDeleteByFilter('3596', { F_3597: 'foo' });
+    assert.strictEqual(legacyCalled, true,
+        'the legacy flow that this PR replaces relied on _m_del_select');
+    console.log('PASS reproduces the pre-fix _m_del_select flow that this issue replaces');
+}
+
+(async function run() {
+    await testReproducesLegacyBehaviourBeforeFix();
+    await testFetchFilterMatchCount();
+    await testBulkDeleteByFilterCallsPerRecordEndpoint();
+    await testBulkDeleteByFilterShowsServerErrors();
+    console.log('\nAll issue #2749 tests passed.');
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -56,6 +56,7 @@ class IntegramTable{
             this.filtersEnabled = false;
             this.objectTableId = null;  // Table ID when data is in object/JSON_OBJ format (for _count=1 queries)
             this.tableGranted = null;  // 'WRITE' = full access, other value = read-only (issue #1508)
+            this.tableDeletable = false;  // True when metadata has delete="1" (issue #2749)
             this.rawObjectData = [];  // Raw data array with {i, u, o, r} for object format (preserves record IDs)
             this.styleColumns = {};  // Map of column IDs to their style column values
             this.idColumns = new Set();  // Set of hidden ID column IDs
@@ -221,6 +222,15 @@ class IntegramTable{
          */
         isStructureWritable() {
             return window.grants && window.grants['1'] === 'WRITE';
+        }
+
+        /**
+         * Check whether the table allows bulk delete-by-filter (issue #2749).
+         * Mirrors the visibility rule of the legacy "Delete by filter" button
+         * from templates/object.html: only shown when metadata.delete === "1".
+         */
+        isTableDeletable() {
+            return this.tableDeletable === true;
         }
 
         /**
@@ -853,6 +863,9 @@ class IntegramTable{
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
 
+                // Store bulk-delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
+
                 // Convert metadata to columns format
                 const columns = [];
 
@@ -942,6 +955,7 @@ class IntegramTable{
                 }
                 this.tableExportAllowed = refreshedMetadata.export === '1' || refreshedMetadata.export === 1;
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
 
                 const refreshedColumns = [];
                 const mainColGranted = this.isTableWritable() ? 1 : 0;
@@ -1041,6 +1055,9 @@ class IntegramTable{
 
             // Store table-level granted value for access control (issue #1508)
             this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
+
+            // Store bulk-delete-by-filter flag from metadata (issue #2749)
+            this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
 
             // Convert metadata to columns format
             const columns = [];
@@ -1152,6 +1169,7 @@ class IntegramTable{
                     });
                 }
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
             }
 
             // Transform object format data to row format
@@ -1253,6 +1271,9 @@ class IntegramTable{
 
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
+
+                // Store bulk-delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
 
                 // Convert metadata to columns format
                 const columns = [];
@@ -1552,6 +1573,12 @@ class IntegramTable{
                             <button class="btn btn-sm btn-danger integram-bulk-delete-btn" id="${ instanceName }-bulk-delete-btn" onclick="window.${ instanceName }.showBulkDeleteConfirm(event)">
                                 Удалить (${ this.selectedRows.size })
                             </button>
+                            ` : '' }
+                            ${ this.isTableDeletable() && this.isTableWritable() ? `
+                            <div class="integram-table-settings integram-table-settings-filter-delete" onclick="window.${ instanceName }.showFilterDeleteConfirm(event)" title="Удалить записи, удовлетворяющие заданному фильтру">
+                                <i class="pi pi-trash"></i>
+                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">удалить по фильтру</span>' : '' }
+                            </div>
                             ` : '' }
                             <div class="integram-table-settings" onclick="window.${ instanceName }.copyConfigUrl()" title="Скопировать ссылку с текущими фильтрами и группами">
                                 <i class="pi pi-copy"></i>
@@ -17328,6 +17355,296 @@ class IntegramTable{
             }
 
             // Clear selection and reload data
+            this.selectedRows.clear();
+            this.data = [];
+            this.rawObjectData = [];
+            this.loadedRecords = 0;
+            this.hasMore = true;
+            this.totalRows = null;
+            await this.loadData(false);
+        }
+
+        /**
+         * Show "delete by filter" confirmation popup (issue #2749).
+         * Mirrors the visibility/UX of the legacy templates/object.html flow:
+         * the button is gated by metadata.delete === "1" (see isTableDeletable),
+         * and the confirmation shows how many records match the current filter
+         * before any deletion is performed.
+         *
+         * @param {Event} event - Click event from the trigger button.
+         */
+        async showFilterDeleteConfirm(event) {
+            if (event) {
+                event.stopPropagation();
+            }
+
+            const btn = event && event.target
+                ? event.target.closest('.integram-table-settings-filter-delete')
+                : null;
+            if (!btn) return;
+
+            // Toggle behaviour: clicking the button again hides any existing popup.
+            const existing = this.container.querySelector('.filter-delete-confirm');
+            if (existing) {
+                existing.remove();
+                return;
+            }
+
+            // Show a "loading" popup while we count matching records.
+            const loadingHtml = `
+                <div class="filter-delete-confirm" style="display:inline-block; margin-left:8px;">
+                    <span>Подсчёт записей…</span>
+                </div>
+            `;
+            btn.insertAdjacentHTML('afterend', loadingHtml);
+            const loadingPopup = this.container.querySelector('.filter-delete-confirm');
+
+            let count;
+            try {
+                count = await this.fetchFilterMatchCount();
+            } catch (err) {
+                console.error('count-by-filter failed:', err);
+                loadingPopup.innerHTML = `<span style="color:#b00;">Ошибка подсчёта: ${ this.escapeHtml(err.message || String(err)) }</span>`;
+                setTimeout(() => loadingPopup.remove(), 4000);
+                return;
+            }
+
+            if (!Number.isFinite(count) || count <= 0) {
+                loadingPopup.innerHTML = '<span>Нет записей, удовлетворяющих фильтру</span>';
+                setTimeout(() => loadingPopup.remove(), 3000);
+                return;
+            }
+
+            loadingPopup.innerHTML = `
+                <span>Удалить ${ count } записей, удовлетворяющих фильтру?</span>
+                <button class="btn btn-sm btn-danger filter-delete-confirm-btn">Да, удалить</button>
+                <button class="btn btn-sm btn-outline-secondary filter-delete-cancel-btn">Отменить</button>
+            `;
+
+            loadingPopup.querySelector('.filter-delete-confirm-btn').addEventListener('click', () => {
+                loadingPopup.remove();
+                this.bulkDeleteByFilter();
+            });
+            loadingPopup.querySelector('.filter-delete-cancel-btn').addEventListener('click', () => {
+                loadingPopup.remove();
+            });
+        }
+
+        /**
+         * Count records matching the current filter (issue #2749).
+         * Reuses the existing _count=1 endpoint by reading from fetchTotalCount's
+         * data source, but isolated so we can await a fresh count even when
+         * this.totalRows is already cached.
+         *
+         * @returns {Promise<number>} number of records matching current filters
+         */
+        async fetchFilterMatchCount() {
+            if (!this.objectTableId) {
+                throw new Error('Доступно только для табличных источников');
+            }
+            const apiBase = this.getApiBase();
+            const params = new URLSearchParams({ _count: '1' });
+
+            const filters = this.filters || {};
+            Object.keys(filters).forEach(colId => {
+                const filter = filters[colId];
+                if (filter.value || filter.type === '%' || filter.type === '!%') {
+                    const column = this.columns.find(c => c.id === colId);
+                    if (column) {
+                        this.applyFilter(params, column, filter);
+                    }
+                }
+            });
+
+            if (this.options.parentId) {
+                params.set('F_U', this.options.parentId);
+            }
+
+            this.appendPageUrlParams(params);
+
+            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
+            const response = await fetch(url);
+            const result = await response.json();
+            return parseInt(result.count, 10);
+        }
+
+        /**
+         * Delete all records matching the current filter (issue #2749).
+         *
+         * Replaces the legacy POST {table_id}/_m_del_select flow (templates/object.html):
+         * instead of a single server-side request gated by an opaque form, this
+         * method fetches the current filter's matching record IDs from the
+         * JSON_OBJ endpoint and then calls the per-record _m_del/{id} endpoint
+         * for each one in parallel. The per-record endpoint is the same one
+         * used by row-level delete and by bulkDelete(), so server-side access
+         * checks and reference-integrity rules are honoured identically.
+         */
+        async bulkDeleteByFilter() {
+            if (!this.objectTableId) {
+                this.showToast('Удаление по фильтру доступно только для табличных источников', 'error');
+                return;
+            }
+
+            // Fetch all matching records (IDs + first-column value for error reports).
+            // We reuse loadDataFromTableForExport which honours the current filter,
+            // sorting, F_U parent, and page-URL params; rawData carries item.i (ID).
+            let records = [];
+            try {
+                const savedTableTypeId = this.options.tableTypeId;
+                if (!this.options.tableTypeId && this.objectTableId) {
+                    this.options.tableTypeId = this.objectTableId;
+                }
+                const json = await this.loadDataFromTableForExport(0, 1000000);
+                this.options.tableTypeId = savedTableTypeId;
+
+                const rawData = (json && json.rawData) || [];
+                records = rawData
+                    .filter(item => item && item.i)
+                    .map(item => ({
+                        id: item.i,
+                        value: (item.r && item.r[0]) || ''
+                    }));
+            } catch (err) {
+                console.error('filter-delete load failed:', err);
+                this.showToast(`Ошибка загрузки записей: ${ err.message }`, 'error');
+                return;
+            }
+
+            if (records.length === 0) {
+                this.showToast('Нет записей, удовлетворяющих фильтру', 'error');
+                return;
+            }
+
+            const apiBase = this.getApiBase();
+            const total = records.length;
+            let completed = 0;
+            const errors = [];
+            const warnings = [];
+
+            // Progress modal (same layout/IDs as bulkDelete so existing CSS applies).
+            const progressId = `filter-delete-progress-${ Date.now() }`;
+            const progressHtml = `
+                <div class="integram-modal-overlay" id="${ progressId }">
+                    <div class="integram-modal" style="max-width: 500px;">
+                        <div class="integram-modal-header">
+                            <h3>Удаление записей по фильтру</h3>
+                        </div>
+                        <div class="integram-modal-body">
+                            <div class="bulk-delete-progress-bar-container">
+                                <div class="bulk-delete-progress-bar" style="width: 0%"></div>
+                            </div>
+                            <div class="bulk-delete-progress-text">Удалено: 0 / ${ total }</div>
+                            <div class="bulk-delete-errors" style="display: none;"></div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            document.body.insertAdjacentHTML('beforeend', progressHtml);
+
+            const progressOverlay = document.getElementById(progressId);
+            const progressBar = progressOverlay.querySelector('.bulk-delete-progress-bar');
+            const progressText = progressOverlay.querySelector('.bulk-delete-progress-text');
+            const errorsDiv = progressOverlay.querySelector('.bulk-delete-errors');
+
+            const updateProgress = () => {
+                const pct = Math.round((completed / total) * 100);
+                progressBar.style.width = `${ pct }%`;
+                progressText.textContent = `Удалено: ${ completed } / ${ total }`;
+            };
+
+            const deletePromises = records.map(async (record) => {
+                try {
+                    const params = new URLSearchParams();
+                    if (typeof xsrf !== 'undefined') {
+                        params.append('_xsrf', xsrf);
+                    }
+
+                    const response = await fetch(`${ apiBase }/_m_del/${ record.id }?JSON`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: params.toString()
+                    });
+
+                    const text = await response.text();
+                    let result;
+                    try {
+                        result = JSON.parse(text);
+                    } catch (parseErr) {
+                        warnings.push(`#${ record.id } : ${ record.value } : ${ text }`);
+                    }
+
+                    if (result) {
+                        let serverError = null;
+                        if (Array.isArray(result)) {
+                            serverError = (result[0] && result[0].error) || null;
+                        } else {
+                            serverError = result.error || null;
+                        }
+                        if (serverError) {
+                            errors.push(`#${ record.id } : ${ record.value } : ${ serverError }`);
+                        }
+                    }
+                } catch (err) {
+                    errors.push(`#${ record.id } : ${ record.value } : ${ err.message }`);
+                } finally {
+                    completed++;
+                    updateProgress();
+                }
+            });
+
+            await Promise.all(deletePromises);
+
+            if (errors.length > 0 || warnings.length > 0) {
+                errorsDiv.style.display = 'block';
+                let html = '';
+
+                if (errors.length > 0) {
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
+                        <strong>Ошибки (блокирующие):</strong><br>
+                        ${ errors.map(e => {
+                            const parts = e.split(' : ');
+                            if (parts.length >= 3) {
+                                const recordId = this.escapeHtml(parts[0]);
+                                const recordValue = this.escapeHtml(parts[1]);
+                                const errorMsg = parts.slice(2).join(' : ');
+                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
+                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
+                            }
+                            return this.escapeHtml(e);
+                        }).join('<br>') }
+                    </div>`;
+                }
+
+                if (warnings.length > 0) {
+                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Предупреждения:</strong><br>
+                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
+                    </div>`;
+                }
+
+                errorsDiv.innerHTML = html;
+            }
+
+            if (errors.length > 0) {
+                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
+            } else {
+                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            }
+
+            if (errors.length === 0 && warnings.length === 0) {
+                setTimeout(() => {
+                    progressOverlay.remove();
+                }, 1500);
+            } else {
+                const closeBtn = document.createElement('button');
+                closeBtn.className = 'btn btn-sm btn-primary';
+                closeBtn.style.marginTop = '10px';
+                closeBtn.textContent = 'Закрыть';
+                closeBtn.addEventListener('click', () => progressOverlay.remove());
+                progressOverlay.querySelector('.integram-modal-body').appendChild(closeBtn);
+            }
+
+            // Reload table data after delete finishes (mirrors bulkDelete()).
             this.selectedRows.clear();
             this.data = [];
             this.rawObjectData = [];

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -39,6 +39,7 @@
             this.filtersEnabled = false;
             this.objectTableId = null;  // Table ID when data is in object/JSON_OBJ format (for _count=1 queries)
             this.tableGranted = null;  // 'WRITE' = full access, other value = read-only (issue #1508)
+            this.tableDeletable = false;  // True when metadata has delete="1" (issue #2749)
             this.rawObjectData = [];  // Raw data array with {i, u, o, r} for object format (preserves record IDs)
             this.styleColumns = {};  // Map of column IDs to their style column values
             this.idColumns = new Set();  // Set of hidden ID column IDs
@@ -204,6 +205,15 @@
          */
         isStructureWritable() {
             return window.grants && window.grants['1'] === 'WRITE';
+        }
+
+        /**
+         * Check whether the table allows bulk delete-by-filter (issue #2749).
+         * Mirrors the visibility rule of the legacy "Delete by filter" button
+         * from templates/object.html: only shown when metadata.delete === "1".
+         */
+        isTableDeletable() {
+            return this.tableDeletable === true;
         }
 
         /**
@@ -836,6 +846,9 @@
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
 
+                // Store bulk-delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
+
                 // Convert metadata to columns format
                 const columns = [];
 
@@ -925,6 +938,7 @@
                 }
                 this.tableExportAllowed = refreshedMetadata.export === '1' || refreshedMetadata.export === 1;
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
 
                 const refreshedColumns = [];
                 const mainColGranted = this.isTableWritable() ? 1 : 0;

--- a/js/integram-table/02-format-helpers.js
+++ b/js/integram-table/02-format-helpers.js
@@ -56,6 +56,9 @@
             // Store table-level granted value for access control (issue #1508)
             this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
 
+            // Store bulk-delete-by-filter flag from metadata (issue #2749)
+            this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
+
             // Convert metadata to columns format
             const columns = [];
 
@@ -166,6 +169,7 @@
                     });
                 }
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
             }
 
             // Transform object format data to row format
@@ -267,6 +271,9 @@
 
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
+
+                // Store bulk-delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
 
                 // Convert metadata to columns format
                 const columns = [];

--- a/js/integram-table/04-render-table.js
+++ b/js/integram-table/04-render-table.js
@@ -78,6 +78,12 @@
                                 Удалить (${ this.selectedRows.size })
                             </button>
                             ` : '' }
+                            ${ this.isTableDeletable() && this.isTableWritable() ? `
+                            <div class="integram-table-settings integram-table-settings-filter-delete" onclick="window.${ instanceName }.showFilterDeleteConfirm(event)" title="Удалить записи, удовлетворяющие заданному фильтру">
+                                <i class="pi pi-trash"></i>
+                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">удалить по фильтру</span>' : '' }
+                            </div>
+                            ` : '' }
                             <div class="integram-table-settings" onclick="window.${ instanceName }.copyConfigUrl()" title="Скопировать ссылку с текущими фильтрами и группами">
                                 <i class="pi pi-copy"></i>
                                 ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">ссылка</span>' : '' }

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -227,6 +227,296 @@
         }
 
         /**
+         * Show "delete by filter" confirmation popup (issue #2749).
+         * Mirrors the visibility/UX of the legacy templates/object.html flow:
+         * the button is gated by metadata.delete === "1" (see isTableDeletable),
+         * and the confirmation shows how many records match the current filter
+         * before any deletion is performed.
+         *
+         * @param {Event} event - Click event from the trigger button.
+         */
+        async showFilterDeleteConfirm(event) {
+            if (event) {
+                event.stopPropagation();
+            }
+
+            const btn = event && event.target
+                ? event.target.closest('.integram-table-settings-filter-delete')
+                : null;
+            if (!btn) return;
+
+            // Toggle behaviour: clicking the button again hides any existing popup.
+            const existing = this.container.querySelector('.filter-delete-confirm');
+            if (existing) {
+                existing.remove();
+                return;
+            }
+
+            // Show a "loading" popup while we count matching records.
+            const loadingHtml = `
+                <div class="filter-delete-confirm" style="display:inline-block; margin-left:8px;">
+                    <span>Подсчёт записей…</span>
+                </div>
+            `;
+            btn.insertAdjacentHTML('afterend', loadingHtml);
+            const loadingPopup = this.container.querySelector('.filter-delete-confirm');
+
+            let count;
+            try {
+                count = await this.fetchFilterMatchCount();
+            } catch (err) {
+                console.error('count-by-filter failed:', err);
+                loadingPopup.innerHTML = `<span style="color:#b00;">Ошибка подсчёта: ${ this.escapeHtml(err.message || String(err)) }</span>`;
+                setTimeout(() => loadingPopup.remove(), 4000);
+                return;
+            }
+
+            if (!Number.isFinite(count) || count <= 0) {
+                loadingPopup.innerHTML = '<span>Нет записей, удовлетворяющих фильтру</span>';
+                setTimeout(() => loadingPopup.remove(), 3000);
+                return;
+            }
+
+            loadingPopup.innerHTML = `
+                <span>Удалить ${ count } записей, удовлетворяющих фильтру?</span>
+                <button class="btn btn-sm btn-danger filter-delete-confirm-btn">Да, удалить</button>
+                <button class="btn btn-sm btn-outline-secondary filter-delete-cancel-btn">Отменить</button>
+            `;
+
+            loadingPopup.querySelector('.filter-delete-confirm-btn').addEventListener('click', () => {
+                loadingPopup.remove();
+                this.bulkDeleteByFilter();
+            });
+            loadingPopup.querySelector('.filter-delete-cancel-btn').addEventListener('click', () => {
+                loadingPopup.remove();
+            });
+        }
+
+        /**
+         * Count records matching the current filter (issue #2749).
+         * Reuses the existing _count=1 endpoint by reading from fetchTotalCount's
+         * data source, but isolated so we can await a fresh count even when
+         * this.totalRows is already cached.
+         *
+         * @returns {Promise<number>} number of records matching current filters
+         */
+        async fetchFilterMatchCount() {
+            if (!this.objectTableId) {
+                throw new Error('Доступно только для табличных источников');
+            }
+            const apiBase = this.getApiBase();
+            const params = new URLSearchParams({ _count: '1' });
+
+            const filters = this.filters || {};
+            Object.keys(filters).forEach(colId => {
+                const filter = filters[colId];
+                if (filter.value || filter.type === '%' || filter.type === '!%') {
+                    const column = this.columns.find(c => c.id === colId);
+                    if (column) {
+                        this.applyFilter(params, column, filter);
+                    }
+                }
+            });
+
+            if (this.options.parentId) {
+                params.set('F_U', this.options.parentId);
+            }
+
+            this.appendPageUrlParams(params);
+
+            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
+            const response = await fetch(url);
+            const result = await response.json();
+            return parseInt(result.count, 10);
+        }
+
+        /**
+         * Delete all records matching the current filter (issue #2749).
+         *
+         * Replaces the legacy POST {table_id}/_m_del_select flow (templates/object.html):
+         * instead of a single server-side request gated by an opaque form, this
+         * method fetches the current filter's matching record IDs from the
+         * JSON_OBJ endpoint and then calls the per-record _m_del/{id} endpoint
+         * for each one in parallel. The per-record endpoint is the same one
+         * used by row-level delete and by bulkDelete(), so server-side access
+         * checks and reference-integrity rules are honoured identically.
+         */
+        async bulkDeleteByFilter() {
+            if (!this.objectTableId) {
+                this.showToast('Удаление по фильтру доступно только для табличных источников', 'error');
+                return;
+            }
+
+            // Fetch all matching records (IDs + first-column value for error reports).
+            // We reuse loadDataFromTableForExport which honours the current filter,
+            // sorting, F_U parent, and page-URL params; rawData carries item.i (ID).
+            let records = [];
+            try {
+                const savedTableTypeId = this.options.tableTypeId;
+                if (!this.options.tableTypeId && this.objectTableId) {
+                    this.options.tableTypeId = this.objectTableId;
+                }
+                const json = await this.loadDataFromTableForExport(0, 1000000);
+                this.options.tableTypeId = savedTableTypeId;
+
+                const rawData = (json && json.rawData) || [];
+                records = rawData
+                    .filter(item => item && item.i)
+                    .map(item => ({
+                        id: item.i,
+                        value: (item.r && item.r[0]) || ''
+                    }));
+            } catch (err) {
+                console.error('filter-delete load failed:', err);
+                this.showToast(`Ошибка загрузки записей: ${ err.message }`, 'error');
+                return;
+            }
+
+            if (records.length === 0) {
+                this.showToast('Нет записей, удовлетворяющих фильтру', 'error');
+                return;
+            }
+
+            const apiBase = this.getApiBase();
+            const total = records.length;
+            let completed = 0;
+            const errors = [];
+            const warnings = [];
+
+            // Progress modal (same layout/IDs as bulkDelete so existing CSS applies).
+            const progressId = `filter-delete-progress-${ Date.now() }`;
+            const progressHtml = `
+                <div class="integram-modal-overlay" id="${ progressId }">
+                    <div class="integram-modal" style="max-width: 500px;">
+                        <div class="integram-modal-header">
+                            <h3>Удаление записей по фильтру</h3>
+                        </div>
+                        <div class="integram-modal-body">
+                            <div class="bulk-delete-progress-bar-container">
+                                <div class="bulk-delete-progress-bar" style="width: 0%"></div>
+                            </div>
+                            <div class="bulk-delete-progress-text">Удалено: 0 / ${ total }</div>
+                            <div class="bulk-delete-errors" style="display: none;"></div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            document.body.insertAdjacentHTML('beforeend', progressHtml);
+
+            const progressOverlay = document.getElementById(progressId);
+            const progressBar = progressOverlay.querySelector('.bulk-delete-progress-bar');
+            const progressText = progressOverlay.querySelector('.bulk-delete-progress-text');
+            const errorsDiv = progressOverlay.querySelector('.bulk-delete-errors');
+
+            const updateProgress = () => {
+                const pct = Math.round((completed / total) * 100);
+                progressBar.style.width = `${ pct }%`;
+                progressText.textContent = `Удалено: ${ completed } / ${ total }`;
+            };
+
+            const deletePromises = records.map(async (record) => {
+                try {
+                    const params = new URLSearchParams();
+                    if (typeof xsrf !== 'undefined') {
+                        params.append('_xsrf', xsrf);
+                    }
+
+                    const response = await fetch(`${ apiBase }/_m_del/${ record.id }?JSON`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: params.toString()
+                    });
+
+                    const text = await response.text();
+                    let result;
+                    try {
+                        result = JSON.parse(text);
+                    } catch (parseErr) {
+                        warnings.push(`#${ record.id } : ${ record.value } : ${ text }`);
+                    }
+
+                    if (result) {
+                        let serverError = null;
+                        if (Array.isArray(result)) {
+                            serverError = (result[0] && result[0].error) || null;
+                        } else {
+                            serverError = result.error || null;
+                        }
+                        if (serverError) {
+                            errors.push(`#${ record.id } : ${ record.value } : ${ serverError }`);
+                        }
+                    }
+                } catch (err) {
+                    errors.push(`#${ record.id } : ${ record.value } : ${ err.message }`);
+                } finally {
+                    completed++;
+                    updateProgress();
+                }
+            });
+
+            await Promise.all(deletePromises);
+
+            if (errors.length > 0 || warnings.length > 0) {
+                errorsDiv.style.display = 'block';
+                let html = '';
+
+                if (errors.length > 0) {
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
+                        <strong>Ошибки (блокирующие):</strong><br>
+                        ${ errors.map(e => {
+                            const parts = e.split(' : ');
+                            if (parts.length >= 3) {
+                                const recordId = this.escapeHtml(parts[0]);
+                                const recordValue = this.escapeHtml(parts[1]);
+                                const errorMsg = parts.slice(2).join(' : ');
+                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
+                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
+                            }
+                            return this.escapeHtml(e);
+                        }).join('<br>') }
+                    </div>`;
+                }
+
+                if (warnings.length > 0) {
+                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Предупреждения:</strong><br>
+                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
+                    </div>`;
+                }
+
+                errorsDiv.innerHTML = html;
+            }
+
+            if (errors.length > 0) {
+                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
+            } else {
+                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            }
+
+            if (errors.length === 0 && warnings.length === 0) {
+                setTimeout(() => {
+                    progressOverlay.remove();
+                }, 1500);
+            } else {
+                const closeBtn = document.createElement('button');
+                closeBtn.className = 'btn btn-sm btn-primary';
+                closeBtn.style.marginTop = '10px';
+                closeBtn.textContent = 'Закрыть';
+                closeBtn.addEventListener('click', () => progressOverlay.remove());
+                progressOverlay.querySelector('.integram-modal-body').appendChild(closeBtn);
+            }
+
+            // Reload table data after delete finishes (mirrors bulkDelete()).
+            this.selectedRows.clear();
+            this.data = [];
+            this.rawObjectData = [];
+            this.loadedRecords = 0;
+            this.hasMore = true;
+            this.totalRows = null;
+            await this.loadData(false);
+        }
+
+        /**
          * Toggle export menu visibility.
          * Issue #1652: the menu is appended to document.body with position:fixed so it
          * escapes the overflow:hidden / overflow-y:hidden clipping of ancestor containers


### PR DESCRIPTION
## Summary

Воспроизводит кнопку «Удалить по фильтру» из старого интерфейса (`templates/object.html`) внутри нового компонента `js/integram-table.js`.

- Кнопка отображается **только** когда `metadata.delete === "1"` — та же проверка прав, что и для удаления по галкам (`.row-select-checkbox`).
- Вместо устаревшего серверного POST `{tableId}/_m_del_select` реализован **отдельный клиентский метод** `bulkDeleteByFilter()`:
  - получает количество подходящих записей через существующий `_count=1` (`fetchFilterMatchCount`) и показывает его в подтверждении;
  - подгружает идентификаторы всех подходящих записей через существующий путь экспорта `loadDataFromTableForExport` (он уже корректно прокидывает фильтры, сортировку, `F_U`, GET-параметры страницы);
  - удаляет записи параллельными запросами `POST /_m_del/{id}?JSON` — тот же эндпоинт, что используется для удаления одной строки и для удаления по галкам, поэтому проверки прав и целостности ссылок выполняются сервером без дублирования.
- Ошибки, возникающие при удалении конкретных записей (например, защищённые ссылочной целостностью), показываются построчно в существующем модальном окне прогресса.

## Files changed

- `js/integram-table/01-core.js` — поле `tableDeletable`, метод `isTableDeletable()`, парсинг `metadata.delete` в `loadDataFromTable` и при metadata-drift refresh.
- `js/integram-table/02-format-helpers.js` — парсинг `metadata.delete` в `parseObjectFormat()` и `parseJsonDataArray()` (включая ветку metadata-refresh).
- `js/integram-table/04-render-table.js` — новая кнопка тулбара (класс `integram-table-settings-filter-delete`, иконка `pi pi-trash`, подпись «удалить по фильтру»). Видимость: `isTableDeletable() && isTableWritable()`.
- `js/integram-table/23-bulk-export.js` — `showFilterDeleteConfirm()`, `fetchFilterMatchCount()`, `bulkDeleteByFilter()`.
- `js/integram-table.js` — пересобран через `bash build.sh`.

## Why a new method instead of `_m_del_select`

Issue прямо требует: «Вместо параметра `_m_del_select` надо сделать отдельный метод для удаления записей». Новый клиент:
- использует тот же per-record эндпоинт, что и остальные пути удаления (нет дублирования server-side кода);
- показывает прогресс и ошибки по каждой записи;
- не зависит от submit-формы и работает в SPA-режиме компонента.

## Test plan

Unit-tests добавлены в `experiments/test-issue-2749-delete-by-filter.js` (выполняются `node experiments/test-issue-2749-delete-by-filter.js`):

- [x] воспроизводит legacy-флоу `_m_del_select`, который этот PR заменяет;
- [x] `fetchFilterMatchCount` форсирует `_count=1` и прокидывает текущие фильтры и `F_U`;
- [x] `bulkDeleteByFilter` шлёт `POST /_m_del/{id}?JSON` для каждой подходящей записи и **не** обращается к `_m_del_select`;
- [x] ошибки удаления конкретных записей попадают в сводку ошибок, а не «глотаются».

Регрессия проверена: `node experiments/test-issue-2746-delete-table-references.js` по-прежнему проходит.

Manual UI test plan:
- [ ] открыть таблицу под пользователем с `delete:"1"` — кнопка «удалить по фильтру» отображается рядом с «удалить (N)» / «копия ссылки»;
- [ ] открыть ту же таблицу под пользователем без `delete:"1"` — кнопка скрыта;
- [ ] задать фильтр на колонку, нажать кнопку — рядом появляется счётчик «Удалить N записей, удовлетворяющих фильтру?»;
- [ ] подтвердить — записи удаляются, таблица перезагружается, итоговый счётчик обновлён;
- [ ] навесить ссылочную защиту на одну запись — её удаление сообщается как ошибка, остальные удаляются.

Closes #2749