### PR TITLE
xcom/match: подсвечивать строку SKU при Сопоставлении

### DIFF
--- a/css/xcom-match.css
+++ b/css/xcom-match.css
@@ -149,6 +149,10 @@
     background: var(--hover-bg, rgba(37, 99, 235, 0.06));
 }
 
+.xcom-match-table tr.xcom-match-row-selected td {
+    background: var(--selected-bg, rgba(37, 99, 235, 0.14));
+}
+
 .xcom-match-action-col {
     width: 8.75rem;
 }

--- a/js/xcom-match.js
+++ b/js/xcom-match.js
@@ -347,7 +347,7 @@
                 return '<td>' + escapeHtml(row.values[fieldIndex]) + '</td>';
             }).join('');
 
-            return '<tr>' + cells +
+            return '<tr data-row-index="' + index + '">' + cells +
                 '<td class="xcom-match-action-col">' +
                 '<button class="xcom-match-btn xcom-match-btn-primary xcom-match-btn-select" type="button" data-row-index="' + index + '" title="Подобрать">' +
                 '<i class="pi pi-check"></i><span>Подобрать</span></button>' +
@@ -469,8 +469,15 @@
             skuResults.addEventListener('click', function(event) {
                 var button = event.target.closest ? event.target.closest('[data-row-index]') : null;
                 if (!button) return;
-                var row = state.rows[Number(button.getAttribute('data-row-index'))];
-                if (row) runMatch(row);
+                var index = Number(button.getAttribute('data-row-index'));
+                var row = state.rows[index];
+                if (!row) return;
+                skuResults.querySelectorAll('tr.xcom-match-row-selected').forEach(function(tr) {
+                    tr.classList.remove('xcom-match-row-selected');
+                });
+                var tr = skuResults.querySelector('tr[data-row-index="' + index + '"]');
+                if (tr) tr.classList.add('xcom-match-row-selected');
+                runMatch(row);
             });
         }
     }


### PR DESCRIPTION
Fixes #2835

## Что сделано

- `renderSkuRows()`: `data-row-index` перенесён с кнопки на `<tr>`, чтобы можно было найти строку по индексу
- `bindEvents()`: при клике на «Подобрать» убираем `xcom-match-row-selected` со всех строк и добавляем на выбранную
- `xcom-match.css`: стиль `.xcom-match-row-selected td` — чуть насыщеннее hover-фона

## Как проверить

1. Открыть `/xcom/match`
2. Найти SKU, нажать «Подобрать» у любой строки
3. Строка должна оставаться подсвеченной пока в правой панели показывается её результат
4. При клике на другую строку подсветка переходит на неё