### PR TITLE
fix(report): горизонтальный скролл в таблице отчёта (closes #2753)

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -57,6 +57,9 @@
 	</TR>
 	<TR>
 	<TD colspan="3">
+		<!-- Issue #2753: горизонтальный скролл, когда таблица шире вьюпорта.
+		     overflow-y оставляем visible, чтобы не ломать position:sticky на шапке. -->
+		<div id="report_scroll" style="overflow-x:auto; overflow-y:visible; -webkit-overflow-scrolling:touch; max-width:100%;">
 		<TABLE id="report_table" class="table table-bordered">
 			<TR style="background-color:var(--bg-secondary,#f9f9f9); position:sticky; top:-1px;" onclick="toggle_filter();">
 				<!-- Begin:&Uni_Report_Head -->
@@ -85,6 +88,7 @@
 			</TR>
 			<!-- End:&Uni_Report_Totals -->
 		</TABLE>
+		</div>
 	</TD>
 	</TR>
 	</TABLE>


### PR DESCRIPTION
## Summary

Closes #2753. Когда \`#report_table\` шире вьюпорта (отчёт с десятками колонок или длинными значениями), правая часть уходила за экран и доехать до неё было невозможно — внешний layout не давал ни прокрутки, ни обрезки с индикатором.

## Что меняется

В \`templates/report.html\` оборачиваю \`#report_table\` в \`<div id=\"report_scroll\">\` с \`overflow-x:auto\` — горизонтальный скролл появляется только когда таблица не помещается, узкие отчёты выглядят как раньше.

## Что **не** ломается

- **Sticky-шапка** (\`<TR style=\"position:sticky; top:-1px\">\` на строке 61): на обёртке задано \`overflow-y:visible\`, чтобы scroll-контейнер не «забрал» вертикальный скролл и containing block для sticky оставался прежним.
- **Экспорт HTML/XLS**: \`tableToExcel('report_table', …)\` и \`XLSX.utils.table_to_book(document.getElementById('report_table'))\` ссылаются по id таблицы, обёртка их не затрагивает.
- **Кнопки compact / refresh / filter**: тоже работают по id-шкам внутри таблицы.
- **Узкие отчёты**: при ширине таблицы ≤ ширины вьюпорта \`overflow-x:auto\` скроллбар не показывает.

## Test plan

- [ ] открыть отчёт с большим числом колонок (или с длинными значениями) на экране, где он не помещается → внизу обёртки появляется горизонтальный скроллбар, правая часть доступна;
- [ ] прокрутить вниз — sticky-шапка прилипает к верху страницы, как и раньше;
- [ ] нажать `.HTML` / `.XLS` — экспорт работает, содержимое то же;
- [ ] открыть отчёт, помещающийся в экран — лишнего скроллбара нет;
- [ ] iOS Safari — инерционный скролл (через `-webkit-overflow-scrolling:touch`).