### PR TITLE
xcom/match: обрезать id из значений справочных полей

### DIFF
--- a/js/xcom-match.js
+++ b/js/xcom-match.js
@@ -179,6 +179,13 @@
             .replace(/'/g, '&#039;');
     }
 
+    function parseRefValue(raw) {
+        var str = String(raw == null ? '' : raw);
+        var m = str.match(/^(\d+):(.*)$/);
+        if (m) return { refId: m[1], label: m[2] };
+        return { refId: null, label: str };
+    }
+
     function normalizeRows(json) {
         if (!Array.isArray(json)) return [];
 
@@ -344,7 +351,9 @@
 
         var body = state.rows.map(function(row, index) {
             var cells = state.searchFields.map(function(field, fieldIndex) {
-                return '<td>' + escapeHtml(row.values[fieldIndex]) + '</td>';
+                var parsed = parseRefValue(row.values[fieldIndex]);
+                var td = '<td' + (parsed.refId ? ' data-ref-id="' + parsed.refId + '"' : '') + '>';
+                return td + escapeHtml(parsed.label) + '</td>';
             }).join('');
 
             return '<tr data-row-index="' + index + '">' + cells +


### PR DESCRIPTION
## Проблема

Справочные поля приходят в формате `2034611:Hewlett-Packard`. В таблице отображается весь стрoкой включая id.

## Решение

Добавлена функция `parseRefValue(raw)`: если значение соответствует `^\d+:.*`, разбивает на `refId` и `label`. В ячейке отображается только `label`, id сохраняется в `data-ref-id` для возможного drill-down или редактирования.

## Пример

`2034611:Hewlett-Packard` → показывает `Hewlett-Packard`, `<td data-ref-id="2034611">`