### PR TITLE
xcom/match: числовой ID таблицы RFP вместо строкового имени

### DIFF
--- a/js/xcom-match.js
+++ b/js/xcom-match.js
@@ -1,7 +1,7 @@
 (function(window, document) {
     'use strict';
 
-    var DEFAULT_SKU_TABLE = 'RFP';
+    var DEFAULT_SKU_TABLE = '2032189';
     var DEFAULT_MATCH_REPORT = 'Сопоставление';
     var DEFAULT_LIMIT = 20;
 


### PR DESCRIPTION
Fixes #2838

## Что сделано

`DEFAULT_SKU_TABLE = 'RFP'` → `DEFAULT_SKU_TABLE = '2032189'`

`buildMetadataUrl` видит числовой ID и строит `/xcom/metadata/2032189` напрямую, минуя поиск по массиву всех таблиц. Раньше при строковом имени `resolveSkuMetadata` находила таблицу `SKU` (`id: 1953593`) вместо `RFP`.

## Как проверить

Открыть `/xcom/match`, ввести запрос — в Network должен уйти запрос на `/xcom/object/2032189/`, не `/xcom/object/1953593/`.