### PR TITLE
fix(app): query auth tokens lazily, only at the captcha decision (#2947)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T16:13:04.394Z for PR creation at branch issue-2947-e0ee0bc8ebfb for issue https://github.com/ideav/crm/issues/2947

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T16:13:04.394Z for PR creation at branch issue-2947-e0ee0bc8ebfb for issue https://github.com/ideav/crm/issues/2947

--- a/experiments/issue-2947-lazy-token.test.js
+++ b/experiments/issue-2947-lazy-token.test.js
@@ -1,0 +1,126 @@
+// Structural regression test for issue #2947:
+// hasValidAuthToken must be called lazily, only inside _ensureCaptchaBypass,
+// never eagerly in App.init().
+//
+// Tests verified against js/app.js source text:
+// 1. hasValidAuthToken() is called exactly once (excluding its own definition),
+//    and that call is inside _ensureCaptchaBypass.
+// 2. _ensureCaptchaBypass is async and memoizes via _captchaBypassChecked.
+// 3. _initCaptchaWidgets is async and awaits _ensureCaptchaBypass.
+// 4. The login submit handler awaits _ensureCaptchaBypass before the captcha gate.
+// 5. The register submit handler awaits _ensureCaptchaBypass before the captcha gate.
+// 6. init() does NOT call hasValidAuthToken directly.
+//
+// Run with: node experiments/issue-2947-lazy-token.test.js
+
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'js', 'app.js'), 'utf8');
+const lines = src.split('\n');
+
+let failures = 0;
+function assert(cond, name, detail) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (!cond) { failures++; if (detail) console.log('  ', detail); }
+}
+
+// Helper: find all 1-based line numbers where pattern matches.
+function findLines(pattern) {
+    return lines.reduce((acc, line, i) => {
+        if (pattern.test(line)) acc.push(i + 1);
+        return acc;
+    }, []);
+}
+
+// Helper: extract the source slice from the line where `defPattern` first
+// matches to the end of that block (tracking brace depth).
+function extractBlock(defPattern) {
+    const start = lines.findIndex(l => defPattern.test(l));
+    if (start === -1) return null;
+    let depth = 0;
+    const body = [];
+    for (let i = start; i < lines.length; i++) {
+        depth += (lines[i].match(/\{/g) || []).length;
+        depth -= (lines[i].match(/\}/g) || []).length;
+        body.push(lines[i]);
+        if (depth === 0 && i > start) break;
+    }
+    return body.join('\n');
+}
+
+// 1. hasValidAuthToken calls (not counting the function definition line itself):
+//    must appear exactly once, inside _ensureCaptchaBypass.
+{
+    // Lines that call hasValidAuthToken (exclude the "async function hasValidAuthToken" definition line).
+    const callLines = findLines(/hasValidAuthToken\s*\(/)
+        .filter(ln => !/^\s*(async\s+)?function\s+hasValidAuthToken\s*\(/.test(lines[ln - 1]));
+
+    assert(callLines.length === 1,
+        'hasValidAuthToken() called exactly once (excluding its own definition)',
+        'found at lines: ' + callLines.join(', '));
+
+    const ensureBody = extractBlock(/async\s+_ensureCaptchaBypass\s*\(/);
+    const inEnsure = ensureBody && /hasValidAuthToken\s*\(/.test(ensureBody);
+    assert(!!inEnsure,
+        'hasValidAuthToken() is called inside _ensureCaptchaBypass');
+}
+
+// 2. _ensureCaptchaBypass: async, memoizes via _captchaBypassChecked.
+{
+    const defLines = findLines(/async\s+_ensureCaptchaBypass\s*\(/);
+    assert(defLines.length === 1,
+        '_ensureCaptchaBypass is defined as async',
+        'found at lines: ' + defLines.join(', '));
+
+    const body = extractBlock(/async\s+_ensureCaptchaBypass\s*\(/);
+    assert(body && /this\._captchaBypassChecked/.test(body),
+        '_ensureCaptchaBypass reads/writes _captchaBypassChecked for memoization');
+}
+
+// 3. _initCaptchaWidgets: async, awaits _ensureCaptchaBypass.
+{
+    const defLines = findLines(/async\s+_initCaptchaWidgets\s*\(/);
+    assert(defLines.length === 1,
+        '_initCaptchaWidgets is defined as async',
+        'found at lines: ' + defLines.join(', '));
+
+    const body = extractBlock(/async\s+_initCaptchaWidgets\s*\(/);
+    assert(body && /await\s+this\._ensureCaptchaBypass\s*\(/.test(body),
+        '_initCaptchaWidgets awaits _ensureCaptchaBypass');
+}
+
+// 4. Login submit handler awaits _ensureCaptchaBypass before the captcha gate.
+//    Locate getCaptchaToken('login-captcha-container') then check the next few lines.
+{
+    const captchaGetIdx = lines.findIndex(l => /getCaptchaToken\('login-captcha-container'\)/.test(l));
+    assert(captchaGetIdx !== -1, 'login submit: getCaptchaToken call found');
+
+    if (captchaGetIdx !== -1) {
+        const snippet = lines.slice(captchaGetIdx, captchaGetIdx + 5).join('\n');
+        assert(/await\s+this\._ensureCaptchaBypass\s*\(/.test(snippet),
+            'login submit: await _ensureCaptchaBypass appears right after getCaptchaToken');
+    }
+}
+
+// 5. Register submit handler awaits _ensureCaptchaBypass before the captcha gate.
+{
+    const captchaGetIdx = lines.findIndex(l => /getCaptchaToken\('register-captcha-container'\)/.test(l));
+    assert(captchaGetIdx !== -1, 'register submit: getCaptchaToken call found');
+
+    if (captchaGetIdx !== -1) {
+        const snippet = lines.slice(captchaGetIdx, captchaGetIdx + 5).join('\n');
+        assert(/await\s+this\._ensureCaptchaBypass\s*\(/.test(snippet),
+            'register submit: await _ensureCaptchaBypass appears right after getCaptchaToken');
+    }
+}
+
+// 6. init() does NOT call hasValidAuthToken directly.
+{
+    const initBody = extractBlock(/^\s*async\s+init\s*\(/);
+    assert(initBody && !/hasValidAuthToken\s*\(/.test(initBody),
+        'init() does not call hasValidAuthToken directly');
+}
+
+console.log('\n' + (failures === 0 ? 'ALL TESTS PASSED' : failures + ' TEST(S) FAILED'));
+process.exit(failures === 0 ? 0 : 1);

--- a/js/app.js
+++ b/js/app.js
@@ -515,7 +515,10 @@ class App {
         this.yandexAuth = new YandexAuthManager(this.apiConfig);
         // Issue #2906: set to true when a valid auth token is found, so the captcha
         // is hidden and its client-side check is skipped for returning users.
+        // Issue #2947: the token check is performed lazily (see _ensureCaptchaBypass),
+        // so this flag stays false until the captcha decision is actually reached.
         this._captchaBypass = false;
+        this._captchaBypassChecked = false;
         window._app = this;
     }
 
@@ -638,6 +641,8 @@ class App {
                     }
                 }
                 const captchaToken = getCaptchaToken('login-captcha-container');
+                // Issue #2947: resolve the captcha bypass lazily, right before the check.
+                await this._ensureCaptchaBypass();
                 if (!this._captchaBypass && captchaToken === null) {
                     showToast('Пожалуйста, пройдите проверку капчи', 'error');
                     loginInProgress = false;
@@ -943,6 +948,8 @@ class App {
                 }
 
                 const captchaToken = getCaptchaToken('register-captcha-container');
+                // Issue #2947: resolve the captcha bypass lazily, right before the check.
+                await this._ensureCaptchaBypass();
                 if (!this._captchaBypass && captchaToken === null) {
                     showToast('Пожалуйста, пройдите проверку капчи', 'error');
                     return;
@@ -980,11 +987,11 @@ class App {
         // Check auth state from cookies
         this.auth.init();
 
-        // Issue #2906: validate existing token cookies. If any is valid, the visitor
-        // is a returning, authenticated user — hide the captcha and skip its check.
-        // Done before any auth panel is shown below so the captcha never flashes.
-        this._captchaBypass = await hasValidAuthToken(this.apiConfig.host);
-        if (this._captchaBypass) this._hideCaptchaWidgets();
+        // Issue #2906/#2947: the validity of existing token cookies decides whether
+        // the captcha can be bypassed. This check is no longer performed eagerly here:
+        // querying tokens on every init wastes requests for users who are already
+        // authorized in a workspace and will never see the captcha. It now runs
+        // lazily, right before the captcha decision, via _ensureCaptchaBypass().
 
         // Handle redirect reasons from the backend: show login form and a visible message
         const urlParams = new URLSearchParams(window.location.search);
@@ -1095,8 +1102,22 @@ class App {
         this._initCaptchaWidgets();
     }
 
-    _initCaptchaWidgets() {
-        // Issue #2906: skip rendering the captcha entirely for returning users with a valid token.
+    // Issue #2947: query the token cookies lazily — only right before the captcha
+    // decision (when the auth panel/captcha is about to be shown for a non-logged-in
+    // user), never eagerly on every init. The result is memoized so repeated
+    // decisions (render, login submit, register submit) reuse the same check.
+    async _ensureCaptchaBypass() {
+        if (this._captchaBypassChecked) return this._captchaBypass;
+        this._captchaBypassChecked = true;
+        this._captchaBypass = await hasValidAuthToken(this.apiConfig.host);
+        if (this._captchaBypass) this._hideCaptchaWidgets();
+        return this._captchaBypass;
+    }
+
+    async _initCaptchaWidgets() {
+        // Issue #2906/#2947: query tokens here, right before deciding whether to
+        // render the captcha, and skip rendering entirely for returning users.
+        await this._ensureCaptchaBypass();
         if (this._captchaBypass) return;
         if (!window.smartCaptcha) return;
         ['login-captcha-container', 'register-captcha-container'].forEach(id => {


### PR DESCRIPTION
## Issue

Fixes #2947 — "Токены надо опрашивать только перед решением о выводе капчи на start.html и index.html."

A user authorized in a workspace already holds a valid token for that base, so there is no reason to re-query tokens. Token cookies should only be checked right before the decision to show the captcha.

## Root cause

`App.init()` in `js/app.js` ran the token check **eagerly on every page load**:

```js
this._captchaBypass = await hasValidAuthToken(this.apiConfig.host);
```

`hasValidAuthToken()` iterates the `idb_*` cookies and issues a `GET …/xsrf` request per base. This happened on every `init()`, even for users who are already authorized and will never be shown the captcha — exactly the wasteful behaviour the issue describes. (PR #2931 short-circuited the *loop*; this PR makes the *call* itself lazy, the documented follow-up.)

## Fix

The token check is now performed **lazily and memoized** in a new helper, invoked only right before the captcha decision:

- `App._ensureCaptchaBypass()` — runs `hasValidAuthToken()` at most once, caches the result in `_captchaBypassChecked` / `_captchaBypass`, and hides the captcha widgets when bypassing.
- The eager call was removed from `init()`.
- It is awaited only at the three captcha-decision points:
  - `_initCaptchaWidgets()` (now `async`) — before rendering / skipping the captcha (preserves the no-flash behaviour for returning users).
  - the login form submit handler — before the captcha gate.
  - the register form submit handler — before the captcha gate.

Result: a user already authorized in a workspace triggers **no** token requests on load; tokens are queried only when the captcha could actually be shown for a non-logged-in user.

## Test

`experiments/issue-2947-lazy-token.test.js` asserts the invariant against `js/app.js`:
- exactly one `hasValidAuthToken(this.apiConfig.host)` call, located inside `_ensureCaptchaBypass` (not in `init()`);
- `_ensureCaptchaBypass` is async and memoized via `_captchaBypassChecked`;
- `_initCaptchaWidgets` and both submit handlers await it before the bypass is read.

Run: `node experiments/issue-2947-lazy-token.test.js`
