### PR TITLE
fix(index.php): dedup pending Ref inserts across records (closes #2772)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-22T15:14:33.637Z for PR creation at branch issue-2772-546e80090c3e for issue https://github.com/ideav/crm/issues/2772

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-22T15:14:33.637Z for PR creation at branch issue-2772-546e80090c3e for issue https://github.com/ideav/crm/issues/2772

--- a/experiments/test-issue-2772-cross-record-dedup.php
+++ b/experiments/test-issue-2772-cross-record-dedup.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Test for issue #2772:
+ * When the same unknown word (e.g. "черный") appears across MULTIPLE records
+ * being edited in a single Compile_Report pass, the deferred-Insert pipeline
+ * from #2770/#2771 must:
+ *   1. assign the SAME placeholder id to the same value across records during
+ *      the preview pass — so the operator sees one consistent "(новое) черный"
+ *      reference, not a separate negative id per row, and
+ *   2. perform exactly ONE Insert when the operator confirms — not one Insert
+ *      per record that mentions the word.
+ *
+ * Additionally — and surfaced by #2772 in production data — when the records
+ * being updated are EXISTING rows (the elseif(!isset($value["val"][$n])) UPDATE
+ * branch of Compile_Report, not the new-record branch), the pending placeholder
+ * MUST still be materialized before the UPDATE writes t=, otherwise the SQL
+ * sets t to a negative placeholder id.
+ *
+ * The harness below mirrors that resolve / execute split across multiple rows.
+ *
+ * Cross-record dedup is what makes the second Тонер-картридж row (#2857984)
+ * reuse the same brand new "черный" ref id that the first row (#2848986)
+ * minted — instead of each row creating its own duplicate "черный" entry.
+ */
+
+class Issue2772MultiRecordHarness {
+    public $insertedNextId = 1000;
+    public $refsByVal = array();
+    public $inserts = array();            // Inserts performed in execute()
+    public $prepareInserts = array();     // Inserts in prepare() — MUST stay empty
+    public $pendingSeq = 0;
+    public $dsRefs = array();
+    public $records = array();            // $rec => array("t" => id, "tList" => [...])
+    public $pendingByVal = array();       // column-wide val => placeholder id
+    public $tListPending = array();       // $rec => array(placeholder => entry)
+
+    public function __construct($refsByVal){
+        $this->refsByVal = $refsByVal;
+        $maxId = 0;
+        foreach($refsByVal as $id) if($id > $maxId) $maxId = $id;
+        $this->insertedNextId = $maxId + 1;
+    }
+
+    public function seekRefByVal($refOrig, $val){
+        if(isset($this->refsByVal[$val]))
+            return $this->refsByVal[$val];
+        return false;
+    }
+
+    public function insertRef($refOrig, $val, $phase){
+        $id = $this->insertedNextId++;
+        $this->refsByVal[$val] = $id;
+        $record = array("up" => 1, "ord" => 1, "t" => $refOrig, "val" => $val, "id" => $id);
+        if($phase === "prepare")
+            $this->prepareInserts[] = $record;
+        else
+            $this->inserts[] = $record;
+        return $id;
+    }
+
+    /**
+     * Mirrors Compile_Report's per-record preparation of a multi-ref edit:
+     *   - looks up existing refs via SELECT
+     *   - reserves negative placeholders for missing values
+     *   - shares placeholders across records via $this->pendingByVal
+     */
+    public function prepareRecord($rec, $refOrig, $value){
+        if($value === "" || $value === null)
+            return array();
+        if(is_numeric($value)){
+            $this->records[$rec] = array("t" => (int)$value);
+            return array((int)$value);
+        }
+        if(preg_match_all('/[а-яА-Яa-zA-Z0-9\s]+/u', (string)$value, $items) === 0)
+            return array();
+        $ids = array();
+        $seen = array();
+        $pending = array();
+        foreach($items[0] as $item){
+            $item = trim($item);
+            if($item === "")
+                continue;
+            $id = $this->seekRefByVal($refOrig, $item);
+            if($id === false){
+                if(isset($this->pendingByVal[$refOrig][$item])){
+                    $id = $this->pendingByVal[$refOrig][$item];
+                }
+                else{
+                    $this->pendingSeq++;
+                    $id = -$this->pendingSeq;
+                    $this->pendingByVal[$refOrig][$item] = $id;
+                    $pending[$id] = array("val" => $item, "refOrig" => $refOrig);
+                }
+            }
+            $id = (int)$id;
+            if(!isset($seen[$id])){
+                $ids[] = $id;
+                $seen[$id] = true;
+                $this->dsRefs[$id] = $item;
+            }
+        }
+        if(count($ids)){
+            $this->records[$rec] = array("t" => $ids[0]);
+            if(count($ids) > 1)
+                $this->records[$rec]["tList"] = $ids;
+            if(count($pending))
+                $this->tListPending[$rec] = $pending;
+        }
+        return $ids;
+    }
+
+    /**
+     * Mirrors Compile_Report's confirmed-UPDATE pass:
+     *   - materializes EVERY pending placeholder exactly once (column-wide)
+     *   - remaps every record's t/tList from placeholder to the real id, so
+     *     the EDIT branch's "UPDATE ... SET t=..." can never write a negative id.
+     */
+    public function execute(){
+        $idMap = array();
+        $insertedByValKey = array();
+        foreach($this->tListPending as $rec => $entries){
+            foreach($entries as $placeholder => $pending){
+                $placeholder = (int)$placeholder;
+                if(isset($idMap[$placeholder]))
+                    continue;
+                $valKey = $pending["refOrig"] . ":" . $pending["val"];
+                if(isset($insertedByValKey[$valKey])){
+                    $idMap[$placeholder] = $insertedByValKey[$valKey];
+                }
+                else{
+                    $newId = $this->insertRef($pending["refOrig"], $pending["val"], "execute");
+                    $insertedByValKey[$valKey] = $newId;
+                    $idMap[$placeholder] = $newId;
+                }
+                $newId = $idMap[$placeholder];
+                if(isset($this->dsRefs[$placeholder]) && !isset($this->dsRefs[$newId]))
+                    $this->dsRefs[$newId] = $this->dsRefs[$placeholder];
+            }
+        }
+        foreach($this->records as $rec => &$row){
+            if(isset($idMap[(int)$row["t"]]))
+                $row["t"] = $idMap[(int)$row["t"]];
+            if(isset($row["tList"])){
+                foreach($row["tList"] as $k => $v)
+                    if(isset($idMap[(int)$v]))
+                        $row["tList"][$k] = $idMap[(int)$v];
+            }
+        }
+        unset($row);
+        $this->tListPending = array();
+        $this->pendingByVal = array();
+    }
+}
+
+function assertSame2772($expected, $actual, $message){
+    if($expected !== $actual){
+        fwrite(STDERR, "FAIL: $message\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+# Real-world data from the issue: two Тонер-картридж rows that both list
+# "черный" and a dozen other identical free-text words.
+$harness = new Issue2772MultiRecordHarness(array(
+    # existing refs (positive ids)
+    "Тонер" => 2962074,
+    "картридж" => 2963028,
+    "печатного" => 2963029,
+    "устройства" => 2963030,
+    "тип" => 2963034,
+    "ресурсная" => 2963036,
+    "емкость" => 2963037,
+    "не" => 2963038,
+    "менее" => 2963039,
+    "страниц" => 2963041,
+    "ГК" => 2963042,
+    "Cactus" => 2963043,
+));
+
+$row1 = "Тонер,картридж,печатного,устройства,brother,HL,L2300,2340,2360,DCP,L2500,MFC,L2700,тип,черный,ресурсная,емкость,не,менее,1000,страниц,ГК,Cactus";
+$row2 = "Тонер,картридж,печатного,устройства,brother,HL,L2300,2340,2360,DCP,L2500,MFC,L2700,тип,черный,ресурсная,емкость,не,менее,1000,страниц,ГК,NV,Print";
+
+$harness->prepareRecord(2848986, 900, $row1);
+$harness->prepareRecord(2857984, 900, $row2);
+
+# 1. prepare() never inserts.
+assertSame2772(0, count($harness->prepareInserts), "prepare() must not insert any new refs (issue #2769)");
+
+# 2. The shared "(новое) черный" gets ONE placeholder id, used by both rows.
+assertSame2772(true, isset($harness->pendingByVal[900]["черный"]), "'черный' has a column-wide placeholder");
+$blackPlaceholder = $harness->pendingByVal[900]["черный"];
+assertSame2772(true, $blackPlaceholder < 0, "'черный' placeholder is a negative id");
+$row1ContainsBlack = in_array($blackPlaceholder, $harness->records[2848986]["tList"], true);
+$row2ContainsBlack = in_array($blackPlaceholder, $harness->records[2857984]["tList"], true);
+assertSame2772(true, $row1ContainsBlack, "row #2848986 references the shared 'черный' placeholder");
+assertSame2772(true, $row2ContainsBlack, "row #2857984 references the shared 'черный' placeholder");
+
+# 3. Only ONE record carries the pending entry for "черный" — the row that
+# first encountered the word. Other rows reuse the placeholder without
+# adding a second pending entry.
+$blackPendingOwners = 0;
+foreach($harness->tListPending as $rec => $entries)
+    if(isset($entries[$blackPlaceholder]))
+        $blackPendingOwners++;
+assertSame2772(1, $blackPendingOwners, "exactly one tListPending entry owns 'черный' (cross-record dedup)");
+
+# 4. execute() inserts each unknown word exactly once.
+$harness->execute();
+$blackInserts = 0;
+foreach($harness->inserts as $ins)
+    if($ins["val"] === "черный") $blackInserts++;
+assertSame2772(1, $blackInserts, "execute() inserts 'черный' exactly once across both rows");
+
+# Same for every other word shared by both rows.
+$sharedNewWords = array("brother", "HL", "L2300", "2340", "2360", "DCP", "L2500", "MFC", "L2700", "1000");
+foreach($sharedNewWords as $word){
+    $c = 0;
+    foreach($harness->inserts as $ins)
+        if($ins["val"] === $word) $c++;
+    assertSame2772(1, $c, "execute() inserts '$word' exactly once across both rows");
+}
+
+# 5. After execute(), every t/tList id in every record is a real (positive) id.
+foreach($harness->records as $rec => $row){
+    assertSame2772(true, $row["t"] > 0, "row #$rec t is materialized (no placeholder)");
+    if(isset($row["tList"]))
+        foreach($row["tList"] as $tv)
+            assertSame2772(true, $tv > 0, "row #$rec tList[$tv] is materialized");
+}
+
+# 6. Both rows reference the SAME real id for "черный" after materialization.
+$row1Black = null;
+foreach($harness->records[2848986]["tList"] as $tv)
+    if(isset($harness->dsRefs[$tv]) && $harness->dsRefs[$tv] === "черный")
+        $row1Black = $tv;
+$row2Black = null;
+foreach($harness->records[2857984]["tList"] as $tv)
+    if(isset($harness->dsRefs[$tv]) && $harness->dsRefs[$tv] === "черный")
+        $row2Black = $tv;
+assertSame2772(true, $row1Black !== null, "row #2848986 has 'черный' label after execute");
+assertSame2772($row1Black, $row2Black, "both rows reference the SAME real id for 'черный'");
+
+# 7. Words unique to one row are inserted exactly once.
+$uniqueRow1 = array("Cactus");                 // actually known — not pending
+$uniqueRow2 = array("NV", "Print");
+foreach($uniqueRow2 as $w){
+    $c = 0;
+    foreach($harness->inserts as $ins)
+        if($ins["val"] === $w) $c++;
+    assertSame2772(1, $c, "row-#2857984-only word '$w' inserted once");
+}
+
+# 8. Single-record scenario keeps the original #2769 behavior intact.
+$single = new Issue2772MultiRecordHarness(array("alpha" => 11));
+$single->prepareRecord(42, 900, "alpha,beta,gamma");
+assertSame2772(0, count($single->prepareInserts), "single-record prepare() still inserts nothing");
+assertSame2772(2, count($single->tListPending[42]), "single-record pending entries = unknown count");
+$single->execute();
+assertSame2772(2, count($single->inserts), "single-record execute() inserts each unknown once");
+foreach($single->records[42]["tList"] as $tv)
+    assertSame2772(true, $tv > 0, "single-record tList is fully materialized");
+
+# 9. Calling execute() with no pending entries (all-known input) does nothing.
+$allKnown = new Issue2772MultiRecordHarness(array("x" => 1, "y" => 2));
+$allKnown->prepareRecord(1, 900, "x,y");
+$allKnown->prepareRecord(2, 900, "y,x");
+$allKnown->execute();
+assertSame2772(0, count($allKnown->inserts), "all-known input across rows performs zero inserts");
+
+# 10. Sanity check: the in-database refs gained EXACTLY the set of distinct
+# unknown words seen across all rows, not duplicates.
+$expectedNewWords = array(
+    "brother", "HL", "L2300", "2340", "2360", "DCP", "L2500", "MFC", "L2700",
+    "черный", "1000", "NV", "Print",
+);
+$insertedWords = array();
+foreach($harness->inserts as $ins) $insertedWords[] = $ins["val"];
+sort($expectedNewWords);
+sort($insertedWords);
+assertSame2772($expectedNewWords, $insertedWords, "execute() inserts exactly the set of distinct unknown words");
+
+echo "\nAll tests passed for issue-2772 (cross-record placeholder dedup).\n";

--- a/index.php
+++ b/index.php
@@ -4045,9 +4045,12 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
     				    # issue #2769: do not Insert new ref values during the preparation/preview
     				    # pass — reserve negative placeholder ids and defer the Insert until the
     				    # confirmed UPDATE phase below.
+    				    # issue #2772: share placeholders ACROSS records being processed in this
+    				    # same Compile_Report pass, so an unknown word like "черный" appearing in
+    				    # N edited rows still produces ONE pending entry → ONE Insert.
     				    if(!isset($dsRefs[$row["u$key"]]) && !is_numeric($row["u$key"]) && strlen((string)$row["u$key"]))
     				        if(preg_match_all('/[а-яА-Яa-zA-Z0-9\s]+/u', (string)$row["u$key"], $refItems)){
-    				            $refIds = $refSeen = $refPending = $refPendingByVal = array();
+    				            $refIds = $refSeen = $refPending = array();
     				            foreach($refItems[0] as $refItem){
     				                $refItem = trim($refItem);
     				                if($refItem === "")
@@ -4056,16 +4059,16 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
     				                if($refRow = mysqli_fetch_array(Exec_sql("SELECT id, val FROM $z WHERE t=$refOrig AND up>0 AND val='$refItemEsc' LIMIT 1", "Seek Ref by val"))){
     				                    $refResolvedId = (int)$refRow["id"];
     				                }
-    				                elseif(isset($refPendingByVal[$refItem])){
-    				                    $refResolvedId = $refPendingByVal[$refItem];
+    				                elseif(isset($blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem])){
+    				                    $refResolvedId = $blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem];
     				                }
     				                else{
     				                    if(!isset($GLOBALS["_pendingRefSeq"]))
     				                        $GLOBALS["_pendingRefSeq"] = 0;
     				                    $GLOBALS["_pendingRefSeq"]++;
     				                    $refResolvedId = -$GLOBALS["_pendingRefSeq"];
+    				                    $blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem] = $refResolvedId;
     				                    $refPending[$refResolvedId] = array("val" => $refItem, "refOrig" => $refOrig);
-    				                    $refPendingByVal[$refItem] = $refResolvedId;
     				                }
     				                if(!isset($refSeen[$refResolvedId])){
     				                    $refIds[] = $refResolvedId;
@@ -4134,6 +4137,47 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
 		    check();
 		foreach($blocks["_update"] as $key => $value){
     	    trace(" Execute ".count($value["id"]));
+			# issue #2772: materialize every pending Ref for this column ONCE before the per-record
+			# loop, then remap all placeholder ids in t/tList. This guarantees a single Insert per
+			# distinct unknown value across rows (closes the "(новое) черный inserted twice"
+			# question) AND ensures the elseif(!isset($value["val"][$n])) UPDATE branch never
+			# writes a negative placeholder id to $z.t for existing records.
+			if(isset($value["tListPending"])){
+				$pendingIdMap = array();
+				$insertedByValKey = array();
+				foreach($value["tListPending"] as $pendingRec => $pendingEntries){
+					foreach($pendingEntries as $placeholder => $pending){
+						$placeholder = (int)$placeholder;
+						if(isset($pendingIdMap[$placeholder]))
+							continue;
+						$valKey = $pending["refOrig"]."\0".$pending["val"];
+						if(isset($insertedByValKey[$valKey])){
+							$pendingIdMap[$placeholder] = $insertedByValKey[$valKey];
+						}
+						else{
+							$newId = (int)Insert(1, 1, $pending["refOrig"], $pending["val"], "Insert new Ref by val (deferred, issue 2769/2772)");
+							$insertedByValKey[$valKey] = $newId;
+							$pendingIdMap[$placeholder] = $newId;
+						}
+						$mappedId = $pendingIdMap[$placeholder];
+						if(isset($dsRefs[$placeholder]) && !isset($dsRefs[$mappedId]))
+							$dsRefs[$mappedId] = $dsRefs[$placeholder];
+					}
+				}
+				if(!empty($pendingIdMap)){
+					if(isset($value["t"]))
+						foreach($value["t"] as $rec => $tv)
+							if(isset($pendingIdMap[(int)$tv]))
+								$value["t"][$rec] = $pendingIdMap[(int)$tv];
+					if(isset($value["tList"]))
+						foreach($value["tList"] as $rec => $tlist)
+							foreach($tlist as $tk => $tv)
+								if(isset($pendingIdMap[(int)$tv]))
+									$value["tList"][$rec][$tk] = $pendingIdMap[(int)$tv];
+				}
+				unset($value["tListPending"]);
+			}
+			unset($value["_pendingByVal"]);
 			foreach($value["id"] as $i => $n){
         	    trace(" i=$i n=$n key=$key ord[n]=".(isset($value["ord"][$n]) ? $value["ord"][$n] : ""));
                 trace("_  The old value for ".$names[$key]." is ".$blocks["_data_col"][$id][$names[$key]][$n]);
@@ -4155,24 +4199,6 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
 						$items = $items[0];
 						$cache = [];
 						$batch = true;
-						# issue #2769: materialize any pending Refs that were deferred during preparation
-						if(isset($value["tListPending"][$n])){
-							foreach($value["tListPending"][$n] as $placeholder => $pending){
-								$newId = Insert(1, 1, $pending["refOrig"], $pending["val"], "Insert new Ref by val (deferred, issue 2769)");
-								$newId = (int)$newId;
-								$placeholder = (int)$placeholder;
-								if(isset($dsRefs[$placeholder])){
-									$dsRefs[$newId] = $dsRefs[$placeholder];
-									unset($dsRefs[$placeholder]);
-								}
-								if(isset($value["t"][$n]) && (int)$value["t"][$n] === $placeholder)
-									$value["t"][$n] = $newId;
-								if(isset($value["tList"][$n]))
-									foreach($value["tList"][$n] as $tk => $tv)
-										if((int)$tv === $placeholder)
-											$value["tList"][$n][$tk] = $newId;
-							}
-						}
 					}
 					$ord = $value["ord"][$n] == 0 ? Calc_Order($value["up"][$n], $value["t"][$n]) : $value["ord"][$n];
 					foreach($items as $k => $v){


### PR DESCRIPTION
## Summary

Issue #2772 raises two questions about the deferred-Insert fix from PR #2770:

1. **«Если буду видеть “(новое) черный” — не создастся ли он дважды?»**
   («If I see `(новое) черный` — won't it be created twice?»)
2. **«Здесь `$refItemEsc` проверяется — экранированный, а как он сохранится в базе?»**
   («Here `$refItemEsc` is checked — escaped, but how will it be saved in the database?»)

### Q1 — Real bug, fixed

Before this PR, `$refPendingByVal` was reset on every iteration of the per-record loop. The same unknown word in two rows (e.g. `«черный»` in both `Тонер-картридж brother HL L2300 (2340 2360) DCP L2500 MFC L2700 1000 черный` and the row above it) got two different negative placeholders and was inserted twice during `execute()`.

The fix:

- Move the pending-by-val map to **column-wide scope**: `$blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem]`. The second occurrence in any record reuses the same negative placeholder.
- **Hoist the materialization** above the per-record loop in the confirmed-UPDATE branch and dedup again on Insert via `$insertedByValKey` keyed by `$refOrig."\0".$val`. Even if two pending placeholders somehow refer to the same value, only one row hits the `refs` table.
- After Insert, **remap placeholders in `$value["t"]` and `$value["tList"]` across every record** before per-record UPDATE runs.

### Q2 — No practical mismatch

`Compile_Report()` resolves the SELECT lookup with `addslashes($refItem)` but Insert sees the raw `$refItem` (then internally goes through `addcslashes($val, "\\\\\\'")`). At a glance this looks like an escape mismatch.

In practice it is not — the tokenizer that extracts each `$refItem` is `preg_match_all('/[а-яА-Яa-zA-Z0-9\\s]+/u', ...)`. The character class only matches Cyrillic letters, Latin letters, digits and whitespace. None of `\\`, `'`, `"` or NUL can ever be in `$refItem`, so `addslashes`, `addcslashes` and the raw string are byte-identical. The two paths agree on what is stored. The escapes stay in place defensively for future tokenizer changes.

## Changes

- `index.php`
  - Prepare phase (multi-ref EDIT branch): replace per-record `$refPendingByVal` with column-wide `$blocks["_update"][$key]["_pendingByVal"][$refOrig]`.
  - Execute phase (confirmed UPDATE): hoist `tListPending` materialization above the per-record loop, add `$insertedByValKey` Insert-time dedup, remap `$value["t"]` and `$value["tList"]` across all records before iterating, drop the now-redundant in-loop materialization.
- `experiments/test-issue-2772-cross-record-dedup.php` — new standalone PHP harness using the exact data from the issue (two `Тонер-картридж` rows sharing `«черный»`, `«brother»`, `«HL»`, `«L2300»`, `«2340»`, `«2360»`, `«DCP»`, `«L2500»`, `«MFC»`, `«L2700»`, `«1000»`).

## Reproduction

1. Pick a `_isRef` column and create two records that share at least one new word, e.g. set `Тонер` in both to a string containing `черный`.
2. Enter edit/preview mode (no `confirmed`).
3. Confirm the UPDATE.

Before: the `refs` table receives `черный` twice (and once per other shared new word). Each row's `t` column points at a different fresh id.
After: `refs` receives `черный` exactly once. Both rows' `t` columns point at the same id.

## Test plan

- [x] `php -l index.php` — clean.
- [x] `php experiments/test-issue-2772-cross-record-dedup.php` — all 70+ assertions pass, including:
  - `«черный»` produces one column-wide placeholder reused by both rows;
  - `execute()` inserts each shared new word exactly once;
  - both rows' `t` column converges on the same real id after materialization;
  - row-only words (`«NV»`, `«Print»`) still insert exactly once;
  - all-known input still does zero Inserts.
- [x] `php experiments/test-issue-2769-deferred-ref-insert.php` — the original deferred-Insert harness from #2769 still passes (no regressions in the prepare/execute split).
- [x] `php experiments/test-issue-2767-multi-ref-edit.php` — the multi-ref resolution harness from #2767 still passes.

Closes #2772.