### PR TITLE
fix(docs): correct Section 4 helper references and line numbers (closes #2802)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-25T21:39:47.786Z for PR creation at branch issue-2802-9eee94c45d13 for issue https://github.com/ideav/crm/issues/2802

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-25T21:39:47.786Z for PR creation at branch issue-2802-9eee94c45d13 for issue https://github.com/ideav/crm/issues/2802

--- a/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
+++ b/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
@@ -156,18 +156,22 @@
 
 - **Каждый POST-запрос обязан содержать токен `_xsrf`.** GET-запросы токен не требуют.
 - Токен берётся из шаблонной переменной: `var xsrf = '{_global_.xsrf}'`
-  (`templates/main.html:128`).
+  (`templates/main.html:131`).
 - В рабочих местах используется хелпер `intApi(method, url, branch, vars, index)`,
-  который **сам подставляет токен** (`templates/upload.html:820-832`):
+  который **сам подставляет токен** (`templates/upload.html:821-832`):
   - если `vars` — объект `FormData`: `vars.append('_xsrf', xsrf)`;
   - если `vars` — строка: `vars = '_xsrf=' + xsrf + '&' + vars` и заголовок
     `Content-Type: application/x-www-form-urlencoded`.
 - Для обычной HTML-формы добавляйте скрытое поле:
   `<input type="hidden" name="_xsrf" value="{_global_.xsrf}">`
   (`templates/edit_obj.html:77`).
-- Аналогичные хелперы (`myApi`, `newApi`) есть в `templates/sql.html`,
-  `templates/form.html`, `templates/quiz.html`, `templates/object.html` — они инжектят
-  токен тем же способом. Не дублируйте логику XSRF вручную, если хелпер уже есть.
+- Аналогичные хелперы используют ту же логику инжекта токена:
+  - `newApi` (с поддержкой `FormData`) — глобальный хелпер в `js/main.js:2-13`;
+  - `myApi` (только строка) — локальный хелпер в `templates/sql.html:691` и
+    `templates/form.html:217`;
+  - `intApi` (с поддержкой `FormData`) — локальный хелпер в
+    `templates/quiz.html:952` и `templates/object.html:1526`.
+- Не дублируйте логику XSRF вручную, если хелпер уже есть.
 
 ---
 


### PR DESCRIPTION
## Проверка раздела 4 — Токен XSRF и хелпер `intApi` (refs #2797)

Fixes #2802

### Что проверено

Все три пункта чеклиста из issue #2802 проверены по коду:

#### ✅ Правило «POST требует `_xsrf`, GET — нет»
Подтверждено: `index.php:9529-9530` — все `_m_*`-команды вызывают `check()`, который проверяет `$_POST["_xsrf"]`.

#### ✅ Механизм инжекта токена в `intApi` (FormData vs строка)
Подтверждено: `templates/upload.html:821-832` точно соответствует описанию руководства.

#### ⚠️ Скрытое поле и хелперы `myApi`/`newApi`
Скрытое поле в формах (`edit_obj.html:77`) подтверждено. Найдены неточности в описании хелперов.

### Найденные ошибки и исправления

| До | После |
|----|-------|
| `templates/main.html:128` (строка `</script>`) | `templates/main.html:131` (строка с `xsrf = ...`) |
| `templates/upload.html:820-832` | `templates/upload.html:821-832` |
| «`myApi`, `newApi` есть в `sql.html`, `form.html`, `quiz.html`, `object.html`» | `newApi` — глобальный хелпер в `js/main.js:2-13`; `myApi` — в `sql.html` и `form.html`; `intApi` — в `quiz.html` и `object.html` |
| Нет различия по поддержке FormData | `myApi` — только строка; `newApi`/`intApi` — поддерживают FormData |

Подробный результат проверки — в комментарии к issue #2802.