### PR TITLE
xcom/match: передавать FR_{поле}ID для справочных полей в Сопоставление

### DIFF
--- a/js/xcom-match.js
+++ b/js/xcom-match.js
@@ -165,6 +165,12 @@
             if (selectedRow.values && selectedRow.values.length) {
                 params.set('FR_SKU', trimValue(selectedRow.values[0]));
             }
+            fields.forEach(function(field, fieldIndex) {
+                var parsed = parseRefValue(selectedRow.values[fieldIndex]);
+                if (!parsed.refId) return;
+                var key = normalizeReportFilterKey(field.name || field.id);
+                if (key) params.set('FR_' + key + 'ID', parsed.refId);
+            });
         }
 
         return '/' + encodePathSegment(dbName) + '/report/' + encodePathSegment(report) + '?' + params.toString();


### PR DESCRIPTION
## Что сделано

В `buildMatchReportUrl` при наличии выбранной строки перебираем все поля. Если значение поля в формате `id:Значение` — добавляем `FR_{имяПоля}ID={id}` в параметры запроса.

## Пример

Строка RFP: Бренд = `2034611:Hewlett-Packard`
Запрос на Сопоставление получит дополнительный фильтр: `FR_БрендID=2034611`

## Зачем

Отчёт «Сопоставление» может использовать id справочного значения для точной фильтрации — без необходимости парсить строку на стороне сервера.