### PR TITLE
fix(integram-table): доработки кнопки «Удалить по фильтру» (#2946)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T16:09:35.192Z for PR creation at branch issue-2946-c7cdc0689c9f for issue https://github.com/ideav/crm/issues/2946

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T16:09:35.192Z for PR creation at branch issue-2946-c7cdc0689c9f for issue https://github.com/ideav/crm/issues/2946

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -3509,6 +3509,26 @@ tr.row-selected {
     font-size: 0.75rem !important;
 }
 
+.filter-delete-confirm {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: 8px;
+    padding: 4px 8px;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    font-size: 0.8125rem;
+}
+
+.filter-delete-confirm-btn {
+    font-size: 0.75rem !important;
+}
+
+.filter-delete-cancel-btn {
+    font-size: 0.75rem !important;
+}
+
 /* Bulk delete progress */
 .bulk-delete-progress-bar-container {
     width: 100%;
@@ -4123,6 +4143,12 @@ tr.row-selected {
 
 /* Bulk delete warning confirmation */
 [data-theme="dark"] .bulk-delete-confirm {
+    background: rgba(245, 158, 11, 0.15);
+    border-color: rgba(245, 158, 11, 0.5);
+    color: var(--text-primary, #e9ecef);
+}
+
+[data-theme="dark"] .filter-delete-confirm {
     background: rgba(245, 158, 11, 0.15);
     border-color: rgba(245, 158, 11, 0.5);
     color: var(--text-primary, #e9ecef);

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1702,7 +1702,7 @@ class IntegramTable{
                             ${ this.isTableDeletable() && this.isTableWritable() ? `
                             <div class="integram-table-settings integram-table-settings-filter-delete" onclick="window.${ instanceName }.showFilterDeleteConfirm(event)" title="Удалить записи, удовлетворяющие заданному фильтру">
                                 <i class="pi pi-trash"></i>
-                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">удалить по фильтру</span>' : '' }
+                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">Удалить</span>' : '' }
                             </div>
                             ` : '' }
                             <div class="integram-table-settings" onclick="window.${ instanceName }.copyConfigUrl()" title="Скопировать ссылку с текущими фильтрами и группами">
@@ -17697,8 +17697,12 @@ class IntegramTable{
                 return;
             }
 
+            const recordWord = count % 100 >= 11 && count % 100 <= 14 ? 'записей'
+                : count % 10 === 1 ? 'запись'
+                : count % 10 >= 2 && count % 10 <= 4 ? 'записи'
+                : 'записей';
             popup.innerHTML = `
-                <span>Удалить ${ count } записей, удовлетворяющих фильтру?</span>
+                <span>Удалить ${ count } ${ recordWord }, удовлетворяющих фильтру?</span>
                 <button class="btn btn-sm btn-danger filter-delete-confirm-btn">Да, удалить</button>
                 <button class="btn btn-sm btn-outline-secondary filter-delete-cancel-btn">Отменить</button>
             `;

--- a/js/integram-table/04-render-table.js
+++ b/js/integram-table/04-render-table.js
@@ -85,7 +85,7 @@
                             ${ this.isTableDeletable() && this.isTableWritable() ? `
                             <div class="integram-table-settings integram-table-settings-filter-delete" onclick="window.${ instanceName }.showFilterDeleteConfirm(event)" title="Удалить записи, удовлетворяющие заданному фильтру">
                                 <i class="pi pi-trash"></i>
-                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">удалить по фильтру</span>' : '' }
+                                ${ !this.settings.hideMenuButtonLabels ? '<span class="btn-label">Удалить</span>' : '' }
                             </div>
                             ` : '' }
                             <div class="integram-table-settings" onclick="window.${ instanceName }.copyConfigUrl()" title="Скопировать ссылку с текущими фильтрами и группами">

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -274,8 +274,12 @@
                 return;
             }
 
+            const recordWord = count % 100 >= 11 && count % 100 <= 14 ? 'записей'
+                : count % 10 === 1 ? 'запись'
+                : count % 10 >= 2 && count % 10 <= 4 ? 'записи'
+                : 'записей';
             popup.innerHTML = `
-                <span>Удалить ${ count } записей, удовлетворяющих фильтру?</span>
+                <span>Удалить ${ count } ${ recordWord }, удовлетворяющих фильтру?</span>
                 <button class="btn btn-sm btn-danger filter-delete-confirm-btn">Да, удалить</button>
                 <button class="btn btn-sm btn-outline-secondary filter-delete-cancel-btn">Отменить</button>
             `;


### PR DESCRIPTION
## Fixes #2946

### Изменения

1. **Переименование кнопки**: «удалить по фильтру» → «Удалить» (`js/integram-table/04-render-table.js`)

2. **Склонение слова «записи»** в тексте подтверждения по правилам русского языка (`js/integram-table/23-bulk-export.js`):
   - 1 → «запись»
   - 2–4 → «записи»
   - 5+ (и 11–14) → «записей»
   
   Пример: «Удалить 3 записи, удовлетворяющих фильтру?»

3. **Жёлтый фон** для `.filter-delete-confirm` — стиль повторяет `.bulk-delete-confirm` (`css/integram-table.css`):
   - светлая тема: `background: #fff3cd; border: 1px solid #ffc107`
   - тёмная тема: `rgba(245, 158, 11, 0.15)`

### Файлы

- `js/integram-table/04-render-table.js` — изменён текст метки кнопки
- `js/integram-table/23-bulk-export.js` — добавлено склонение
- `css/integram-table.css` — добавлены стили `.filter-delete-confirm`
- `js/integram-table.js` — пересобран через `bash build.sh`