### PR TITLE
js: add REGEXP filter type for text columns

### DIFF
--- a/index.php
+++ b/index.php
@@ -1012,6 +1012,12 @@ function Construct_WHERE($key, $filter, $cur_typ, $join_req=0)
 			$inID = true;
     		$EQ = "";
         }
+        elseif(strtoupper(substr(trim($value), 0, 7)) === "REGEXP:"){ # Regular expression filter (issue #2790)
+            $pattern = addslashes(substr(trim($value), 7));
+            $search_val = ($NOT_flag ? "NOT " : "") . "REGEXP '$pattern'";
+            $EQ = "";
+            $NOT = "";
+        }
         else{ # If we have a [substitute], don't add '' and slash the existing ''
 			if(preg_match("/\[([^\[\]]+)\]/", $value))
 			    $v = strpos($value, "'") !== FALSE ? checkInjection($value) : $value;

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -123,7 +123,8 @@ class IntegramTable{
                     { symbol: '%', name: 'не пустое', format: 'FR_{ T }=%' },
                     { symbol: '!%', name: 'пустое', format: 'FR_{ T }=!%' },
                     { symbol: '(,)', name: 'в списке', format: 'FR_{ T }=IN({ X })' },
-                    { symbol: '$', name: 'заканчивается', format: 'FR_{ T }=%{ X }' }
+                    { symbol: '$', name: 'заканчивается', format: 'FR_{ T }=%{ X }' },
+                    { symbol: '/', name: 'regexp', format: 'FR_{ T }=REGEXP:{ X }' }
                 ],
                 'NUMBER': [
                     { symbol: '^', name: 'начинается с...', format: 'FR_{ T }={ X }%' },
@@ -10279,6 +10280,11 @@ class IntegramTable{
             // Note: > and < are less common as URL values may use different encoding
             // The format uses FR_{T}>{X} but the value itself doesn't include >
             // After parsing in applyFilter, it becomes just the value
+
+            // Check for REGEXP filter: REGEXP:pattern (issue #2790)
+            if (rawValue.toUpperCase().startsWith('REGEXP:')) {
+                return { type: '/', value: rawValue.substring(7) };
+            }
 
             // Check for "contains" filter: %value%
             if (rawValue.startsWith('%') && rawValue.endsWith('%') && rawValue.length > 2) {

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -106,7 +106,8 @@
                     { symbol: '%', name: 'не пустое', format: 'FR_{ T }=%' },
                     { symbol: '!%', name: 'пустое', format: 'FR_{ T }=!%' },
                     { symbol: '(,)', name: 'в списке', format: 'FR_{ T }=IN({ X })' },
-                    { symbol: '$', name: 'заканчивается', format: 'FR_{ T }=%{ X }' }
+                    { symbol: '$', name: 'заканчивается', format: 'FR_{ T }=%{ X }' },
+                    { symbol: '/', name: 'regexp', format: 'FR_{ T }=REGEXP:{ X }' }
                 ],
                 'NUMBER': [
                     { symbol: '^', name: 'начинается с...', format: 'FR_{ T }={ X }%' },

--- a/js/integram-table/14-url-config.js
+++ b/js/integram-table/14-url-config.js
@@ -442,6 +442,11 @@
             // The format uses FR_{T}>{X} but the value itself doesn't include >
             // After parsing in applyFilter, it becomes just the value
 
+            // Check for REGEXP filter: REGEXP:pattern (issue #2790)
+            if (rawValue.toUpperCase().startsWith('REGEXP:')) {
+                return { type: '/', value: rawValue.substring(7) };
+            }
+
             // Check for "contains" filter: %value%
             if (rawValue.startsWith('%') && rawValue.endsWith('%') && rawValue.length > 2) {
                 return { type: '~', value: rawValue.slice(1, -1) };


### PR DESCRIPTION
Closes #2790

## Что добавлено

Новый тип фильтра **«regexp»** (символ `/`) для текстовых колонок (CHARS / SHORT / MEMO).

### Использование
```
FR_{colId}=REGEXP:pattern
```
Например: `FR_2962065=REGEXP:^[А-Я].*2026`

Поддерживает `!REGEXP:pattern` (отрицание через `!` префикс).

### Изменения
- **`js/integram-table/01-core.js`**: добавлен `{ symbol: '/', name: 'regexp', format: 'FR_{ T }=REGEXP:{ X }' }` в `filterTypes.CHARS`
- **`js/integram-table/14-url-config.js`**: разбор `REGEXP:pattern` в `parseFilterValue` → type `'/'`
- **`js/integram-table.js`**: пересобранный бандл
- **`index.php`** (`Construct_WHERE`): обработка префикса `REGEXP:` — генерирует `REGEXP 'pattern'` / `NOT REGEXP 'pattern'`; паттерн защищён `addslashes()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)