### PR TITLE
Fix password invitation generation for new users

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-26T08:00:37.695Z for PR creation at branch issue-2825-b3f7479edaf5 for issue https://github.com/ideav/crm/issues/2825

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-26T08:00:37.695Z for PR creation at branch issue-2825-b3f7479edaf5 for issue https://github.com/ideav/crm/issues/2825

--- a/experiments/test-issue-2823-password-invitation.js
+++ b/experiments/test-issue-2823-password-invitation.js
@@ -1,0 +1,232 @@
+/**
+ * Regression coverage for issue #2823.
+ *
+ * Password invitations must be copyable before the new user record is saved,
+ * using the current username field value. The generated password must then be
+ * saved after _m_new returns an ID, because password hashing is salted by user
+ * ID on the server.
+ *
+ * Run with: node experiments/test-issue-2823-password-invitation.js
+ */
+
+const assert = require('assert');
+const IntegramTable = require('../js/integram-table.js');
+
+function createTable() {
+    const table = Object.create(IntegramTable.prototype);
+    table.getApiBase = () => '/db';
+    table.getServerError = () => null;
+    table.showToast = () => {};
+    table.showWarningModal = () => {};
+    table.showWarningsModal = () => {};
+    table.clearAllReferenceOptionCaches = () => {};
+    table.loadData = async () => {};
+    table.currentEditModal = null;
+    table.cellSubordinateContext = null;
+    table.data = [];
+    table.loadedRecords = 0;
+    table.hasMore = false;
+    table.totalRows = null;
+    return table;
+}
+
+function passwordInput(name, value, disabled = false) {
+    return {
+        name,
+        type: 'password',
+        value,
+        disabled,
+        getAttribute(attr) {
+            return attr === 'name' ? name : null;
+        }
+    };
+}
+
+function modalForUsername(mainInput) {
+    return {
+        dataset: {},
+        querySelector(selector) {
+            return selector === '#field-main' ? mainInput : null;
+        },
+        querySelectorAll() {
+            return [];
+        }
+    };
+}
+
+async function testInvitationUsernameUsesUnsavedMainField() {
+    const table = createTable();
+
+    const createModal = modalForUsername({ type: 'text', value: '  ivan  ' });
+    assert.strictEqual(
+        table.getPasswordInvitationUsername(createModal),
+        'ivan',
+        'create invitation should use the unsaved main field value'
+    );
+
+    createModal.dataset.firstColumnValue = 'saved-user';
+    assert.strictEqual(
+        table.getPasswordInvitationUsername(createModal),
+        'saved-user',
+        'edit invitation should keep using the saved first-column value'
+    );
+
+    const emptyModal = modalForUsername({ type: 'text', value: '   ' });
+    assert.strictEqual(
+        table.getPasswordInvitationUsername(emptyModal),
+        '',
+        'blank usernames should still be rejected'
+    );
+}
+
+function testPasswordFieldCollectionAndRecordIds() {
+    const table = createTable();
+    const pwd = passwordInput('t20', 'secret');
+    const mainPwd = passwordInput('main', 'main-secret');
+    const disabledPwd = passwordInput('t21', 'skip-me', true);
+    const emptyPwd = passwordInput('t22', '');
+
+    const modal = {
+        querySelectorAll(selector) {
+            if (selector === 'input[type="password"][name]') {
+                return [pwd, mainPwd, disabledPwd, emptyPwd];
+            }
+            return [];
+        }
+    };
+
+    assert.deepStrictEqual(
+        table.collectCreatePasswordFields(modal, 41),
+        [
+            { formKey: 't20', saveKey: 't20', value: 'secret' },
+            { formKey: 'main', saveKey: 't41', value: 'main-secret' }
+        ],
+        'create password fields should be collected with save keys'
+    );
+
+    assert.strictEqual(table.isDeferredPasswordField('t20', [{ formKey: 't20' }]), true);
+    assert.strictEqual(table.isDeferredPasswordField('t30', [{ formKey: 't20' }]), false);
+    assert.strictEqual(table.isDeferredPasswordField('t20'), false);
+
+    assert.strictEqual(table.getSavedRecordId({ obj: '777' }), '777');
+    assert.strictEqual(table.getSavedRecordId({ id: '778' }), '778');
+    assert.strictEqual(table.getSavedRecordId({ i: '779' }), '779');
+    assert.strictEqual(table.getSavedRecordId({ obj: { id: '780' } }), '780');
+    assert.strictEqual(table.getSavedRecordId({}), null);
+}
+
+async function testCreateSaveDefersPasswordField() {
+    const table = createTable();
+    const calls = [];
+    const dispatchedEvents = [];
+
+    const originalFetch = global.fetch;
+    const originalFormData = global.FormData;
+    const originalDocument = global.document;
+    const originalWindow = global.window;
+    const originalCustomEvent = global.CustomEvent;
+
+    class FakeFormData {
+        constructor(form) {
+            this.values = new Map(form._entries);
+        }
+
+        get(key) {
+            return this.values.has(key) ? this.values.get(key) : null;
+        }
+
+        entries() {
+            return this.values.entries();
+        }
+    }
+
+    const form = {
+        _entries: [
+            ['main', 'ivan'],
+            ['t20', 'secret'],
+            ['t30', 'note']
+        ],
+        checkValidity() {
+            return true;
+        },
+        reportValidity() {}
+    };
+
+    const modal = {
+        _overlayElement: { remove() {} },
+        querySelector(selector) {
+            if (selector === '#edit-form') return form;
+            if (selector === '.form-file-upload[data-req-id="20"]') return null;
+            if (selector === '.form-file-upload[data-req-id="30"]') return null;
+            return null;
+        },
+        querySelectorAll(selector) {
+            if (selector === '.form-file-upload') return [];
+            if (selector === 'input[type="password"][name]') return [passwordInput('t20', 'secret')];
+            return [];
+        },
+        remove() {
+            this.removed = true;
+        }
+    };
+
+    try {
+        global.FormData = FakeFormData;
+        global.window = { _integramModalDepth: 1 };
+        global.document = {
+            dispatchEvent(event) {
+                dispatchedEvents.push(event);
+            }
+        };
+        global.CustomEvent = class CustomEvent {
+            constructor(type, init) {
+                this.type = type;
+                this.detail = init.detail;
+            }
+        };
+        global.fetch = async (url, options) => {
+            calls.push({ url: String(url), options });
+            if (calls.length === 1) {
+                return {
+                    ok: true,
+                    statusText: 'OK',
+                    text: async () => JSON.stringify({ obj: '777' })
+                };
+            }
+            return {
+                ok: true,
+                statusText: 'OK',
+                text: async () => JSON.stringify({ success: true })
+            };
+        };
+
+        await table.saveRecord(modal, true, null, 41, 1);
+    } finally {
+        global.fetch = originalFetch;
+        global.FormData = originalFormData;
+        global.document = originalDocument;
+        global.window = originalWindow;
+        global.CustomEvent = originalCustomEvent;
+    }
+
+    assert.strictEqual(calls.length, 2, 'create with password should make two save requests');
+    assert.strictEqual(calls[0].url, '/db/_m_new/41?JSON&up=1');
+    assert.strictEqual(calls[0].options.body, 't30=note&t41=ivan');
+    assert.strictEqual(
+        calls[0].options.body.includes('t20=secret'),
+        false,
+        'initial create request must not include password'
+    );
+
+    assert.strictEqual(calls[1].url, '/db/_m_save/777?JSON');
+    assert.strictEqual(calls[1].options.body, 't20=secret');
+    assert.strictEqual(modal.removed, true, 'modal should close after both saves succeed');
+    assert.strictEqual(dispatchedEvents[0].detail.recordId, '777');
+}
+
+(async function run() {
+    await testInvitationUsernameUsesUnsavedMainField();
+    testPasswordFieldCollectionAndRecordIds();
+    await testCreateSaveDefersPasswordField();
+    console.log('Issue #2823 password invitation regression tests passed');
+})();

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -14164,10 +14164,10 @@ class IntegramTable{
                     const pwdInput = modal.querySelector(`#field-${ fieldId }`);
                     if (!pwdInput) return;
                     // Copy login link (username from first column of the table, issue #1479)
-                    // Do not allow copying invitation before the record is saved (issue #1591)
-                    const username = modal.dataset.firstColumnValue || '';
+                    // In create mode, use the current main field value instead of requiring a saved record.
+                    const username = this.getPasswordInvitationUsername(modal);
                     if (!username) {
-                        this.showCopyNotification('Сохраните запись перед копированием приглашения', true, 5000);
+                        this.showCopyNotification('Укажите имя пользователя перед копированием приглашения', true, 5000);
                         return;
                     }
                     const pwd = generatePassword();
@@ -14181,6 +14181,115 @@ class IntegramTable{
                     this.showCopyNotification('Пароль сгенерирован и скопирован в буфер. Обязательно сохраните эту форму!', false, 7000);
                 });
             });
+        }
+
+        getPasswordInvitationUsername(modal) {
+            const savedUsername = (modal && modal.dataset && modal.dataset.firstColumnValue) || '';
+            if (savedUsername) return savedUsername;
+
+            const mainInput = modal && modal.querySelector ? modal.querySelector('#field-main') : null;
+            if (!mainInput) return '';
+
+            if (mainInput.type === 'checkbox') {
+                return mainInput.checked ? '1' : '';
+            }
+
+            return (mainInput.value || '').trim();
+        }
+
+        collectCreatePasswordFields(modal, typeId) {
+            if (!modal || !modal.querySelectorAll) return [];
+
+            const fields = [];
+            modal.querySelectorAll('input[type="password"][name]').forEach(input => {
+                if (!input || input.disabled) return;
+
+                const rawName = input.getAttribute ? input.getAttribute('name') : input.name;
+                if (!rawName) return;
+
+                const value = input.value;
+                if (value === '' || value === null || value === undefined) return;
+
+                const saveKey = rawName === 'main' ? `t${ typeId }` : rawName;
+                if (!/^t\d+$/.test(saveKey)) return;
+
+                fields.push({
+                    formKey: rawName,
+                    saveKey,
+                    value
+                });
+            });
+
+            return fields;
+        }
+
+        isDeferredPasswordField(formKey, deferredPasswordFields) {
+            if (!Array.isArray(deferredPasswordFields)) return false;
+            return deferredPasswordFields.some(field => field.formKey === formKey);
+        }
+
+        getSavedRecordId(result) {
+            if (!result) return null;
+
+            const candidates = [result.obj, result.id, result.i];
+            for (const candidate of candidates) {
+                if (candidate === null || candidate === undefined || candidate === '') continue;
+
+                if (typeof candidate === 'object') {
+                    const nested = candidate.id ?? candidate.i ?? candidate.obj;
+                    if (nested !== null && nested !== undefined && nested !== '') {
+                        return nested;
+                    }
+                    continue;
+                }
+
+                return candidate;
+            }
+
+            return null;
+        }
+
+        async saveDeferredPasswordFields(apiBase, recordId, passwordFields) {
+            if (!passwordFields || passwordFields.length === 0) return null;
+            if (!recordId) {
+                throw new Error('Сервер не вернул ID созданной записи для сохранения пароля');
+            }
+
+            const params = new URLSearchParams();
+            if (typeof xsrf !== 'undefined') {
+                params.append('_xsrf', xsrf);
+            }
+
+            passwordFields.forEach(field => {
+                params.append(field.saveKey, field.value);
+            });
+
+            const response = await fetch(`${ apiBase }/_m_save/${ recordId }?JSON`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: params.toString()
+            });
+
+            const text = await response.text();
+            let result;
+            try {
+                result = JSON.parse(text);
+            } catch (e) {
+                if (text.includes('error') || !response.ok) {
+                    throw new Error(text);
+                }
+                result = { success: true };
+            }
+
+            const serverError = this.getServerError(result);
+            if (serverError) {
+                throw new Error(serverError);
+            }
+            if (!response.ok) {
+                throw new Error(`Ошибка сохранения пароля: ${ response.statusText }`);
+            }
+
+            return result;
         }
 
         attachDatePickerHandlers(modal) {
@@ -15862,6 +15971,7 @@ class IntegramTable{
             }
 
             const apiBase = this.getApiBase();
+            const deferredPasswordFields = isCreate ? this.collectCreatePasswordFields(modal, typeId) : [];
 
             try {
                 // Step 1: Prepare form data for save
@@ -15897,7 +16007,8 @@ class IntegramTable{
 
                     // Add main value as t{typeId}
                     if (isCreate) {
-                        if (mainValue !== '' && mainValue !== null && mainValue !== undefined) {
+                        if (!this.isDeferredPasswordField('main', deferredPasswordFields) &&
+                            mainValue !== '' && mainValue !== null && mainValue !== undefined) {
                             requestBody.append(`t${ typeId }`, mainValue);
                         }
                     } else {
@@ -15907,6 +16018,7 @@ class IntegramTable{
                     // Add all form fields
                     for (const [key, value] of formData.entries()) {
                         if (key === 'main') continue;
+                        if (isCreate && this.isDeferredPasswordField(key, deferredPasswordFields)) continue;
 
                         // Check if this is a file field
                         const fieldMatch = key.match(/^t(\d+)$/);
@@ -15962,6 +16074,7 @@ class IntegramTable{
                     // Add all form fields (skip 'main' since it's handled separately as t{typeId})
                     for (const [key, value] of formData.entries()) {
                         if (key === 'main') continue;
+                        if (isCreate && this.isDeferredPasswordField(key, deferredPasswordFields)) continue;
 
                         // Skip file fields that haven't changed
                         const fieldMatch = key.match(/^t(\d+)$/);
@@ -15990,7 +16103,8 @@ class IntegramTable{
                     }
 
                     if (isCreate) {
-                        if (mainValue !== '' && mainValue !== null && mainValue !== undefined) {
+                        if (!this.isDeferredPasswordField('main', deferredPasswordFields) &&
+                            mainValue !== '' && mainValue !== null && mainValue !== undefined) {
                             params.append(`t${ typeId }`, mainValue);
                         }
                     } else {
@@ -16037,8 +16151,14 @@ class IntegramTable{
                 // Check for warning - show modal and stay in edit mode
                 // Pass result.obj to show a link to the existing/found record if available
                 if (result.warning) {
-                    this.showWarningModal(result.warning, result.id || null);
+                    this.showWarningModal(result.warning, this.getSavedRecordId(result));
                     return;
+                }
+
+                const savedId = isCreate ? this.getSavedRecordId(result) : recordId;
+
+                if (isCreate && deferredPasswordFields.length > 0) {
+                    await this.saveDeferredPasswordFields(apiBase, savedId, deferredPasswordFields);
                 }
 
                 // Check for warnings (plural) - show modal but continue with save (issue #610)
@@ -16061,7 +16181,6 @@ class IntegramTable{
                 this.clearAllReferenceOptionCaches();
 
                 // Dispatch event for external listeners
-                const savedId = isCreate ? (result.id || result.i || null) : recordId;
                 document.dispatchEvent(new CustomEvent('integram-record-saved', {
                     detail: { isCreate, recordId: savedId, typeId, result }
                 }));
@@ -16096,7 +16215,7 @@ class IntegramTable{
                     // Handle special refresh for column header create
                     if (isCreate && columnId) {
                         // Extract created record ID from response
-                        const createdId = result.id || result.i;
+                        const createdId = this.getSavedRecordId(result);
 
                         if (createdId) {
                             await this.refreshWithNewRecord(columnId, createdId);
@@ -16296,7 +16415,7 @@ class IntegramTable{
                 const serverError = this.getServerError(result);
                 if (serverError) throw new Error(serverError);
 
-                const newId = result.id || result.i || null;
+                const newId = this.getSavedRecordId(result);
                 if (!newId) throw new Error('Сервер не вернул ID новой записи');
 
                 // Close the current modal

--- a/js/integram-table/20-form-create.js
+++ b/js/integram-table/20-form-create.js
@@ -404,10 +404,10 @@
                     const pwdInput = modal.querySelector(`#field-${ fieldId }`);
                     if (!pwdInput) return;
                     // Copy login link (username from first column of the table, issue #1479)
-                    // Do not allow copying invitation before the record is saved (issue #1591)
-                    const username = modal.dataset.firstColumnValue || '';
+                    // In create mode, use the current main field value instead of requiring a saved record.
+                    const username = this.getPasswordInvitationUsername(modal);
                     if (!username) {
-                        this.showCopyNotification('Сохраните запись перед копированием приглашения', true, 5000);
+                        this.showCopyNotification('Укажите имя пользователя перед копированием приглашения', true, 5000);
                         return;
                     }
                     const pwd = generatePassword();
@@ -421,6 +421,115 @@
                     this.showCopyNotification('Пароль сгенерирован и скопирован в буфер. Обязательно сохраните эту форму!', false, 7000);
                 });
             });
+        }
+
+        getPasswordInvitationUsername(modal) {
+            const savedUsername = (modal && modal.dataset && modal.dataset.firstColumnValue) || '';
+            if (savedUsername) return savedUsername;
+
+            const mainInput = modal && modal.querySelector ? modal.querySelector('#field-main') : null;
+            if (!mainInput) return '';
+
+            if (mainInput.type === 'checkbox') {
+                return mainInput.checked ? '1' : '';
+            }
+
+            return (mainInput.value || '').trim();
+        }
+
+        collectCreatePasswordFields(modal, typeId) {
+            if (!modal || !modal.querySelectorAll) return [];
+
+            const fields = [];
+            modal.querySelectorAll('input[type="password"][name]').forEach(input => {
+                if (!input || input.disabled) return;
+
+                const rawName = input.getAttribute ? input.getAttribute('name') : input.name;
+                if (!rawName) return;
+
+                const value = input.value;
+                if (value === '' || value === null || value === undefined) return;
+
+                const saveKey = rawName === 'main' ? `t${ typeId }` : rawName;
+                if (!/^t\d+$/.test(saveKey)) return;
+
+                fields.push({
+                    formKey: rawName,
+                    saveKey,
+                    value
+                });
+            });
+
+            return fields;
+        }
+
+        isDeferredPasswordField(formKey, deferredPasswordFields) {
+            if (!Array.isArray(deferredPasswordFields)) return false;
+            return deferredPasswordFields.some(field => field.formKey === formKey);
+        }
+
+        getSavedRecordId(result) {
+            if (!result) return null;
+
+            const candidates = [result.obj, result.id, result.i];
+            for (const candidate of candidates) {
+                if (candidate === null || candidate === undefined || candidate === '') continue;
+
+                if (typeof candidate === 'object') {
+                    const nested = candidate.id ?? candidate.i ?? candidate.obj;
+                    if (nested !== null && nested !== undefined && nested !== '') {
+                        return nested;
+                    }
+                    continue;
+                }
+
+                return candidate;
+            }
+
+            return null;
+        }
+
+        async saveDeferredPasswordFields(apiBase, recordId, passwordFields) {
+            if (!passwordFields || passwordFields.length === 0) return null;
+            if (!recordId) {
+                throw new Error('Сервер не вернул ID созданной записи для сохранения пароля');
+            }
+
+            const params = new URLSearchParams();
+            if (typeof xsrf !== 'undefined') {
+                params.append('_xsrf', xsrf);
+            }
+
+            passwordFields.forEach(field => {
+                params.append(field.saveKey, field.value);
+            });
+
+            const response = await fetch(`${ apiBase }/_m_save/${ recordId }?JSON`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: params.toString()
+            });
+
+            const text = await response.text();
+            let result;
+            try {
+                result = JSON.parse(text);
+            } catch (e) {
+                if (text.includes('error') || !response.ok) {
+                    throw new Error(text);
+                }
+                result = { success: true };
+            }
+
+            const serverError = this.getServerError(result);
+            if (serverError) {
+                throw new Error(serverError);
+            }
+            if (!response.ok) {
+                throw new Error(`Ошибка сохранения пароля: ${ response.statusText }`);
+            }
+
+            return result;
         }
 
         attachDatePickerHandlers(modal) {

--- a/js/integram-table/21-form-field-settings.js
+++ b/js/integram-table/21-form-field-settings.js
@@ -333,6 +333,7 @@
             }
 
             const apiBase = this.getApiBase();
+            const deferredPasswordFields = isCreate ? this.collectCreatePasswordFields(modal, typeId) : [];
 
             try {
                 // Step 1: Prepare form data for save
@@ -368,7 +369,8 @@
 
                     // Add main value as t{typeId}
                     if (isCreate) {
-                        if (mainValue !== '' && mainValue !== null && mainValue !== undefined) {
+                        if (!this.isDeferredPasswordField('main', deferredPasswordFields) &&
+                            mainValue !== '' && mainValue !== null && mainValue !== undefined) {
                             requestBody.append(`t${ typeId }`, mainValue);
                         }
                     } else {
@@ -378,6 +380,7 @@
                     // Add all form fields
                     for (const [key, value] of formData.entries()) {
                         if (key === 'main') continue;
+                        if (isCreate && this.isDeferredPasswordField(key, deferredPasswordFields)) continue;
 
                         // Check if this is a file field
                         const fieldMatch = key.match(/^t(\d+)$/);
@@ -433,6 +436,7 @@
                     // Add all form fields (skip 'main' since it's handled separately as t{typeId})
                     for (const [key, value] of formData.entries()) {
                         if (key === 'main') continue;
+                        if (isCreate && this.isDeferredPasswordField(key, deferredPasswordFields)) continue;
 
                         // Skip file fields that haven't changed
                         const fieldMatch = key.match(/^t(\d+)$/);
@@ -461,7 +465,8 @@
                     }
 
                     if (isCreate) {
-                        if (mainValue !== '' && mainValue !== null && mainValue !== undefined) {
+                        if (!this.isDeferredPasswordField('main', deferredPasswordFields) &&
+                            mainValue !== '' && mainValue !== null && mainValue !== undefined) {
                             params.append(`t${ typeId }`, mainValue);
                         }
                     } else {
@@ -508,8 +513,14 @@
                 // Check for warning - show modal and stay in edit mode
                 // Pass result.obj to show a link to the existing/found record if available
                 if (result.warning) {
-                    this.showWarningModal(result.warning, result.id || null);
+                    this.showWarningModal(result.warning, this.getSavedRecordId(result));
                     return;
+                }
+
+                const savedId = isCreate ? this.getSavedRecordId(result) : recordId;
+
+                if (isCreate && deferredPasswordFields.length > 0) {
+                    await this.saveDeferredPasswordFields(apiBase, savedId, deferredPasswordFields);
                 }
 
                 // Check for warnings (plural) - show modal but continue with save (issue #610)
@@ -532,7 +543,6 @@
                 this.clearAllReferenceOptionCaches();
 
                 // Dispatch event for external listeners
-                const savedId = isCreate ? (result.id || result.i || null) : recordId;
                 document.dispatchEvent(new CustomEvent('integram-record-saved', {
                     detail: { isCreate, recordId: savedId, typeId, result }
                 }));
@@ -567,7 +577,7 @@
                     // Handle special refresh for column header create
                     if (isCreate && columnId) {
                         // Extract created record ID from response
-                        const createdId = result.id || result.i;
+                        const createdId = this.getSavedRecordId(result);
 
                         if (createdId) {
                             await this.refreshWithNewRecord(columnId, createdId);
@@ -767,7 +777,7 @@
                 const serverError = this.getServerError(result);
                 if (serverError) throw new Error(serverError);
 
-                const newId = result.id || result.i || null;
+                const newId = this.getSavedRecordId(result);
                 if (!newId) throw new Error('Сервер не вернул ID новой записи');
 
                 // Close the current modal


### PR DESCRIPTION
Fixes #2823
Related: #2825

## Summary
- Allow password invitation generation on create forms by using the current username field instead of requiring a saved record.
- Defer password fields from `_m_new` and save them through `_m_save` after the created record ID is available.
- Normalize created record ID extraction across `obj`, `id`, and `i` responses.
- Remove the auto-generated branch placeholder `.gitkeep`.

## Testing
- `node experiments/test-issue-2823-password-invitation.js`
- `node --check js/integram-table.js`
- `node --check experiments/test-issue-2823-password-invitation.js`


Fixes #2825