### PR TITLE
fix(templates/sql.html): preserve $-sequences in .save-input values (closes #2791)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-23T20:51:25.627Z for PR creation at branch issue-2791-2e3bf7e10a0e for issue https://github.com/ideav/crm/issues/2791

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-23T20:51:25.627Z for PR creation at branch issue-2791-2e3bf7e10a0e for issue https://github.com/ideav/crm/issues/2791

--- a/experiments/range-fix-test-2791.js
+++ b/experiments/range-fix-test-2791.js
@@ -1,0 +1,35 @@
+// Verify the range-filter inputs (t102/t103/t105/t106) are also safe after the fix.
+var templateRange = '\n<input type="text" id="t102_:id:" value="" placeholder="От" class="form-control form-control-sm save-input">\n<input type="text" id="t103_:id:" value="" placeholder="До" class="form-control form-control-sm save-input">\n';
+
+function getReq(id, r, mockMap) {
+    var k = id + ':' + r;
+    if (mockMap[k] === undefined) return '';
+    return mockMap[k].replace(/"/gm, '&quot;');
+}
+
+var id = 7;
+
+// Mock filter values that contain $ patterns
+var mocks = {
+    '7:102': "[TODAY] $' edge",     // tricky $' near start
+    '7:103': "value with $1 $&"
+};
+
+// === FIXED code path ===
+var control = templateRange.replace(/:t:/g, '102').replace(/:id:/g, id);
+var v102 = getReq(id, 102, mocks), v103 = getReq(id, 103, mocks);
+control = control.replace('id="t102_'+id+'" value=""', function(){return 'id="t102_'+id+'" value="'+v102+'"';})
+                 .replace('id="t103_'+id+'" value=""', function(){return 'id="t103_'+id+'" value="'+v103+'"';});
+
+console.log('t102 expected:', JSON.stringify(mocks['7:102']));
+console.log('t103 expected:', JSON.stringify(mocks['7:103']));
+
+var m102 = control.match(/id="t102_7" value="([^"]*)"/);
+var m103 = control.match(/id="t103_7" value="([^"]*)"/);
+console.log('t102 got:     ', JSON.stringify(m102 && m102[1]));
+console.log('t103 got:     ', JSON.stringify(m103 && m103[1]));
+
+var ok102 = m102 && m102[1] === mocks['7:102'];
+var ok103 = m103 && m103[1] === mocks['7:103'];
+console.log('t102 match?', ok102, 't103 match?', ok103);
+process.exit(ok102 && ok103 ? 0 : 1);

--- a/experiments/reproduce-2791.js
+++ b/experiments/reproduce-2791.js
@@ -1,0 +1,38 @@
+// Reproduce bug from issue #2791
+// JavaScript .replace() interprets $ patterns in REPLACEMENT strings:
+//   $$ → $
+//   $& → matched substring
+//   $` → portion BEFORE the match
+//   $' → portion AFTER the match
+//   $n → captured group
+
+// Simulated template (innerHTML of div#template101)
+var template = '\n        <label class="control-label" for="t101_42">\n            <i class="pi pi-pencil"></i>\n        </label>\n        <!--Expression-->\n\t\t<input type="text" name="t101" id="t101_42" class="form-control form-control-sm save-input" value="">\n\t';
+
+// User input from issue 2791 (simplified to last lines)
+var userValue = "REGEXP_REPLACE(x,'^,|,$', '')";
+
+console.log("=== INPUT ===");
+console.log(JSON.stringify(userValue));
+
+// This is the buggy line from templates/sql.html:843
+var result = template.replace('value=""', 'value="' + userValue + '" title="' + userValue + '"');
+console.log("\n=== OUTPUT (with bug) ===");
+console.log(result);
+
+// Extract just the value attribute back to see corruption
+var m = result.match(/value="([^"]*)"/);
+console.log("\n=== Recovered value (from value attribute) ===");
+console.log(JSON.stringify(m && m[1]));
+
+// Compare original vs recovered
+console.log("\n=== Match? ===", m && m[1] === userValue);
+
+// Now demonstrate the fix using function-as-replacement (no $ substitution)
+var fixed = template.replace('value=""', function () {
+    return 'value="' + userValue + '" title="' + userValue + '"';
+});
+var m2 = fixed.match(/value="([^"]*)"/);
+console.log("\n=== FIXED Recovered value ===");
+console.log(JSON.stringify(m2 && m2[1]));
+console.log("=== FIXED Match? ===", m2 && m2[1] === userValue);

--- a/experiments/verify-fix-2791.js
+++ b/experiments/verify-fix-2791.js
@@ -1,0 +1,74 @@
+// End-to-end verification: simulate the actual code path from templates/sql.html
+// after the fix, with the exact user input from issue #2791.
+
+// Simulated getReq() from templates/sql.html:643-648 (escapes " to &quot;)
+function getReq(id, r, mockValue) {
+    if (mockValue === undefined) return '';
+    return mockValue.replace(/"/gm, '&quot;');
+}
+
+// Simulated innerHTML of div#template101 (used for t101 Expression filter)
+var template101innerHTML = '\n        <label class="control-label" for="t101_:id:">\n            <i class="pi pi-pencil"></i>\n        </label>\n        <!--Expression-->\n\t\t<input type="text" name="t101" id="t101_:id:" class="form-control form-control-sm save-input" value="">\n\t';
+
+// Exact value from issue #2791
+var userValue = `CONCAT('[',
+    REGEXP_REPLACE(
+      REGEXP_REPLACE(
+        REGEXP_REPLACE(
+          REGEXP_REPLACE(
+            REGEXP_REPLACE(
+              REGEXP_REPLACE(
+                REGEXP_REPLACE(
+                  Наименование,
+                  '[™№#"\\'«»]', ''),
+                '(^| )(для|за|под|без|не|в|к|от|с|на|и)( |$)', ' '),
+              '([0-9])([A-Za-zА-Яа-я])', '$1,$2'),
+            '([A-Za-zА-Яа-я])([0-9])', '$1,$2'),
+          '[^a-zA-Z0-9а-яА-Я]+', ','),
+        ',,+', ','),
+      '^,|,$', ''),
+    ']')`;
+
+var id = 42;
+var ctlk = 101;
+
+// === Reproduce the original buggy code ===
+var control = template101innerHTML.replace(/:t:/g, ctlk).replace(/:id:/g, id);
+var buggy = control.replace('value=""',
+    'value="' + getReq(id, ctlk, userValue).replace(/"/g, '\"') + '" title="' +
+    getReq(id, ctlk, userValue).replace(/"/g, '\"') + '"');
+var buggyValueMatch = buggy.match(/value="([^"]*)"/);
+var buggyValue = buggyValueMatch ? buggyValueMatch[1].replace(/&quot;/g, '"') : null;
+
+// === Reproduce the FIXED code ===
+var control2 = template101innerHTML.replace(/:t:/g, ctlk).replace(/:id:/g, id);
+var v = getReq(id, ctlk, userValue);
+var fixed = control2.replace('value=""', function () {
+    return 'value="' + v + '" title="' + v + '"';
+});
+var fixedValueMatch = fixed.match(/value="([^"]*)"/);
+var fixedValue = fixedValueMatch ? fixedValueMatch[1].replace(/&quot;/g, '"') : null;
+
+console.log('Original user value contains $1, $2, and ^,|,$\' patterns.');
+console.log('');
+console.log('--- BUGGY behaviour ---');
+console.log('Matches original?', buggyValue === userValue);
+if (buggyValue !== userValue) {
+    // Show the diverging tail (the part that got corrupted)
+    var idx = 0;
+    while (idx < userValue.length && idx < buggyValue.length && userValue[idx] === buggyValue[idx]) idx++;
+    console.log('Diverges at char', idx);
+    console.log('Expected tail:', JSON.stringify(userValue.slice(idx, idx + 30)));
+    console.log('Got tail:     ', JSON.stringify(buggyValue.slice(idx, idx + 30)));
+}
+
+console.log('');
+console.log('--- FIXED behaviour ---');
+console.log('Matches original?', fixedValue === userValue);
+if (fixedValue !== userValue) {
+    var idx = 0;
+    while (idx < userValue.length && idx < fixedValue.length && userValue[idx] === fixedValue[idx]) idx++;
+    console.log('Diverges at char', idx);
+    console.log('Expected tail:', JSON.stringify(userValue.slice(idx, idx + 30)));
+    console.log('Got tail:     ', JSON.stringify(fixedValue.slice(idx, idx + 30)));
+}

--- a/templates/sql.html
+++ b/templates/sql.html
@@ -809,12 +809,14 @@ function myApi(m,u,b,vars,index){ // Параметры: метод, адрес,
                             if(getReq(id,58)!=='') // Alias - select input
                                 control=control.replace('value="'+getReq(id,58)+'"','value="'+getReq(id,58)+'" selected');
                             else if(ctl[k]==102){ // Range input for Filter
-                                control=control.replace('id="t102_'+id+'" value=""','id="t102_'+id+'" value="'+getReq(id,102)+'"')
-                                                .replace('id="t103_'+id+'" value=""','id="t103_'+id+'" value="'+getReq(id,103)+'"');
+                                var v102=getReq(id,102),v103=getReq(id,103);
+                                control=control.replace('id="t102_'+id+'" value=""',function(){return 'id="t102_'+id+'" value="'+v102+'"';})
+                                                .replace('id="t103_'+id+'" value=""',function(){return 'id="t103_'+id+'" value="'+v103+'"';});
                             }
                             else if(ctl[k]==105){ // Range input for HAVING
-                                control=control.replace('id="t105_'+id+'" value=""','id="t105_'+id+'" value="'+getReq(id,105)+'"')
-                                                .replace('id="t106_'+id+'" value=""','id="t106_'+id+'" value="'+getReq(id,106)+'"');
+                                var v105=getReq(id,105),v106=getReq(id,106);
+                                control=control.replace('id="t105_'+id+'" value=""',function(){return 'id="t105_'+id+'" value="'+v105+'"';})
+                                                .replace('id="t106_'+id+'" value=""',function(){return 'id="t106_'+id+'" value="'+v106+'"';});
                             }
                             else if(ctl[k]==109){ // Order
                                 dir=getReq(id,ctl[k]);
@@ -839,8 +841,12 @@ function myApi(m,u,b,vars,index){ // Параметры: метод, адрес,
                                             +'" onclick="showLoading(this);setOrder('+id+',0,\'\')" class="pi pi-times-circle icon8 text-danger"></i>';
                                 }
                             }
-                            else
-                                control=control.replace('value=""','value="'+getReq(id,ctl[k]).replace(/"/g,'\"')+'" title="'+getReq(id,ctl[k]).replace(/"/g,'\"')+'"');
+                            else{
+                                // Use a function as the replacement so that $-sequences ($', $&, $`, $n) in the
+                                // user value are not interpreted by String.prototype.replace (fixes #2791).
+                                var v=getReq(id,ctl[k]);
+                                control=control.replace('value=""',function(){return 'value="'+v+'" title="'+v+'"';});
+                            }
                             c[k]+=control+'</td>';
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #2791. In `templates/sql.html`, control values (filter / function / totals / set inputs on the SQL report page) were being spliced into the rendered control HTML through `String.prototype.replace(searchString, replacementString)`. That API gives special meaning to `$'`, `$&`, `` $` `` and `$n` **inside the replacement string** — so any user value containing those sequences was corrupted on the next render.

The issue's reproducer is a `REGEXP_REPLACE(..., '^,|,$', '')` expression. The trailing `$'` was being replaced with the portion of the control template that came after the matched `value=""` (a literal `>` followed by the next line's indentation), turning `'^,|,$'` into `'^,|,>\t,` — exactly what the reporter sees in the debug panel.

## Root cause

`templates/sql.html:843` (and three sibling lines at 812/813/816/817) did:

```js
control = control.replace(
  'value=""',
  'value="' + getReq(id, ctl[k]) + '" title="' + getReq(id, ctl[k]) + '"'
);
```

The second argument is a **replacement string** — `$'` inside it expands to "portion of `control` after the matched `value=""`".

## Fix

Switch the four splices to use a **function** as the replacement, so the value is returned verbatim with no `$`-interpretation:

```js
var v = getReq(id, ctl[k]);
control = control.replace('value=""', function () {
  return 'value="' + v + '" title="' + v + '"';
});
```

Same change applied to the t102/t103 filter range and t105/t106 having range inputs (also `.save-input` fields).

## Verification

`experiments/verify-fix-2791.js` runs the **exact value from issue #2791** through the original and fixed code paths:

```
--- BUGGY behaviour ---
Matches original? false
Diverges at char 503
Expected tail: "$', ''),\n    ']')"
Got tail:      ">\n\t, ''),\n    ']')"

--- FIXED behaviour ---
Matches original? true
```

`experiments/range-fix-test-2791.js` confirms the same fix preserves `$'`, `$1`, `$&` in the t102/t103 range filter inputs.

## Test plan

- [x] Reproduce the corruption in a Node harness using the exact user value (`experiments/reproduce-2791.js`)
- [x] Verify the fix round-trips the user value byte-for-byte (`experiments/verify-fix-2791.js`)
- [x] Verify the fix also covers t102/t103/t105/t106 range inputs (`experiments/range-fix-test-2791.js`)
- [x] Syntax-check the resulting `templates/sql.html` script blocks with `node --check`
- [ ] Manual smoke test on a SQL report page: paste the issue's `REGEXP_REPLACE` expression into a `t101` filter, save, navigate away and back, confirm the value is preserved verbatim

Fixes #2791