### PR TITLE
xcom/match: data-sku-table RFP id вместо sku

### DIFF
--- a/templates/xcom/match.html
+++ b/templates/xcom/match.html
@@ -3,7 +3,7 @@
 <div id="xcom-match-app"
      class="xcom-match"
      data-db="{_global_.z}"
-     data-sku-table="sku"
+     data-sku-table="2032189"
      data-match-report="Сопоставление">
     <section class="xcom-match-search-panel" aria-label="Поиск SKU для строки RFP">
         <form id="xcom-match-search-form" class="xcom-match-search-form">


### PR DESCRIPTION
Fixes #2838

## Причина

Шаблон `templates/xcom/match.html` задавал `data-sku-table="sku"`. `init()` читает этот атрибут с приоритетом над константой `DEFAULT_SKU_TABLE`, поэтому `resolveSkuMetadata` находила таблицу SKU (`id: 1953593`) вместо RFP (`id: 2032189`).

## Изменение

`data-sku-table="sku"` → `data-sku-table="2032189"`

## Как проверить

Открыть `/xcom/match`, в Network убедиться что поиск идёт на `/xcom/object/2032189/`, не `/xcom/object/1953593/`.