### PR TITLE
fix(#3000): bootstrap-скрипты шлют токен заголовком X-Authorization

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-31T12:39:43.122Z for PR creation at branch issue-3000-12a9c2a54e61 for issue https://github.com/ideav/crm/issues/3000

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-31T12:39:43.122Z for PR creation at branch issue-3000-12a9c2a54e61 for issue https://github.com/ideav/crm/issues/3000

--- a/docs/create_atex_menu.ps1
+++ b/docs/create_atex_menu.ps1
@@ -86,9 +86,17 @@ function Invoke-ApiRequest {
     foreach ($key in $FormData.Keys) {
         $body[$key] = $FormData[$key]
     }
+    $headers = @{}
     if (-not $Anonymous) {
         if ($script:XsrfToken) { $body["_xsrf"] = $script:XsrfToken }
-        if ($script:AuthToken) { $body["token"] = $script:AuthToken }
+        if ($script:AuthToken) {
+            $body["token"] = $script:AuthToken
+            # issue #3000: токен доходит до сервера только заголовком X-Authorization.
+            # Живой Integram игнорирует cookie, заданный вручную через -Headers, и
+            # строку запроса ?token= (см. atex#44), поэтому без этого заголовка
+            # сервер отвечает 401 "No authorization token provided".
+            $headers["X-Authorization"] = $script:AuthToken
+        }
     }
 
     if ($body.Count -gt 0) {
@@ -108,9 +116,9 @@ function Invoke-ApiRequest {
 
     try {
         if ($Method -eq "POST") {
-            return Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded"
+            return Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded" -Headers $headers
         }
-        return Invoke-RestMethod -Uri $url -Method Get -Body $body
+        return Invoke-RestMethod -Uri $url -Method Get -Body $body -Headers $headers
     } catch {
         $bodyText = Get-HttpErrorBody -ErrorRecord $_
         Write-Log "  ERROR: $($_.Exception.Message)"
@@ -149,9 +157,11 @@ function Get-XsrfByToken {
         $url = "$url&JSON=1"
     }
 
-    Write-Log "  GET xsrf  [cookie idb_$DbName=***]"
+    Write-Log "  GET xsrf  [X-Authorization ***; cookie idb_$DbName=***]"
     try {
-        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ Cookie = "idb_$DbName=$TokenValue" }
+        # issue #3000: токен в заголовке X-Authorization — транспорт, который
+        # сервер реально читает; cookie дублируем для совместимости.
+        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ "X-Authorization" = $TokenValue; Cookie = "idb_$DbName=$TokenValue" }
     } catch {
         $bodyText = Get-HttpErrorBody -ErrorRecord $_
         Write-Log "  ERROR: $($_.Exception.Message)"

--- a/docs/create_db_from_scratch.ps1
+++ b/docs/create_db_from_scratch.ps1
@@ -101,9 +101,17 @@ function Invoke-ApiRequest {
     foreach ($key in $FormData.Keys) {
         $body[$key] = $FormData[$key]
     }
+    $headers = @{}
     if (-not $Anonymous) {
         if ($script:XsrfToken) { $body["_xsrf"] = $script:XsrfToken }
-        if ($script:AuthToken) { $body["token"] = $script:AuthToken }
+        if ($script:AuthToken) {
+            $body["token"] = $script:AuthToken
+            # issue #3000: токен доходит до сервера только заголовком X-Authorization.
+            # Живой Integram игнорирует cookie, заданный вручную через -Headers, и
+            # строку запроса ?token= (см. atex#44), поэтому без этого заголовка
+            # сервер отвечает 401 "No authorization token provided".
+            $headers["X-Authorization"] = $script:AuthToken
+        }
     }
 
     if ($body.Count -gt 0) {
@@ -120,9 +128,9 @@ function Invoke-ApiRequest {
 
     try {
         if ($Method -eq "POST") {
-            $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded"
+            $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded" -Headers $headers
         } else {
-            $response = Invoke-RestMethod -Uri $url -Method Get -Body $body
+            $response = Invoke-RestMethod -Uri $url -Method Get -Body $body -Headers $headers
         }
         return $response
     } catch {
@@ -166,9 +174,11 @@ function Get-XsrfByToken {
         $url = "$url&JSON=1"
     }
 
-    Write-Log "  GET xsrf  [cookie idb_$DbName=***]"
+    Write-Log "  GET xsrf  [X-Authorization ***; cookie idb_$DbName=***]"
     try {
-        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ Cookie = "idb_$DbName=$TokenValue" }
+        # issue #3000: токен в заголовке X-Authorization — транспорт, который
+        # сервер реально читает; cookie дублируем для совместимости.
+        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ "X-Authorization" = $TokenValue; Cookie = "idb_$DbName=$TokenValue" }
     } catch {
         $bodyText = Get-HttpErrorBody -ErrorRecord $_
         Write-Log "  ERROR: $($_.Exception.Message)"

--- a/docs/create_perelidoz.ps1
+++ b/docs/create_perelidoz.ps1
@@ -42,11 +42,17 @@ function Invoke-ApiRequest {
         $body[$key] = $FormData[$key]
     }
 
+    $headers = @{}
     if ($XsrfToken) {
         $body["_xsrf"] = $XsrfToken
     }
     if ($AuthToken) {
         $body["token"] = $AuthToken
+        # issue #3000: токен доходит до сервера только заголовком X-Authorization.
+        # Живой Integram игнорирует cookie, заданный вручную через -Headers, и
+        # строку запроса ?token= (см. atex#44), поэтому без этого заголовка
+        # сервер отвечает 401 "No authorization token provided".
+        $headers["X-Authorization"] = $AuthToken
     }
 
     Write-Log "Request: $Method $url"
@@ -59,9 +65,9 @@ function Invoke-ApiRequest {
 
     try {
         if ($Method -eq "POST") {
-            $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded"
+            $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded" -Headers $headers
         } else {
-            $response = Invoke-RestMethod -Uri $url -Method Get -Body $body
+            $response = Invoke-RestMethod -Uri $url -Method Get -Body $body -Headers $headers
         }
         Write-Log "Response: $($response | ConvertTo-Json -Compress -Depth 20)"
         return $response
@@ -88,9 +94,11 @@ function Get-XsrfByToken {
     }
 
     Write-Log "Request: GET $url"
-    Write-Log "Cookie: idb_$DbName=***"
+    Write-Log "Headers: X-Authorization=***; Cookie: idb_$DbName=***"
     try {
-        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ Cookie = "idb_$DbName=$TokenValue" }
+        # issue #3000: токен в заголовке X-Authorization — транспорт, который
+        # сервер реально читает; cookie дублируем для совместимости.
+        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ "X-Authorization" = $TokenValue; Cookie = "idb_$DbName=$TokenValue" }
     } catch {
         Write-Log "ERROR: $($_.Exception.Message)"
         if ($_.Exception.Response) {

--- a/docs/create_roles_users.ps1
+++ b/docs/create_roles_users.ps1
@@ -99,9 +99,17 @@ function Invoke-ApiRequest {
     foreach ($key in $FormData.Keys) {
         $body[$key] = $FormData[$key]
     }
+    $headers = @{}
     if (-not $Anonymous) {
         if ($script:XsrfToken) { $body["_xsrf"] = $script:XsrfToken }
-        if ($script:AuthToken) { $body["token"] = $script:AuthToken }
+        if ($script:AuthToken) {
+            $body["token"] = $script:AuthToken
+            # issue #3000: токен доходит до сервера только заголовком X-Authorization.
+            # Живой Integram игнорирует cookie, заданный вручную через -Headers, и
+            # строку запроса ?token= (см. atex#44), поэтому без этого заголовка
+            # сервер отвечает 401 "No authorization token provided".
+            $headers["X-Authorization"] = $script:AuthToken
+        }
     }
 
     if ($body.Count -gt 0) {
@@ -121,9 +129,9 @@ function Invoke-ApiRequest {
 
     try {
         if ($Method -eq "POST") {
-            $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded"
+            $response = Invoke-RestMethod -Uri $url -Method Post -Body $body -ContentType "application/x-www-form-urlencoded" -Headers $headers
         } else {
-            $response = Invoke-RestMethod -Uri $url -Method Get -Body $body
+            $response = Invoke-RestMethod -Uri $url -Method Get -Body $body -Headers $headers
         }
         return $response
     } catch {
@@ -167,9 +175,11 @@ function Get-XsrfByToken {
         $url = "$url&JSON=1"
     }
 
-    Write-Log "  GET xsrf  [cookie idb_$DbName=***]"
+    Write-Log "  GET xsrf  [X-Authorization ***; cookie idb_$DbName=***]"
     try {
-        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ Cookie = "idb_$DbName=$TokenValue" }
+        # issue #3000: токен в заголовке X-Authorization — транспорт, который
+        # сервер реально читает; cookie дублируем для совместимости.
+        return Invoke-RestMethod -Uri $url -Method Get -Headers @{ "X-Authorization" = $TokenValue; Cookie = "idb_$DbName=$TokenValue" }
     } catch {
         $bodyText = Get-HttpErrorBody -ErrorRecord $_
         Write-Log "  ERROR: $($_.Exception.Message)"

--- a/docs/integram-app-workflow.md
+++ b/docs/integram-app-workflow.md
@@ -51,23 +51,32 @@
 **Как агент использует токен** (без `/auth`, без капчи). Токен распознаётся механизмом валидации сессии в любом из видов:
 
 ```bash
-# 1. Через cookie idb_{db} (предпочтительно для GET-чтений)
+# 1. Через HTTP-заголовок X-Authorization (рекомендуется — это транспорт
+#    браузерного SPA, и его сервер читает на любом запросе)
+curl -s -H "X-Authorization: <token>" "https://ideav.ru/{db}/metadata?JSON=1"
+
+# 2. Через cookie idb_{db} (тоже читается сервером для GET-чтений)
 curl -s -b "idb_{db}=<token>" "https://ideav.ru/{db}/metadata?JSON=1"
 
-# 2. Через form-поле token= (для POST _m_*/_d_*)
+# 3. Через form-поле token= (для POST _m_*/_d_*)
 curl -s -X POST "https://ideav.ru/{db}/_m_new/18?JSON=1" \
   -F "token=<token>" -F "_xsrf=<xsrf>" -F "up=1" -F "t18=manager"
-
-# 3. Через HTTP-заголовок Authorization: Bearer (или X-Authorization)
-curl -s -H "Authorization: Bearer <token>" "https://ideav.ru/{db}/metadata?JSON=1"
 ```
+
+> ⚠️ Сервер читает токен **только** из заголовка `X-Authorization`, cookie
+> `idb_{db}` или form-поля `token=`. Заголовок `Authorization: Bearer <token>`
+> и строка запроса `?token=<token>` сервером **игнорируются** — на такой запрос
+> приходит `401 [{"error":"No authorization token provided"}]` (issue #3000,
+> подтверждено зондированием живого сервера в atex#44). PowerShell-скрипты в
+> `docs/` посылают токен заголовком `X-Authorization`, потому что вручную
+> заданный через `-Headers` cookie `Invoke-RestMethod` отбрасывает.
 
 **Получение `_xsrf` под токеном.** Для POST-команд изменения данных
 (`_m_*`/`_d_*`) нужен `_xsrf`. Имея только токен, его забирают одним вызовом —
 `/auth` (и значит капча) для этого не требуется:
 
 ```bash
-curl -s -b "idb_{db}=<token>" "https://ideav.ru/{db}/xsrf?JSON"
+curl -s -H "X-Authorization: <token>" "https://ideav.ru/{db}/xsrf?JSON"
 # Ответ: {"_xsrf":"<hex>","token":"<token>","user":"claude","role":"...","id":"<userId>","msg":""}
 ```
 
@@ -449,7 +458,7 @@ api_call() {
 1. **Получение `_xsrf` под уже выданным токеном:**
    ```bash
    GET /{db}/xsrf?JSON=1
-   Cookie: idb_{db}=<token>
+   X-Authorization: <token>
    Returns: { token, _xsrf, id, user, role }
    ```
    Агент не вызывает `POST /{db}/auth`: этот путь требует пароль и может упереться
@@ -627,7 +636,8 @@ api_call "_m_new/${positionTableId}?full=1" "up=${orderRecordId}&t${positionTabl
 ### 3.5 Чтение существующих записей и метаданных
 
 После создания структуры (и в любой момент позже) данные читаются GET-запросами;
-авторизация — через cookie `idb_{db}` (см. Этап инициации) или через `?token=...`.
+авторизация — через заголовок `X-Authorization: <token>` или cookie `idb_{db}`
+(см. Этап инициации). Строку запроса `?token=...` сервер игнорирует (issue #3000).
 
 **Метаданные базы — список всех таблиц и их колонок:**
 ```bash

--- a/experiments/test-issue-3000-xauth-bootstrap.py
+++ b/experiments/test-issue-3000-xauth-bootstrap.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Regression check for issue #3000: bootstrap scripts must carry the token in
+the X-Authorization header.
+
+PR #2999 switched the PowerShell bootstrap scripts to token auth but delivered
+the token only through a manually-set Cookie header on `Invoke-RestMethod`.
+PowerShell drops that header, so the live Integram server answered
+`401 [{"error":"No authorization token provided"}]` (see the issue log and the
+live-server transport probe in atex#44).
+
+The server only reads the token from the `X-Authorization` header, the
+`idb_<db>` cookie, or the POST body `token=` field — never from an
+`Authorization: Bearer` header or a `?token=` query string. The scripts must
+therefore send the token in the `X-Authorization` header on every request.
+
+Run with:
+  python3 experiments/test-issue-3000-xauth-bootstrap.py
+"""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+POWERSHELL_SCRIPTS = [
+    ROOT / "docs" / "create_db_from_scratch.ps1",
+    ROOT / "docs" / "create_roles_users.ps1",
+    ROOT / "docs" / "create_atex_menu.ps1",
+    ROOT / "docs" / "create_perelidoz.ps1",
+]
+
+WORKFLOW_DOC = ROOT / "docs" / "integram-app-workflow.md"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}")
+    sys.exit(1)
+
+
+for path in POWERSHELL_SCRIPTS:
+    rel = path.relative_to(ROOT)
+    text = read(path)
+
+    # The xsrf bootstrap GET must send the token via X-Authorization.
+    if not re.search(r'"X-Authorization"\s*=\s*\$TokenValue', text):
+        fail(f"{rel} does not send the token via X-Authorization on the /xsrf GET")
+
+    # Authenticated API calls must also attach the X-Authorization header.
+    if not re.search(r'"X-Authorization"\]?\s*=\s*\$(script:)?AuthToken', text):
+        fail(f"{rel} does not attach X-Authorization to authenticated API requests")
+
+    # Every Invoke-RestMethod that performs a real request must forward -Headers
+    # so the X-Authorization header is actually sent.
+    for line in text.splitlines():
+        if "Invoke-RestMethod" not in line:
+            continue
+        if "function Invoke-RestMethod" in line or "param(" in line:
+            continue
+        if "-Uri" not in line:
+            continue
+        if "-Headers" not in line:
+            fail(f"{rel} has an Invoke-RestMethod without -Headers: {line.strip()}")
+
+
+workflow = read(WORKFLOW_DOC)
+
+# The doc must steer agents to the working transport and warn off the ignored
+# ones. A bare "Authorization: Bearer" recommendation (without being marked as
+# ignored) would re-introduce the bug for future readers.
+if "X-Authorization" not in workflow:
+    fail("docs/integram-app-workflow.md no longer documents the X-Authorization transport")
+
+wf_lines = workflow.splitlines()
+for i, ln in enumerate(wf_lines):
+    if "Authorization: Bearer" not in ln:
+        continue
+    # A mention is acceptable only if it is flagged as ignored within the same
+    # warning block (this or an adjacent line).
+    context = " ".join(wf_lines[max(0, i - 2): i + 3]).lower()
+    if "игнор" not in context:
+        fail(
+            "docs/integram-app-workflow.md still recommends Authorization: Bearer "
+            f"without marking it as ignored: {ln.strip()}"
+        )
+
+print("PASS: bootstrap scripts send the token via X-Authorization; docs warn off ignored transports")

--- a/experiments/test-issue-3000-xauth-smoke.ps1
+++ b/experiments/test-issue-3000-xauth-smoke.ps1
@@ -1,0 +1,71 @@
+# Offline smoke-test for issue #3000: the bootstrap scripts must send the token
+# via the X-Authorization header (the transport the live Integram server reads).
+#
+# It mocks Invoke-RestMethod, dot-sources each bootstrap script in -DryRun-free
+# mode against the mock, and asserts that BOTH the /xsrf bootstrap GET and the
+# subsequent authenticated write/read requests carry X-Authorization=<token>.
+#
+# Run: pwsh -NoProfile -File experiments/test-issue-3000-xauth-smoke.ps1
+$ErrorActionPreference = "Stop"
+$script:failed = $false
+function Assert($label, $cond) {
+    if ($cond) { Write-Host "  PASS $label" }
+    else { Write-Host "  FAIL $label"; $script:failed = $true }
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+$cases = @(
+    @{ Script = "create_atex_menu.ps1";       Token = "tok-menu";  Db = "atex" },
+    @{ Script = "create_roles_users.ps1";      Token = "tok-roles"; Db = "atex" },
+    @{ Script = "create_db_from_scratch.ps1";  Token = "tok-db";    Db = "atex" },
+    @{ Script = "create_perelidoz.ps1";        Token = "tok-pere";  Db = "perelidoz" }
+)
+
+foreach ($case in $cases) {
+    $scriptPath = Join-Path $repoRoot (Join-Path "docs" $case.Script)
+    Write-Host "=== $($case.Script) ==="
+    $script:Calls = New-Object System.Collections.ArrayList
+
+    # Mock Invoke-RestMethod: record every call's URI/headers and return shapes
+    # the bootstrap flow expects so it runs through xsrf + a few write/read calls.
+    function Invoke-RestMethod {
+        param(
+            [string]$Uri, [string]$Method, [object]$Body, [string]$ContentType,
+            [hashtable]$Headers, [object]$WebSession, [switch]$SkipCertificateCheck
+        )
+        [void]$script:Calls.Add([pscustomobject]@{ Uri = $Uri; Method = $Method; Headers = $Headers })
+        if ($Uri -match '/xsrf') {
+            return [pscustomobject]@{ token = 'srv-token'; _xsrf = 'XSRF'; id = '7'; user = 'claude' }
+        }
+        if ($Uri -match '/object/') {
+            return [pscustomobject]@{ object = @(); reqs = [pscustomobject]@{} }
+        }
+        if ($Uri -match '/edit_types') {
+            return [pscustomobject]@{ id = @(); val = @() }
+        }
+        return [pscustomobject]@{ obj = '1000'; id = '1000' }
+    }
+
+    # Run only the auth bootstrap by invoking it in a child scope where the rest
+    # of the script body is harmless: pass a token and a tiny data file isn't
+    # required because we stop right after Initialize-TokenSession via a probe.
+    & {
+        param($path, $tok, $db)
+        $env:INTEGRAM_TOKEN = $tok
+        # Dot-source definitions, then call the auth bootstrap explicitly. The
+        # scripts also auto-run at the bottom; we tolerate that against the mock.
+        try { . $path -Token $tok -DbName $db *> $null } catch { }
+    } $scriptPath $case.Token $case.Db
+
+    $xsrfCalls = @($script:Calls | Where-Object { $_.Uri -match '/xsrf' })
+    Assert "xsrf bootstrap called" ($xsrfCalls.Count -ge 1)
+    if ($xsrfCalls.Count -ge 1) {
+        Assert "xsrf carries X-Authorization=token" ($xsrfCalls[0].Headers['X-Authorization'] -eq $case.Token)
+    }
+    $authedWrites = @($script:Calls | Where-Object { $_.Uri -notmatch '/xsrf' -and $_.Headers -and $_.Headers['X-Authorization'] })
+    Assert "authenticated requests carry X-Authorization" ($authedWrites.Count -ge 1)
+    $env:INTEGRAM_TOKEN = $null
+}
+
+if ($script:failed) { Write-Host 'SMOKE FAILED'; exit 1 } else { Write-Host 'ALL SMOKE CHECKS PASSED' }


### PR DESCRIPTION
## Что и почему

Fixes #3000

PR #2999 перевёл bootstrap-скрипты (`docs/*.ps1`) на токенную авторизацию, но
токен доставлялся серверу **только cookie `idb_<db>`**, заданным вручную через
`Invoke-RestMethod -Headers @{ Cookie = ... }`. PowerShell управляет cookie
через собственный контейнер и **отбрасывает** вручную выставленный заголовок
`Cookie`, поэтому токен до сервера не доходил и живой Integram отвечал:

```
GET xsrf  [cookie idb_atex=***]
ERROR: (401) Несанкционированный.
Response Body: [{"error":"No authorization token provided"}]
```

## Корень проблемы

Зондирование живого сервера в **[atex#44](https://github.com/ideav/atex/pull/44)**
показало, какие транспорты сервер реально читает:

| Транспорт | Читается сервером |
|---|---|
| заголовок `X-Authorization` | ✅ да (его использует браузерный SPA) |
| cookie `idb_<db>` | ✅ да |
| form-поле `token=` в теле POST | ✅ да |
| строка запроса `?token=` | ❌ нет |
| заголовок `Authorization: Bearer` | ❌ нет |

Скрипты не слали `X-Authorization` вовсе, а единственный их транспорт (cookie
через `-Headers`) PowerShell не передаёт — отсюда 401.

## Решение

- Все четыре `docs/*.ps1` (`create_atex_menu`, `create_roles_users`,
  `create_db_from_scratch`, `create_perelidoz`) шлют токен заголовком
  **`X-Authorization`** на каждом запросе — и на `GET /<db>/xsrf`, и на
  `_m_*/_d_*/object`. Cookie `idb_<db>` и form-поле `token=` оставлены для
  совместимости.
- `docs/integram-app-workflow.md`: `X-Authorization` помечен как рекомендуемый
  транспорт; добавлено явное предупреждение, что `Authorization: Bearer` и
  `?token=` сервер **игнорирует** (исправление документации «на будущее»,
  о чём просил issue).

## Тесты

- `experiments/test-issue-3000-xauth-bootstrap.py` — статическая
  regression-проверка: каждый скрипт шлёт `X-Authorization`, каждый реальный
  `Invoke-RestMethod` передаёт `-Headers`, документация не рекомендует
  игнорируемые транспорты.
- `experiments/test-issue-3000-xauth-smoke.ps1` — offline smoke: мок
  `Invoke-RestMethod`, реальный прогон каждого скрипта, проверка, что
  `X-Authorization=<token>` уходит и на bootstrap `/xsrf`, и на
  аутентифицированных запросах.

## Как проверено локально

```
$ python3 experiments/test-issue-3000-xauth-bootstrap.py
PASS: bootstrap scripts send the token via X-Authorization; docs warn off ignored transports
$ python3 experiments/test-issue-2998-token-bootstrap.py
PASS: bootstrap scripts and docs use token + /xsrf, not login/password auth
$ pwsh -NoProfile -File experiments/test-issue-3000-xauth-smoke.ps1
ALL SMOKE CHECKS PASSED          # 4 скрипта × 3 проверки
# ParseFile по всем docs/*.ps1 → PARSE OK
$ git diff --check               # чисто
```

PowerShell 7.4.6 установлен локально, поэтому в этот раз скрипты реально
исполнены против мок-сервера (а не только статически проверены).
