### PR TITLE
feat(#2906): skip captcha for returning users with a valid auth token

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T20:41:18.357Z for PR creation at branch issue-2906-51ae6792480a for issue https://github.com/ideav/crm/issues/2906

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T20:41:18.357Z for PR creation at branch issue-2906-51ae6792480a for issue https://github.com/ideav/crm/issues/2906

--- a/experiments/issue-2906-captcha-bypass.php
+++ b/experiments/issue-2906-captcha-bypass.php
@@ -1,0 +1,100 @@
+<?php
+// Verification of the backend captcha-bypass helper hasValidTokenCookie() from
+// issue #2906 ("the same logic in the core"). The function lives in index.php;
+// this test runs an exact mirror of it inside a namespace where mysqli_* and
+// checkDbName are stubbed, so the cookie-filtering and "first valid token wins"
+// behavior can be exercised without a real database.
+//
+// Run with: php experiments/issue-2906-captcha-bypass.php
+
+namespace Test2906;
+
+const USER = 110;
+const TOKEN = 125;
+const USER_DB_MASK = "/^[a-z]\w{2,14}$/i";
+
+// Tokens that the fake DB considers valid, keyed by "db|token".
+$GLOBALS['VALID'] = [];
+// Records every DB queried, so we can assert which cookies triggered a lookup.
+$GLOBALS['QUERIED'] = [];
+
+function checkDbName($mask, $db){ return preg_match($mask, $db); }
+
+function mysqli_query($connection, $sql){
+    // Parse "SELECT 1 FROM <db> tok, <db> u ... tok.val='<tok>' ..."
+    if(!preg_match('/FROM (\w+) tok/', $sql, $m)) return false;
+    $db = $m[1];
+    preg_match("/tok.val='([^']*)'/", $sql, $tm);
+    $tok = isset($tm[1]) ? $tm[1] : '';
+    $GLOBALS['QUERIED'][] = $db;
+    return isset($GLOBALS['VALID']["$db|$tok"]) ? ['hit' => true] : false;
+}
+function mysqli_fetch_array($res){ return is_array($res) ? $res : false; }
+
+// ---- Mirror of index.php hasValidTokenCookie() ----
+function hasValidTokenCookie(){
+    global $connection;
+    if(empty($_COOKIE) || !is_array($_COOKIE)) return false;
+    foreach($_COOKIE as $name => $value){
+        if(strpos($name, "idb_") !== 0) continue;
+        $db = substr($name, 4);
+        if(!checkDbName(USER_DB_MASK, $db)) continue;
+        if($value === "" || $value === "gtuoeksetn") continue; // Empty or guest token
+        $tok = addslashes($value);
+        $res = @mysqli_query($connection, "SELECT 1 FROM $db tok, $db u"
+            ." WHERE u.t=".USER." AND u.val!='guest' AND tok.up=u.id AND tok.val='$tok' AND tok.t=".TOKEN." LIMIT 1");
+        if($res && mysqli_fetch_array($res)) return true;
+    }
+    return false;
+}
+
+$failures = 0;
+function check($cond, $name){
+    global $failures;
+    echo ($cond ? "PASS" : "FAIL") . " — $name\n";
+    if(!$cond) $failures++;
+}
+
+function scenario($cookies, $valid){
+    $_COOKIE = $cookies;
+    $GLOBALS['VALID'] = $valid;
+    $GLOBALS['QUERIED'] = [];
+    return hasValidTokenCookie();
+}
+
+// 1) Valid token => bypass.
+check(scenario(['idb_acme' => 'tok-acme'], ['acme|tok-acme' => 1]) === true,
+    'valid token => bypass');
+
+// 2) No idb_* cookies => no bypass, no DB query.
+$r = scenario(['session' => 'x', '_aff' => '5'], []);
+check($r === false && count($GLOBALS['QUERIED']) === 0,
+    'non-idb cookies are ignored, no query issued');
+
+// 3) Guest token => skipped, no bypass, no query.
+$r = scenario(['idb_demo' => 'gtuoeksetn'], ['demo|gtuoeksetn' => 1]);
+check($r === false && count($GLOBALS['QUERIED']) === 0,
+    'guest token is skipped without a query');
+
+// 4) Empty token value => skipped, no query.
+$r = scenario(['idb_x' => ''], []);
+check($r === false && count($GLOBALS['QUERIED']) === 0,
+    'empty token value is skipped');
+
+// 5) Bad db name (fails USER_DB_MASK) => skipped, no query.
+$r = scenario(['idb_a' => 'tok'], ['a|tok' => 1]); // "a" is too short for the mask
+check($r === false && count($GLOBALS['QUERIED']) === 0,
+    'db name failing the mask is skipped');
+
+// 6) Stale token (not valid in DB) => no bypass, but a query was attempted.
+$r = scenario(['idb_stale' => 'tok-stale'], []);
+check($r === false && $GLOBALS['QUERIED'] === ['stale'],
+    'stale token queried but does not bypass');
+
+// 7) Mixed: first invalid then valid => bypass, both queried in order.
+$r = scenario(['idb_bad' => 'tok-bad', 'idb_good' => 'tok-good'], ['good|tok-good' => 1]);
+check($r === true && $GLOBALS['QUERIED'] === ['bad', 'good'],
+    'mixed cookies => bypass once a valid token is found');
+
+echo "\n" . ($failures === 0 ? "ALL TESTS PASSED" : "$failures TEST(S) FAILED") . "\n";
+exit($failures === 0 ? 0 : 1);

--- a/experiments/issue-2906-captcha-bypass.test.js
+++ b/experiments/issue-2906-captcha-bypass.test.js
@@ -1,0 +1,174 @@
+// Verification of the captcha-bypass logic from issue #2906 (start.html).
+// Loads the real js/app.js in a sandbox with stubbed document/window/fetch and
+// exercises hasValidAuthToken() against several cookie/xsrf scenarios.
+//
+// Rule: if any idb_* cookie holds a token whose GET xsrf check succeeds for a
+// non-guest user, the captcha is bypassed. Tokens that fail validation are
+// deleted from the cookies; guest tokens never bypass the captcha.
+//
+// Run with: node experiments/issue-2906-captcha-bypass.test.js
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const appSrc = fs.readFileSync(path.join(__dirname, '..', 'js', 'app.js'), 'utf8');
+
+// Minimal cookie jar that backs a mutable document.cookie (get returns the
+// "a=1; b=2" string; set with "name=; expires=..1970.." deletes the cookie).
+function makeCookieJar(initial) {
+    const jar = Object.assign({}, initial);
+    return {
+        get cookie() {
+            return Object.keys(jar).map(k => k + '=' + jar[k]).join('; ');
+        },
+        set cookie(str) {
+            const [pair] = str.split(';');
+            const eq = pair.indexOf('=');
+            const name = pair.slice(0, eq).trim();
+            const value = pair.slice(eq + 1).trim();
+            if (/expires=Thu, 01 Jan 1970/i.test(str) || value === '') {
+                delete jar[name];
+            } else {
+                jar[name] = value;
+            }
+        },
+        _jar: jar,
+    };
+}
+
+// Build a sandbox, run app.js inside it, and return the populated context.
+function makeSandbox(cookies, xsrfResponder) {
+    const cookieJar = makeCookieJar(cookies);
+    const documentStub = {
+        addEventListener() {},          // swallow DOMContentLoaded so init() never runs
+        getElementById() { return null; },
+        querySelectorAll() { return []; },
+        querySelector() { return null; },
+        createElement() { return { classList: { add() {} }, style: {}, addEventListener() {} }; },
+        get cookie() { return cookieJar.cookie; },
+        set cookie(v) { cookieJar.cookie = v; },
+        documentElement: { setAttribute() {} },
+        body: { appendChild() {} },
+    };
+    const ctx = {
+        document: documentStub,
+        window: { location: { hostname: 'example.com', origin: 'https://example.com', search: '' }, localStorage: null },
+        localStorage: { getItem() { return null; }, setItem() {} },
+        console,
+        setTimeout,
+        URLSearchParams,
+        fetch: async (url) => xsrfResponder(url),
+        _cookieJar: cookieJar,
+    };
+    ctx.window.localStorage = ctx.localStorage;
+    vm.createContext(ctx);
+    vm.runInContext(appSrc, ctx);
+    return ctx;
+}
+
+// xsrf responder factory: maps db name -> { ok, body } describing the response.
+function responderFrom(map) {
+    return async (url) => {
+        const m = /\/([^/]+)\/xsrf/.exec(url);
+        const db = m ? m[1] : '';
+        const entry = map[db];
+        if (!entry || entry.network === false) {
+            throw new Error('network error');
+        }
+        return {
+            ok: entry.ok !== false,
+            status: entry.status || (entry.ok === false ? 401 : 200),
+            json: async () => entry.body,
+        };
+    };
+}
+
+let failures = 0;
+function assert(cond, name, extra) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (!cond) { failures++; if (extra) console.log('  ', extra); }
+}
+
+async function run() {
+    // 1) A single valid, non-guest token bypasses the captcha.
+    {
+        const ctx = makeSandbox(
+            { idb_acme: 'tok-acme' },
+            responderFrom({ acme: { ok: true, body: { _xsrf: 'x1', user: 'alice' } } })
+        );
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === true, 'valid non-guest token => bypass');
+        assert(ctx._cookieJar._jar.idb_acme === 'tok-acme', 'valid token kept in cookies');
+    }
+
+    // 2) Only a guest token => no bypass (guest must still see the captcha).
+    {
+        const ctx = makeSandbox(
+            { idb_demo: 'tok-demo' },
+            responderFrom({ demo: { ok: true, body: { _xsrf: 'x2', user: 'guest' } } })
+        );
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === false, 'guest token => no bypass');
+    }
+
+    // 3) An invalid token (HTTP 401) => deleted from cookies, no bypass.
+    {
+        const ctx = makeSandbox(
+            { idb_stale: 'tok-stale' },
+            responderFrom({ stale: { ok: false, status: 401 } })
+        );
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === false, 'invalid token => no bypass');
+        assert(ctx._cookieJar._jar.idb_stale === undefined, 'invalid token deleted from cookies');
+    }
+
+    // 4) A 200 response without _xsrf => treated as invalid, deleted, no bypass.
+    {
+        const ctx = makeSandbox(
+            { idb_empty: 'tok-empty' },
+            responderFrom({ empty: { ok: true, body: { error: 'nope' } } })
+        );
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === false, 'no _xsrf in body => no bypass');
+        assert(ctx._cookieJar._jar.idb_empty === undefined, 'token without _xsrf deleted');
+    }
+
+    // 5) Mixed: invalid token is deleted, valid one kept, overall bypass = true.
+    {
+        const ctx = makeSandbox(
+            { idb_bad: 'tok-bad', idb_good: 'tok-good' },
+            responderFrom({
+                bad: { ok: false, status: 401 },
+                good: { ok: true, body: { _xsrf: 'x5', user: 'bob' } },
+            })
+        );
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === true, 'mixed tokens => bypass when one is valid');
+        assert(ctx._cookieJar._jar.idb_bad === undefined, 'invalid token deleted in mixed case');
+        assert(ctx._cookieJar._jar.idb_good === 'tok-good', 'valid token kept in mixed case');
+    }
+
+    // 6) No idb_* cookies => no bypass.
+    {
+        const ctx = makeSandbox({ other: '1' }, responderFrom({}));
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === false, 'no idb_* cookies => no bypass');
+    }
+
+    // 7) Network error during check => token deleted, no bypass.
+    {
+        const ctx = makeSandbox(
+            { idb_neterr: 'tok-net' },
+            responderFrom({ neterr: { network: false } })
+        );
+        const bypass = await ctx.hasValidAuthToken('example.com');
+        assert(bypass === false, 'network error => no bypass');
+        assert(ctx._cookieJar._jar.idb_neterr === undefined, 'token deleted on network error');
+    }
+
+    console.log('\n' + (failures === 0 ? 'ALL TESTS PASSED' : failures + ' TEST(S) FAILED'));
+    process.exit(failures === 0 ? 0 : 1);
+}
+
+run();

--- a/index.php
+++ b/index.php
@@ -193,7 +193,7 @@ if(($z === "my") && ((isset($com[2]) ? $com[2] : "") === "register")){ # Registe
     	if(!strlen($_POST["agree"]))
     		$msg .= t9n("[RU]Пожалуйста, поставьте отметку, что ознакомились с&nbsp;Лицензионным соглашением"
     		    ."[EN]Please confirm that you have read the&nbsp;<a href=\"offer.html\">papers to protect you")."<br/><br/>\n";
-        if(!verifyCaptcha(isset($_POST["smart-token"]) ? $_POST["smart-token"] : ""))
+        if(!hasValidTokenCookie() && !verifyCaptcha(isset($_POST["smart-token"]) ? $_POST["smart-token"] : ""))
             $msg .= t9n("[RU]Пожалуйста, пройдите проверку капчи.[EN]Please complete the captcha verification.")."<br/><br/>\n";
         # Stage one: Inform of the errors, if any, and let him try again
         if(strlen($msg))
@@ -545,6 +545,28 @@ function verifyCaptcha($token) {
     if ($result === false) return false;
     $data = json_decode($result, true);
     return isset($data['status']) && $data['status'] === 'ok';
+}
+
+# Issue #2906: a returning visitor who already holds a valid auth token (an idb_*
+# cookie) is not a bot, so the captcha may be skipped for them. This mirrors the
+# start.html logic: every idb_* cookie is checked against its DB one by one and the
+# first valid, non-guest token bypasses the captcha. Guest tokens never count.
+function hasValidTokenCookie(){
+    global $connection;
+    if(empty($_COOKIE) || !is_array($_COOKIE)) return false;
+    foreach($_COOKIE as $name => $value){
+        if(strpos($name, "idb_") !== 0) continue;
+        $db = substr($name, 4);
+        if(!checkDbName(USER_DB_MASK, $db)) continue;
+        if($value === "" || $value === "gtuoeksetn") continue; # Empty or guest token
+        $tok = addslashes($value);
+        # Query the DB directly (not Exec_sql) so a missing table is ignored here
+        # rather than triggering a dBNotExists redirect.
+        $res = @mysqli_query($connection, "SELECT 1 FROM $db tok, $db u"
+            ." WHERE u.t=".USER." AND u.val!='guest' AND tok.up=u.id AND tok.val='$tok' AND tok.t=".TOKEN." LIMIT 1");
+        if($res && mysqli_fetch_array($res)) return true;
+    }
+    return false;
 }
 
 function mail2DB($email, $uid){
@@ -9297,7 +9319,7 @@ switch($a)  # Check actions, which don't require authentication
 			$GLOBALS["tzone"] = round(((int)$_POST["tzone"] - time() - date("Z"))/1800)*1800; # Round the time zone shift to 30 min
 			setcookie("tzone", $GLOBALS["tzone"], time() + COOKIES_EXPIRE, "/"); # 30 days
 		}
-		if(isset($_POST["smart-token"]) && !verifyCaptcha($_POST["smart-token"])){
+		if(isset($_POST["smart-token"]) && !hasValidTokenCookie() && !verifyCaptcha($_POST["smart-token"])){
 			$captchaMsg = t9n("[RU]Проверка капчи не пройдена. Пожалуйста, попробуйте снова.[EN]Captcha verification failed. Please try again.");
 			if(isApi()){
 				header("HTTP/1.0 403 Forbidden");

--- a/js/app.js
+++ b/js/app.js
@@ -121,6 +121,23 @@ async function validateToken(host, dbName) {
     }
 }
 
+// Issue #2906: a returning visitor who already holds a valid auth token should not
+// be bothered with the captcha. Every idb_* cookie is checked for validity one by
+// one (GET xsrf); a valid response keeps the cookie, a failed one deletes it (see
+// validateToken). Returns true if at least one non-guest token is valid.
+async function hasValidAuthToken(host) {
+    const dbNames = CookieUtil.getAllIdb();
+    let anyValid = false;
+    for (const db of dbNames) {
+        const data = await validateToken(host, db);
+        // Guest sessions are not real authentications and must not bypass the captcha.
+        if (data && data.user && data.user !== 'guest') {
+            anyValid = true;
+        }
+    }
+    return anyValid;
+}
+
 // ============================================================
 // Notification utility
 // ============================================================
@@ -490,6 +507,9 @@ class App {
         this.apiConfig = new ApiConfig();
         this.auth = new AuthManager(this.apiConfig);
         this.yandexAuth = new YandexAuthManager(this.apiConfig);
+        // Issue #2906: set to true when a valid auth token is found, so the captcha
+        // is hidden and its client-side check is skipped for returning users.
+        this._captchaBypass = false;
         window._app = this;
     }
 
@@ -612,7 +632,7 @@ class App {
                     }
                 }
                 const captchaToken = getCaptchaToken('login-captcha-container');
-                if (captchaToken === null) {
+                if (!this._captchaBypass && captchaToken === null) {
                     showToast('Пожалуйста, пройдите проверку капчи', 'error');
                     loginInProgress = false;
                     return;
@@ -917,7 +937,7 @@ class App {
                 }
 
                 const captchaToken = getCaptchaToken('register-captcha-container');
-                if (captchaToken === null) {
+                if (!this._captchaBypass && captchaToken === null) {
                     showToast('Пожалуйста, пройдите проверку капчи', 'error');
                     return;
                 }
@@ -953,6 +973,12 @@ class App {
 
         // Check auth state from cookies
         this.auth.init();
+
+        // Issue #2906: validate existing token cookies. If any is valid, the visitor
+        // is a returning, authenticated user — hide the captcha and skip its check.
+        // Done before any auth panel is shown below so the captcha never flashes.
+        this._captchaBypass = await hasValidAuthToken(this.apiConfig.host);
+        if (this._captchaBypass) this._hideCaptchaWidgets();
 
         // Handle redirect reasons from the backend: show login form and a visible message
         const urlParams = new URLSearchParams(window.location.search);
@@ -1064,6 +1090,8 @@ class App {
     }
 
     _initCaptchaWidgets() {
+        // Issue #2906: skip rendering the captcha entirely for returning users with a valid token.
+        if (this._captchaBypass) return;
         if (!window.smartCaptcha) return;
         ['login-captcha-container', 'register-captcha-container'].forEach(id => {
             const el = document.getElementById(id);
@@ -1073,6 +1101,14 @@ class App {
             const robustness = el.dataset.robustness || 'strict';
             const widgetId = window.smartCaptcha.render(el, { sitekey, robustness });
             el.dataset.widgetId = widgetId;
+        });
+    }
+
+    // Issue #2906: hide the captcha containers when a valid token bypasses the captcha.
+    _hideCaptchaWidgets() {
+        ['login-captcha-container', 'register-captcha-container'].forEach(id => {
+            const el = document.getElementById(id);
+            if (el) el.style.display = 'none';
         });
     }
 


### PR DESCRIPTION
## Summary

Closes #2906.

A returning, authenticated visitor already proved they are not a bot, so the
captcha should not be shown to them. This PR validates every existing auth-token
cookie and bypasses the captcha when at least one is valid — both in `start.html`
(frontend) and in the core/backend (`index.php`), as the issue requests.

### Issue requirements

> Если есть куки с токенами в БД, проверять их на валидность все по очереди — запрашивать команду GET xsrf.
> Если ответ успешный — капчу не показывать, иначе — токен удалять из куки.
> Предусмотреть ту же логику в ядре.

- ✅ Check **all** `idb_*` token cookies one by one via **GET xsrf**.
- ✅ On a successful response → **do not show** the captcha.
- ✅ On a failed response → **delete** the stale token from the cookie.
- ✅ The **same logic in the core** (backend).

## Changes

### Frontend — `js/app.js` (start.html)
- New `hasValidAuthToken(host)`: iterates every `idb_*` cookie (`CookieUtil.getAllIdb()`)
  and calls the existing `validateToken()` (GET `xsrf`) for each. A valid, **non-guest**
  response counts as a bypass; an invalid one deletes the cookie (already handled inside
  `validateToken()`).
- `App.init()` awaits the check **before** any auth panel is shown, so the captcha never
  flashes. On success it sets `_captchaBypass` and calls `_hideCaptchaWidgets()`.
- `_initCaptchaWidgets()` returns early when bypassing, and the login/register submit
  handlers skip the client-side captcha-token requirement when `_captchaBypass` is set.
  (`AuthManager` only appends `smart-token` when truthy, so the backend then also skips
  verification.)

### Core/backend — `index.php`
- New `hasValidTokenCookie()` mirrors the frontend logic server-side: for every `idb_*`
  cookie (validated against `USER_DB_MASK`) it checks the token against its DB, skipping
  empty and guest (`gtuoeksetn`) tokens. Uses raw `mysqli_query` (not `Exec_sql`) so a
  missing table is ignored rather than triggering a `dBNotExists` redirect.
- Both captcha verification points are guarded so a valid token bypasses server-side
  verification: registration (`my/register`) and login.

### Guest-token edge case
Guest sessions (`idb_<db>="gtuoeksetn"`, user `guest`) return a valid xsrf but are **not**
real authentications, so they are explicitly excluded on both sides and still see the captcha.

## Reproduction & tests

No formal test framework exists in the repo; tests follow the existing standalone-script
pattern in `experiments/`.

- `experiments/issue-2906-captcha-bypass.test.js` — runs the **real** `js/app.js` in a
  Node `vm` sandbox (stubbed document/window/fetch + mutable cookie jar) across 7 scenarios:
  valid token, guest token, invalid (401), 200 without `_xsrf`, mixed valid/invalid,
  no `idb_*` cookies, network error. Verifies bypass result **and** cookie deletion.
  Run: `node experiments/issue-2906-captcha-bypass.test.js`
- `experiments/issue-2906-captcha-bypass.php` — mirror of `hasValidTokenCookie()` with
  stubbed `mysqli_*`/`checkDbName` across 7 cookie-filtering scenarios (idb prefix, DB
  mask, empty/guest skip, stale token, first-valid-wins).
  Run: `php experiments/issue-2906-captcha-bypass.php`

Both suites pass (`ALL TESTS PASSED`). `php -l index.php` and `node --check js/app.js` are clean.
