### PR TITLE
docs(workspace-guide): fix section 7 IntegramTable options list (closes #2805)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-25T21:43:38.850Z for PR creation at branch issue-2805-b3cddf3f39b8 for issue https://github.com/ideav/crm/issues/2805

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-25T21:43:38.850Z for PR creation at branch issue-2805-b3cddf3f39b8 for issue https://github.com/ideav/crm/issues/2805

--- a/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
+++ b/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
@@ -233,9 +233,10 @@
   (`templates/query.html:1-8`, `templates/table.html:1-8`)
 - **Программно**: `new IntegramTable('container-id', { apiUrl, dataSource, tableTypeId,
   parentId, recordId, pageSize, cookiePrefix, title, instanceName, onCellClick,
-  onDataLoad })` (`templates/calendar.html:1328`).
+  onDataLoad, debug })` (`templates/calendar.html:1328`).
 - `parentId` берётся из опции или из URL (`parentId` / `F_U` / `up`); `recordId` —
-  фильтр по записи (`issue #563`).
+  фильтр по записи, берётся из опции или из GET-параметра `F_I` (`issue #563`).
+- `debug: false` — включить трассировку в консоль (`js/integram-table/01-core.js:22`).
 
 ### 7.2. Правило сборки бандла
 


### PR DESCRIPTION
## Summary

Verifies the correctness of Section 7 (IntegramTable Component) of `docs/WORKSPACE_DEVELOPMENT_GUIDE.md` as requested in issue #2805, and applies the corrections found.

## Verification Results

### 7.1 Initialization — data-attribute examples
✅ **Correct.** Both `templates/query.html:1-8` and `templates/table.html:1-8` match the guide's examples. (Real templates also have `data-title=""` but that's an optional empty attribute — not an error in the guide.)

### 7.1 Initialization — programmatic `new IntegramTable`
⚠️ **Two issues found and fixed:**

1. **Missing option `debug`** — the code in `js/integram-table/01-core.js:22` accepts a `debug` option (enables console tracing, default `false`), but it was absent from the guide's options list.

2. **`recordId` URL param not named** — the guide said «фильтр по записи» but didn't specify the GET parameter name. The code reads it from `F_I` (`01-core.js:7`).

The reference `templates/calendar.html:1328` was verified correct ✅

### 7.2 Build rule
✅ **Fully correct.** `bash build.sh` command verified against actual `build.sh`; `CLAUDE.md:1-7` reference is accurate; the auto-generated-bundle claim is confirmed by the `// AUTO-GENERATED — DO NOT EDIT` header.

## Changes

- `docs/WORKSPACE_DEVELOPMENT_GUIDE.md` — Section 7.1:
  - Added `debug` to the constructor options list
  - Clarified that `recordId` is read from GET parameter `F_I`
  - Added a dedicated bullet for `debug: false` with source reference

## Cross-references
- Verification comment: https://github.com/ideav/crm/issues/2805#issuecomment-4537460373
- Fixes #2805