### PR TITLE
xcom/match: пропорциональные колонки таблиц

### DIFF
--- a/css/xcom-match.css
+++ b/css/xcom-match.css
@@ -123,7 +123,7 @@
     width: 100%;
     border-collapse: separate;
     border-spacing: 0;
-    table-layout: fixed;
+    table-layout: auto;
     font-size: 0.88rem;
 }
 


### PR DESCRIPTION
## Изменение

`table-layout: fixed` → `table-layout: auto`

При `fixed` браузер делит ширину поровну между колонками. При `auto` — пропорционально содержимому: короткие значения получают меньше места, длинные наименования — больше.