### PR TITLE
fix(integram-table): keep filters editable when load fails with non-JSON response (closes #2758)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-05-20T11:21:28.991Z for PR creation at branch issue-2738-8e8b4c897b21 for issue https://github.com/ideav/crm/issues/2738
 # Updated: 2026-05-20T14:14:44.011Z
 # Updated: 2026-05-20T16:00:49.504Z
+# Updated: 2026-05-22T07:44:28.680Z

--- a/experiments/test-issue-2758-non-json-error.js
+++ b/experiments/test-issue-2758-non-json-error.js
@@ -1,0 +1,234 @@
+/**
+ * Issue #2758 regression coverage for IntegramTable filter error handling.
+ *
+ * When a filter triggers a request that returns a non-JSON body (e.g. the
+ * server's "Couldn't extract ..." plaintext error for an invalid IN() list),
+ * the table previously replaced its entire container with a static alert,
+ * destroying the filter row so the user could not correct the bad input.
+ *
+ * The fix has two parts:
+ *   1. fetchJson() surfaces the server's text instead of the cryptic
+ *      "Unexpected token ..." JSON parse error.
+ *   2. handleLoadDataError() preserves the rendered table when columns are
+ *      already loaded, showing the error as a toast so filters stay editable.
+ *
+ * Run with: node experiments/test-issue-2758-non-json-error.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const rootDir = path.join(__dirname, '..');
+
+(async function run() {
+    const sourcePath = path.join(rootDir, 'js', 'integram-table.js');
+    const source = fs.readFileSync(sourcePath, 'utf8');
+
+    const toasts = [];
+    const fetches = [];
+    const elements = new Map();
+
+    function createElement(tag) {
+        return {
+            tagName: tag,
+            className: '',
+            style: {},
+            dataset: {},
+            children: [],
+            innerHTML: '',
+            textContent: '',
+            classList: { add() {}, remove() {}, contains() { return false; }, toggle() {} },
+            setAttribute() {},
+            removeAttribute() {},
+            getAttribute() { return null; },
+            appendChild(child) { this.children.push(child); return child; },
+            removeChild(child) {
+                const idx = this.children.indexOf(child);
+                if (idx >= 0) this.children.splice(idx, 1);
+                return child;
+            },
+            insertBefore(child) { this.children.push(child); return child; },
+            querySelector() { return null; },
+            querySelectorAll() { return []; },
+            addEventListener() {},
+            removeEventListener() {},
+            getBoundingClientRect() { return { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0 }; },
+            cloneNode() { return createElement(tag); },
+            remove() {},
+            focus() {},
+            blur() {},
+            click() {},
+        };
+    }
+
+    const container = createElement('div');
+    container.id = 'integram-test-container';
+    container.parentElement = { parentElement: { style: {} } };
+    elements.set('integram-test-container', container);
+
+    let nextFetchHandler = null;
+
+    const sandbox = {
+        console,
+        window: {
+            location: { origin: 'https://example.test', pathname: '/test', search: '' },
+            _integramTableInstances: [],
+            _integramStandaloneMetadataCache: {},
+            _integramStandaloneMetadataFetchPromises: {},
+            showToast(message, type) { toasts.push({ message, type }); },
+            requestAnimationFrame(cb) { cb(); return 0; },
+            setTimeout,
+            clearTimeout,
+            innerWidth: 1024,
+            innerHeight: 768,
+            scrollX: 0,
+            scrollY: 0,
+        },
+        document: {
+            readyState: 'loading',
+            addEventListener() {},
+            removeEventListener() {},
+            getElementById(id) { return elements.get(id) || null; },
+            querySelector() { return null; },
+            querySelectorAll() { return []; },
+            createElement(tag) { return createElement(tag); },
+            body: createElement('body'),
+            documentElement: createElement('html'),
+            activeElement: null,
+            cookie: '',
+        },
+        fetch(url, options) {
+            fetches.push({ url: String(url), options });
+            if (typeof nextFetchHandler === 'function') {
+                return nextFetchHandler(String(url), options);
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                statusText: 'OK',
+                headers: { get() { return 'application/json'; } },
+                text() { return Promise.resolve('{}'); },
+                json() { return Promise.resolve({}); },
+            });
+        },
+        URLSearchParams,
+        URL,
+        setTimeout,
+        clearTimeout,
+        Promise,
+        Map,
+        Set,
+        WeakMap,
+        WeakSet,
+        Symbol,
+        Date,
+        Math,
+        JSON,
+        Array,
+        Object,
+        Number,
+        String,
+        Boolean,
+        Error,
+        RegExp,
+        Intl,
+        navigator: { clipboard: { writeText: () => Promise.resolve() }, userAgent: 'node-test' },
+    };
+    sandbox.window.window = sandbox.window;
+    sandbox.window.document = sandbox.document;
+    sandbox.globalThis = sandbox;
+    sandbox.self = sandbox.window;
+
+    vm.createContext(sandbox);
+    // Append a small shim so the top-level class declaration becomes reachable
+    // via the sandbox (vm runs the file as a script, not a module).
+    const exposed = source + '\n;this.IntegramTable = IntegramTable;\n';
+    vm.runInContext(exposed, sandbox, { filename: sourcePath });
+
+    const IntegramTable = sandbox.IntegramTable || sandbox.window.IntegramTable;
+    assert.ok(IntegramTable, 'IntegramTable class should be exposed');
+
+    // Build an instance manually without running init(), which kicks off
+    // network calls and full rendering we don't need for this regression.
+    const instance = Object.create(IntegramTable.prototype);
+    instance.container = container;
+    instance.columns = [];
+    instance.data = [];
+    instance.filters = {};
+    instance.options = { apiUrl: '/test', instanceName: 'test', pageSize: 20 };
+
+    // --- Part 1: fetchJson surfaces non-JSON server payload ---------------
+    nextFetchHandler = () => Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: { get() { return 'text/plain'; } },
+        text() { return Promise.resolve("Couldn't extract IN list from filter"); },
+    });
+
+    let caught;
+    try {
+        await instance.fetchJson('/api/test');
+    } catch (error) {
+        caught = error;
+    }
+    assert.ok(caught, 'fetchJson should reject non-JSON responses');
+    assert.strictEqual(
+        caught.message,
+        "Couldn't extract IN list from filter",
+        'fetchJson surfaces the server text instead of the JSON parse error'
+    );
+    assert.strictEqual(caught.isNonJsonResponse, true, 'fetchJson tags the error');
+
+    // --- Part 2: handleLoadDataError keeps filters when columns exist ----
+    instance.columns = [
+        { id: '101', name: 'Имя', format: 'CHARS', granted: 0, ref: 0 },
+    ];
+    container.innerHTML = '<div class="integram-table-wrapper">existing filter row</div>';
+
+    let rendered = 0;
+    instance.render = function () { rendered++; container.innerHTML = '<div class="integram-table-wrapper">re-rendered</div>'; };
+    instance.showToast = function (message, type) { toasts.push({ message, type }); };
+
+    instance.handleLoadDataError(new Error("Couldn't extract IN list from filter"), false);
+
+    assert.strictEqual(rendered, 1, 'handleLoadDataError re-renders existing table');
+    assert.ok(
+        container.innerHTML.includes('integram-table-wrapper'),
+        'container keeps the rendered table (filters stay visible)'
+    );
+    assert.ok(
+        !container.innerHTML.includes('alert-danger'),
+        'container does not get replaced with an alert when columns exist'
+    );
+    assert.strictEqual(toasts.length, 1, 'a toast notifies the user about the error');
+    assert.strictEqual(
+        toasts[0].message,
+        "Ошибка загрузки данных: Couldn't extract IN list from filter"
+    );
+    assert.strictEqual(toasts[0].type, 'error');
+
+    // --- Part 3: initial-load failure still shows an inline alert --------
+    const freshInstance = Object.create(IntegramTable.prototype);
+    const freshContainer = createElement('div');
+    freshInstance.container = freshContainer;
+    freshInstance.columns = [];
+
+    freshInstance.handleLoadDataError(new Error('Server is down'), false);
+
+    assert.ok(
+        freshContainer.innerHTML.includes('alert-danger'),
+        'initial load failure (no columns yet) still surfaces inline alert'
+    );
+    assert.ok(
+        freshContainer.innerHTML.includes('Server is down'),
+        'inline alert message includes the underlying error'
+    );
+
+    console.log('issue-2758 non-JSON error handling: ok');
+})().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -583,13 +583,67 @@ class IntegramTable{
                 }
             } catch (error) {
                 console.error('Error loading data:', error);
-                if (!append && this.container) {
-                    this.container.innerHTML = `<div class="alert alert-danger">Ошибка загрузки данных: ${ error.message }</div>`;
-                }
+                this.handleLoadDataError(error, append);
             } finally {
                 this.isLoading = false;
                 // Check if table fits on screen and needs more data
                 this.checkAndLoadMore();
+            }
+        }
+
+        /**
+         * Surface a data-loading error without destroying the rendered table.
+         * Issue #2758: replacing container.innerHTML on a failed filter request
+         * removed the filter inputs, so users could not correct the bad input
+         * (e.g. an empty IN(,) list). When columns are already loaded we keep the
+         * existing layout (with an empty body) and show the error as a toast so
+         * the filter row remains editable.
+         */
+        handleLoadDataError(error, append) {
+            const message = (error && error.message) ? error.message : String(error);
+            if (!this.container) {
+                return;
+            }
+
+            if (this.columns.length > 0) {
+                try {
+                    this.render();
+                } catch (renderError) {
+                    console.error('Failed to re-render table after load error:', renderError);
+                }
+                this.showToast(`Ошибка загрузки данных: ${ message }`, 'error');
+                return;
+            }
+
+            if (!append) {
+                this.container.innerHTML = `<div class="alert alert-danger">Ошибка загрузки данных: ${ message }</div>`;
+            } else {
+                this.showToast(`Ошибка загрузки данных: ${ message }`, 'error');
+            }
+        }
+
+        /**
+         * Fetch a URL and parse the response as JSON.
+         * When the server returns a non-JSON payload (e.g. a plaintext error like
+         * "Couldn't extract ..."), surface that text so the user sees the actual
+         * server message instead of a cryptic "Unexpected token ..." parse error
+         * (issue #2758).
+         */
+        async fetchJson(url) {
+            const response = await fetch(url);
+            const text = await response.text();
+
+            try {
+                return text === '' ? null : JSON.parse(text);
+            } catch (parseError) {
+                const trimmed = (text || '').trim();
+                const preview = trimmed
+                    ? trimmed.slice(0, 300)
+                    : `HTTP ${ response.status } ${ response.statusText }`.trim();
+                const error = new Error(preview);
+                error.isNonJsonResponse = true;
+                error.status = response.status;
+                throw error;
             }
         }
 
@@ -629,8 +683,7 @@ class IntegramTable{
             this.appendPageUrlParams(params);
 
             const separator = this.options.apiUrl.includes('?') ? '&' : '?';
-            const response = await fetch(`${ this.options.apiUrl }${ separator }${ params }`);
-            const json = await response.json();
+            const json = await this.fetchJson(`${ this.options.apiUrl }${ separator }${ params }`);
 
             // Check if this is object format (has id, type keys but not columns, data)
             if (this.isObjectFormat(json)) {
@@ -926,8 +979,7 @@ class IntegramTable{
                 dataUrl += `&${ pageParams.toString() }`;
             }
 
-            const dataResponse = await fetch(dataUrl);
-            const data = await dataResponse.json();
+            const data = await this.fetchJson(dataUrl);
 
             // Detect metadata drift: rows whose `r` length differs from the
             // current column count mean another user changed the table schema

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -566,13 +566,67 @@
                 }
             } catch (error) {
                 console.error('Error loading data:', error);
-                if (!append && this.container) {
-                    this.container.innerHTML = `<div class="alert alert-danger">Ошибка загрузки данных: ${ error.message }</div>`;
-                }
+                this.handleLoadDataError(error, append);
             } finally {
                 this.isLoading = false;
                 // Check if table fits on screen and needs more data
                 this.checkAndLoadMore();
+            }
+        }
+
+        /**
+         * Surface a data-loading error without destroying the rendered table.
+         * Issue #2758: replacing container.innerHTML on a failed filter request
+         * removed the filter inputs, so users could not correct the bad input
+         * (e.g. an empty IN(,) list). When columns are already loaded we keep the
+         * existing layout (with an empty body) and show the error as a toast so
+         * the filter row remains editable.
+         */
+        handleLoadDataError(error, append) {
+            const message = (error && error.message) ? error.message : String(error);
+            if (!this.container) {
+                return;
+            }
+
+            if (this.columns.length > 0) {
+                try {
+                    this.render();
+                } catch (renderError) {
+                    console.error('Failed to re-render table after load error:', renderError);
+                }
+                this.showToast(`Ошибка загрузки данных: ${ message }`, 'error');
+                return;
+            }
+
+            if (!append) {
+                this.container.innerHTML = `<div class="alert alert-danger">Ошибка загрузки данных: ${ message }</div>`;
+            } else {
+                this.showToast(`Ошибка загрузки данных: ${ message }`, 'error');
+            }
+        }
+
+        /**
+         * Fetch a URL and parse the response as JSON.
+         * When the server returns a non-JSON payload (e.g. a plaintext error like
+         * "Couldn't extract ..."), surface that text so the user sees the actual
+         * server message instead of a cryptic "Unexpected token ..." parse error
+         * (issue #2758).
+         */
+        async fetchJson(url) {
+            const response = await fetch(url);
+            const text = await response.text();
+
+            try {
+                return text === '' ? null : JSON.parse(text);
+            } catch (parseError) {
+                const trimmed = (text || '').trim();
+                const preview = trimmed
+                    ? trimmed.slice(0, 300)
+                    : `HTTP ${ response.status } ${ response.statusText }`.trim();
+                const error = new Error(preview);
+                error.isNonJsonResponse = true;
+                error.status = response.status;
+                throw error;
             }
         }
 
@@ -612,8 +666,7 @@
             this.appendPageUrlParams(params);
 
             const separator = this.options.apiUrl.includes('?') ? '&' : '?';
-            const response = await fetch(`${ this.options.apiUrl }${ separator }${ params }`);
-            const json = await response.json();
+            const json = await this.fetchJson(`${ this.options.apiUrl }${ separator }${ params }`);
 
             // Check if this is object format (has id, type keys but not columns, data)
             if (this.isObjectFormat(json)) {
@@ -909,8 +962,7 @@
                 dataUrl += `&${ pageParams.toString() }`;
             }
 
-            const dataResponse = await fetch(dataUrl);
-            const data = await dataResponse.json();
+            const data = await this.fetchJson(dataUrl);
 
             // Detect metadata drift: rows whose `r` length differs from the
             // current column count mean another user changed the table schema


### PR DESCRIPTION
## Summary

Fixes #2758. When a filter triggered a request whose response was not valid JSON (e.g. the server's `Couldn't extract IN list from filter` plaintext error for an empty `IN(,)` list), the table previously replaced its entire container with a static `Ошибка загрузки данных: Unexpected token 'C', "Couldn't e"... is not valid JSON` alert. The filter row vanished along with the table, so the user could not correct the bad input.

## Changes

- `js/integram-table/01-core.js`
  - New `fetchJson(url)` helper: reads the response as text, parses it with `JSON.parse`, and on failure throws an `Error` whose `message` is the server's response text (trimmed to 300 chars). This surfaces the actual server-side cause instead of a cryptic JSON parse error.
  - New `handleLoadDataError(error, append)` method: when columns are already loaded (i.e. the table has been rendered at least once), it calls `render()` to redraw the existing layout — keeping the filter row visible — and shows the error as a toast. The original inline `alert-danger` is still used for the very first load failure (no columns yet) and for `append=true` scroll failures fall back to a toast.
  - Both `loadDataFromReport()` and `loadDataFromTable()` now use `fetchJson()` instead of `await response.json()`.
- `js/integram-table.js` rebuilt via `bash build.sh`.
- `experiments/test-issue-2758-non-json-error.js` — Node regression test covering:
  1. `fetchJson` surfaces the raw server text from a non-JSON body.
  2. `handleLoadDataError` preserves the rendered table (filters stay visible) and shows a toast when columns are already loaded.
  3. The initial-load failure still shows the inline alert.

## How to reproduce the original bug

1. Open any Integram table that supports filters.
2. Select a `(,) в списке` (`IN`) filter on a column.
3. Enter a value containing only delimiters, e.g. `,`.
4. Before the fix: the table and filter row disappear, replaced by `Ошибка загрузки данных: Unexpected token 'C', "Couldn't e"... is not valid JSON`. After the fix: a toast appears with the readable server message and the filter row stays editable so you can correct the input.

## Test plan

- [x] `node experiments/test-issue-2758-non-json-error.js` passes.
- [x] `node experiments/test-issue-2226-create-helper-server-error.js` still passes (regression check for sibling helper).
- [x] `node --check js/integram-table.js` passes.
- [ ] Manual verification in the CRM UI with a real `IN(,)` filter on a known table.