### PR TITLE
feat(integram-table): batch endpoint for delete-by-filter (closes #2749)

### DIFF
--- a/experiments/test-issue-2749-delete-by-filter.js
+++ b/experiments/test-issue-2749-delete-by-filter.js
@@ -1,0 +1,414 @@
+/*
+ * Test for issue #2749: js/integram-table.js
+ * "Кнопка «Удалить по фильтру»: добавить кнопку, видимую только пользователям,
+ *  у которых есть метаданное delete:"1", и реализовать удаление через отдельный
+ *  метод (не через _m_del_select)."
+ *
+ * The test exercises bulkDeleteByFilter() and fetchFilterMatchCount() from
+ * js/integram-table/23-bulk-export.js against a mocked server. It verifies:
+ *
+ *   1. fetchFilterMatchCount() hits the JSON_OBJ&_count=1 endpoint with the
+ *      current filters/parent forwarded so the user sees the correct number
+ *      of records before confirming.
+ *   2. bulkDeleteByFilter() sends ONE POST per chunk to /_m_del_batch/{tableId}
+ *      — NOT one POST per record. For N matching records and chunk size 500
+ *      it sends ceil(N/500) requests, which is the whole point of the fix.
+ *   3. Per-record server errors returned in the chunk response surface in
+ *      the bulk-delete errors panel.
+ *   4. The legacy _m_del_select endpoint is NOT touched.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// --- Load just the methods we need straight from the source module ----------
+
+const moduleSource = fs.readFileSync(
+    path.join(__dirname, '..', 'js', 'integram-table', '23-bulk-export.js'),
+    'utf8'
+);
+
+function extractMethod(name) {
+    const re = new RegExp(`(?:^|\\n)        (async\\s+)?${name}\\s*\\([^)]*\\)\\s*\\{`);
+    const match = moduleSource.match(re);
+    if (!match) throw new Error(`Could not find method ${name} in module source`);
+    const start = match.index + match[0].length - 1;
+    let depth = 0;
+    for (let i = start; i < moduleSource.length; i++) {
+        const ch = moduleSource[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) {
+                return moduleSource.slice(match.index + 1, i + 1);
+            }
+        }
+    }
+    throw new Error(`Could not find matching closing brace for ${name}`);
+}
+
+const methodSources = [
+    extractMethod('bulkDeleteByFilter'),
+    extractMethod('fetchFilterMatchCount'),
+].join('\n');
+
+const Host = new Function('fetchRef', 'documentRef', `
+    const fetch = (...args) => fetchRef(...args);
+    const document = new Proxy({}, {
+        get(_, prop) { return documentRef()[prop]; },
+    });
+    const xsrf = undefined; // typeof xsrf !== 'undefined' will be false
+    class Host {
+        constructor(opts) { Object.assign(this, opts); }
+        getApiBase() { return this._apiBase; }
+        applyFilter(params, column, filter) {
+            if (filter.type === '=') params.set('F_' + column.id, filter.value);
+            else if (filter.type === '^') params.set('FR_' + column.id, filter.value);
+        }
+        appendPageUrlParams() {}
+        escapeHtml(s) { return String(s); }
+        sanitizeInlineMessageHtml(s) { return String(s); }
+        showToast(msg, level) {
+            (this.toasts = this.toasts || []).push({ msg, level });
+        }
+        loadData() {
+            this.reloadCalls = (this.reloadCalls || 0) + 1;
+            return Promise.resolve();
+        }
+        loadDataFromTableForExport(offset, limit) {
+            this.loadCalls = (this.loadCalls || []);
+            this.loadCalls.push({ offset, limit });
+            return Promise.resolve({
+                columns: this.columns,
+                rows: this._rawDataResponse.map(r => r.r),
+                rawData: this._rawDataResponse,
+            });
+        }
+        ${methodSources}
+    }
+    return Host;
+`)(
+    (...args) => global.fetch(...args),
+    () => global.document
+);
+
+function defaultDocument() {
+    return {
+        body: { insertAdjacentHTML() {} },
+        getElementById() {
+            return {
+                querySelector() { return { style: {}, textContent: '', innerHTML: '', appendChild() {} }; },
+                remove() {},
+            };
+        },
+        createElement() {
+            return { className: '', style: {}, textContent: '', addEventListener() {} };
+        },
+    };
+}
+
+function makeFetch(routes) {
+    return async function fetch(url, init) {
+        for (const route of routes) {
+            const match = route.match(url, init);
+            if (match) {
+                route.calls.push({ url, init, match });
+                return route.respond(match);
+            }
+        }
+        throw new Error(`Unexpected fetch to ${url}`);
+    };
+}
+
+function jsonResponse(status, body) {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        async text() { return text; },
+        async json() { return JSON.parse(text); },
+    };
+}
+
+const API = 'https://example.test/db';
+
+async function testFetchFilterMatchCount() {
+    // The button must show how many records currently match the filter
+    // BEFORE asking for confirmation. fetchFilterMatchCount() must hit
+    // /object/{id}/?JSON_OBJ&_count=1 with current filters forwarded.
+    global.document = defaultDocument();
+    const routes = [
+        {
+            calls: [],
+            match: (url) => {
+                const m = url.match(/^https:\/\/example\.test\/db\/object\/3596\/\?JSON_OBJ&(.+)$/);
+                return m ? { qs: new URLSearchParams(m[1]) } : null;
+            },
+            respond: () => jsonResponse(200, { count: 7 }),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: { '3597': { type: '=', value: 'foo' } },
+        options: { parentId: '999' },
+    });
+
+    const count = await tbl.fetchFilterMatchCount();
+    assert.strictEqual(count, 7);
+    assert.strictEqual(routes[0].calls.length, 1);
+
+    const qs = routes[0].calls[0].match.qs;
+    assert.strictEqual(qs.get('_count'), '1');
+    assert.strictEqual(qs.get('F_3597'), 'foo');
+    assert.strictEqual(qs.get('F_U'), '999');
+    console.log('PASS fetchFilterMatchCount forwards filters and parent to the _count endpoint');
+}
+
+async function testBulkDeleteByFilterUsesBatchEndpoint() {
+    // The core fix: bulkDeleteByFilter must POST chunks to /_m_del_batch/{tableId}
+    // — one request per chunk, NOT one request per record. Legacy _m_del_select
+    // and per-record _m_del/{id} endpoints must NOT be touched.
+    global.document = defaultDocument();
+    const batchCalls = [];
+    const routes = [
+        {
+            calls: [],
+            match: (url, init) => {
+                const m = url.match(/^https:\/\/example\.test\/db\/_m_del_batch\/(\d+)\?JSON$/);
+                return (m && init && init.method === 'POST') ? { tableId: m[1] } : null;
+            },
+            respond: ({ tableId }, ctx) => {
+                // body should contain ids=...
+                return null; // sentinel — actual respond set below
+            },
+        },
+        {
+            calls: [],
+            match: (url) => url.includes('/_m_del_select') ? {} : null,
+            respond: () => { throw new Error('legacy _m_del_select must NOT be used'); },
+        },
+        {
+            calls: [],
+            match: (url) => /\/_m_del\/\d+/.test(url) ? {} : null,
+            respond: () => { throw new Error('per-record _m_del/{id} must NOT be used for filter delete'); },
+        },
+    ];
+    // Replace batch respond so it parses the body and answers
+    routes[0].respond = (match) => {
+        const init = routes[0].calls[routes[0].calls.length - 1].init;
+        const body = new URLSearchParams(init.body);
+        const ids = (body.get('ids') || '').split(',').filter(Boolean).map(s => parseInt(s, 10));
+        batchCalls.push({ tableId: match.tableId, ids });
+        return jsonResponse(200, { deleted: ids, errors: {} });
+    };
+    global.fetch = makeFetch(routes);
+
+    // 1234 records — exercises chunking (FILTER_DELETE_CHUNK = 500 in source)
+    const N = 1234;
+    const raw = [];
+    for (let i = 1; i <= N; i++) raw.push({ i, u: 1, o: i - 1, r: ['v' + i] });
+
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: {},
+        options: { tableTypeId: '3596' },
+        rawObjectData: [],
+        selectedRows: new Set(),
+        data: [],
+        loadedRecords: 0,
+        hasMore: true,
+        totalRows: null,
+        _rawDataResponse: raw,
+    });
+
+    await tbl.bulkDeleteByFilter();
+
+    // 1234 records / chunk size 500 = 3 chunks
+    assert.strictEqual(routes[0].calls.length, 3, `expected 3 batch calls, got ${routes[0].calls.length}`);
+    assert.strictEqual(routes[1].calls.length, 0, 'legacy _m_del_select must not be called');
+    assert.strictEqual(routes[2].calls.length, 0, 'per-record _m_del/{id} must not be called');
+    assert.strictEqual(batchCalls[0].ids.length, 500);
+    assert.strictEqual(batchCalls[1].ids.length, 500);
+    assert.strictEqual(batchCalls[2].ids.length, 234);
+    assert.strictEqual(batchCalls[0].tableId, '3596', 'tableId in URL must equal objectTableId');
+    // No overlap, full coverage
+    const allIds = new Set([...batchCalls[0].ids, ...batchCalls[1].ids, ...batchCalls[2].ids]);
+    assert.strictEqual(allIds.size, N, 'every record id must be sent exactly once');
+    for (let i = 1; i <= N; i++) assert.ok(allIds.has(i), `id ${i} missing from batches`);
+    assert.strictEqual(tbl.reloadCalls, 1, 'table must reload once at the end');
+    console.log(`PASS bulkDeleteByFilter sends ${routes[0].calls.length} batch requests for ${N} records (was ${N} per-record requests)`);
+}
+
+async function testBulkDeleteByFilterSurfacesPerRecordErrors() {
+    // The server's _m_del_batch response carries {deleted, errors} per chunk.
+    // Per-record errors must be reported in the bulk-delete errors panel —
+    // not silently swallowed and not aggregated into a single "chunk failed".
+    const capturedErrors = [];
+    global.document = {
+        body: { insertAdjacentHTML() {} },
+        getElementById() {
+            return {
+                querySelector(sel) {
+                    if (sel === '.bulk-delete-errors') {
+                        return {
+                            style: {},
+                            set innerHTML(v) { capturedErrors.push(v); },
+                            get innerHTML() { return capturedErrors[capturedErrors.length - 1] || ''; },
+                            appendChild() {},
+                        };
+                    }
+                    return { style: {}, textContent: '', innerHTML: '', appendChild() {} };
+                },
+                remove() {},
+            };
+        },
+        createElement() { return { className: '', style: {}, textContent: '', addEventListener() {} }; },
+    };
+
+    const routes = [
+        {
+            calls: [],
+            match: (url, init) => /\/_m_del_batch\/\d+\?JSON$/.test(url) && init.method === 'POST' ? {} : null,
+            respond: () => jsonResponse(200, {
+                deleted: [101, 103],
+                errors: { '102': 'Запись используется как ссылка' },
+            }),
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: {},
+        options: {},
+        rawObjectData: [],
+        selectedRows: new Set(),
+        data: [],
+        loadedRecords: 0,
+        hasMore: true,
+        totalRows: null,
+        _rawDataResponse: [
+            { i: 101, u: 1, o: 0, r: ['Alpha'] },
+            { i: 102, u: 1, o: 1, r: ['Beta'] },
+            { i: 103, u: 1, o: 2, r: ['Gamma'] },
+        ],
+    });
+
+    await tbl.bulkDeleteByFilter();
+
+    const allErrorHtml = capturedErrors.join('\n');
+    assert.ok(/102/.test(allErrorHtml), 'error report must include failing record id 102');
+    assert.ok(/Beta/.test(allErrorHtml), 'error report must include the failing record value');
+    assert.ok(/Запись используется как ссылка/.test(allErrorHtml),
+        'error report must include the server-side error message');
+    console.log('PASS bulkDeleteByFilter surfaces per-record server errors');
+}
+
+async function testBulkDeleteByFilterHandlesChunkLevelFailure() {
+    // If a chunk itself fails (network error, HTTP 5xx, top-level {error}),
+    // every id in that chunk must be reported — not silently lost.
+    global.document = defaultDocument();
+    let callCount = 0;
+    const routes = [
+        {
+            calls: [],
+            match: (url, init) => /\/_m_del_batch\/\d+\?JSON$/.test(url) && init.method === 'POST' ? {} : null,
+            respond: () => {
+                callCount++;
+                if (callCount === 2) {
+                    return jsonResponse(403, [{ error: 'forbidden' }]);
+                }
+                // chunk 1 + chunk 3 succeed
+                const init = routes[0].calls[routes[0].calls.length - 1].init;
+                const ids = new URLSearchParams(init.body).get('ids').split(',').map(Number);
+                return jsonResponse(200, { deleted: ids, errors: {} });
+            },
+        },
+    ];
+    global.fetch = makeFetch(routes);
+
+    // 3 chunks of 500 each
+    const raw = [];
+    for (let i = 1; i <= 1500; i++) raw.push({ i, u: 1, o: i - 1, r: ['v' + i] });
+
+    let errorAccumulator = [];
+    // Spy on what the impl puts into errorsDiv. Easier: monkey-patch escapeHtml
+    // to fold every error string through us.
+    const tbl = new Host({
+        _apiBase: API,
+        objectTableId: '3596',
+        columns: [{ id: '3597' }],
+        filters: {},
+        options: {},
+        rawObjectData: [],
+        selectedRows: new Set(),
+        data: [],
+        loadedRecords: 0,
+        hasMore: true,
+        totalRows: null,
+        _rawDataResponse: raw,
+    });
+    const origEscape = tbl.escapeHtml.bind(tbl);
+    tbl.escapeHtml = (s) => { errorAccumulator.push(String(s)); return origEscape(s); };
+
+    await tbl.bulkDeleteByFilter();
+
+    assert.strictEqual(routes[0].calls.length, 3, 'three chunks issued');
+    const joined = errorAccumulator.join('|');
+    // Chunk 2 covers ids 501..1000 — at least the first and last should be there
+    assert.ok(/#501\b/.test(joined), 'failed chunk start id (#501) must appear in errors');
+    assert.ok(/#1000\b/.test(joined), 'failed chunk end id (#1000) must appear in errors');
+    // Successful chunks (1 and 3) should NOT appear in errors
+    assert.ok(!/#1\b/.test(joined), 'successful chunk ids must not appear in errors');
+    assert.ok(!/#1500\b/.test(joined), 'successful chunk ids must not appear in errors');
+    console.log('PASS chunk-level failures surface every id of the failed chunk');
+}
+
+async function testReproducesLegacyBehaviourBeforeFix() {
+    // Before issue #2749 was filed, the legacy flow was a server-side form POST
+    // to {tableId}/_m_del_select. Re-implement it locally so we can document
+    // what is being replaced.
+    async function legacyDeleteByFilter(tableId, filterParams) {
+        const params = new URLSearchParams(filterParams);
+        params.set('_m_del_select', '1');
+        const resp = await fetch(`${API}/${tableId}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: params.toString(),
+        });
+        return { ok: resp.ok };
+    }
+    let legacyCalled = false;
+    global.fetch = async (url, init) => {
+        if (url === `${API}/3596` && init && init.body && init.body.includes('_m_del_select=1')) {
+            legacyCalled = true;
+            return jsonResponse(200, { ok: true });
+        }
+        throw new Error(`unexpected ${url}`);
+    };
+    await legacyDeleteByFilter('3596', { F_3597: 'foo' });
+    assert.strictEqual(legacyCalled, true,
+        'the legacy flow that this PR replaces relied on _m_del_select');
+    console.log('PASS reproduces the pre-fix _m_del_select flow that this issue replaces');
+}
+
+(async function run() {
+    await testReproducesLegacyBehaviourBeforeFix();
+    await testFetchFilterMatchCount();
+    await testBulkDeleteByFilterUsesBatchEndpoint();
+    await testBulkDeleteByFilterSurfacesPerRecordErrors();
+    await testBulkDeleteByFilterHandlesChunkLevelFailure();
+    console.log('\nAll issue #2749 tests passed.');
+})().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/index.php
+++ b/index.php
@@ -9887,6 +9887,98 @@ if(Validate_Token())
             $a = "object";
 			break;
 
+		case "_m_del_batch":
+			# Bulk delete a chunk of records of a single type in ONE request (issue #2749).
+			# Replaces the per-record _m_del/{id} loop bulkDeleteByFilter used to do.
+			# URL: /db/_m_del_batch/{type_id}?JSON  (POST)
+			# Body: ids=1,2,3,...  OR  ids[]=1&ids[]=2&...
+			# Returns: {"deleted":[1,2], "errors":{"3":"reason", ...}}
+			if($_SERVER["REQUEST_METHOD"] !== "POST")
+				my_die(t9n("[RU]Для массового удаления используйте POST[EN]Use POST for batch delete"), "405 Method Not Allowed");
+			if($id == 0)
+				my_die(t9n("[RU]Не указан тип записей (table id)[EN]Table id is required"));
+
+			# Parse ids — accept both ids=1,2,3 and ids[]=1&ids[]=2 conventions
+			$idsRaw = isset($_POST["ids"]) ? $_POST["ids"] : (isset($_REQUEST["ids"]) ? $_REQUEST["ids"] : "");
+			if(is_array($idsRaw))
+				$idsList = $idsRaw;
+			elseif(is_string($idsRaw) && $idsRaw !== "")
+				$idsList = explode(",", $idsRaw);
+			else
+				$idsList = array();
+			$ids = array();
+			$seen = array();
+			foreach($idsList as $rid){
+				$rid = (int)$rid;
+				if($rid > 0 && !isset($seen[$rid])){
+					$seen[$rid] = true;
+					$ids[] = $rid;
+				}
+			}
+			if(empty($ids))
+				my_die(t9n("[RU]Пустой список идентификаторов[EN]Empty list of ids"));
+			if(count($ids) > 10000)
+				my_die(t9n("[RU]Слишком большой батч (max 10000)[EN]Batch too large (max 10000)"));
+
+			# Permission check at type level — mirrors the legacy _m_del_select gate (index.php "case &uni_obj")
+			if(!isset($GLOBALS["GRANTS"]["DELETE"][1])
+				&& !isset($GLOBALS["GRANTS"]["DELETE"][$id])
+				&& ($GLOBALS["GLOBAL_VARS"]["user"] != "admin")
+				&& (Grant_1level($id) != "WRITE"))
+				my_die(t9n("[RU]У вас нет прав на массовое удаление объектов этого типа[EN]You do not have access to delete this type of object in bulk"), "403 Forbidden");
+
+			$idsCsv = implode(",", $ids);
+			$userIdNum = (int)$GLOBALS["GLOBAL_VARS"]["user_id"];
+
+			# One SELECT validates the entire batch: type match, has real parent (not metadata),
+			# has no incoming references. Mirrors per-record checks in case "_m_del" (above).
+			$data_set = Exec_sql(
+				"SELECT obj.id, obj.up, obj.ord, obj.t, obj.val, par.up pup, type.up tup, COUNT(r.id) ref_cnt"
+				." FROM $z obj"
+				." LEFT JOIN $z type ON type.id=obj.t"
+				." LEFT JOIN $z par ON par.id=obj.up"
+				." LEFT JOIN $z r ON r.t=obj.id"
+				." WHERE obj.id IN ($idsCsv) AND obj.t=$id AND obj.t!=obj.up"
+				." GROUP BY obj.id, obj.up, obj.ord, obj.t, obj.val, par.up, type.up"
+				, "Get batch info for _m_del_batch");
+
+			$deleted = array();
+			$errors = array();
+			$found = array();
+			while($row = mysqli_fetch_array($data_set)){
+				$rid = (int)$row["id"];
+				$found[$rid] = true;
+				if($row["pup"] == 0){
+					$errors[(string)$rid] = t9n("[RU]Нельзя удалить метаданные[EN]Can't delete metadata");
+					continue;
+				}
+				if($rid === $userIdNum){
+					$errors[(string)$rid] = t9n("[RU]Нельзя удалить себя как пользователя[EN]Can't delete yourself");
+					continue;
+				}
+				if($row["ref_cnt"] > 0){
+					$errors[(string)$rid] = t9n("[RU]Нельзя удалить объект, на который существуют ссылки (всего: [EN]Can't delete an object with incoming references (total: ").$row["ref_cnt"].")";
+					continue;
+				}
+				# Adjust peer order in arrays / multiselect refs (same as case "_m_del")
+				if($row["up"] > 1){
+					if($row["tup"] === "0")
+						Exec_sql("UPDATE $z SET ord=ord-1 WHERE up=".$row["up"]." AND t=".$row["t"]." AND ord>".$row["ord"], "Move peers");
+					elseif(is_numeric($row["val"]))
+						Exec_sql("UPDATE $z SET ord=ord-1 WHERE up=".$row["up"]." AND val='".$row["val"]."' AND ord>".$row["ord"], "Move peers");
+				}
+				BatchDelete($rid);
+				$deleted[] = $rid;
+			}
+			BatchDelete(""); // Flush batch (single grouped DELETE per the BatchDelete contract)
+
+			foreach($ids as $rid)
+				if(!isset($found[$rid]))
+					$errors[(string)$rid] = t9n("[RU]Не найден или другой тип[EN]Not found or wrong type");
+
+			api_dump(json_encode(array("deleted" => $deleted, "errors" => $errors), JSON_UNESCAPED_UNICODE), "del_batch.json");
+			break;
+
 		case "_m_new":
 			if($up == 0)
 				my_die(t9n("[RU]Недопустимые данные: up=0. Установите значение=1 для независимых объектов.[EN]Data is invalid: up=0. Set up=1 for independent objects."));

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -56,6 +56,7 @@ class IntegramTable{
             this.filtersEnabled = false;
             this.objectTableId = null;  // Table ID when data is in object/JSON_OBJ format (for _count=1 queries)
             this.tableGranted = null;  // 'WRITE' = full access, other value = read-only (issue #1508)
+            this.tableDeletable = false;  // True when metadata.delete === "1" — enables "Delete by filter" (issue #2749)
             this.rawObjectData = [];  // Raw data array with {i, u, o, r} for object format (preserves record IDs)
             this.styleColumns = {};  // Map of column IDs to their style column values
             this.idColumns = new Set();  // Set of hidden ID column IDs
@@ -221,6 +222,15 @@ class IntegramTable{
          */
         isStructureWritable() {
             return window.grants && window.grants['1'] === 'WRITE';
+        }
+
+        /**
+         * Check whether bulk "Delete by filter" is allowed (issue #2749).
+         * Mirrors the legacy templates/object.html gate: visible only when
+         * metadata.delete === "1".
+         */
+        isTableDeletable() {
+            return this.tableDeletable === true;
         }
 
         /**
@@ -853,6 +863,9 @@ class IntegramTable{
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
 
+                // Store bulk delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
+
                 // Convert metadata to columns format
                 const columns = [];
 
@@ -942,6 +955,7 @@ class IntegramTable{
                 }
                 this.tableExportAllowed = refreshedMetadata.export === '1' || refreshedMetadata.export === 1;
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
 
                 const refreshedColumns = [];
                 const mainColGranted = this.isTableWritable() ? 1 : 0;
@@ -1041,6 +1055,9 @@ class IntegramTable{
 
             // Store table-level granted value for access control (issue #1508)
             this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
+
+            // Store bulk delete-by-filter flag from metadata (issue #2749)
+            this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
 
             // Convert metadata to columns format
             const columns = [];
@@ -1152,6 +1169,7 @@ class IntegramTable{
                     });
                 }
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
             }
 
             // Transform object format data to row format
@@ -1253,6 +1271,9 @@ class IntegramTable{
 
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
+
+                // Store bulk delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
 
                 // Convert metadata to columns format
                 const columns = [];
@@ -1552,6 +1573,12 @@ class IntegramTable{
                             <button class="btn btn-sm btn-danger integram-bulk-delete-btn" id="${ instanceName }-bulk-delete-btn" onclick="window.${ instanceName }.showBulkDeleteConfirm(event)">
                                 Удалить (${ this.selectedRows.size })
                             </button>
+                            ` : '' }
+                            ${ this.isTableDeletable() && this.isTableWritable() ? `
+                            <div class="integram-table-settings integram-table-settings-filter-delete" onclick="window.${ instanceName }.showFilterDeleteConfirm(event)" title="Удалить записи, удовлетворяющие заданному фильтру">
+                                <i class="pi pi-trash"></i>
+                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">удалить по фильтру</span>' : '' }
+                            </div>
                             ` : '' }
                             <div class="integram-table-settings" onclick="window.${ instanceName }.copyConfigUrl()" title="Скопировать ссылку с текущими фильтрами и группами">
                                 <i class="pi pi-copy"></i>
@@ -17328,6 +17355,321 @@ class IntegramTable{
             }
 
             // Clear selection and reload data
+            this.selectedRows.clear();
+            this.data = [];
+            this.rawObjectData = [];
+            this.loadedRecords = 0;
+            this.hasMore = true;
+            this.totalRows = null;
+            await this.loadData(false);
+        }
+
+        /**
+         * Show "delete by filter" confirmation popup (issue #2749).
+         * Visible only when metadata.delete === "1" (see isTableDeletable).
+         * Shows the matching count from the existing _count=1 endpoint so
+         * the user knows exactly how many records the bulk delete will hit.
+         * @param {Event} event - click on the trigger button
+         */
+        async showFilterDeleteConfirm(event) {
+            if (event) {
+                event.stopPropagation();
+            }
+
+            const btn = event && event.target
+                ? event.target.closest('.integram-table-settings-filter-delete')
+                : null;
+            if (!btn) return;
+
+            // Toggle: a second click hides the popup
+            const existing = this.container.querySelector('.filter-delete-confirm');
+            if (existing) {
+                existing.remove();
+                return;
+            }
+
+            const loadingHtml = `
+                <div class="filter-delete-confirm" style="display:inline-block; margin-left:8px;">
+                    <span>Подсчёт записей…</span>
+                </div>
+            `;
+            btn.insertAdjacentHTML('afterend', loadingHtml);
+            const popup = this.container.querySelector('.filter-delete-confirm');
+
+            let count;
+            try {
+                count = await this.fetchFilterMatchCount();
+            } catch (err) {
+                console.error('count-by-filter failed:', err);
+                popup.innerHTML = `<span style="color:#b00;">Ошибка подсчёта: ${ this.escapeHtml(err.message || String(err)) }</span>`;
+                setTimeout(() => popup.remove(), 4000);
+                return;
+            }
+
+            if (!Number.isFinite(count) || count <= 0) {
+                popup.innerHTML = '<span>Нет записей, удовлетворяющих фильтру</span>';
+                setTimeout(() => popup.remove(), 3000);
+                return;
+            }
+
+            popup.innerHTML = `
+                <span>Удалить ${ count } записей, удовлетворяющих фильтру?</span>
+                <button class="btn btn-sm btn-danger filter-delete-confirm-btn">Да, удалить</button>
+                <button class="btn btn-sm btn-outline-secondary filter-delete-cancel-btn">Отменить</button>
+            `;
+            popup.querySelector('.filter-delete-confirm-btn').addEventListener('click', () => {
+                popup.remove();
+                this.bulkDeleteByFilter();
+            });
+            popup.querySelector('.filter-delete-cancel-btn').addEventListener('click', () => {
+                popup.remove();
+            });
+        }
+
+        /**
+         * Count records matching the current filter (issue #2749).
+         * Re-uses the existing /object/{id}/?JSON_OBJ&_count=1 endpoint so we
+         * can show an authoritative number in the confirmation without
+         * piggy-backing on cached this.totalRows.
+         * @returns {Promise<number>}
+         */
+        async fetchFilterMatchCount() {
+            if (!this.objectTableId) {
+                throw new Error('Доступно только для табличных источников');
+            }
+            const apiBase = this.getApiBase();
+            const params = new URLSearchParams({ _count: '1' });
+
+            const filters = this.filters || {};
+            Object.keys(filters).forEach(colId => {
+                const filter = filters[colId];
+                if (filter.value || filter.type === '%' || filter.type === '!%') {
+                    const column = this.columns.find(c => c.id === colId);
+                    if (column) {
+                        this.applyFilter(params, column, filter);
+                    }
+                }
+            });
+
+            if (this.options.parentId) {
+                params.set('F_U', this.options.parentId);
+            }
+            this.appendPageUrlParams(params);
+
+            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
+            const response = await fetch(url);
+            const result = await response.json();
+            return parseInt(result.count, 10);
+        }
+
+        /**
+         * Delete all records matching the current filter (issue #2749).
+         *
+         * Replaces both the legacy POST {table_id}/_m_del_select form flow
+         * (templates/object.html) AND the naive "POST /_m_del/{id} per record"
+         * approach. Instead this method:
+         *   1. Fetches matching record IDs from the JSON_OBJ endpoint
+         *      (loadDataFromTableForExport already honours filters/sort/F_U).
+         *   2. Splits the IDs into chunks of FILTER_DELETE_CHUNK records.
+         *   3. POSTs each chunk to /_m_del_batch/{tableId}?JSON in ONE request
+         *      per chunk. The server runs them in a single transaction via
+         *      BatchDelete() — the same path the legacy _m_del_select used.
+         *   4. Updates the progress bar per-chunk and reports per-record
+         *      server errors (reference constraints, missing rights, etc.).
+         *
+         * For a 100k delete this is ~100-200 HTTP requests instead of 100k.
+         */
+        async bulkDeleteByFilter() {
+            if (!this.objectTableId) {
+                this.showToast('Удаление по фильтру доступно только для табличных источников', 'error');
+                return;
+            }
+
+            // Chunk size — bounded to keep individual DB transactions reasonable
+            // and to give the progress bar useful granularity. The server caps
+            // _m_del_batch at 10000 ids per request anyway.
+            const FILTER_DELETE_CHUNK = 500;
+
+            // Load all matching record IDs through the existing export pathway.
+            let records = [];
+            try {
+                const savedTableTypeId = this.options.tableTypeId;
+                if (!this.options.tableTypeId && this.objectTableId) {
+                    this.options.tableTypeId = this.objectTableId;
+                }
+                const json = await this.loadDataFromTableForExport(0, 1000000);
+                this.options.tableTypeId = savedTableTypeId;
+
+                const rawData = (json && json.rawData) || [];
+                records = rawData
+                    .filter(item => item && item.i)
+                    .map(item => ({
+                        id: item.i,
+                        value: (item.r && item.r[0]) || ''
+                    }));
+            } catch (err) {
+                console.error('filter-delete load failed:', err);
+                this.showToast(`Ошибка загрузки записей: ${ err.message }`, 'error');
+                return;
+            }
+
+            if (records.length === 0) {
+                this.showToast('Нет записей, удовлетворяющих фильтру', 'error');
+                return;
+            }
+
+            const apiBase = this.getApiBase();
+            const total = records.length;
+            let completed = 0;
+            const errors = [];
+            const warnings = [];
+
+            // Map id -> first-column value, for human-readable error rows.
+            const valueById = new Map();
+            for (const r of records) valueById.set(String(r.id), r.value);
+
+            const progressId = `filter-delete-progress-${ Date.now() }`;
+            const progressHtml = `
+                <div class="integram-modal-overlay" id="${ progressId }">
+                    <div class="integram-modal" style="max-width: 500px;">
+                        <div class="integram-modal-header">
+                            <h3>Удаление записей по фильтру</h3>
+                        </div>
+                        <div class="integram-modal-body">
+                            <div class="bulk-delete-progress-bar-container">
+                                <div class="bulk-delete-progress-bar" style="width: 0%"></div>
+                            </div>
+                            <div class="bulk-delete-progress-text">Удалено: 0 / ${ total }</div>
+                            <div class="bulk-delete-errors" style="display: none;"></div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            document.body.insertAdjacentHTML('beforeend', progressHtml);
+
+            const progressOverlay = document.getElementById(progressId);
+            const progressBar = progressOverlay.querySelector('.bulk-delete-progress-bar');
+            const progressText = progressOverlay.querySelector('.bulk-delete-progress-text');
+            const errorsDiv = progressOverlay.querySelector('.bulk-delete-errors');
+
+            const updateProgress = () => {
+                const pct = Math.round((completed / total) * 100);
+                progressBar.style.width = `${ pct }%`;
+                progressText.textContent = `Удалено: ${ completed } / ${ total }`;
+            };
+
+            // Send chunks sequentially — we want to update progress between
+            // chunks, and parallelising large server-side transactions just
+            // moves the contention from network to MySQL.
+            for (let i = 0; i < records.length; i += FILTER_DELETE_CHUNK) {
+                const chunk = records.slice(i, i + FILTER_DELETE_CHUNK);
+                const chunkIds = chunk.map(r => r.id);
+
+                const params = new URLSearchParams();
+                params.append('ids', chunkIds.join(','));
+                if (typeof xsrf !== 'undefined') {
+                    params.append('_xsrf', xsrf);
+                }
+
+                try {
+                    const response = await fetch(`${ apiBase }/_m_del_batch/${ this.objectTableId }?JSON`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: params.toString()
+                    });
+
+                    const text = await response.text();
+                    let result;
+                    try {
+                        result = JSON.parse(text);
+                    } catch (parseErr) {
+                        // Non-JSON response (e.g. PHP fatal) — record as a warning
+                        // for the whole chunk so the user can see what happened.
+                        warnings.push(`chunk ${ i / FILTER_DELETE_CHUNK + 1 } : ${ text.slice(0, 200) }`);
+                        completed += chunk.length;
+                        updateProgress();
+                        continue;
+                    }
+
+                    // Top-level error from the endpoint (e.g. 403): mark all ids
+                    // in this chunk as failed.
+                    if (result && Array.isArray(result) && result[0] && result[0].error) {
+                        const msg = result[0].error;
+                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ msg }`);
+                        completed += chunk.length;
+                        updateProgress();
+                        continue;
+                    }
+                    if (result && result.error) {
+                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ result.error }`);
+                        completed += chunk.length;
+                        updateProgress();
+                        continue;
+                    }
+
+                    const deletedIds = (result && Array.isArray(result.deleted)) ? result.deleted : [];
+                    const chunkErrors = (result && result.errors && typeof result.errors === 'object') ? result.errors : {};
+
+                    for (const rid of deletedIds) completed++;
+                    for (const rid of Object.keys(chunkErrors)) {
+                        const value = valueById.get(String(rid)) || '';
+                        errors.push(`#${ rid } : ${ value } : ${ chunkErrors[rid] }`);
+                    }
+                    updateProgress();
+                } catch (err) {
+                    // Network/transport failure — surface every id in the chunk
+                    for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ err.message }`);
+                    completed += chunk.length;
+                    updateProgress();
+                }
+            }
+
+            if (errors.length > 0 || warnings.length > 0) {
+                errorsDiv.style.display = 'block';
+                let html = '';
+                if (errors.length > 0) {
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
+                        <strong>Ошибки (блокирующие):</strong><br>
+                        ${ errors.map(e => {
+                            const parts = e.split(' : ');
+                            if (parts.length >= 3) {
+                                const recordId = this.escapeHtml(parts[0]);
+                                const recordValue = this.escapeHtml(parts[1]);
+                                const errorMsg = parts.slice(2).join(' : ');
+                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
+                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
+                            }
+                            return this.escapeHtml(e);
+                        }).join('<br>') }
+                    </div>`;
+                }
+                if (warnings.length > 0) {
+                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Предупреждения:</strong><br>
+                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
+                    </div>`;
+                }
+                errorsDiv.innerHTML = html;
+            }
+
+            if (errors.length > 0) {
+                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
+            } else {
+                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            }
+
+            if (errors.length === 0 && warnings.length === 0) {
+                setTimeout(() => progressOverlay.remove(), 1500);
+            } else {
+                const closeBtn = document.createElement('button');
+                closeBtn.className = 'btn btn-sm btn-primary';
+                closeBtn.style.marginTop = '10px';
+                closeBtn.textContent = 'Закрыть';
+                closeBtn.addEventListener('click', () => progressOverlay.remove());
+                progressOverlay.querySelector('.integram-modal-body').appendChild(closeBtn);
+            }
+
+            // Reset state and reload (mirrors bulkDelete())
             this.selectedRows.clear();
             this.data = [];
             this.rawObjectData = [];

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -39,6 +39,7 @@
             this.filtersEnabled = false;
             this.objectTableId = null;  // Table ID when data is in object/JSON_OBJ format (for _count=1 queries)
             this.tableGranted = null;  // 'WRITE' = full access, other value = read-only (issue #1508)
+            this.tableDeletable = false;  // True when metadata.delete === "1" — enables "Delete by filter" (issue #2749)
             this.rawObjectData = [];  // Raw data array with {i, u, o, r} for object format (preserves record IDs)
             this.styleColumns = {};  // Map of column IDs to their style column values
             this.idColumns = new Set();  // Set of hidden ID column IDs
@@ -204,6 +205,15 @@
          */
         isStructureWritable() {
             return window.grants && window.grants['1'] === 'WRITE';
+        }
+
+        /**
+         * Check whether bulk "Delete by filter" is allowed (issue #2749).
+         * Mirrors the legacy templates/object.html gate: visible only when
+         * metadata.delete === "1".
+         */
+        isTableDeletable() {
+            return this.tableDeletable === true;
         }
 
         /**
@@ -836,6 +846,9 @@
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
 
+                // Store bulk delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
+
                 // Convert metadata to columns format
                 const columns = [];
 
@@ -925,6 +938,7 @@
                 }
                 this.tableExportAllowed = refreshedMetadata.export === '1' || refreshedMetadata.export === 1;
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
 
                 const refreshedColumns = [];
                 const mainColGranted = this.isTableWritable() ? 1 : 0;

--- a/js/integram-table/02-format-helpers.js
+++ b/js/integram-table/02-format-helpers.js
@@ -56,6 +56,9 @@
             // Store table-level granted value for access control (issue #1508)
             this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
 
+            // Store bulk delete-by-filter flag from metadata (issue #2749)
+            this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
+
             // Convert metadata to columns format
             const columns = [];
 
@@ -166,6 +169,7 @@
                     });
                 }
                 this.tableGranted = refreshedMetadata.granted !== undefined ? refreshedMetadata.granted : null;
+                this.tableDeletable = refreshedMetadata.delete === '1' || refreshedMetadata.delete === 1;
             }
 
             // Transform object format data to row format
@@ -267,6 +271,9 @@
 
                 // Store table-level granted value for access control (issue #1508)
                 this.tableGranted = metadata.granted !== undefined ? metadata.granted : null;
+
+                // Store bulk delete-by-filter flag from metadata (issue #2749)
+                this.tableDeletable = metadata.delete === '1' || metadata.delete === 1;
 
                 // Convert metadata to columns format
                 const columns = [];

--- a/js/integram-table/04-render-table.js
+++ b/js/integram-table/04-render-table.js
@@ -78,6 +78,12 @@
                                 Удалить (${ this.selectedRows.size })
                             </button>
                             ` : '' }
+                            ${ this.isTableDeletable() && this.isTableWritable() ? `
+                            <div class="integram-table-settings integram-table-settings-filter-delete" onclick="window.${ instanceName }.showFilterDeleteConfirm(event)" title="Удалить записи, удовлетворяющие заданному фильтру">
+                                <i class="pi pi-trash"></i>
+                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">удалить по фильтру</span>' : '' }
+                            </div>
+                            ` : '' }
                             <div class="integram-table-settings" onclick="window.${ instanceName }.copyConfigUrl()" title="Скопировать ссылку с текущими фильтрами и группами">
                                 <i class="pi pi-copy"></i>
                                 ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">ссылка</span>' : '' }

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -227,6 +227,321 @@
         }
 
         /**
+         * Show "delete by filter" confirmation popup (issue #2749).
+         * Visible only when metadata.delete === "1" (see isTableDeletable).
+         * Shows the matching count from the existing _count=1 endpoint so
+         * the user knows exactly how many records the bulk delete will hit.
+         * @param {Event} event - click on the trigger button
+         */
+        async showFilterDeleteConfirm(event) {
+            if (event) {
+                event.stopPropagation();
+            }
+
+            const btn = event && event.target
+                ? event.target.closest('.integram-table-settings-filter-delete')
+                : null;
+            if (!btn) return;
+
+            // Toggle: a second click hides the popup
+            const existing = this.container.querySelector('.filter-delete-confirm');
+            if (existing) {
+                existing.remove();
+                return;
+            }
+
+            const loadingHtml = `
+                <div class="filter-delete-confirm" style="display:inline-block; margin-left:8px;">
+                    <span>Подсчёт записей…</span>
+                </div>
+            `;
+            btn.insertAdjacentHTML('afterend', loadingHtml);
+            const popup = this.container.querySelector('.filter-delete-confirm');
+
+            let count;
+            try {
+                count = await this.fetchFilterMatchCount();
+            } catch (err) {
+                console.error('count-by-filter failed:', err);
+                popup.innerHTML = `<span style="color:#b00;">Ошибка подсчёта: ${ this.escapeHtml(err.message || String(err)) }</span>`;
+                setTimeout(() => popup.remove(), 4000);
+                return;
+            }
+
+            if (!Number.isFinite(count) || count <= 0) {
+                popup.innerHTML = '<span>Нет записей, удовлетворяющих фильтру</span>';
+                setTimeout(() => popup.remove(), 3000);
+                return;
+            }
+
+            popup.innerHTML = `
+                <span>Удалить ${ count } записей, удовлетворяющих фильтру?</span>
+                <button class="btn btn-sm btn-danger filter-delete-confirm-btn">Да, удалить</button>
+                <button class="btn btn-sm btn-outline-secondary filter-delete-cancel-btn">Отменить</button>
+            `;
+            popup.querySelector('.filter-delete-confirm-btn').addEventListener('click', () => {
+                popup.remove();
+                this.bulkDeleteByFilter();
+            });
+            popup.querySelector('.filter-delete-cancel-btn').addEventListener('click', () => {
+                popup.remove();
+            });
+        }
+
+        /**
+         * Count records matching the current filter (issue #2749).
+         * Re-uses the existing /object/{id}/?JSON_OBJ&_count=1 endpoint so we
+         * can show an authoritative number in the confirmation without
+         * piggy-backing on cached this.totalRows.
+         * @returns {Promise<number>}
+         */
+        async fetchFilterMatchCount() {
+            if (!this.objectTableId) {
+                throw new Error('Доступно только для табличных источников');
+            }
+            const apiBase = this.getApiBase();
+            const params = new URLSearchParams({ _count: '1' });
+
+            const filters = this.filters || {};
+            Object.keys(filters).forEach(colId => {
+                const filter = filters[colId];
+                if (filter.value || filter.type === '%' || filter.type === '!%') {
+                    const column = this.columns.find(c => c.id === colId);
+                    if (column) {
+                        this.applyFilter(params, column, filter);
+                    }
+                }
+            });
+
+            if (this.options.parentId) {
+                params.set('F_U', this.options.parentId);
+            }
+            this.appendPageUrlParams(params);
+
+            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
+            const response = await fetch(url);
+            const result = await response.json();
+            return parseInt(result.count, 10);
+        }
+
+        /**
+         * Delete all records matching the current filter (issue #2749).
+         *
+         * Replaces both the legacy POST {table_id}/_m_del_select form flow
+         * (templates/object.html) AND the naive "POST /_m_del/{id} per record"
+         * approach. Instead this method:
+         *   1. Fetches matching record IDs from the JSON_OBJ endpoint
+         *      (loadDataFromTableForExport already honours filters/sort/F_U).
+         *   2. Splits the IDs into chunks of FILTER_DELETE_CHUNK records.
+         *   3. POSTs each chunk to /_m_del_batch/{tableId}?JSON in ONE request
+         *      per chunk. The server runs them in a single transaction via
+         *      BatchDelete() — the same path the legacy _m_del_select used.
+         *   4. Updates the progress bar per-chunk and reports per-record
+         *      server errors (reference constraints, missing rights, etc.).
+         *
+         * For a 100k delete this is ~100-200 HTTP requests instead of 100k.
+         */
+        async bulkDeleteByFilter() {
+            if (!this.objectTableId) {
+                this.showToast('Удаление по фильтру доступно только для табличных источников', 'error');
+                return;
+            }
+
+            // Chunk size — bounded to keep individual DB transactions reasonable
+            // and to give the progress bar useful granularity. The server caps
+            // _m_del_batch at 10000 ids per request anyway.
+            const FILTER_DELETE_CHUNK = 500;
+
+            // Load all matching record IDs through the existing export pathway.
+            let records = [];
+            try {
+                const savedTableTypeId = this.options.tableTypeId;
+                if (!this.options.tableTypeId && this.objectTableId) {
+                    this.options.tableTypeId = this.objectTableId;
+                }
+                const json = await this.loadDataFromTableForExport(0, 1000000);
+                this.options.tableTypeId = savedTableTypeId;
+
+                const rawData = (json && json.rawData) || [];
+                records = rawData
+                    .filter(item => item && item.i)
+                    .map(item => ({
+                        id: item.i,
+                        value: (item.r && item.r[0]) || ''
+                    }));
+            } catch (err) {
+                console.error('filter-delete load failed:', err);
+                this.showToast(`Ошибка загрузки записей: ${ err.message }`, 'error');
+                return;
+            }
+
+            if (records.length === 0) {
+                this.showToast('Нет записей, удовлетворяющих фильтру', 'error');
+                return;
+            }
+
+            const apiBase = this.getApiBase();
+            const total = records.length;
+            let completed = 0;
+            const errors = [];
+            const warnings = [];
+
+            // Map id -> first-column value, for human-readable error rows.
+            const valueById = new Map();
+            for (const r of records) valueById.set(String(r.id), r.value);
+
+            const progressId = `filter-delete-progress-${ Date.now() }`;
+            const progressHtml = `
+                <div class="integram-modal-overlay" id="${ progressId }">
+                    <div class="integram-modal" style="max-width: 500px;">
+                        <div class="integram-modal-header">
+                            <h3>Удаление записей по фильтру</h3>
+                        </div>
+                        <div class="integram-modal-body">
+                            <div class="bulk-delete-progress-bar-container">
+                                <div class="bulk-delete-progress-bar" style="width: 0%"></div>
+                            </div>
+                            <div class="bulk-delete-progress-text">Удалено: 0 / ${ total }</div>
+                            <div class="bulk-delete-errors" style="display: none;"></div>
+                        </div>
+                    </div>
+                </div>
+            `;
+            document.body.insertAdjacentHTML('beforeend', progressHtml);
+
+            const progressOverlay = document.getElementById(progressId);
+            const progressBar = progressOverlay.querySelector('.bulk-delete-progress-bar');
+            const progressText = progressOverlay.querySelector('.bulk-delete-progress-text');
+            const errorsDiv = progressOverlay.querySelector('.bulk-delete-errors');
+
+            const updateProgress = () => {
+                const pct = Math.round((completed / total) * 100);
+                progressBar.style.width = `${ pct }%`;
+                progressText.textContent = `Удалено: ${ completed } / ${ total }`;
+            };
+
+            // Send chunks sequentially — we want to update progress between
+            // chunks, and parallelising large server-side transactions just
+            // moves the contention from network to MySQL.
+            for (let i = 0; i < records.length; i += FILTER_DELETE_CHUNK) {
+                const chunk = records.slice(i, i + FILTER_DELETE_CHUNK);
+                const chunkIds = chunk.map(r => r.id);
+
+                const params = new URLSearchParams();
+                params.append('ids', chunkIds.join(','));
+                if (typeof xsrf !== 'undefined') {
+                    params.append('_xsrf', xsrf);
+                }
+
+                try {
+                    const response = await fetch(`${ apiBase }/_m_del_batch/${ this.objectTableId }?JSON`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: params.toString()
+                    });
+
+                    const text = await response.text();
+                    let result;
+                    try {
+                        result = JSON.parse(text);
+                    } catch (parseErr) {
+                        // Non-JSON response (e.g. PHP fatal) — record as a warning
+                        // for the whole chunk so the user can see what happened.
+                        warnings.push(`chunk ${ i / FILTER_DELETE_CHUNK + 1 } : ${ text.slice(0, 200) }`);
+                        completed += chunk.length;
+                        updateProgress();
+                        continue;
+                    }
+
+                    // Top-level error from the endpoint (e.g. 403): mark all ids
+                    // in this chunk as failed.
+                    if (result && Array.isArray(result) && result[0] && result[0].error) {
+                        const msg = result[0].error;
+                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ msg }`);
+                        completed += chunk.length;
+                        updateProgress();
+                        continue;
+                    }
+                    if (result && result.error) {
+                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ result.error }`);
+                        completed += chunk.length;
+                        updateProgress();
+                        continue;
+                    }
+
+                    const deletedIds = (result && Array.isArray(result.deleted)) ? result.deleted : [];
+                    const chunkErrors = (result && result.errors && typeof result.errors === 'object') ? result.errors : {};
+
+                    for (const rid of deletedIds) completed++;
+                    for (const rid of Object.keys(chunkErrors)) {
+                        const value = valueById.get(String(rid)) || '';
+                        errors.push(`#${ rid } : ${ value } : ${ chunkErrors[rid] }`);
+                    }
+                    updateProgress();
+                } catch (err) {
+                    // Network/transport failure — surface every id in the chunk
+                    for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ err.message }`);
+                    completed += chunk.length;
+                    updateProgress();
+                }
+            }
+
+            if (errors.length > 0 || warnings.length > 0) {
+                errorsDiv.style.display = 'block';
+                let html = '';
+                if (errors.length > 0) {
+                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
+                        <strong>Ошибки (блокирующие):</strong><br>
+                        ${ errors.map(e => {
+                            const parts = e.split(' : ');
+                            if (parts.length >= 3) {
+                                const recordId = this.escapeHtml(parts[0]);
+                                const recordValue = this.escapeHtml(parts[1]);
+                                const errorMsg = parts.slice(2).join(' : ');
+                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
+                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
+                            }
+                            return this.escapeHtml(e);
+                        }).join('<br>') }
+                    </div>`;
+                }
+                if (warnings.length > 0) {
+                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
+                        <strong>Предупреждения:</strong><br>
+                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
+                    </div>`;
+                }
+                errorsDiv.innerHTML = html;
+            }
+
+            if (errors.length > 0) {
+                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
+            } else {
+                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
+            }
+
+            if (errors.length === 0 && warnings.length === 0) {
+                setTimeout(() => progressOverlay.remove(), 1500);
+            } else {
+                const closeBtn = document.createElement('button');
+                closeBtn.className = 'btn btn-sm btn-primary';
+                closeBtn.style.marginTop = '10px';
+                closeBtn.textContent = 'Закрыть';
+                closeBtn.addEventListener('click', () => progressOverlay.remove());
+                progressOverlay.querySelector('.integram-modal-body').appendChild(closeBtn);
+            }
+
+            // Reset state and reload (mirrors bulkDelete())
+            this.selectedRows.clear();
+            this.data = [];
+            this.rawObjectData = [];
+            this.loadedRecords = 0;
+            this.hasMore = true;
+            this.totalRows = null;
+            await this.loadData(false);
+        }
+
+        /**
          * Toggle export menu visibility.
          * Issue #1652: the menu is appended to document.body with position:fixed so it
          * escapes the overflow:hidden / overflow-y:hidden clipping of ancestor containers


### PR DESCRIPTION
## Summary

Реализует кнопку «Удалить по фильтру» из старого `templates/object.html` в новом компоненте — закрывает #2749. Альтернатива #2751: вместо N HTTP-запросов (`POST /_m_del/{id}` на каждую запись) использует **серверный батч-эндпоинт**.

### Почему не как в #2751

На таблице в 100 000 строк подход «один HTTP на запись» из #2751 шлёт **100 000** одновременных `fetch` через `Promise.all`. Это:
- DDoS-ит собственный сервер (десятки параллельных PHP-воркеров, сотни SQL-транзакций в секунду);
- кладёт браузер в TCP-очередь на десятки минут;
- генерирует 100 000 DOM-обновлений прогресс-бара.

Legacy `_m_del_select` (`index.php:6566`) делал то же самое **одним** SQL-проходом через готовую `BatchDelete()`. Issue требует «отдельный метод», но это не значит «отдельный HTTP на запись».

### Что делает этот PR

**Сервер** (`index.php`, новый `case "_m_del_batch"`):
- `POST /db/_m_del_batch/{type_id}?JSON`, body: `ids=1,2,3,...` или `ids[]=...`
- Один запрос проверки прав уровня типа — как в legacy `_m_del_select`.
- Один `SELECT … WHERE id IN (…)` валидирует весь батч сразу (тот же тип, есть родитель, нет входящих ссылок).
- `BatchDelete($id)` в цикле + один `BatchDelete(\"\")` flush — итог: один пакетный `DELETE` на сервере.
- Ответ: `{deleted:[…], errors:{id:reason}}` — UI видит per-record ошибки.
- Жёсткий предел 10 000 ID на запрос.

**Клиент** (`js/integram-table/`):
- `01-core.js` / `02-format-helpers.js` — флаг `tableDeletable` из `metadata.delete === \"1\"` + хелпер `isTableDeletable()`. Парсится во всех путях загрузки метаданных, включая metadata-drift refresh.
- `04-render-table.js` — кнопка «удалить по фильтру» в тулбаре, видна только при `isTableDeletable() && isTableWritable()`.
- `23-bulk-export.js`:
  - `showFilterDeleteConfirm()` — показывает кол-во через существующий `?JSON_OBJ&_count=1` (`fetchFilterMatchCount()`).
  - `bulkDeleteByFilter()` — берёт все ID через существующий `loadDataFromTableForExport` (фильтры, сортировка, `F_U`, GET-параметры — всё уже там), режет на чанки по **500**, шлёт `POST /_m_del_batch/{tableId}?JSON` **последовательно**, обновляет прогресс-бар после каждого чанка, собирает per-record и chunk-level ошибки (network, 403, не-JSON-ответ).

**Эффект:** 100 000 записей → ~200 HTTP-запросов вместо 100 000 (× 500 меньше). Один SQL-`DELETE … WHERE id IN (…)` на чанк вместо 100 000 индивидуальных.

## Files changed

- `index.php` — новый `case \"_m_del_batch\"` рядом с существующим `_m_del`.
- `js/integram-table/01-core.js` — `tableDeletable`, `isTableDeletable()`, парсинг `metadata.delete` в `loadDataFromTable` и в metadata-drift refresh.
- `js/integram-table/02-format-helpers.js` — парсинг `metadata.delete` в `parseObjectFormat()` и `parseJsonDataArray()` (включая refresh-ветку).
- `js/integram-table/04-render-table.js` — кнопка тулбара.
- `js/integram-table/23-bulk-export.js` — `showFilterDeleteConfirm()`, `fetchFilterMatchCount()`, `bulkDeleteByFilter()` (чанковая реализация).
- `js/integram-table.js` — пересобран через `bash build.sh`.
- `experiments/test-issue-2749-delete-by-filter.js` — unit-тесты.

## Test plan

```
node experiments/test-issue-2749-delete-by-filter.js
```
Проверяет:
- [x] воспроизводит legacy-флоу `_m_del_select`, который этот PR заменяет;
- [x] `fetchFilterMatchCount` форсирует `_count=1` и прокидывает фильтры + `F_U`;
- [x] на 1234 матча `bulkDeleteByFilter` шлёт **3** запроса в `/_m_del_batch`, а не 1234 в `/_m_del/{id}`;
- [x] legacy `_m_del_select` и per-record `/_m_del/{id}` **не вызываются**;
- [x] per-record ошибки из ответа `_m_del_batch` попадают в сводку;
- [x] полный отказ чанка (HTTP 403, network error, не-JSON-ответ) рапортуется по всем ID этого чанка, при этом успешные чанки не пятнаются.

Регрессия: `node experiments/test-issue-2746-delete-table-references.js` — проходит.

Manual:
- [ ] пользователь с `metadata.delete:\"1\"` видит кнопку «удалить по фильтру»;
- [ ] без `delete:\"1\"` — кнопки нет;
- [ ] задать фильтр, нажать — попап со счётчиком;
- [ ] подтвердить — прогресс-бар двигается по чанкам, в DevTools видно `POST /_m_del_batch/{tableId}?JSON` ровно `ceil(N/500)` раз;
- [ ] навесить ссылочную защиту на запись — её ID появится в списке ошибок, остальные удалятся;
- [ ] на таблице 100k+ записей — сервер не падает, браузер не виснет.

Closes #2749
Supersedes #2751 (тот же issue, серверный батч вместо N HTTP-запросов на запись).