### PR TITLE
fix(index.php): dedup duplicate rows in JSON_OBJ list responses (closes #2783)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-23T12:01:55.708Z for PR creation at branch issue-2783-5d58cf977e01 for issue https://github.com/ideav/crm/issues/2783

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-23T12:01:55.708Z for PR creation at branch issue-2783-5d58cf977e01 for issue https://github.com/ideav/crm/issues/2783

--- a/experiments/issue-2783-helpers.php
+++ b/experiments/issue-2783-helpers.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Shared assertion helpers for issue #2783 test harnesses.
+ */
+
+if(!function_exists("assert_eq")){
+    function assert_eq($label, $expected, $actual){
+        $expStr = is_scalar($expected) ? (string)$expected : json_encode($expected, JSON_UNESCAPED_UNICODE);
+        $actStr = is_scalar($actual)   ? (string)$actual   : json_encode($actual,   JSON_UNESCAPED_UNICODE);
+        if($expected === $actual){
+            echo "  OK  $label  ($actStr)\n";
+            return;
+        }
+        echo "  FAIL  $label\n";
+        echo "    expected: $expStr\n";
+        echo "    actual:   $actStr\n";
+        throw new RuntimeException("Assertion failed: $label");
+    }
+}

--- a/experiments/test-issue-2783-client-dedup.js
+++ b/experiments/test-issue-2783-client-dedup.js
@@ -1,0 +1,170 @@
+/**
+ * Test for issue #2783 — client-side dedup of duplicate `i` entries in the
+ * JSON_OBJ response.
+ *
+ * The server-side fix in index.php is the primary correction. This test
+ * covers the defense-in-depth in
+ * js/integram-table/02-format-helpers.js -> dedupeJsonDataArrayById(), which
+ * guards against a mid-rollout server still emitting the legacy split-row
+ * response. The function must:
+ *
+ *   - leave non-duplicated input untouched (same reference, no copy);
+ *   - collapse duplicate ids to the entry with the longest `r` cell array;
+ *   - preserve original ordering for non-duplicates;
+ *   - not crash on empty / malformed input.
+ *
+ * Run with: node experiments/test-issue-2783-client-dedup.js
+ */
+
+const { strict: assert } = require("node:assert");
+
+// Inline the function under test verbatim from
+// js/integram-table/02-format-helpers.js. Kept in sync with the source file.
+function dedupeJsonDataArrayById(dataArray) {
+    if (!Array.isArray(dataArray) || dataArray.length < 2) {
+        return dataArray;
+    }
+    const seenIndexById = new Map();
+    const keep = new Set();
+    let hasDuplicates = false;
+    for (let i = 0; i < dataArray.length; i++) {
+        const item = dataArray[i];
+        if (!item || item.i === undefined) {
+            keep.add(i);
+            continue;
+        }
+        const prevIndex = seenIndexById.get(item.i);
+        if (prevIndex === undefined) {
+            seenIndexById.set(item.i, i);
+            keep.add(i);
+            continue;
+        }
+        hasDuplicates = true;
+        const prevLen = Array.isArray(dataArray[prevIndex].r) ? dataArray[prevIndex].r.length : 0;
+        const curLen = Array.isArray(item.r) ? item.r.length : 0;
+        if (curLen > prevLen) {
+            keep.delete(prevIndex);
+            seenIndexById.set(item.i, i);
+            keep.add(i);
+        }
+    }
+    if (!hasDuplicates) {
+        return dataArray;
+    }
+    return dataArray.filter((_, idx) => keep.has(idx));
+}
+
+function describe(label, fn) {
+    console.log(label);
+    fn();
+}
+function it(label, fn) {
+    try {
+        fn();
+        console.log("  OK  " + label);
+    } catch (e) {
+        console.log("  FAIL  " + label);
+        throw e;
+    }
+}
+
+// --------------------------------------------------------------------------
+// The exact symptom from the issue: id 3893632 split + doubled.
+const fromIssue = [
+    { i: 3893632, u: 1, o: 0, r: ["00-00627661"] },
+    {
+        i: 3893632,
+        u: 1,
+        o: 0,
+        r: [
+            "00-00627661",
+            "R-2406758:foo",
+            "R-2406759:bar",
+            "R-2406760:%5180%",
+            "R-2406761:baz",
+            "R-2406762:qux",
+            "R-2406758:foo",
+            "R-2406759:bar",
+            "R-2406760:%5180%",
+            "R-2406761:baz",
+            "R-2406762:qux",
+        ],
+    },
+];
+
+describe("Issue #2783 client-side dedup", () => {
+    it("collapses the broken pair to the entry with the most cells", () => {
+        const deduped = dedupeJsonDataArrayById(fromIssue);
+        assert.equal(deduped.length, 1);
+        // Keep the longer entry (the one carrying the reqs) so column
+        // alignment matches metadata.length.
+        assert.equal(deduped[0].r.length, 11);
+        assert.equal(deduped[0].i, 3893632);
+    });
+
+    it("returns the original array reference when no duplicates exist", () => {
+        const input = [
+            { i: 1, r: ["a", "b"] },
+            { i: 2, r: ["c", "d"] },
+            { i: 3, r: ["e", "f"] },
+        ];
+        const deduped = dedupeJsonDataArrayById(input);
+        assert.equal(deduped, input);
+    });
+
+    it("keeps the first occurrence when duplicates have equal r length", () => {
+        const input = [
+            { i: 7, r: ["first"] },
+            { i: 7, r: ["second"] },
+        ];
+        const deduped = dedupeJsonDataArrayById(input);
+        assert.equal(deduped.length, 1);
+        assert.equal(deduped[0].r[0], "first");
+    });
+
+    it("preserves order across non-duplicate ids", () => {
+        const input = [
+            { i: 10, r: ["a"] },
+            { i: 11, r: ["b", "x"] },
+            { i: 10, r: ["a", "y", "z"] }, // longer wins for id 10
+            { i: 12, r: ["c"] },
+        ];
+        const deduped = dedupeJsonDataArrayById(input);
+        assert.deepEqual(deduped.map(d => d.i), [11, 10, 12]);
+        assert.equal(deduped.find(d => d.i === 10).r.length, 3);
+    });
+
+    it("handles three duplicates of the same id by keeping the longest", () => {
+        const input = [
+            { i: 9, r: ["only-main"] },
+            { i: 9, r: ["only-main", "req1"] },
+            { i: 9, r: ["only-main", "req1", "req2", "req3"] },
+        ];
+        const deduped = dedupeJsonDataArrayById(input);
+        assert.equal(deduped.length, 1);
+        assert.equal(deduped[0].r.length, 4);
+    });
+
+    it("returns the input untouched for trivial cases", () => {
+        assert.deepEqual(dedupeJsonDataArrayById([]), []);
+        const single = [{ i: 1, r: ["x"] }];
+        assert.equal(dedupeJsonDataArrayById(single), single);
+        assert.equal(dedupeJsonDataArrayById(null), null);
+        assert.equal(dedupeJsonDataArrayById(undefined), undefined);
+    });
+
+    it("skips entries missing the i field rather than crashing", () => {
+        const input = [
+            { r: ["a"] },                // no i
+            { i: 5, r: ["b"] },
+            { i: 5, r: ["b", "c"] },
+        ];
+        const deduped = dedupeJsonDataArrayById(input);
+        // Entry without i is preserved (no dedup signal); duplicate of i=5
+        // collapses to the longer one.
+        assert.equal(deduped.length, 2);
+        assert.equal(deduped.find(d => d.i === 5).r.length, 2);
+    });
+});
+
+console.log("\nAll client-side dedup tests passed for issue #2783.");

--- a/experiments/test-issue-2783-duplicate-row-dedup.php
+++ b/experiments/test-issue-2783-duplicate-row-dedup.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * Test for issue #2783:
+ * When the JSON_OBJ endpoint applies a LIKE filter (FR_{colid}=%foo%) on a
+ * non-MULTI/ARRAY column, Construct_WHERE() does not set $GLOBALS["distinct"]
+ * (only MULTI/ARRAY types set it). The resulting SELECT may return duplicate
+ * rows for the same vals.id when the joined column legitimately has more than
+ * one matching row for one object. Reported symptoms in the issue:
+ *
+ *   - The filter URL
+ *       /test/object/2406756/?JSON_OBJ&LIMIT=0,21&FR_2406760=%255180%25
+ *     returns record id 3893632 twice: once with only the main value
+ *     (`r:["00-00627661"]`) and once with the full row whose `r` has eleven
+ *     elements — the five reqs appended twice.
+ *   - A single-record query for id 3893632 returns the correct six elements,
+ *     proving the data itself is fine; the bug is in how the list endpoint
+ *     assembles its response.
+ *
+ * Root cause: index.php's &uni_obj_all loop creates one newapi[] entry per
+ * row and points newapicnt[id] at the latest entry. When a duplicate row
+ * lands, both entries share the same id but newapicnt is overwritten, so
+ * every subsequent &uni_object_view_reqs appends into the latest entry —
+ * once per blocks[$block]["id"][] occurrence, doubling the reqs there and
+ * leaving the earlier entry with only the main value.
+ *
+ * The fix dedups duplicate rows at the top of the while-loop body before the
+ * blocks/newapi pipeline sees them. This harness emulates that pipeline and
+ * asserts that:
+ *   1. The legacy behaviour reproduces the issue's symptom exactly
+ *      (split + doubled entries for the same id).
+ *   2. The fixed behaviour collapses to one entry with the correct cell
+ *      count for a duplicated row.
+ *   3. JSON_DATA (the older string-builder API) is also dedeuped so
+ *      &uni_object_view_reqs is no longer fired twice per duplicate id.
+ *   4. Distinct ids are untouched (no over-eager dedup).
+ */
+
+require_once __DIR__ . "/../experiments/issue-2783-helpers.php";
+
+class Issue2783DuplicateRowHarness {
+    /** @var bool When true, applies the fix; when false, simulates legacy. */
+    public $applyFix = true;
+
+    /** @var array Mock GLOBAL_VARS["newapi"] state, JSON_OBJ shape (array). */
+    public $newapiObj = array();
+    /** @var array Mock GLOBAL_VARS["newapicnt"] map id -> index. */
+    public $newapicnt = array();
+
+    /** @var array Mock GLOBAL_VARS["newapi"] state, JSON_DATA shape (strings keyed by id). */
+    public $newapiData = array();
+
+    /** @var array Mock blocks["uni_obj_all"]["id"] entries (drives reqs case). */
+    public $blocksIds = array();
+
+    /** @var string Mode: "JSON_OBJ" or "JSON_DATA". */
+    public $mode;
+
+    /** @var array Per-id "reqs" payload to attach during the reqs case. */
+    public $reqsById = array();
+
+    public function __construct($mode){
+        $this->mode = $mode;
+    }
+
+    /**
+     * Mirror the &uni_obj_all loop body for one fetched row, applying the
+     * dedup guard from the fix when $applyFix is true.
+     */
+    public function ingestRow($row){
+        if($this->applyFix){
+            if($this->mode === "JSON_OBJ" && isset($this->newapicnt[$row["id"]]))
+                return;
+            if($this->mode === "JSON_DATA" && isset($this->newapiData[$row["id"]]))
+                return;
+        }
+        if($this->mode === "JSON_OBJ"){
+            $this->newapiObj[] = array(
+                "i" => (int)$row["id"],
+                "u" => (int)$row["up"],
+                "o" => (int)$row["val_ord"],
+                "r" => array($row["val"]),
+            );
+            $this->newapicnt[$row["id"]] = count($this->newapiObj) - 1;
+        }
+        else {
+            // The real code starts an open string here that &uni_object_view_reqs
+            // appends to. We only care about whether the id is "claimed" already.
+            $this->newapiData[$row["id"]] = "{\"i\":".$row["id"]
+                .",\"u\":".$row["up"]
+                .",\"o\":".$row["val_ord"]
+                .",\"r\":[\"".$row["val"]."\"";
+        }
+        $this->blocksIds[] = $row["id"];
+    }
+
+    /**
+     * Mirror the &uni_object_view_reqs case: for each id in blocksIds, append
+     * that id's reqs to the entry pointed to by newapicnt (JSON_OBJ) or to
+     * the string keyed by id (JSON_DATA).
+     */
+    public function runReqsCase(){
+        foreach($this->blocksIds as $parent_id){
+            $reqs = isset($this->reqsById[$parent_id]) ? $this->reqsById[$parent_id] : array();
+            if($this->mode === "JSON_OBJ"){
+                $idx = $this->newapicnt[$parent_id];
+                foreach($reqs as $req)
+                    $this->newapiObj[$idx]["r"][] = $req;
+            }
+            else {
+                foreach($reqs as $req)
+                    $this->newapiData[$parent_id] .= ",\"$req\"";
+            }
+        }
+        if($this->mode === "JSON_DATA")
+            foreach($this->newapiData as $id => $s)
+                $this->newapiData[$id] = $s . "]}";
+    }
+}
+
+# Helper: run a duplicate-row scenario end-to-end and return the harness.
+function run_dup_scenario($mode, $applyFix, $rows, $reqsById){
+    $h = new Issue2783DuplicateRowHarness($mode);
+    $h->applyFix = $applyFix;
+    $h->reqsById = $reqsById;
+    foreach($rows as $r)
+        $h->ingestRow($r);
+    $h->runReqsCase();
+    return $h;
+}
+
+# ---------------------------------------------------------------------------
+# Reproduce the symptom from issue #2783, JSON_OBJ shape.
+# Record 3893632 appears twice in the SELECT result set due to a filter join.
+$row3893632 = array("id" => 3893632, "up" => 1, "val_ord" => 0, "val" => "00-00627661");
+$reqsById3893632 = array(
+    3893632 => array("R-2406758:foo", "R-2406759:bar", "R-2406760:%5180%", "R-2406761:baz", "R-2406762:qux"),
+);
+
+# Legacy (broken) behaviour: split into two entries, the latter doubled.
+$legacy = run_dup_scenario("JSON_OBJ", false, array($row3893632, $row3893632), $reqsById3893632);
+assert_eq("Legacy JSON_OBJ produces two newapi entries for duplicate id", 2, count($legacy->newapiObj));
+assert_eq("Legacy JSON_OBJ first entry has only main value", 1, count($legacy->newapiObj[0]["r"]));
+assert_eq("Legacy JSON_OBJ second entry has 1 main + 2 * 5 reqs = 11", 11, count($legacy->newapiObj[1]["r"]));
+
+# Fixed behaviour: collapses to one entry with main + reqs once.
+$fixed = run_dup_scenario("JSON_OBJ", true, array($row3893632, $row3893632), $reqsById3893632);
+assert_eq("Fixed JSON_OBJ produces one entry for duplicate id", 1, count($fixed->newapiObj));
+assert_eq("Fixed JSON_OBJ entry has 1 main + 5 reqs = 6", 6, count($fixed->newapiObj[0]["r"]));
+assert_eq("Fixed JSON_OBJ entry's main value is intact", "00-00627661", $fixed->newapiObj[0]["r"][0]);
+
+# Same scenario via JSON_DATA shape: legacy fires reqs twice (doubled string),
+# fixed fires reqs once.
+$legacyData = run_dup_scenario("JSON_DATA", false, array($row3893632, $row3893632), $reqsById3893632);
+$legacyReqOccurrences = substr_count($legacyData->newapiData[3893632], "R-2406758:foo");
+assert_eq("Legacy JSON_DATA appends each req twice for duplicate id", 2, $legacyReqOccurrences);
+
+$fixedData = run_dup_scenario("JSON_DATA", true, array($row3893632, $row3893632), $reqsById3893632);
+$fixedReqOccurrences = substr_count($fixedData->newapiData[3893632], "R-2406758:foo");
+assert_eq("Fixed JSON_DATA appends each req exactly once for duplicate id", 1, $fixedReqOccurrences);
+
+# ---------------------------------------------------------------------------
+# Three duplicates (e.g. column joined three times by overlapping LIKE matches)
+# should still collapse to one entry under the fix.
+$tripled = run_dup_scenario("JSON_OBJ", true, array($row3893632, $row3893632, $row3893632), $reqsById3893632);
+assert_eq("Fixed JSON_OBJ collapses three duplicates to one entry", 1, count($tripled->newapiObj));
+assert_eq("Fixed JSON_OBJ tripled-case still has 1 main + 5 reqs = 6", 6, count($tripled->newapiObj[0]["r"]));
+
+# ---------------------------------------------------------------------------
+# Distinct ids must not be dedeuped together: two different records on the
+# page each keep their own entry.
+$rowOther = array("id" => 3893633, "up" => 1, "val_ord" => 1, "val" => "00-00627662");
+$reqsByIdMixed = array(
+    3893632 => array("R-2406758:foo", "R-2406759:bar"),
+    3893633 => array("R-2406758:other"),
+);
+$mixed = run_dup_scenario("JSON_OBJ", true, array($row3893632, $row3893632, $rowOther), $reqsByIdMixed);
+assert_eq("Distinct ids stay separate after dedup", 2, count($mixed->newapiObj));
+assert_eq("Dedup entry #0 keeps id 3893632", 3893632, $mixed->newapiObj[0]["i"]);
+assert_eq("Dedup entry #1 keeps id 3893633", 3893633, $mixed->newapiObj[1]["i"]);
+assert_eq("Dedup entry #0 has 1 main + 2 reqs = 3", 3, count($mixed->newapiObj[0]["r"]));
+assert_eq("Dedup entry #1 has 1 main + 1 req = 2", 2, count($mixed->newapiObj[1]["r"]));
+
+# ---------------------------------------------------------------------------
+# A single non-duplicated row is the trivial passthrough case — must still
+# produce one well-formed entry.
+$single = run_dup_scenario("JSON_OBJ", true, array($row3893632), $reqsById3893632);
+assert_eq("Single-row case yields one entry", 1, count($single->newapiObj));
+assert_eq("Single-row case yields 1 main + 5 reqs = 6", 6, count($single->newapiObj[0]["r"]));
+
+echo "\nAll assertions passed for issue #2783 duplicate-row dedup.\n";

--- a/index.php
+++ b/index.php
@@ -6812,6 +6812,21 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 			$i = 0; # Row count for Array elements
 			while($row = mysqli_fetch_array($data_set))
 			{
+				# Issue #2783: a filter LEFT JOIN on a non-MULTI/ARRAY column can
+				# produce duplicate rows for the same vals.id. Construct_WHERE only
+				# sets $GLOBALS["distinct"] for MULTI/ARRAY types, so the SELECT
+				# above may legitimately return the same id multiple times. Without
+				# dedup, JSON_OBJ creates one newapi[] entry per duplicate and the
+				# newapicnt[$id] -> latest-index map gets overwritten, routing every
+				# &uni_object_view_reqs append into the latest entry — earlier
+				# entries lose their reqs, the latest collects them once per
+				# duplicate. JSON_DATA suffers the same per-id req doubling because
+				# &uni_object_view_reqs fires once per blocks[$block]["id"][] entry.
+				# Skip duplicates before they reach the blocks/newapi pipeline.
+				if(isset($_REQUEST["JSON_OBJ"]) && isset($GLOBALS["GLOBAL_VARS"]["newapicnt"][$row["id"]]))
+					continue;
+				if(isset($_REQUEST["JSON_DATA"]) && isset($GLOBALS["GLOBAL_VARS"]["newapi"][$row["id"]]))
+					continue;
     			if(isset($GLOBALS["dataExport"])){
     				$GLOBALS["dataExport"][] = Export_reqs($id, $row["id"], $row["val"]);
     				#$str = Export_reqs($id, $row["id"], $row["val"]);

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1370,15 +1370,64 @@ class IntegramTable{
                 this.columns = columns;
             }
 
+            // Issue #2783: dedupe rows that share the same id. A filter LEFT
+            // JOIN on a non-MULTI/ARRAY column on the server can return the
+            // same vals.id more than once, which used to produce one entry
+            // with only the main value and one entry with reqs duplicated.
+            // Server-side fix lives in index.php; this client guard keeps a
+            // mid-rollout server from breaking column alignment by keeping
+            // the entry with the most cells per id.
+            const dedupedArray = this.dedupeJsonDataArrayById(dataArray);
+
             // Transform JSON_OBJ array to row format
             // LIMIT is already applied server-side via the fetch URL in loadDataFromReport
-            const rows = dataArray.map(item => item.r || []);
+            const rows = dedupedArray.map(item => item.r || []);
 
             return {
                 columns: this.columns,
                 rows: rows,
-                rawData: dataArray  // Preserve raw data with 'i' keys
+                rawData: dedupedArray  // Preserve raw data with 'i' keys
             };
+        }
+
+        /**
+         * Dedupe JSON_OBJ array entries by their `i` field, keeping the entry
+         * with the most cells in `r` when duplicates exist (issue #2783).
+         * Returns the input untouched when no duplicates are present.
+         */
+        dedupeJsonDataArrayById(dataArray) {
+            if (!Array.isArray(dataArray) || dataArray.length < 2) {
+                return dataArray;
+            }
+            const seenIndexById = new Map();
+            const keep = new Set();
+            let hasDuplicates = false;
+            for (let i = 0; i < dataArray.length; i++) {
+                const item = dataArray[i];
+                if (!item || item.i === undefined) {
+                    // Malformed entries can't be deduped by id — keep them as-is.
+                    keep.add(i);
+                    continue;
+                }
+                const prevIndex = seenIndexById.get(item.i);
+                if (prevIndex === undefined) {
+                    seenIndexById.set(item.i, i);
+                    keep.add(i);
+                    continue;
+                }
+                hasDuplicates = true;
+                const prevLen = Array.isArray(dataArray[prevIndex].r) ? dataArray[prevIndex].r.length : 0;
+                const curLen = Array.isArray(item.r) ? item.r.length : 0;
+                if (curLen > prevLen) {
+                    keep.delete(prevIndex);
+                    seenIndexById.set(item.i, i);
+                    keep.add(i);
+                }
+            }
+            if (!hasDuplicates) {
+                return dataArray;
+            }
+            return dataArray.filter((_, idx) => keep.has(idx));
         }
 
         async fetchTotalCount() {

--- a/js/integram-table/02-format-helpers.js
+++ b/js/integram-table/02-format-helpers.js
@@ -297,15 +297,64 @@
                 this.columns = columns;
             }
 
+            // Issue #2783: dedupe rows that share the same id. A filter LEFT
+            // JOIN on a non-MULTI/ARRAY column on the server can return the
+            // same vals.id more than once, which used to produce one entry
+            // with only the main value and one entry with reqs duplicated.
+            // Server-side fix lives in index.php; this client guard keeps a
+            // mid-rollout server from breaking column alignment by keeping
+            // the entry with the most cells per id.
+            const dedupedArray = this.dedupeJsonDataArrayById(dataArray);
+
             // Transform JSON_OBJ array to row format
             // LIMIT is already applied server-side via the fetch URL in loadDataFromReport
-            const rows = dataArray.map(item => item.r || []);
+            const rows = dedupedArray.map(item => item.r || []);
 
             return {
                 columns: this.columns,
                 rows: rows,
-                rawData: dataArray  // Preserve raw data with 'i' keys
+                rawData: dedupedArray  // Preserve raw data with 'i' keys
             };
+        }
+
+        /**
+         * Dedupe JSON_OBJ array entries by their `i` field, keeping the entry
+         * with the most cells in `r` when duplicates exist (issue #2783).
+         * Returns the input untouched when no duplicates are present.
+         */
+        dedupeJsonDataArrayById(dataArray) {
+            if (!Array.isArray(dataArray) || dataArray.length < 2) {
+                return dataArray;
+            }
+            const seenIndexById = new Map();
+            const keep = new Set();
+            let hasDuplicates = false;
+            for (let i = 0; i < dataArray.length; i++) {
+                const item = dataArray[i];
+                if (!item || item.i === undefined) {
+                    // Malformed entries can't be deduped by id — keep them as-is.
+                    keep.add(i);
+                    continue;
+                }
+                const prevIndex = seenIndexById.get(item.i);
+                if (prevIndex === undefined) {
+                    seenIndexById.set(item.i, i);
+                    keep.add(i);
+                    continue;
+                }
+                hasDuplicates = true;
+                const prevLen = Array.isArray(dataArray[prevIndex].r) ? dataArray[prevIndex].r.length : 0;
+                const curLen = Array.isArray(item.r) ? item.r.length : 0;
+                if (curLen > prevLen) {
+                    keep.delete(prevIndex);
+                    seenIndexById.set(item.i, i);
+                    keep.add(i);
+                }
+            }
+            if (!hasDuplicates) {
+                return dataArray;
+            }
+            return dataArray.filter((_, idx) => keep.has(idx));
         }
 
         async fetchTotalCount() {


### PR DESCRIPTION
## Summary

- Filter LEFT JOINs on non-MULTI/ARRAY columns can legitimately return the same `vals.id` more than once because `Construct_WHERE` only sets `$GLOBALS[\"distinct\"]` for MULTI/ARRAY types. In the JSON_OBJ branch of `&uni_obj_all`, each duplicate created a fresh `newapi[]` entry and the `newapicnt[$id]` -> latest-index map was overwritten, so every `&uni_object_view_reqs` append routed into the latest entry — once per duplicate occurrence. The earlier entry kept only the main value, the latest collected the reqs twice.
- Symptom on the URL from the issue (`/object/2406756/?JSON_OBJ&LIMIT=0,21&FR_2406760=%255180%25`): record `3893632` appeared twice — once as `r:[\"00-00627661\"]` and once with 11 cells (1 main + 5 reqs duplicated).
- Fix: skip duplicate rows at the top of the while-loop body in `index.php` before blocks/newapi see them. JSON_DATA gets the same guard because `&uni_object_view_reqs` would otherwise double-append reqs to the (overwritten) per-id string.
- Defense in depth: `js/integram-table/02-format-helpers.js` -> `parseJsonDataArray` now collapses duplicate `i` ids in the response by keeping the entry with the most cells, so a mid-rollout client doesn't lose column alignment if it talks to a server bundle that still has the legacy behaviour.

## Reproduction

Server URL: `/test/object/2406756/?JSON_OBJ&LIMIT=0,21&FR_2406760=%255180%25` — used to return record `3893632` twice.

The two harnesses under `experiments/` reproduce the symptom and verify the fix without needing a database:

- `experiments/test-issue-2783-duplicate-row-dedup.php`
  - First runs the legacy pipeline on a duplicated row → asserts the broken shape (split + doubled).
  - Then runs the fixed pipeline → asserts a single, well-formed entry.
  - Also covers JSON_DATA, three-way duplicates, distinct ids, and the single-row trivial case.
- `experiments/test-issue-2783-client-dedup.js`
  - Covers the `dedupeJsonDataArrayById` helper with the issue's exact split + doubled payload, equal-length ties, three duplicates of one id, and entries missing the `i` field.

## Test plan
- [x] `php -l index.php`
- [x] `node --check js/integram-table.js`
- [x] `php experiments/test-issue-2783-duplicate-row-dedup.php`
- [x] `node experiments/test-issue-2783-client-dedup.js`
- [x] `bash build.sh` reproduces `js/integram-table.js`


Fixes #2783