### PR TITLE
xcom/match: подсвечивать строки ТММ=1 светло-зелёным

### DIFF
--- a/css/xcom-match.css
+++ b/css/xcom-match.css
@@ -153,6 +153,14 @@
     background: var(--selected-bg, rgba(37, 99, 235, 0.14));
 }
 
+.xcom-match-table tr.xcom-match-row-tmm td {
+    background: rgba(134, 239, 172, 0.2);
+}
+
+.xcom-match-table tr.xcom-match-row-tmm.xcom-match-row-selected td {
+    background: rgba(134, 239, 172, 0.38);
+}
+
 .xcom-match-action-col {
     width: 8.75rem;
 }

--- a/js/xcom-match.js
+++ b/js/xcom-match.js
@@ -385,13 +385,20 @@
             return;
         }
 
+        var tmmIndex = -1;
+        report.columns.forEach(function(col, i) {
+            if (col.name === 'ТММ') tmmIndex = i;
+        });
+
         var headers = report.columns.map(function(column) {
             return '<th>' + escapeHtml(column.name) + '</th>';
         }).join('');
         var body = report.rows.map(function(row) {
-            return '<tr>' + report.columns.map(function(column, index) {
-                return '<td>' + escapeHtml(row[index]) + '</td>';
-            }).join('') + '</tr>';
+            var isTmm = tmmIndex >= 0 && trimValue(row[tmmIndex]) === '1';
+            return '<tr' + (isTmm ? ' class="xcom-match-row-tmm"' : '') + '>' +
+                report.columns.map(function(column, index) {
+                    return '<td>' + escapeHtml(row[index]) + '</td>';
+                }).join('') + '</tr>';
         }).join('');
 
         container.innerHTML = '<table class="xcom-match-table">' +


### PR DESCRIPTION
## Что сделано

В `renderReport` перед рендером находим индекс колонки `ТММ`. Если в строке `ТММ === '1'` — вешаем класс `xcom-match-row-tmm`.

CSS: очень светлый зелёный `rgba(134, 239, 172, 0.2)`. При одновременном выборе строки (selected) — чуть насыщеннее `0.38`, чтобы подсветка выбора не перекрывала зелёный полностью.