### PR TITLE
fix(#3033): корректная переадресация после смены БД

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-31T19:55:44.571Z for PR creation at branch issue-3033-a3ce0471f805 for issue https://github.com/ideav/crm/issues/3033

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-31T19:55:44.571Z for PR creation at branch issue-3033-a3ce0471f805 for issue https://github.com/ideav/crm/issues/3033

--- a/experiments/test-issue-3033-post-login-uri.js
+++ b/experiments/test-issue-3033-post-login-uri.js
@@ -1,0 +1,196 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error('FAIL: ' + message);
+    }
+    console.log('PASS:', message);
+}
+
+class FakeElement {
+    constructor(id) {
+        this.id = id;
+        this.value = '';
+        this.textContent = '';
+        this.className = '';
+        this.dataset = {};
+        this.style = {};
+        this.children = [];
+        this.options = [];
+        this.listeners = {};
+        this.required = false;
+        this.classList = {
+            add() {},
+            remove() {}
+        };
+    }
+
+    set innerHTML(value) {
+        this._innerHTML = value;
+        this.children = [];
+        this.options = [];
+    }
+
+    get innerHTML() {
+        return this._innerHTML || '';
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        if (child.tagName === 'OPTION') {
+            this.options.push(child);
+            if (this.value === '') {
+                this.value = child.value;
+            }
+        }
+        return child;
+    }
+
+    addEventListener(type, listener) {
+        if (!this.listeners[type]) this.listeners[type] = [];
+        this.listeners[type].push(listener);
+    }
+
+    async dispatch(type, event = {}) {
+        const listeners = this.listeners[type] || [];
+        for (const listener of listeners) {
+            await listener(event);
+        }
+    }
+
+    focus() {}
+
+    setAttribute(name, value) {
+        this[name] = value === '' ? true : value;
+    }
+
+    removeAttribute(name) {
+        delete this[name];
+    }
+
+    querySelector() {
+        return null;
+    }
+
+    querySelectorAll() {
+        return [];
+    }
+}
+
+function createFakeDocument() {
+    const elements = new Map();
+    const requiredIds = [
+        'login-form',
+        'login-email',
+        'login-password',
+        'auth-db-select',
+        'auth-db-custom',
+        'auth-db-custom-group',
+        'auth-db-back',
+        'login-captcha-container',
+        'auth-panel',
+        'welcome-section',
+        'login-section',
+        'register-section',
+        'tab-login',
+        'tab-register',
+        'auth-message',
+        'login-btn',
+        'db-btn-wrapper',
+        'db-btn',
+        'db-dropdown-toggle',
+        'db-dropdown'
+    ];
+
+    for (const id of requiredIds) {
+        elements.set(id, new FakeElement(id));
+    }
+
+    return {
+        cookie: '',
+        documentElement: new FakeElement('documentElement'),
+        body: new FakeElement('body'),
+        createElement(tagName) {
+            const el = new FakeElement('');
+            el.tagName = tagName.toUpperCase();
+            return el;
+        },
+        getElementById(id) {
+            return elements.get(id) || null;
+        },
+        querySelectorAll() {
+            return [];
+        },
+        addEventListener() {},
+        _elements: elements
+    };
+}
+
+async function runLoginScenario({ selectedDbValue, customDbValue, expectedHref, message }) {
+    const document = createFakeDocument();
+    const origin = 'https://ideav.ru';
+    const location = {
+        origin,
+        hostname: 'ideav.ru',
+        search: '?db=atex&r=InvalidToken&uri=/atex/table/1',
+        href: origin + '/start.html?db=atex&r=InvalidToken&uri=/atex/table/1'
+    };
+    const context = {
+        console,
+        URLSearchParams,
+        Date,
+        setTimeout,
+        document,
+        window: {
+            location,
+            smartCaptcha: null
+        },
+        localStorage: {
+            getItem() { return null; },
+            setItem() {}
+        }
+    };
+    context.globalThis = context;
+
+    const appSource = fs.readFileSync(path.join(__dirname, '..', 'js', 'app.js'), 'utf8');
+    vm.runInNewContext(appSource + '\nglobalThis.__App = App;', context);
+
+    const app = new context.__App();
+    await app.init();
+    app._captchaBypass = true;
+    app._captchaBypassChecked = true;
+    app.auth.login = async () => ({ success: true, message: 'ok' });
+
+    document.getElementById('auth-db-select').value = selectedDbValue;
+    document.getElementById('auth-db-custom').value = customDbValue || '';
+    document.getElementById('login-email').value = 'user';
+    document.getElementById('login-password').value = 'password';
+
+    await document.getElementById('login-form').dispatch('submit', {
+        preventDefault() {}
+    });
+
+    assert(location.href === expectedHref, message);
+}
+
+async function main() {
+    await runLoginScenario({
+        selectedDbValue: '__other__',
+        customDbValue: 'ateh',
+        expectedHref: 'https://ideav.ru/ateh',
+        message: 'changing DB during InvalidToken login discards the stale post-login URI'
+    });
+
+    await runLoginScenario({
+        selectedDbValue: 'atex',
+        expectedHref: 'https://ideav.ru/atex/table/1',
+        message: 'logging into the original DB keeps the saved post-login URI'
+    });
+}
+
+main().catch(error => {
+    console.error(error.message || error);
+    process.exit(1);
+});

--- a/js/app.js
+++ b/js/app.js
@@ -519,11 +519,31 @@ class App {
         // so this flag stays false until the captcha decision is actually reached.
         this._captchaBypass = false;
         this._captchaBypassChecked = false;
+        this._postLoginUri = '';
+        this._postLoginDb = '';
         window._app = this;
     }
 
     navigateToDb() {
         this.auth.navigateToDb();
+    }
+
+    _getDbFromUri(uri) {
+        if (!uri || typeof uri !== 'string') return '';
+        try {
+            const url = new URL(uri, window.location.origin);
+            if (url.origin !== window.location.origin) return '';
+            const firstSegment = url.pathname.split('/').filter(Boolean)[0] || '';
+            return firstSegment ? decodeURIComponent(firstSegment) : '';
+        } catch (e) {
+            return '';
+        }
+    }
+
+    _getPostLoginUriForDb(selectedDb) {
+        if (!this._postLoginUri) return '';
+        if (!selectedDb || this._postLoginDb !== selectedDb) return '';
+        return this._postLoginUri;
     }
 
     async init() {
@@ -651,8 +671,9 @@ class App {
                 const result = await this.auth.login(email, password, selectedDb, captchaToken);
                 if (result.success) {
                     CookieUtil.set('last_db', selectedDb, 365);
-                    if (this._postLoginUri) {
-                        window.location.href = window.location.origin + this._postLoginUri;
+                    const postLoginUri = this._getPostLoginUriForDb(selectedDb);
+                    if (postLoginUri) {
+                        window.location.href = window.location.origin + postLoginUri;
                     } else {
                         window.location.href = window.location.origin + '/' + selectedDb;
                     }
@@ -1018,6 +1039,7 @@ class App {
             // Store uri for post-login redirect, but never redirect back to OAuth callbacks
             if (uriParam && !uriParam.toLowerCase().includes('auth.asp')) {
                 this._postLoginUri = uriParam;
+                this._postLoginDb = this._getDbFromUri(uriParam) || dbParam || '';
             }
 
             this.showAuthPanel(dbParam || undefined);


### PR DESCRIPTION
Fixes #3033

### Как воспроизвести
1. Открыть `start.html?db=atex&r=InvalidToken&uri=/atex/` после перехода с `/atex/` без валидного токена.
2. В форме входа выбрать `База данных: другая`.
3. Ввести имя другой базы, например `ateh`, и успешно войти.

### Что изменено
- `start.html` теперь использует сохраненный `uri` после логина только если пользователь вошел в ту же БД, к которой относится этот `uri`.
- При смене БД в форме входа старый URL забывается, и успешный вход ведет в выбранную БД.
- Добавлен regression-test для сценариев: смена БД сбрасывает старый `uri`, вход в исходную БД сохраняет возврат на исходную страницу.

### Проверка
- `node experiments/test-issue-3033-post-login-uri.js`
- `node experiments/test-issue-1969-login-after-logout.js`
- `node experiments/test-issue-2248-start-otp-endpoints.js`
- `node --check js/app.js`
- `git diff --check`

Скриншоты не прикладываю: изменение касается только логики переадресации после логина, без визуальных изменений.