### PR TITLE
docs(workspace): verify and correct section 8 — modal windows (closes #2806)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-25T21:54:15.032Z for PR creation at branch issue-2806-2a187e38cbbd for issue https://github.com/ideav/crm/issues/2806

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-25T21:54:15.032Z for PR creation at branch issue-2806-2a187e38cbbd for issue https://github.com/ideav/crm/issues/2806

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ IntegramTable component, modals, and user hints. Each rule cites its source clos
 issue (`issue #NNN`) and/or code location (`file:line`).
 
 - **Never use** `alert()`, `confirm()`, or `prompt()`. Use the modal methods instead:
-  - `showDeleteConfirmModal(message)` — for delete confirmations
+  - `showDeleteConfirmModal()` — for delete confirmations (in `IntegramTable`, no parameter — fixed message text)
   - `showErrorModal(message)` — for errors (in `MainAppController`)
-  - `showWarningModal(message)` — for warnings (in `IntegTable`)
+  - `showWarningModal(message)` — for warnings during save (in `IntegramTable`)
+  - `showWarningsModal(message)` — for informational warnings after save, non-blocking (in `IntegramTable`)
 - Template variables must not have spaces: `{_global_.version}`, not `{ _global_.version }`
 - Styles go in `.css` files, scripts in `.js` files — no inline styles or scripts in templates
 - Asset URLs must include version for cache busting: `href="/css/file.css?{_global_.version}"`

--- a/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
+++ b/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
@@ -250,10 +250,16 @@
 ## 8. Модальные окна и запрет `alert`/`confirm`/`prompt`
 
 - **Никогда не используйте** `alert()`, `confirm()`, `prompt()`. Вместо них —
-  модальные методы (`README.md:41,67-69`):
-  - `showDeleteConfirmModal(message)` — подтверждение удаления;
-  - `showErrorModal(message)` — ошибки (в `MainAppController`);
-  - `showWarningModal(message)` — предупреждения (в `IntegramTable`).
+  модальные методы (`README.md:41,73-76`):
+  - `showDeleteConfirmModal()` — подтверждение удаления (в `IntegramTable`, без
+    параметра — текст фиксированный; `js/integram-table/21-form-field-settings.js:893`);
+  - `showErrorModal(message)` — ошибки (в `MainAppController`;
+    `js/main-app.js:1607`);
+  - `showWarningModal(message, objId = null)` — предупреждения во время сохранения
+    (в `IntegramTable`; `js/integram-table/22-utils.js:430`);
+  - `showWarningsModal(message)` — информационные предупреждения **после** сохранения,
+    не блокирует операцию (в `IntegramTable`; `js/integram-table/22-utils.js:491`;
+    `issue #610`).
 
 ---
 


### PR DESCRIPTION
## Проверка раздела 8 руководства: модальные окна

Closes #2806

### Что проверено

**Раздел 8 — Модальные окна и запрет `alert`/`confirm`/`prompt`** в `docs/WORKSPACE_DEVELOPMENT_GUIDE.md`.

### Результаты проверки

| # | Утверждение | Статус |
|---|-------------|--------|
| 1 | Запрет `alert`/`confirm`/`prompt` актуален | ✅ Подтверждено (`README.md:41,73-76`) |
| 2 | `showErrorModal(message)` — в `MainAppController` | ✅ Корректно (`js/main-app.js:1607`) |
| 3 | `showDeleteConfirmModal(message)` — для удаления | ⚠️ Неточность: в `IntegramTable` без параметра |
| 4 | `showWarningModal(message)` — в `IntegramTable` | ✅ Корректно (`js/integram-table/22-utils.js:430`) |

### Исправления

1. **Сигнатура `showDeleteConfirmModal`**: убран параметр `message` — в `IntegramTable` метод вызывается без параметров (`js/integram-table/21-form-field-settings.js:893`). Параметр `message` есть только у реализаций в `MainAppController` и `tables.js`.

2. **Добавлен `showWarningsModal(message)`** — незадокументированный метод `IntegramTable` для информационных предупреждений **после** сохранения без блокировки операции (`js/integram-table/22-utils.js:491`, `issue #610`).

3. **Исправлена ссылка на источник**: `README.md:41,67-69` → `README.md:41,73-76` (строки 67–69 были общим текстом, не о модалках).

4. **Исправлена опечатка в `README.md:76`**: `IntegTable` → `IntegramTable`.

5. Добавлены `file:line` ссылки для каждого метода.

### Попутно найдено (нарушения правила, за рамками задачи)

- `templates/gssync.html:409,499` — `alert(...)`
- `templates/gssync.html:482` — `confirm(...)`
- `templates/dict.html:546` — `alert(...)`