### PR TITLE
fix(atex): «Слиттер» → «Станок» на странице планирования производства

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -134,7 +134,7 @@
             var s = c.slitter || { id: null, label: '' };
             var key = s.id == null ? '\u0000none' : String(s.id);
             if (!groups[key]) {
-                groups[key] = { slitter: { id: s.id, label: s.label || (s.id == null ? 'Без слиттера' : '#' + s.id) }, cuts: [] };
+                groups[key] = { slitter: { id: s.id, label: s.label || (s.id == null ? 'Без станка' : '#' + s.id) }, cuts: [] };
                 order.push(key);
             }
             groups[key].cuts.push(c);
@@ -362,7 +362,7 @@
         if (this.busy) return;
         var meta = this.meta.cut;
         var d = this.draft;
-        if (!d.slitterId) { this.notify('Выберите слиттер', 'error'); return; }
+        if (!d.slitterId) { this.notify('Выберите станок', 'error'); return; }
         if (!d.cutTypeId) { this.notify('Выберите тип резки', 'error'); return; }
 
         var reqIds = {
@@ -509,7 +509,7 @@
         form.appendChild(el('h2', { class: 'atex-pp-form-title', text: 'Новая производственная резка' }));
         form.appendChild(el('p', { class: 'atex-pp-hint', text: 'Номер присваивается автоматически при сохранении.' }));
 
-        form.appendChild(field('Слиттер', this.selectRef(this.slitters, d.slitterId, '— выберите слиттер —',
+        form.appendChild(field('Станок', this.selectRef(this.slitters, d.slitterId, '— выберите станок —',
             function(v) { d.slitterId = v; }, reqIdByName(this.meta.cut, CUT_REQ.slitter))));
         form.appendChild(field('Тип резки', this.selectRef(this.cutTypes, d.cutTypeId, '— выберите тип резки —',
             function(v) { d.cutTypeId = v; }, reqIdByName(this.meta.cut, CUT_REQ.cutType))));
@@ -542,14 +542,14 @@
 
         // Панель фильтров.
         var filters = el('div', { class: 'atex-pp-filters' });
-        var slitterFilter = this.selectRef(this.slitters, this.filter.slitter, 'Все слиттеры',
+        var slitterFilter = this.selectRef(this.slitters, this.filter.slitter, 'Все станки',
             function(v) { self.filter.slitter = v; self.renderQueue(); },
             reqIdByName(this.meta.cut, CUT_REQ.slitter),
             { clearOnInput: false });
         var statusFilter = this.selectText([''].concat(CUT_STATUSES), this.filter.status, function(v) { self.filter.status = v; self.renderQueue(); });
         // первый пункт статуса — «все»
         statusFilter.options[0].textContent = 'Все статусы';
-        filters.appendChild(field('Слиттер', slitterFilter));
+        filters.appendChild(field('Станок', slitterFilter));
         filters.appendChild(field('Статус', statusFilter));
         box.appendChild(filters);
 
@@ -669,7 +669,7 @@
         var layout = el('div', { class: 'atex-pp-layout' });
         this.formEl = el('section', { class: 'atex-pp-panel atex-pp-form' });
         var queueWrap = el('section', { class: 'atex-pp-panel atex-pp-queue-panel' }, [
-            el('h2', { class: 'atex-pp-form-title', text: 'Очередь резок по слиттерам' })
+            el('h2', { class: 'atex-pp-form-title', text: 'Очередь резок по станкам' })
         ]);
         this.queueEl = el('div', { class: 'atex-pp-queue' });
         queueWrap.appendChild(this.queueEl);

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -73,8 +73,8 @@ var cuts = [
 
 var groups = planning.groupBySlitter(cuts);
 assertEqual(groups.map(function(g) { return g.slitter.label; }),
-    ['Слиттер №1', 'Слиттер №2', 'Без слиттера'],
-    'groupBySlitter orders by label, «без слиттера» last');
+    ['Слиттер №1', 'Слиттер №2', 'Без станка'],
+    'groupBySlitter orders by label, «без станка» last');
 assertEqual(groups[0].cuts.length, 2, 'groupBySlitter groups two cuts under Слиттер №1');
 
 // фильтр по слиттеру


### PR DESCRIPTION
На странице `/atex/production-planning` («Планирование производства», роль Диспетчер) заменены видимые пользователю подписи **«Слиттер» → «Станок»**.

## Что изменено
| Где | Было | Стало |
|---|---|---|
| Заголовок очереди | Очередь резок по **слиттерам** | Очередь резок по **станкам** |
| Поле формы + плейсхолдер | **Слиттер** / «— выберите **слиттер** —» | **Станок** / «— выберите **станок** —» |
| Фильтр очереди | **Слиттер** / Все **слиттеры** | **Станок** / Все **станки** |
| Группа без привязки | Без **слиттера** | Без **станка** |
| Валидация | Выберите **слиттер** | Выберите **станок** |

## Чего НЕ касается (намеренно)
- **Имя термина/реквизита «Слиттер» в БД не изменено** — он общий для 6 рабочих мест (slitter.js «Пульт слиттера», warehouse, cut-map, dashboards, sleeve-cutter), переименование термина затронуло бы их все. Поэтому изменены только подписи на самой странице.
- Записи справочника в боевой БД уже названы «Станок 1–4» / «SL-01–04», поэтому выпадающий список и так показывает «Станок …».
- Идентификаторы кода (`slitter`, `slitterId`, `groupBySlitter`) и CSS-классы не тронуты; поиск метаданных по имени работает как прежде.

## Тесты
`node experiments/atex-production-planning.test.js` — 17/17 ✅ (обновлена ожидаемая подпись группы «Без станка»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)