### PR TITLE
update.php: support multiple repositories

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-28T10:43:29.502Z for PR creation at branch issue-2873-20c263d1434b for issue https://github.com/ideav/crm/issues/2873

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-28T10:43:29.502Z for PR creation at branch issue-2873-20c263d1434b for issue https://github.com/ideav/crm/issues/2873

--- a/docs/UPDATE_SCRIPT.md
+++ b/docs/UPDATE_SCRIPT.md
@@ -25,7 +25,7 @@ https://your-server.com/update.php?config=update.conf
 ### Configuration File Format
 
 ```conf
-# Repository settings
+[repository crm]
 repository: https://github.com/ideav/crm/
 branch: main
 
@@ -33,6 +33,12 @@ branch: main
 css/* : /var/www/site/css/
 js/* : /var/www/site/js/
 templates/main.html : /var/www/site/templates/
+
+[repository assets]
+repository: https://github.com/owner/assets/
+branch: main
+
+download/assets/js/* : /var/www/site/download/assets/js/
 ```
 
 ### Configuration Options
@@ -42,6 +48,11 @@ templates/main.html : /var/www/site/templates/
 | `repository` | GitHub repository URL | `https://github.com/owner/repo/` |
 | `branch` | Branch to sync from | `main` |
 | `source : target` | File mapping (source path : target directory) | `css/* : /var/www/css/` |
+
+To copy from more than one repository in a single run, split the config into
+`[repository name]` sections. Each section has its own `repository`, `branch`,
+`token`, `ignore_cache`, and mappings. Existing single-repository configs
+without section headers continue to work.
 
 ### Wildcard Patterns
 

--- a/experiments/test-update/test-multiple-repositories.php
+++ b/experiments/test-update/test-multiple-repositories.php
@@ -1,0 +1,66 @@
+<?php
+define('UPDATE_PHP_NO_MAIN', true);
+require_once __DIR__ . '/../../update.php';
+
+$pass = 0;
+$fail = 0;
+
+function test($name, $condition, $details = '') {
+    global $pass, $fail;
+    if ($condition) {
+        echo "PASS: {$name}\n";
+        $pass++;
+    } else {
+        echo "FAIL: {$name}" . ($details !== '' ? " ({$details})" : "") . "\n";
+        $fail++;
+    }
+}
+
+$legacy = tempnam(sys_get_temp_dir(), 'update-legacy-') . '.conf';
+file_put_contents($legacy, implode("\n", [
+    'repository: https://github.com/ideav/crm/',
+    'branch: main',
+    'token: xxx',
+    'ignore_cache: yes',
+    'css/* : /var/www/css/',
+]));
+
+$legacyConfig = parseConfig($legacy);
+unlink($legacy);
+
+test('legacy config keeps repository', $legacyConfig['repository'] === 'https://github.com/ideav/crm/');
+test('legacy config keeps branch', $legacyConfig['branch'] === 'main');
+test('legacy config keeps token', $legacyConfig['token'] === 'xxx');
+test('legacy config keeps ignore_cache', $legacyConfig['ignore_cache'] === true);
+test('legacy config does not require repository sections', !isset($legacyConfig['repositories']));
+test('legacy config keeps mappings', count($legacyConfig['mappings']) === 1 && $legacyConfig['mappings'][0]['source'] === 'css/*');
+
+$multi = tempnam(sys_get_temp_dir(), 'update-multi-') . '.conf';
+file_put_contents($multi, implode("\n", [
+    '[repository crm]',
+    'repository: https://github.com/ideav/crm/',
+    'branch: main',
+    'token: xxx',
+    'css/* : /var/www/css/',
+    '',
+    '[repository atex]',
+    'repository: https://github.com/ideav/atex/',
+    'branch: main',
+    'templates/atex/* : /var/www/templates/custom/atex/',
+    'download/atex/js/* : /var/www/download/atex/js/',
+    'download/atex/css/* : /var/www/download/atex/css/',
+]));
+
+$multiConfig = parseConfig($multi);
+unlink($multi);
+
+test('multi config has repositories', isset($multiConfig['repositories']) && count($multiConfig['repositories']) === 2);
+test('first repository name', $multiConfig['repositories'][0]['name'] === 'crm');
+test('first repository url', $multiConfig['repositories'][0]['repository'] === 'https://github.com/ideav/crm/');
+test('second repository name', $multiConfig['repositories'][1]['name'] === 'atex');
+test('second repository url', $multiConfig['repositories'][1]['repository'] === 'https://github.com/ideav/atex/');
+test('second repository has three mappings', count($multiConfig['repositories'][1]['mappings']) === 3);
+test('second repository first mapping target', $multiConfig['repositories'][1]['mappings'][0]['target'] === '/var/www/templates/custom/atex/');
+
+echo "\n{$pass} passed, {$fail} failed\n";
+exit($fail > 0 ? 1 : 0);

--- a/update.conf
+++ b/update.conf
@@ -14,7 +14,7 @@
 #   - Target path is a directory (file keeps original name)
 #   - Only files newer than local versions will be copied
 
-# Repository settings
+[repository crm]
 repository: https://github.com/ideav/crm/
 branch: main
 token: xxx
@@ -33,7 +33,6 @@ templates/* : /var/www/www-root/data/www/ideav.ru/templates/
 templates/my/* : /var/www/www-root/data/www/ideav.ru/templates/custom/my/
 templates/sportzania/* : /var/www/www-root/data/www/ideav.ru/templates/custom/sportzania/
 templates/xcom/* : /var/www/www-root/data/www/ideav.ru/templates/custom/xcom/
-templates/atex/* : /var/www/www-root/data/www/ideav.ru/templates/custom/xcom/
 
 # Custom templates - ru2 folder (all files)
 templates/main.html : /var/www/www-root/data/www/ideav.ru/templates/custom/ru2/
@@ -45,8 +44,6 @@ templates/info.html : /var/www/www-root/data/www/ideav.ru/templates/custom/ru/
 
 download/sportzania/css/* : /var/www/www-root/data/www/ideav.ru/download/sportzania/css/
 download/sportzania/js/* : /var/www/www-root/data/www/ideav.ru/download/sportzania/js/
-download/atex/js/* : /var/www/www-root/data/www/ideav.ru/download/sportzania/js/
-download/atex/css/* : /var/www/www-root/data/www/ideav.ru/download/sportzania/css/
 
 #google_sheets_sync.config.php : /var/www/www-root/data/www/ideav.ru/
 include/google_sheets_sync.php : /var/www/www-root/data/www/ideav.ru/include/
@@ -58,3 +55,12 @@ export_b3x_departments.php : /var/www/www-root/data/www/ideav.ru/
 export_b3x_value_maps.php : /var/www/www-root/data/www/ideav.ru/
 
 start.html : /var/www/www-root/data/www/ideav.ru/
+
+[repository atex]
+repository: https://github.com/ideav/atex/
+branch: main
+token: xxx
+
+templates/atex/* : /var/www/www-root/data/www/ideav.ru/templates/custom/atex/
+download/atex/js/* : /var/www/www-root/data/www/ideav.ru/download/atex/js/
+download/atex/css/* : /var/www/www-root/data/www/ideav.ru/download/atex/css/

--- a/update.php
+++ b/update.php
@@ -219,31 +219,86 @@ function downloadParallel($tasks, $info, $branch, $token, $concurrency) {
 
 // ------------------------ Config / Manifest ------------------------
 
+function defaultConfigRepository() {
+    return ['repository' => '', 'branch' => 'main', 'token' => '', 'ignore_cache' => false, 'mappings' => []];
+}
+
+function normalizeConfigRepositories($repositories) {
+    $out = [];
+    foreach ($repositories as $idx => $repoConfig) {
+        $name = isset($repoConfig['name']) && $repoConfig['name'] !== '' ? $repoConfig['name'] : "repo" . ($idx + 1);
+        $repoConfig['name'] = $name;
+        $out[] = $repoConfig;
+    }
+    return $out;
+}
+
 function parseConfig($path) {
     if (!file_exists($path)) return false;
     $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
     if ($lines === false) return false;
 
-    $cfg = ['repository' => '', 'branch' => 'main', 'token' => '', 'ignore_cache' => false, 'mappings' => []];
+    $cfg = defaultConfigRepository();
+    $repositories = [];
+    $current = $cfg;
+    $currentHasContent = false;
+    $hasSections = false;
+    $repoCounter = 0;
+
+    $flushCurrent = function () use (&$repositories, &$current, &$currentHasContent, &$repoCounter) {
+        if (!$currentHasContent) return;
+        $repoCounter++;
+        if (!isset($current['name']) || $current['name'] === '') {
+            $info = parseRepo($current['repository']);
+            $current['name'] = $info ? $info['owner'] . '/' . $info['repo'] : "repo{$repoCounter}";
+        }
+        $repositories[] = $current;
+    };
+
     foreach ($lines as $line) {
         $line = trim($line);
         if ($line === '' || $line[0] === '#') continue;
 
-        if (preg_match('/^repository\s*:\s*(.+)$/i', $line, $m)) {
-            $cfg['repository'] = trim($m[1]);
+        if (preg_match('/^\[repository\s+(.+)\]$/i', $line, $m) || preg_match('/^\[repo\s+(.+)\]$/i', $line, $m)) {
+            $hasSections = true;
+            $flushCurrent();
+            $current = defaultConfigRepository();
+            $current['name'] = trim($m[1]);
+            $currentHasContent = true;
+        } elseif (preg_match('/^repository\s*:\s*(.+)$/i', $line, $m)) {
+            if ($currentHasContent && $current['repository'] !== '') {
+                $flushCurrent();
+                $current = defaultConfigRepository();
+            }
+            $current['repository'] = trim($m[1]);
+            $currentHasContent = true;
         } elseif (preg_match('/^branch\s*:\s*(.+)$/i', $line, $m)) {
-            $cfg['branch'] = trim($m[1]);
+            $current['branch'] = trim($m[1]);
+            $currentHasContent = true;
         } elseif (preg_match('/^token\s*:\s*(.+)$/i', $line, $m)) {
-            $cfg['token'] = trim($m[1]);
+            $current['token'] = trim($m[1]);
+            $currentHasContent = true;
         } elseif (preg_match('/^ignore_cache\s*:\s*(.+)$/i', $line, $m)) {
             $v = strtolower(trim($m[1]));
-            $cfg['ignore_cache'] = ($v === '1' || $v === 'true' || $v === 'yes');
+            $current['ignore_cache'] = ($v === '1' || $v === 'true' || $v === 'yes');
+            $currentHasContent = true;
         } elseif (strpos($line, ':') !== false) {
             $parts = explode(':', $line, 2);
             $src = trim($parts[0]);
             $tgt = trim($parts[1]);
-            if ($src !== '' && $tgt !== '') $cfg['mappings'][] = ['source' => $src, 'target' => $tgt];
+            if ($src !== '' && $tgt !== '') {
+                $current['mappings'][] = ['source' => $src, 'target' => $tgt];
+                $currentHasContent = true;
+            }
         }
+    }
+    $flushCurrent();
+
+    if ($hasSections && !empty($repositories)) {
+        $cfg = $repositories[0];
+        $cfg['repositories'] = normalizeConfigRepositories($repositories);
+    } elseif (!empty($repositories)) {
+        $cfg = $repositories[0];
     }
     return $cfg;
 }
@@ -435,6 +490,27 @@ function syncWithCache($config, $configName) {
     return $results;
 }
 
+function syncConfig($config, $configName) {
+    if (empty($config['repositories']) || !is_array($config['repositories'])) {
+        return syncWithCache($config, $configName);
+    }
+
+    $combined = ['fast_path' => true, 'success' => [], 'skipped' => [], 'errors' => [], 'cleaned' => 0, 'repositories' => []];
+    foreach ($config['repositories'] as $repoConfig) {
+        $repoName = isset($repoConfig['name']) ? $repoConfig['name'] : $repoConfig['repository'];
+        $result = syncWithCache($repoConfig, $configName . ':' . $repoName);
+        $combined['repositories'][$repoName] = $result;
+        $combined['fast_path'] = $combined['fast_path'] && !empty($result['fast_path']);
+        foreach (['success', 'skipped', 'errors'] as $key) {
+            foreach ($result[$key] as $msg) {
+                $combined[$key][] = "[{$repoName}] {$msg}";
+            }
+        }
+        if (!empty($result['cleaned'])) $combined['cleaned'] += $result['cleaned'];
+    }
+    return $combined;
+}
+
 // ------------------------ Output ------------------------
 
 function outputResults($results, $config, $configName, $elapsedMs) {
@@ -456,8 +532,8 @@ function outputResults($results, $config, $configName, $elapsedMs) {
     echo "<!DOCTYPE html><html lang='ru'><head><meta charset='UTF-8'><title>GitHub Sync Results</title>{$css}</head><body><div class='container'>";
     echo "<h1>GitHub Sync Results</h1>";
     echo "<div class='meta'>config: " . htmlspecialchars($configName)
-        . " &middot; branch: " . htmlspecialchars($config['branch'])
-        . " &middot; commit: " . htmlspecialchars(isset($results['commit']) ? substr($results['commit'], 0, 7) : '?')
+        . " &middot; branch: " . htmlspecialchars(isset($config['branch']) ? $config['branch'] : 'multiple')
+        . " &middot; commit: " . htmlspecialchars(isset($results['commit']) ? substr($results['commit'], 0, 7) : (isset($results['repositories']) ? 'multiple' : '?'))
         . " &middot; elapsed: {$elapsedMs} ms</div>";
 
     if (!empty($results['fast_path'])) {
@@ -485,34 +561,36 @@ function outputResults($results, $config, $configName, $elapsedMs) {
 
 // ------------------------ Main ------------------------
 
-$configFile = isset($_GET['config']) ? basename($_GET['config']) : '';
-if ($configFile === '') {
-    echo "<h1>Error</h1><p>Usage: update.php?config=your-config.conf [&cleanup_legacy_sha=1]</p>";
-    exit(1);
+if (!defined('UPDATE_PHP_NO_MAIN')) {
+    $configFile = isset($_GET['config']) ? basename($_GET['config']) : '';
+    if ($configFile === '') {
+        echo "<h1>Error</h1><p>Usage: update.php?config=your-config.conf [&cleanup_legacy_sha=1]</p>";
+        exit(1);
+    }
+
+    $configPath = __DIR__ . '/' . $configFile;
+    $config = parseConfig($configPath);
+    if ($config === false) {
+        echo "<h1>Error</h1><p>Could not read config file: " . htmlspecialchars($configFile) . "</p>";
+        exit(1);
+    }
+
+    $lockPath = __DIR__ . '/' . LOCK_NAME;
+    $lockFp = @fopen($lockPath, 'c');
+    if ($lockFp && !flock($lockFp, LOCK_EX | LOCK_NB)) {
+        fclose($lockFp);
+        echo "<h1>Busy</h1><p>Another sync is already running. Try again in a moment.</p>";
+        exit(1);
+    }
+
+    $start = microtime(true);
+    $results = syncConfig($config, $configFile);
+    $elapsedMs = (int) round((microtime(true) - $start) * 1000);
+
+    if ($lockFp) {
+        flock($lockFp, LOCK_UN);
+        fclose($lockFp);
+    }
+
+    outputResults($results, $config, $configFile, $elapsedMs);
 }
-
-$configPath = __DIR__ . '/' . $configFile;
-$config = parseConfig($configPath);
-if ($config === false) {
-    echo "<h1>Error</h1><p>Could not read config file: " . htmlspecialchars($configFile) . "</p>";
-    exit(1);
-}
-
-$lockPath = __DIR__ . '/' . LOCK_NAME;
-$lockFp = @fopen($lockPath, 'c');
-if ($lockFp && !flock($lockFp, LOCK_EX | LOCK_NB)) {
-    fclose($lockFp);
-    echo "<h1>Busy</h1><p>Another sync is already running. Try again in a moment.</p>";
-    exit(1);
-}
-
-$start = microtime(true);
-$results = syncWithCache($config, $configFile);
-$elapsedMs = (int) round((microtime(true) - $start) * 1000);
-
-if ($lockFp) {
-    flock($lockFp, LOCK_UN);
-    fclose($lockFp);
-}
-
-outputResults($results, $config, $configFile, $elapsedMs);


### PR DESCRIPTION
## Summary
- Adds sectioned `[repository name]` config support so one `update.conf` can sync several GitHub repositories.
- Keeps legacy single-repository configs working with the original manifest key behavior.
- Updates `update.conf` to sync `ideav/crm` and `ideav/atex`, with ATEX mappings to `templates/custom/atex/`, `download/atex/js/`, and `download/atex/css/`.
- Documents the multi-repository config syntax.

## Reproduction / Verification
- Added `experiments/test-update/test-multiple-repositories.php` to cover legacy config parsing and the new multi-repository section parsing.
- Verified `update.conf` parses as two repositories: `crm` and `atex`.

## Tests
- `php experiments/test-update/test-multiple-repositories.php`
- `php -l update.php`
- `php -l experiments/test-update/test-multiple-repositories.php`
- `git diff --check`

Fixes #2873