### PR TITLE
feat: add local Docker install package (#2943)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+.env
+.env.local
+ci-logs/
+docker/certs/
+experiments/
+logs/
+mcp-server/node_modules/
+node_modules/
+*.log
+*.tmp

--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,9 @@
+INTEGRAM_MASTER_PASSWORD=change-this-master-password
+INTEGRAM_DB_NAME=ideav
+INTEGRAM_DB_USER=ideav
+INTEGRAM_DB_PASSWORD=ideav-local-password
+INTEGRAM_DB_ROOT_PASSWORD=ideav-local-root-password
+INTEGRAM_HTTP_PORT=8080
+INTEGRAM_HTTPS_PORT=8443
+INTEGRAM_ADMIN_EMAIL=admin@example.local
+INTEGRAM_SALT=change-this-local-salt

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /include/credentials.json
 /google_sheets_sync.bki
 /logs/google_sheets_sync.bki
+/.env
+/.env.local
+/docker/certs/
 
 # Local research artifacts for issue #2895
 experiments/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T10:31:36.096Z for PR creation at branch issue-2943-f4ccbe55306b for issue https://github.com/ideav/crm/issues/2943

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T10:31:36.096Z for PR creation at branch issue-2943-f4ccbe55306b for issue https://github.com/ideav/crm/issues/2943

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM php:8.2-apache
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        default-mysql-client \
+        libonig-dev \
+        libzip-dev \
+        openssl \
+        unzip \
+    && docker-php-ext-install mysqli mbstring zip \
+    && a2enmod rewrite ssl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /var/www/html
+
+COPY . /var/www/html
+COPY docker/apache/integram.conf /etc/apache2/sites-available/000-default.conf
+COPY docker/entrypoint.sh /usr/local/bin/integram-entrypoint
+COPY docker/mysql/010-integram-bootstrap.sql /usr/local/share/integram/010-integram-bootstrap.sql
+
+RUN mkdir -p \
+        /usr/local/share/integram/download-seed \
+        /usr/local/share/integram/templates-custom-seed/my \
+        /usr/local/share/integram/templates-custom-seed/ru \
+        /usr/local/share/integram/templates-custom-seed/en \
+        /var/www/html/logs \
+        /var/www/html/templates/custom \
+        /var/www/html/download \
+    && cp -a /var/www/html/download/. /usr/local/share/integram/download-seed/ \
+    && cp -a /var/www/html/templates/my/. /usr/local/share/integram/templates-custom-seed/my/ \
+    && cp -a /var/www/html/templates/ru/. /usr/local/share/integram/templates-custom-seed/ru/ \
+    && cp -a /var/www/html/templates/ru/. /usr/local/share/integram/templates-custom-seed/en/ \
+    && chmod +x /usr/local/bin/integram-entrypoint \
+    && chown -R www-data:www-data /var/www/html/logs /var/www/html/templates /var/www/html/download
+
+ENTRYPOINT ["integram-entrypoint"]
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ curl https://ideav.ru/update.php?config=update.conf
 
 See [ASSETS_DEPLOYMENT.md](ASSETS_DEPLOYMENT.md) for details on asset structure and deployment.
 
+For a local client-side Docker install with a master password and HTTPS certificate,
+see [docs/LOCAL_DOCKER_INSTALL.md](docs/LOCAL_DOCKER_INSTALL.md).
+
 ## Development Rules
 
 Before building or changing a workspace (`templates/*.html` embedded into

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,50 @@
+name: integram-local
+
+services:
+  db:
+    image: mariadb:11.4
+    restart: unless-stopped
+    environment:
+      MARIADB_DATABASE: ${INTEGRAM_DB_NAME:-ideav}
+      MARIADB_USER: ${INTEGRAM_DB_USER:-ideav}
+      MARIADB_PASSWORD: ${INTEGRAM_DB_PASSWORD:-ideav-local-password}
+      MARIADB_ROOT_PASSWORD: ${INTEGRAM_DB_ROOT_PASSWORD:-ideav-local-root-password}
+    volumes:
+      - integram-db:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -h 127.0.0.1 -u$${MARIADB_USER} -p$${MARIADB_PASSWORD} --silent"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  app:
+    build: .
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      INTEGRAM_DB_HOST: db
+      INTEGRAM_DB_PORT: 3306
+      INTEGRAM_DB_NAME: ${INTEGRAM_DB_NAME:-ideav}
+      INTEGRAM_DB_USER: ${INTEGRAM_DB_USER:-ideav}
+      INTEGRAM_DB_PASSWORD: ${INTEGRAM_DB_PASSWORD:-ideav-local-password}
+      INTEGRAM_MASTER_PASSWORD: ${INTEGRAM_MASTER_PASSWORD:?Set INTEGRAM_MASTER_PASSWORD in .env.local}
+      INTEGRAM_ADMIN_EMAIL: ${INTEGRAM_ADMIN_EMAIL:-admin@example.local}
+      INTEGRAM_SALT: ${INTEGRAM_SALT:-integram-local-salt}
+      INTEGRAM_SMTP_DEBUG: ${INTEGRAM_SMTP_DEBUG:-false}
+      INTEGRAM_SMARTCAPTCHA_SERVER_KEY: ${INTEGRAM_SMARTCAPTCHA_SERVER_KEY:-ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}
+    ports:
+      - "${INTEGRAM_HTTP_PORT:-8080}:80"
+      - "${INTEGRAM_HTTPS_PORT:-8443}:443"
+    volumes:
+      - integram-download:/var/www/html/download
+      - integram-templates:/var/www/html/templates/custom
+      - integram-logs:/var/www/html/logs
+      - ./docker/certs:/etc/integram/certs
+
+volumes:
+  integram-db:
+  integram-download:
+  integram-templates:
+  integram-logs:

--- a/docker/apache/integram.conf
+++ b/docker/apache/integram.conf
@@ -1,0 +1,35 @@
+ServerName localhost
+
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+
+    <Directory /var/www/html>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+        FallbackResource /index.php
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>
+
+<IfModule mod_ssl.c>
+<VirtualHost *:443>
+    DocumentRoot /var/www/html
+
+    SSLEngine on
+    SSLCertificateFile /etc/integram/certs/local.crt
+    SSLCertificateKeyFile /etc/integram/certs/local.key
+
+    <Directory /var/www/html>
+        Options FollowSymLinks
+        AllowOverride All
+        Require all granted
+        FallbackResource /index.php
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/ssl-error.log
+    CustomLog ${APACHE_LOG_DIR}/ssl-access.log combined
+</VirtualHost>
+</IfModule>

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${INTEGRAM_DB_HOST:=db}"
+: "${INTEGRAM_DB_PORT:=3306}"
+: "${INTEGRAM_DB_NAME:=ideav}"
+: "${INTEGRAM_DB_USER:=ideav}"
+: "${INTEGRAM_DB_PASSWORD:=ideav-local-password}"
+
+cert_dir="/etc/integram/certs"
+mkdir -p "$cert_dir"
+if [[ ! -s "$cert_dir/local.crt" || ! -s "$cert_dir/local.key" ]]; then
+    openssl req -x509 -nodes -newkey rsa:2048 -days 825 \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+        -keyout "$cert_dir/local.key" \
+        -out "$cert_dir/local.crt"
+    chmod 600 "$cert_dir/local.key"
+fi
+
+for _ in $(seq 1 60); do
+    if mysqladmin ping \
+        --host="$INTEGRAM_DB_HOST" \
+        --port="$INTEGRAM_DB_PORT" \
+        --user="$INTEGRAM_DB_USER" \
+        --password="$INTEGRAM_DB_PASSWORD" \
+        --silent >/dev/null 2>&1; then
+        break
+    fi
+    sleep 2
+done
+
+if ! mysqladmin ping \
+    --host="$INTEGRAM_DB_HOST" \
+    --port="$INTEGRAM_DB_PORT" \
+    --user="$INTEGRAM_DB_USER" \
+    --password="$INTEGRAM_DB_PASSWORD" \
+    --silent >/dev/null 2>&1; then
+    echo "Database is not reachable at $INTEGRAM_DB_HOST:$INTEGRAM_DB_PORT" >&2
+    exit 1
+fi
+
+mysql \
+    --host="$INTEGRAM_DB_HOST" \
+    --port="$INTEGRAM_DB_PORT" \
+    --user="$INTEGRAM_DB_USER" \
+    --password="$INTEGRAM_DB_PASSWORD" \
+    "$INTEGRAM_DB_NAME" \
+    < /usr/local/share/integram/010-integram-bootstrap.sql
+
+seed_dir_if_empty() {
+    local source_dir="$1"
+    local target_dir="$2"
+    mkdir -p "$target_dir"
+    if [[ -d "$source_dir" ]] && ! find "$target_dir" -mindepth 1 -maxdepth 1 | grep -q .; then
+        cp -a "$source_dir"/. "$target_dir"/
+    fi
+}
+
+seed_dir_if_empty /usr/local/share/integram/download-seed /var/www/html/download
+seed_dir_if_empty /usr/local/share/integram/templates-custom-seed/my /var/www/html/templates/custom/my
+seed_dir_if_empty /usr/local/share/integram/templates-custom-seed/ru /var/www/html/templates/custom/ru
+seed_dir_if_empty /usr/local/share/integram/templates-custom-seed/en /var/www/html/templates/custom/en
+
+mkdir -p /var/www/html/logs /var/www/html/download/ru /var/www/html/download/en
+chown -R www-data:www-data /var/www/html/logs /var/www/html/download /var/www/html/templates/custom
+
+exec "$@"

--- a/docker/mysql/010-integram-bootstrap.sql
+++ b/docker/mysql/010-integram-bootstrap.sql
@@ -1,0 +1,84 @@
+CREATE TABLE IF NOT EXISTS my (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    up INT UNSIGNED NOT NULL DEFAULT 0,
+    ord INT NOT NULL DEFAULT 0,
+    t INT UNSIGNED NOT NULL DEFAULT 0,
+    val MEDIUMTEXT NOT NULL,
+    PRIMARY KEY (id),
+    KEY up_t (up, t),
+    KEY t_up (t, up),
+    KEY t_val (t, val(191)),
+    KEY up_ord (up, ord)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS ru LIKE my;
+CREATE TABLE IF NOT EXISTS en LIKE my;
+
+CREATE TEMPORARY TABLE integram_seed LIKE my;
+
+INSERT INTO integram_seed (id, up, ord, t, val) VALUES
+    (1, 0, 0, 1, 'FREE_LINK'),
+    (2, 0, 0, 2, 'HTML'),
+    (3, 0, 0, 3, 'SHORT'),
+    (4, 0, 0, 4, 'DATETIME'),
+    (5, 0, 0, 5, 'GRANT'),
+    (6, 0, 0, 6, 'PWD'),
+    (7, 0, 0, 7, 'BUTTON'),
+    (8, 0, 0, 8, 'CHARS'),
+    (9, 0, 0, 9, 'DATE'),
+    (10, 0, 0, 10, 'FILE'),
+    (11, 0, 0, 11, 'BOOLEAN'),
+    (12, 0, 0, 12, 'MEMO'),
+    (13, 0, 0, 13, 'NUMBER'),
+    (14, 0, 0, 14, 'SIGNED'),
+    (15, 0, 0, 15, 'CALCULATABLE'),
+    (16, 0, 0, 16, 'REPORT_COLUMN'),
+    (17, 0, 0, 17, 'PATH'),
+    (18, 0, 1, 3, 'Пользователь'),
+    (20, 18, 1, 6, 'Пароль'),
+    (30, 18, 2, 3, 'Телефон'),
+    (33, 18, 3, 3, 'Имя'),
+    (40, 18, 4, 6, 'xsrf'),
+    (41, 18, 5, 3, 'Email'),
+    (42, 0, 2, 3, 'Роль'),
+    (47, 0, 3, 3, 'Уровень доступа'),
+    (49, 116, 2, 3, 'Маска'),
+    (55, 116, 3, 11, 'Экспорт'),
+    (56, 116, 4, 11, 'Удаление'),
+    (115, 18, 6, 144, 'Роль'),
+    (116, 42, 1, 5, 'Объекты'),
+    (124, 18, 7, 4, 'Activity'),
+    (125, 18, 8, 6, 'Token'),
+    (130, 18, 9, 3, 'Secret'),
+    (135, 42, 2, 12, 'Описание'),
+    (144, 0, 0, 42, ''),
+    (145, 1, 1, 42, 'admin'),
+    (151, 0, 4, 3, 'Меню'),
+    (153, 151, 1, 8, 'Адрес'),
+    (156, 18, 10, 9, 'Дата'),
+    (158, 151, 2, 3, 'Параметры'),
+    (164, 1, 2, 42, 'user'),
+    (170, 1, 1, 47, 'WRITE'),
+    (171, 1, 2, 47, 'READ'),
+    (172, 1, 3, 47, 'BARRED'),
+    (271, 18, 11, 3, 'База'),
+    (275, 271, 1, 9, 'Дата'),
+    (276, 271, 2, 12, 'Описание'),
+    (283, 271, 3, 3, 'Шаблон'),
+    (285, 271, 4, 13, 'Баланс'),
+    (300, 18, 12, 13, 'Retries'),
+    (391, 151, 3, 8, 'Иконка'),
+    (1001, 145, 1, 116, '1'),
+    (1002, 1001, 1, 170, ''),
+    (1003, 145, 2, 116, '0'),
+    (1004, 1003, 1, 170, ''),
+    (1005, 145, 3, 116, '10'),
+    (1006, 1005, 1, 170, ''),
+    (1010, 164, 1, 116, '1'),
+    (1011, 1010, 1, 171, '');
+
+INSERT IGNORE INTO my SELECT * FROM integram_seed;
+INSERT IGNORE INTO ru SELECT * FROM integram_seed;
+INSERT IGNORE INTO en SELECT * FROM integram_seed;
+
+DROP TEMPORARY TABLE integram_seed;

--- a/docs/LOCAL_DOCKER_INSTALL.md
+++ b/docs/LOCAL_DOCKER_INSTALL.md
@@ -1,0 +1,107 @@
+# Локальная установка Интеграм в Docker
+
+Этот вариант поднимает Интеграм на машине клиента без ручной настройки PHP,
+Apache и MariaDB. Установщик спрашивает master-пароль, генерирует локальный
+сертификат и запускает контейнеры.
+
+## Требования
+
+- Docker Engine с Docker Compose.
+- Свободные порты `8080` и `8443`.
+- Доступ к репозиторию с исходниками.
+
+## Быстрый запуск
+
+```bash
+bash scripts/install-local-docker.sh
+```
+
+Скрипт создаёт `.env.local`, `docker/certs/local.crt` и
+`docker/certs/local.key`, затем выполняет `docker compose up -d --build`.
+
+Откройте:
+
+```text
+https://localhost:8443
+```
+
+Данные первого входа:
+
+```text
+База: my
+Логин: admin
+Пароль: master-пароль, введённый при установке
+```
+
+Браузер покажет предупреждение о certificate, потому что по умолчанию
+используется самоподписанный сертификат для `localhost`. Для рабочей установки
+замените `docker/certs/local.crt` и `docker/certs/local.key` сертификатом
+клиента и перезапустите контейнер:
+
+```bash
+docker compose --env-file .env.local restart app
+```
+
+## Ручной запуск
+
+```bash
+cp .env.docker.example .env.local
+```
+
+Заполните в `.env.local` минимум:
+
+```text
+INTEGRAM_MASTER_PASSWORD=...
+INTEGRAM_DB_PASSWORD=...
+INTEGRAM_DB_ROOT_PASSWORD=...
+INTEGRAM_SALT=...
+```
+
+Создайте или положите сертификат:
+
+```bash
+mkdir -p docker/certs
+openssl req -x509 -nodes -newkey rsa:2048 -days 825 \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+  -keyout docker/certs/local.key \
+  -out docker/certs/local.crt
+```
+
+Запустите:
+
+```bash
+docker compose --env-file .env.local up -d --build
+```
+
+## Обновление и остановка
+
+```bash
+docker compose --env-file .env.local pull
+docker compose --env-file .env.local up -d --build
+docker compose --env-file .env.local logs -f app
+```
+
+Остановить сервис:
+
+```bash
+docker compose --env-file .env.local down
+```
+
+Данные остаются в Docker volumes `integram-local_integram-db`,
+`integram-local_integram-download`, `integram-local_integram-templates` и
+`integram-local_integram-logs`.
+
+## Резервная копия базы
+
+```bash
+docker compose --env-file .env.local exec db \
+  mariadb-dump -u root -p ideav > integram-local.sql
+```
+
+Восстановление:
+
+```bash
+docker compose --env-file .env.local exec -T db \
+  mariadb -u root -p ideav < integram-local.sql
+```

--- a/experiments/test-issue-2943-docker-packaging.sh
+++ b/experiments/test-issue-2943-docker-packaging.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+require_file() {
+    local path="$1"
+    if [[ ! -f "$root/$path" ]]; then
+        echo "FAIL: missing $path" >&2
+        exit 1
+    fi
+}
+
+require_text() {
+    local path="$1"
+    local pattern="$2"
+    if ! grep -Eq "$pattern" "$root/$path"; then
+        echo "FAIL: $path does not match $pattern" >&2
+        exit 1
+    fi
+}
+
+require_file "Dockerfile"
+require_file "compose.yaml"
+require_file ".env.docker.example"
+require_file "docker/entrypoint.sh"
+require_file "docker/mysql/010-integram-bootstrap.sql"
+require_file "scripts/install-local-docker.sh"
+require_file "docs/LOCAL_DOCKER_INSTALL.md"
+
+require_text "Dockerfile" "docker-php-ext-install .*mysqli"
+require_text "Dockerfile" "a2enmod .*rewrite .*ssl"
+require_text "compose.yaml" "mariadb:"
+require_text "compose.yaml" "INTEGRAM_HTTPS_PORT:-8443.*:443"
+require_text ".env.docker.example" "INTEGRAM_MASTER_PASSWORD="
+require_text ".gitignore" "^/\\.env\\.local$"
+require_text "include/connection.php" "INTEGRAM_DB_HOST"
+require_text "include/connection.php" "INTEGRAM_MASTER_PASSWORD"
+require_text "docker/mysql/010-integram-bootstrap.sql" "CREATE TABLE IF NOT EXISTS my"
+require_text "docker/mysql/010-integram-bootstrap.sql" "CREATE TABLE IF NOT EXISTS ru"
+require_text "docker/mysql/010-integram-bootstrap.sql" "CREATE TABLE IF NOT EXISTS en"
+require_text "scripts/install-local-docker.sh" "read -rs .*master"
+require_text "scripts/install-local-docker.sh" "openssl req -x509"
+require_text "docs/LOCAL_DOCKER_INSTALL.md" "master"
+require_text "docs/LOCAL_DOCKER_INSTALL.md" "https://localhost:8443"
+require_text "docs/LOCAL_DOCKER_INSTALL.md" "certificate"
+
+echo "issue-2943 docker packaging checks: ok"

--- a/include/connection.php
+++ b/include/connection.php
@@ -1,26 +1,40 @@
 <?php
-$connection = mysqli_connect("localhost", "ideav", "x", "ideav") or die("Couldn't connect.");
+if(!function_exists('integram_env')){
+    function integram_env($name, $default = ''){
+        $value = getenv($name);
+        return ($value === false || $value === '') ? $default : $value;
+    }
+}
+
+$dbHost = integram_env('INTEGRAM_DB_HOST', 'localhost');
+$dbPort = (int)integram_env('INTEGRAM_DB_PORT', '3306');
+$dbName = integram_env('INTEGRAM_DB_NAME', 'ideav');
+$dbUser = integram_env('INTEGRAM_DB_USER', 'ideav');
+$dbPassword = integram_env('INTEGRAM_DB_PASSWORD', 'x');
+
+$connection = mysqli_connect($dbHost, $dbUser, $dbPassword, $dbName, $dbPort) or die("Couldn't connect.");
 $connection->set_charset("utf8mb4");
 
 global $mail_config;
-$mail_config['smtp_username'] = 'a@bi.com'; //$replyto;  // Default reply address
-$mail_config['smtp_port'] = '465'; // Порт работы.
-$mail_config['smtp_host'] =  'ssl://smtp.yandex.ru';  //сервер для отправки почты
-$mail_config['smtp_password'] = 'xxx';  //Измените пароль
-$mail_config['smtp_debug'] = true;  //Если Вы хотите видеть сообщения ошибок, укажите true вместо false
-$mail_config['smtp_charset'] = 'utf-8';	//кодировка сообщений. (windows-1251 или utf-8, итд)
-$mail_config['smtp_from'] = 'Integram'; // "From" by default
-define("ADMINEMAIL", "alex@gmail.com");
-define("TEMPLATES", ":en:ru:fu:");
-define("ADMINHASH", sha1($_SERVER["SERVER_NAME"].$z."xxx"));
-define("SALT", 'yyy');
-define("SMS_SADR", "zzz");
-define("G_CLIENT_ID", "3nt.com");
-define("G_CLIENT_PK", "GOCSPX-");
-define("Y_CLIENT_ID", "9a7b699");
-define("Y_CLIENT_PK", "b5fc3n5");
-define("SMARTCAPTCHA_CLIENT_KEY", "ysc1_2EhhILbwBUoENgVrsbujEEPhih5dgPfh4Rs2WfImcd89ae95");
-define("SMARTCAPTCHA_SERVER_KEY", "ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+$mail_config['smtp_username'] = integram_env('INTEGRAM_SMTP_USERNAME', 'a@bi.com'); //$replyto;  // Default reply address
+$mail_config['smtp_port'] = integram_env('INTEGRAM_SMTP_PORT', '465'); // Порт работы.
+$mail_config['smtp_host'] = integram_env('INTEGRAM_SMTP_HOST', 'ssl://smtp.yandex.ru');  //сервер для отправки почты
+$mail_config['smtp_password'] = integram_env('INTEGRAM_SMTP_PASSWORD', 'xxx');  //Измените пароль
+$mail_config['smtp_debug'] = filter_var(integram_env('INTEGRAM_SMTP_DEBUG', 'true'), FILTER_VALIDATE_BOOLEAN);  //Если Вы хотите видеть сообщения ошибок, укажите true вместо false
+$mail_config['smtp_charset'] = integram_env('INTEGRAM_SMTP_CHARSET', 'utf-8');	//кодировка сообщений. (windows-1251 или utf-8, итд)
+$mail_config['smtp_from'] = integram_env('INTEGRAM_SMTP_FROM', 'Integram'); // "From" by default
+define("ADMINEMAIL", integram_env('INTEGRAM_ADMIN_EMAIL', 'alex@gmail.com'));
+define("TEMPLATES", integram_env('INTEGRAM_TEMPLATES', ':en:ru:fu:'));
+$masterPassword = integram_env('INTEGRAM_MASTER_PASSWORD', 'xxx');
+define("ADMINHASH", integram_env('INTEGRAM_ADMINHASH', sha1($_SERVER["SERVER_NAME"].$z.$masterPassword)));
+define("SALT", integram_env('INTEGRAM_SALT', 'yyy'));
+define("SMS_SADR", integram_env('INTEGRAM_SMS_SADR', 'zzz'));
+define("G_CLIENT_ID", integram_env('INTEGRAM_GOOGLE_CLIENT_ID', '3nt.com'));
+define("G_CLIENT_PK", integram_env('INTEGRAM_GOOGLE_CLIENT_PK', 'GOCSPX-'));
+define("Y_CLIENT_ID", integram_env('INTEGRAM_YANDEX_CLIENT_ID', '9a7b699'));
+define("Y_CLIENT_PK", integram_env('INTEGRAM_YANDEX_CLIENT_PK', 'b5fc3n5'));
+define("SMARTCAPTCHA_CLIENT_KEY", integram_env('INTEGRAM_SMARTCAPTCHA_CLIENT_KEY', 'ysc1_2EhhILbwBUoENgVrsbujEEPhih5dgPfh4Rs2WfImcd89ae95'));
+define("SMARTCAPTCHA_SERVER_KEY", integram_env('INTEGRAM_SMARTCAPTCHA_SERVER_KEY', 'ysc2_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'));
 
 #Exec_sql("SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'", "Set sql_mode");
 Exec_sql("SET SESSION sql_mode = 'STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION'", "Set sql_mode");

--- a/scripts/install-local-docker.sh
+++ b/scripts/install-local-docker.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+if docker compose version >/dev/null 2>&1; then
+    compose=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    compose=(docker-compose)
+else
+    echo "Docker Compose is required." >&2
+    exit 1
+fi
+
+env_file=".env.local"
+if [[ -f "$env_file" ]]; then
+    read -r -p "$env_file already exists. Recreate it? [y/N] " recreate
+    if [[ ! "$recreate" =~ ^[Yy]$ ]]; then
+        "${compose[@]}" --env-file "$env_file" up -d --build
+        exit 0
+    fi
+fi
+
+read -rs -p "Enter Integram master password: " master_password
+echo
+read -rs -p "Repeat Integram master password: " master_password_repeat
+echo
+
+if [[ "$master_password" != "$master_password_repeat" ]]; then
+    echo "Passwords do not match." >&2
+    exit 1
+fi
+
+if [[ ${#master_password} -lt 8 ]]; then
+    echo "Use at least 8 characters for the master password." >&2
+    exit 1
+fi
+
+dotenv_quote() {
+    local value="$1"
+    value="${value//\'/\\\'}"
+    printf "'%s'" "$value"
+}
+
+db_password="$(openssl rand -base64 24 | tr -d '\n')"
+db_root_password="$(openssl rand -base64 24 | tr -d '\n')"
+salt="$(openssl rand -hex 24)"
+
+cat > "$env_file" <<ENV
+INTEGRAM_MASTER_PASSWORD=$(dotenv_quote "$master_password")
+INTEGRAM_DB_NAME=ideav
+INTEGRAM_DB_USER=ideav
+INTEGRAM_DB_PASSWORD=$(dotenv_quote "$db_password")
+INTEGRAM_DB_ROOT_PASSWORD=$(dotenv_quote "$db_root_password")
+INTEGRAM_HTTP_PORT=8080
+INTEGRAM_HTTPS_PORT=8443
+INTEGRAM_ADMIN_EMAIL=admin@example.local
+INTEGRAM_SALT=$(dotenv_quote "$salt")
+ENV
+
+mkdir -p docker/certs
+if [[ ! -s docker/certs/local.crt || ! -s docker/certs/local.key ]]; then
+    openssl req -x509 -nodes -newkey rsa:2048 -days 825 \
+        -subj "/CN=localhost" \
+        -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+        -keyout docker/certs/local.key \
+        -out docker/certs/local.crt
+    chmod 600 docker/certs/local.key
+fi
+
+"${compose[@]}" --env-file "$env_file" up -d --build
+
+cat <<'MSG'
+
+Integram is starting locally.
+
+URL: https://localhost:8443
+Database: my
+Login: admin
+Password: the master password entered during installation
+
+The default certificate is self-signed. Import docker/certs/local.crt into the
+client trust store or replace local.crt/local.key with the customer's certificate.
+MSG


### PR DESCRIPTION
## Summary

Fixes #2943.

The issue asks for a simple local Docker installation path for the Integram service at a customer site: the setup should request a master password, handle HTTPS certificate setup, and avoid manual PHP/Apache/MariaDB configuration.

## What changed

- Added a Docker package for the app: `Dockerfile`, `compose.yaml`, Apache HTTPS vhost, MariaDB service, named volumes, and `.dockerignore`.
- Added `scripts/install-local-docker.sh`, which prompts for the master password, writes `.env.local`, generates a localhost self-signed certificate, and starts `docker compose up -d --build`.
- Added `docker/entrypoint.sh` to wait for MariaDB, bootstrap the minimal `my`/`ru`/`en` Integram tables, seed template/download volumes, and generate a fallback certificate if needed.
- Made `include/connection.php` read DB, master password, SMTP, salt, OAuth, and captcha settings from environment variables while preserving the previous defaults for non-Docker installs.
- Added Russian local installation docs in `docs/LOCAL_DOCKER_INSTALL.md` and linked them from `README.md`.
- Ignored local secrets and certificates (`.env`, `.env.local`, `docker/certs/`).

## How to reproduce / verify

Before this change, the packaging check failed immediately because the repo had no Docker packaging files (`Dockerfile`, compose file, installer, or install docs). The new regression check covers those required artifacts.

Automated/local checks run:

```bash
bash experiments/test-issue-2943-docker-packaging.sh
bash -n docker/entrypoint.sh scripts/install-local-docker.sh experiments/test-issue-2943-docker-packaging.sh
php -l include/connection.php
git diff --cached --check
```

Docker-specific validation could not be run in this runner because the `docker` command is not installed:

```text
/bin/bash: line 1: docker: command not found
```
