### PR TITLE
fix(index.php): cache "Seek Ref by val" hits column-wide (closes #2776)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-22T18:04:03.468Z for PR creation at branch issue-2776-f6bb9957e887 for issue https://github.com/ideav/crm/issues/2776

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-22T18:04:03.468Z for PR creation at branch issue-2776-f6bb9957e887 for issue https://github.com/ideav/crm/issues/2776

--- a/experiments/test-issue-2776-seek-ref-cache.php
+++ b/experiments/test-issue-2776-seek-ref-cache.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Test for issue #2776:
+ * In Compile_Report's multi-ref EDIT branch, "Seek Ref by val" (the SELECT
+ * lookup that resolves a free-text word to an existing refs.id) used to run
+ * once per (record, word) pair. When mass-editing dozens of records that all
+ * share the same Russian/Latin words (Тонер, картридж, печатного, устройства,
+ * brother, HL, ...), the same SELECT for "Тонер" / "brother" / ... fires N
+ * times even though the result is identical.
+ *
+ * #2772 already deduplicated PENDING placeholders across records via
+ * $blocks["_update"][$key]["_pendingByVal"] but did NOT cache the SELECT
+ * result for words that ARE already in refs. Issue #2776 asks us to cache
+ * those, so each distinct (refOrig, refItem) pair triggers at most one
+ * "Seek Ref by val" within the same prepare pass.
+ *
+ * The harness below mirrors the prepare phase exactly and counts SELECTs.
+ */
+
+class Issue2776SeekRefCacheHarness {
+    public $insertedNextId = 1000;
+    public $refsByVal = array();
+    public $inserts = array();
+    public $prepareInserts = array();
+    public $pendingSeq = 0;
+    public $dsRefs = array();
+    public $records = array();
+    public $pendingByVal = array();
+    public $resolvedByVal = array();
+    public $tListPending = array();
+    public $seekCalls = array();        // every (refOrig, val) lookup
+    public $seekCallsByKey = array();   // (refOrig, val) => count
+
+    public function __construct($refsByVal){
+        $this->refsByVal = $refsByVal;
+        $maxId = 0;
+        foreach($refsByVal as $id) if($id > $maxId) $maxId = $id;
+        $this->insertedNextId = $maxId + 1;
+    }
+
+    public function seekRefByVal($refOrig, $val){
+        $this->seekCalls[] = array("refOrig" => $refOrig, "val" => $val);
+        $key = $refOrig."\0".$val;
+        if(!isset($this->seekCallsByKey[$key]))
+            $this->seekCallsByKey[$key] = 0;
+        $this->seekCallsByKey[$key]++;
+        if(isset($this->refsByVal[$val]))
+            return $this->refsByVal[$val];
+        return false;
+    }
+
+    public function insertRef($refOrig, $val, $phase){
+        $id = $this->insertedNextId++;
+        $this->refsByVal[$val] = $id;
+        $record = array("up" => 1, "ord" => 1, "t" => $refOrig, "val" => $val, "id" => $id);
+        if($phase === "prepare")
+            $this->prepareInserts[] = $record;
+        else
+            $this->inserts[] = $record;
+        return $id;
+    }
+
+    /**
+     * Mirrors the post-fix Compile_Report prepare phase for a multi-ref edit:
+     *   - check the column-wide resolvedByVal cache first
+     *   - check the column-wide pendingByVal cache next
+     *   - only fall through to the actual SELECT lookup when both miss
+     *   - cache the SELECT result so the next record reuses it
+     */
+    public function prepareRecord($rec, $refOrig, $value){
+        if($value === "" || $value === null)
+            return array();
+        if(is_numeric($value)){
+            $this->records[$rec] = array("t" => (int)$value);
+            return array((int)$value);
+        }
+        if(preg_match_all('/[а-яА-Яa-zA-Z0-9\s]+/u', (string)$value, $items) === 0)
+            return array();
+        $ids = array();
+        $seen = array();
+        $pending = array();
+        foreach($items[0] as $item){
+            $item = trim($item);
+            if($item === "")
+                continue;
+            if(isset($this->resolvedByVal[$refOrig][$item])){
+                $id = $this->resolvedByVal[$refOrig][$item];
+            }
+            elseif(isset($this->pendingByVal[$refOrig][$item])){
+                $id = $this->pendingByVal[$refOrig][$item];
+            }
+            else{
+                $found = $this->seekRefByVal($refOrig, $item);
+                if($found !== false){
+                    $id = (int)$found;
+                    $this->resolvedByVal[$refOrig][$item] = $id;
+                }
+                else{
+                    $this->pendingSeq++;
+                    $id = -$this->pendingSeq;
+                    $this->pendingByVal[$refOrig][$item] = $id;
+                    $pending[$id] = array("val" => $item, "refOrig" => $refOrig);
+                }
+            }
+            $id = (int)$id;
+            if(!isset($seen[$id])){
+                $ids[] = $id;
+                $seen[$id] = true;
+                $this->dsRefs[$id] = $item;
+            }
+        }
+        if(count($ids)){
+            $this->records[$rec] = array("t" => $ids[0]);
+            if(count($ids) > 1)
+                $this->records[$rec]["tList"] = $ids;
+            if(count($pending))
+                $this->tListPending[$rec] = $pending;
+        }
+        return $ids;
+    }
+
+    public function execute(){
+        $idMap = array();
+        $insertedByValKey = array();
+        foreach($this->tListPending as $rec => $entries){
+            foreach($entries as $placeholder => $pending){
+                $placeholder = (int)$placeholder;
+                if(isset($idMap[$placeholder]))
+                    continue;
+                $valKey = $pending["refOrig"] . "\0" . $pending["val"];
+                if(isset($insertedByValKey[$valKey])){
+                    $idMap[$placeholder] = $insertedByValKey[$valKey];
+                }
+                else{
+                    $newId = $this->insertRef($pending["refOrig"], $pending["val"], "execute");
+                    $insertedByValKey[$valKey] = $newId;
+                    $idMap[$placeholder] = $newId;
+                }
+                $newId = $idMap[$placeholder];
+                if(isset($this->dsRefs[$placeholder]) && !isset($this->dsRefs[$newId]))
+                    $this->dsRefs[$newId] = $this->dsRefs[$placeholder];
+            }
+        }
+        foreach($this->records as $rec => &$row){
+            if(isset($idMap[(int)$row["t"]]))
+                $row["t"] = $idMap[(int)$row["t"]];
+            if(isset($row["tList"])){
+                foreach($row["tList"] as $k => $v)
+                    if(isset($idMap[(int)$v]))
+                        $row["tList"][$k] = $idMap[(int)$v];
+            }
+        }
+        unset($row);
+        $this->tListPending = array();
+        $this->pendingByVal = array();
+        $this->resolvedByVal = array();
+    }
+}
+
+function assertSame2776($expected, $actual, $message){
+    if($expected !== $actual){
+        fwrite(STDERR, "FAIL: $message\nExpected: " . var_export($expected, true) . "\nActual:   " . var_export($actual, true) . "\n");
+        exit(1);
+    }
+    echo "OK: $message\n";
+}
+
+# Real-world data from issue #2776 / #2772: a column being mass-edited where
+# every record's free-text value shares the same dictionary of words.
+$harness = new Issue2776SeekRefCacheHarness(array(
+    # existing refs (positive ids) — these MUST be looked up via SELECT
+    "Тонер" => 2962074,
+    "картридж" => 2963028,
+    "печатного" => 2963029,
+    "устройства" => 2963030,
+    "тип" => 2963034,
+    "ресурсная" => 2963036,
+    "емкость" => 2963037,
+    "не" => 2963038,
+    "менее" => 2963039,
+    "страниц" => 2963041,
+    "ГК" => 2963042,
+    "Cactus" => 2963043,
+));
+
+$sharedKnown = "Тонер,картридж,печатного,устройства,тип,ресурсная,емкость,не,менее,страниц,ГК";
+$sharedUnknown = "brother,HL,L2300,2340,2360,DCP,L2500,MFC,L2700,черный,1000";
+
+# Eight records, all sharing the same dictionary of words. This is the
+# "right column of values" pattern from the screenshot in issue #2776.
+$rows = array(
+    2848986 => $sharedKnown . "," . $sharedUnknown . ",Cactus",
+    2857984 => $sharedKnown . "," . $sharedUnknown . ",NV,Print",
+    2857985 => $sharedKnown . "," . $sharedUnknown . ",Cactus",
+    2857986 => $sharedKnown . "," . $sharedUnknown . ",Cactus",
+    2857987 => $sharedKnown . "," . $sharedUnknown . ",NV,Print",
+    2857988 => $sharedKnown . "," . $sharedUnknown . ",Cactus",
+    2857989 => $sharedKnown . "," . $sharedUnknown . ",NV,Print",
+    2857990 => $sharedKnown . "," . $sharedUnknown . ",Cactus",
+);
+
+foreach($rows as $rec => $val)
+    $harness->prepareRecord($rec, 900, $val);
+
+# 1. prepare() never inserts (#2769 invariant still holds).
+assertSame2776(0, count($harness->prepareInserts), "prepare() must not insert any new refs");
+
+# 2. Issue #2776 core: every distinct (refOrig, val) is SELECTed at most ONCE,
+#    regardless of how many records mention it.
+foreach($harness->seekCallsByKey as $key => $count){
+    assertSame2776(1, $count, "'$key' was SELECTed exactly once (cache hit on repeat)");
+}
+
+# 3. Total SELECT count equals the number of DISTINCT (refOrig, val) pairs.
+$expectedDistinct = array();
+foreach($rows as $rec => $val){
+    foreach(explode(",", $val) as $item){
+        $item = trim($item);
+        if($item === "") continue;
+        $expectedDistinct[$item] = true;
+    }
+}
+assertSame2776(count($expectedDistinct), count($harness->seekCallsByKey),
+    "SELECT count == number of distinct words across all records");
+
+# 4. Known words: previously each known word was looked up once per record
+#    (count(rows) calls). After the fix it's 1.
+$knownWords = array("Тонер", "картридж", "печатного", "устройства", "тип",
+    "ресурсная", "емкость", "не", "менее", "страниц", "ГК");
+foreach($knownWords as $w){
+    $key = "900\0".$w;
+    assertSame2776(true, isset($harness->seekCallsByKey[$key]),
+        "known word '$w' was SELECTed at least once");
+    assertSame2776(1, $harness->seekCallsByKey[$key],
+        "known word '$w' SELECTed exactly once (was " . count($rows) . "x before the fix)");
+}
+
+# 5. Unknown words go to pendingByVal on the first encounter. The fall-through
+#    means the second record's lookup hits the cache and never re-runs SELECT.
+$unknownWords = array("brother", "HL", "L2300", "2340", "2360", "DCP", "L2500",
+    "MFC", "L2700", "черный", "1000", "NV", "Print");
+foreach($unknownWords as $w){
+    $key = "900\0".$w;
+    assertSame2776(1, $harness->seekCallsByKey[$key],
+        "unknown word '$w' SELECTed exactly once before placeholder takes over");
+}
+
+# 6. Resolve correctness: every record still maps known words to the same
+#    real ids the database returned.
+foreach($rows as $rec => $val){
+    $tList = $harness->records[$rec]["tList"];
+    $thisRowMap = array();
+    foreach($tList as $rid)
+        if(isset($harness->dsRefs[$rid]))
+            $thisRowMap[$harness->dsRefs[$rid]] = $rid;
+    foreach($knownWords as $w){
+        assertSame2776($harness->refsByVal[$w], $thisRowMap[$w],
+            "row #$rec '$w' resolves to its real id");
+    }
+}
+
+# 7. execute() inserts each shared unknown word exactly once across all rows.
+$harness->execute();
+foreach(array("brother","HL","L2300","2340","2360","DCP","L2500","MFC","L2700","черный","1000","NV","Print") as $w){
+    $c = 0;
+    foreach($harness->inserts as $ins)
+        if($ins["val"] === $w) $c++;
+    assertSame2776(1, $c, "execute() inserts '$w' exactly once");
+}
+
+# 8. After execute(), every record's t/tList contains real (positive) ids.
+foreach($harness->records as $rec => $row){
+    assertSame2776(true, $row["t"] > 0, "row #$rec t is materialized");
+    if(isset($row["tList"]))
+        foreach($row["tList"] as $tv)
+            assertSame2776(true, $tv > 0, "row #$rec tList[$tv] is materialized");
+}
+
+# 9. Single-record + all-known input keeps the original behavior: each word is
+#    SELECTed once and zero pending inserts happen.
+$single = new Issue2776SeekRefCacheHarness(array("alpha" => 11, "beta" => 12, "gamma" => 13));
+$single->prepareRecord(42, 900, "alpha,beta,gamma");
+assertSame2776(3, count($single->seekCallsByKey), "single-record: each word triggers one SELECT");
+$single->execute();
+assertSame2776(0, count($single->inserts), "all-known input across rows performs zero inserts");
+
+# 10. Repeated identical lookups within a SINGLE record also short-circuit.
+#     The tokenizer can split "брат брат брат" into three identical tokens,
+#     each of which should hit the cache after the first lookup.
+$repeat = new Issue2776SeekRefCacheHarness(array("брат" => 77));
+$repeat->prepareRecord(1, 900, "брат,брат,брат,брат,брат");
+assertSame2776(1, count($repeat->seekCalls), "repeated identical tokens trigger one SELECT total");
+assertSame2776(array(77), $repeat->records[1]["t"] ? array($repeat->records[1]["t"]) : array(),
+    "repeated tokens resolve to the same real id and dedup at the seen-list level");
+
+# 11. Cache is column-scoped (cleared by execute()) — a SECOND prepare pass
+#     after execute() rebuilds the cache. This protects against stale data if
+#     refs is mutated between pre-confirm and confirm.
+$stale = new Issue2776SeekRefCacheHarness(array("alpha" => 11));
+$stale->prepareRecord(1, 900, "alpha");
+$stale->execute();
+$stale->prepareRecord(2, 900, "alpha");
+assertSame2776(2, count($stale->seekCalls), "cache resets after execute(); next prepare re-queries");
+
+echo "\nAll tests passed for issue-2776 (Seek Ref by val caching).\n";

--- a/index.php
+++ b/index.php
@@ -4049,20 +4049,29 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
     				                $refItem = trim($refItem);
     				                if($refItem === "")
     				                    continue;
-    				                $refItemEsc = addslashes($refItem);
-    				                if($refRow = mysqli_fetch_array(Exec_sql("SELECT id, val FROM $z WHERE t=$refOrig AND up>0 AND val='$refItemEsc' LIMIT 1", "Seek Ref by val"))){
-    				                    $refResolvedId = (int)$refRow["id"];
+    				                # Cache "Seek Ref by val" hits column-wide so the same word
+    				                # mentioned across many records (or repeated inside one record)
+    				                # triggers at most one SELECT per prepare pass (issue #2776).
+    				                if(isset($blocks["_update"][$key]["_resolvedByVal"][$refOrig][$refItem])){
+    				                    $refResolvedId = $blocks["_update"][$key]["_resolvedByVal"][$refOrig][$refItem];
     				                }
     				                elseif(isset($blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem])){
     				                    $refResolvedId = $blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem];
     				                }
     				                else{
-    				                    if(!isset($GLOBALS["_pendingRefSeq"]))
-    				                        $GLOBALS["_pendingRefSeq"] = 0;
-    				                    $GLOBALS["_pendingRefSeq"]++;
-    				                    $refResolvedId = -$GLOBALS["_pendingRefSeq"];
-    				                    $blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem] = $refResolvedId;
-    				                    $refPending[$refResolvedId] = array("val" => $refItem, "refOrig" => $refOrig);
+    				                    $refItemEsc = addslashes($refItem);
+    				                    if($refRow = mysqli_fetch_array(Exec_sql("SELECT id, val FROM $z WHERE t=$refOrig AND up>0 AND val='$refItemEsc' LIMIT 1", "Seek Ref by val"))){
+    				                        $refResolvedId = (int)$refRow["id"];
+    				                        $blocks["_update"][$key]["_resolvedByVal"][$refOrig][$refItem] = $refResolvedId;
+    				                    }
+    				                    else{
+    				                        if(!isset($GLOBALS["_pendingRefSeq"]))
+    				                            $GLOBALS["_pendingRefSeq"] = 0;
+    				                        $GLOBALS["_pendingRefSeq"]++;
+    				                        $refResolvedId = -$GLOBALS["_pendingRefSeq"];
+    				                        $blocks["_update"][$key]["_pendingByVal"][$refOrig][$refItem] = $refResolvedId;
+    				                        $refPending[$refResolvedId] = array("val" => $refItem, "refOrig" => $refOrig);
+    				                    }
     				                }
     				                if(!isset($refSeen[$refResolvedId])){
     				                    $refIds[] = $refResolvedId;
@@ -4173,6 +4182,7 @@ function Compile_Report($id, $cur_block, $exe=TRUE, $check=FALSE, $noFilters=FAL
 				Insert_batch("", "", "", "", "Flush INSERT new rec ($n)");
 			}
 			unset($value["_pendingByVal"]);
+			unset($value["_resolvedByVal"]);
 			foreach($value["id"] as $i => $n){
         	    trace(" i=$i n=$n key=$key ord[n]=".(isset($value["ord"][$n]) ? $value["ord"][$n] : ""));
                 trace("_  The old value for ".$names[$key]." is ".$blocks["_data_col"][$id][$names[$key]][$n]);


### PR DESCRIPTION
## Summary

Issue #2776 reports that the `"Seek Ref by val"` SELECT inside the multi-ref EDIT branch of `Compile_Report` runs repeatedly for the same word. The screenshot shows a column being mass-edited where every row's free-text value shares the same dictionary (`Тонер, картридж, печатного, устройства, тип, ресурсная, емкость, не, менее, страниц, ГК, brother, HL, L2300, ...`) — and the previous fixes from #2767 / #2769 / #2770 / #2773 ran the SELECT once per `(record, word)` pair even though the result is identical.

## The fix

PR #2773 introduced `$blocks["_update"][$key]["_pendingByVal"]` to share placeholders for UNKNOWN values across records. This PR adds a symmetric `$blocks["_update"][$key]["_resolvedByVal"]` cache for KNOWN values and reorders the resolution lookup so the SELECT is the LAST step, not the first:

1. **`_resolvedByVal`** — return the cached real `refs.id`. 
2. **`_pendingByVal`** — return the cached negative placeholder id (created earlier in this prepare pass).
3. **`Exec_sql("Seek Ref by val")`** — only fires when both caches miss; the hit is then stored into `_resolvedByVal` so subsequent records short-circuit.
4. **Miss** — mint a placeholder, store into `_pendingByVal`.

After `execute()` materializes pending refs, both caches are unset alongside the existing `_pendingByVal` cleanup so a subsequent prepare pass cannot read a stale resolved id.

Scope is column-wide, mirroring `_pendingByVal` for symmetry (one column = one ref type = one consistent set of ids).

## Before / after

For the screenshot's eight-row mass edit where every row mentions `Тонер`, `картридж`, `печатного`, ... (11 shared known words + 11 shared unknown words):

| | Known-word SELECTs | Unknown-word SELECTs | Total |
|---|---|---|---|
| Before #2776 | 11 × 8 = 88 | 11 × 8 = 88 | **176** |
| After #2776  | 11 × 1 = 11 | 11 × 1 = 11 | **22**  |

Scales linearly with the row count — bigger savings on larger edits.

## Changes

- `index.php`
  - Prepare phase: check `_resolvedByVal` then `_pendingByVal` before issuing the SELECT; cache the SELECT hit into `_resolvedByVal` on success.
  - Execute phase: `unset($value["_resolvedByVal"])` next to the existing `unset($value["_pendingByVal"])`.
- `experiments/test-issue-2776-seek-ref-cache.php` — new harness modelling the prepare/execute split with a SELECT call counter.

## Reproduction

1. Pick a `_isRef` column whose free-text values share words across many records (the issue's case: dozens of `Тонер-картридж ... черный` rows differing only by SKU).
2. Enter edit/preview mode (no `confirmed`).
3. Watch the SQL log.

**Before:** `Seek Ref by val` fires once per `(record, word)` — e.g., `черный` is selected once per row.  
**After:** `Seek Ref by val` fires once per distinct `(refOrig, word)` across the whole prepare pass.

## Test plan

- [x] `php -l index.php` — clean.
- [x] `php experiments/test-issue-2776-seek-ref-cache.php` — all assertions pass:
  - every known word is SELECTed exactly once across eight rows (was N times);
  - every unknown word is SELECTed exactly once before its placeholder takes over;
  - total SELECT count equals the number of distinct words across all rows;
  - row-only words still resolve correctly;
  - repeated identical tokens within a single record trigger one SELECT total;
  - cache resets after `execute()` so a second prepare pass re-queries.
- [x] `php experiments/test-issue-2772-cross-record-dedup.php` — cross-record placeholder dedup still passes (no regressions in #2772).
- [x] `php experiments/test-issue-2769-deferred-ref-insert.php` — deferred-Insert harness still passes.
- [x] `php experiments/test-issue-2767-multi-ref-edit.php` — multi-ref edit harness still passes.

Closes #2776.