### PR TITLE
xcom/match: добавить определение parseRefValue (потеряно при мерже)

### DIFF
--- a/js/xcom-match.js
+++ b/js/xcom-match.js
@@ -185,6 +185,13 @@
             .replace(/'/g, '&#039;');
     }
 
+    function parseRefValue(raw) {
+        var str = String(raw == null ? '' : raw);
+        var m = str.match(/^(\d+):(.*)$/);
+        if (m) return { refId: m[1], label: m[2] };
+        return { refId: null, label: str };
+    }
+
     function normalizeRows(json) {
         if (!Array.isArray(json)) return [];
 
@@ -350,7 +357,9 @@
 
         var body = state.rows.map(function(row, index) {
             var cells = state.searchFields.map(function(field, fieldIndex) {
-                return '<td>' + escapeHtml(row.values[fieldIndex]) + '</td>';
+                var parsed = parseRefValue(row.values[fieldIndex]);
+                var td = '<td' + (parsed.refId ? ' data-ref-id="' + parsed.refId + '"' : '') + '>';
+                return td + escapeHtml(parsed.label) + '</td>';
             }).join('');
 
             return '<tr data-row-index="' + index + '">' + cells +


### PR DESCRIPTION
Fixes #2842 regression.

PR #2843 перезаписал файл версией без определения `parseRefValue`, которое было добавлено в PR #2842. Результат: `ReferenceError: parseRefValue is not defined` при нажатии «Подобрать».

## Что восстановлено

- Функция `parseRefValue(raw)` — разбирает `^\d+:(.*)` на `{refId, label}`
- Рендер ячеек: отображает только `label`, id в `data-ref-id`

Оба изменения теперь в одном файле вместе с логикой фильтра `FR_{поле}ID`.