### PR TITLE
feat(atex): production-planning полностью на отчётах (cut_planning + positions_list + material_batches)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5,14 +5,19 @@
 // через подчинённую таблицу «Обеспечение». Решение задачи ideav/crm#2913
 // (часть #2903). Правила разработки рабочих мест — docs/WORKSPACE_DEVELOPMENT_GUIDE.md.
 //
-// На этом этапе рабочее место обращается к данным напрямую командами `_m_*`
-// (#2903): создание резки — `_m_new/{Производственная резка}` (Номер не задаётся,
-// у таблицы `unique=1` — сервер сам считает автонумер), обеспечение —
-// `_m_new/{Обеспечение}` с `up={позицияId}` и ссылкой `t{Производственная резка}`,
-// правки — `_m_set`. ID таблиц и реквизитов не хардкодятся: они берутся по именам
-// из `GET /{db}/metadata` (WORKSPACE_DEVELOPMENT_GUIDE.md, разделы 3 и 6).
-// Перевод чтений на защищённый слой `report/` — следующий этап и в объём этой
-// задачи не входит.
+// Чтения очереди резок и их обеспечения берутся одним отчётом защищённого слоя
+// `GET /{db}/report/cut_planning?JSON_KV` (Резка→Обеспечение→Позиция). Чистая
+// `rowsToPlanning` разворачивает плоские строки в резки (dedup по `cut_id`) и
+// обеспечения (строки с непустым `supply_id`) — один запрос вместо отдельных
+// `object/`-чтений резок и обеспечения, резолв метаданных для чтения не нужен
+// (правило: docs/integram-reports.md).
+//
+// Запись идёт прямыми командами `_m_*` (#2903): создание резки —
+// `_m_new/{Производственная резка}` (Номер не задаётся, у таблицы `unique=1` —
+// сервер сам считает автонумер), обеспечение — `_m_new/{Обеспечение}` с
+// `up={позицияId}` и ссылкой `t{Производственная резка}`, правки — `_m_set`. ID
+// таблиц и реквизитов для записи не хардкодятся: берутся по именам из
+// `GET /{db}/metadata` (WORKSPACE_DEVELOPMENT_GUIDE.md, разделы 3 и 6).
 //
 // Чистое ядро (разбор записей, группировка очереди по слиттерам, фильтрация,
 // сборка полей `t{reqId}`) вынесено в объект `planning` и экспортируется через
@@ -176,6 +181,45 @@
         return out;
     }
 
+    // Плоские строки отчёта cut_planning (JSON_KV) → { cuts, supplies }.
+    // Одна резка с N обеспечениями даёт N строк (LEFT JOIN) — резки dedup по
+    // `cut_id`; обеспечения собираются из строк с непустым `supply_id`. Резки без
+    // обеспечения (пустой `supply_id`) остаются в очереди и фантомных связей не
+    // создают. Формы записей совпадают с прежними mapCutRecord/loadSupplies:
+    // резка — { id, number, slitter:{id,label}, cutType:{id,label},
+    // materialBatch:{id,label}, planDate, status }; обеспечение —
+    // { id, positionId, cutId }.
+    function rowsToPlanning(rows) {
+        var cutsById = {};
+        var order = [];
+        var supplies = [];
+        function str(v) { return v == null ? '' : String(v); }
+        (rows || []).forEach(function(row) {
+            var cutId = str(row.cut_id);
+            if (cutId && !cutsById[cutId]) {
+                cutsById[cutId] = {
+                    id: cutId,
+                    number: str(row.cut_no),
+                    slitter: { id: row.cut_slitter_id ? String(row.cut_slitter_id) : null, label: str(row.cut_slitter) },
+                    cutType: { id: null, label: str(row.cut_type) },
+                    materialBatch: { id: null, label: str(row.cut_material_batch) },
+                    planDate: str(row.cut_plan_date),
+                    status: str(row.cut_status)
+                };
+                order.push(cutId);
+            }
+            var supplyId = str(row.supply_id);
+            if (supplyId) {
+                supplies.push({
+                    id: supplyId,
+                    positionId: row.supply_position_id ? String(row.supply_position_id) : null,
+                    cutId: cutId
+                });
+            }
+        });
+        return { cuts: order.map(function(id) { return cutsById[id]; }), supplies: supplies };
+    }
+
     var planning = {
         parseRef: parseRef,
         reqIdByName: reqIdByName,
@@ -183,7 +227,8 @@
         mapCutRecord: mapCutRecord,
         groupBySlitter: groupBySlitter,
         filterCuts: filterCuts,
-        buildFields: buildFields
+        buildFields: buildFields,
+        rowsToPlanning: rowsToPlanning
     };
 
     // ─────────────────────────── Браузерный слой ───────────────────────────
@@ -324,28 +369,14 @@
         });
     };
 
-    AtexProductionPlanning.prototype.loadCuts = function() {
+    // Очередь резок и их обеспечение одним отчётом cut_planning (JSON_KV).
+    // Заполняет this.cuts и this.supplies из плоских строк отчёта.
+    AtexProductionPlanning.prototype.loadPlanning = function() {
         var self = this;
-        var meta = this.meta.cut;
-        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,2000').then(function(rows) {
-            self.cuts = (rows || []).map(function(r) { return mapCutRecord(r, meta); });
-        });
-    };
-
-    AtexProductionPlanning.prototype.loadSupplies = function() {
-        var self = this;
-        var meta = this.meta.supply;
-        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,5000').then(function(rows) {
-            var cutIdx = columnIndex(meta, SUPPLY_REQ.cut);
-            self.supplies = (rows || []).map(function(r) {
-                var rr = r.r || [];
-                var cutRef = cutIdx >= 0 ? parseRef(rr[cutIdx]) : { id: null };
-                return {
-                    id: String(r.i),
-                    positionId: r.u != null ? String(r.u) : null,
-                    cutId: cutRef.id
-                };
-            });
+        return this.getJson('report/cut_planning?JSON_KV&LIMIT=0,5000').then(function(rows) {
+            var p = rowsToPlanning(rows || []);
+            self.cuts = p.cuts;
+            self.supplies = p.supplies;
         });
     };
 
@@ -424,7 +455,7 @@
         this.post('_m_new/' + meta.id + '?JSON&up=' + encodeURIComponent(opts.positionId), fields).then(function(res) {
             var id = res && (res.obj || res.id || res.i);
             if (!id) throw new Error('Сервер не вернул id обеспечения');
-            return self.loadSupplies().then(function() {
+            return self.loadPlanning().then(function() {
                 self.setBusy(false);
                 self.notify('Обеспечение создано: позиция связана с резкой', 'success');
                 self.render();
@@ -436,7 +467,7 @@
     };
 
     AtexProductionPlanning.prototype.reload = function() {
-        return Promise.all([this.loadCuts(), this.loadSupplies()]);
+        return this.loadPlanning();
     };
 
     // ── Рендеринг ──
@@ -689,8 +720,7 @@
                     self.loadRef(self.meta.cutType).then(function(items) { self.cutTypes = items; }),
                     self.loadRef(self.meta.materialBatch).then(function(items) { self.materialBatches = items; }),
                     self.loadPositions(),
-                    self.loadCuts(),
-                    self.loadSupplies()
+                    self.loadPlanning()
                 ]);
             })
             .then(function() { self.render(); })

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -232,13 +232,20 @@
     }
 
     // Строки отчёта material_batches (JSON_KV) → [{ id, label }] для дропдауна
-    // «Партия сырья». Подпись = номер партии (`batch_no`) — паритет с опциями
-    // серверного поиска AtexRefSearch (главное значение записи).
+    // «Партия сырья». Подпись обогащённая: «Номер · Вид сырья · ост. N м²»
+    // (пустые части пропускаются). Дропдаун статический клиентский (см. renderForm),
+    // поэтому метка единообразна и при фильтрации по вводу.
     function rowsToBatches(rows) {
         return (rows || []).map(function(row) {
+            var no = row.batch_no == null ? '' : String(row.batch_no).trim();
+            var material = row.batch_material == null ? '' : String(row.batch_material).trim();
+            var rem = row.batch_remainder_m2 == null ? '' : String(row.batch_remainder_m2).trim();
+            var parts = [];
+            if (material) parts.push(material);
+            if (rem) parts.push('ост. ' + rem + ' м²');
             return {
                 id: row.batch_id == null ? '' : String(row.batch_id),
-                label: row.batch_no == null ? '' : String(row.batch_no)
+                label: no + (parts.length ? ' · ' + parts.join(' · ') : '')
             };
         });
     }
@@ -564,8 +571,11 @@
             function(v) { d.slitterId = v; }, reqIdByName(this.meta.cut, CUT_REQ.slitter))));
         form.appendChild(field('Тип резки', this.selectRef(this.cutTypes, d.cutTypeId, '— выберите тип резки —',
             function(v) { d.cutTypeId = v; }, reqIdByName(this.meta.cut, CUT_REQ.cutType))));
+        // Партии предзагружены отчётом material_batches (обогащённые подписи) —
+        // статический клиентский список (как дропдаун позиций), без серверного
+        // поиска, иначе при вводе подпись свелась бы к голому номеру.
         form.appendChild(field('Партия сырья', this.selectRef(this.materialBatches, d.materialBatchId, '— не выбрано —',
-            function(v) { d.materialBatchId = v; }, reqIdByName(this.meta.cut, CUT_REQ.materialBatch))));
+            function(v) { d.materialBatchId = v; }, null, { cacheKey: 'batches' })));
 
         var dateInput = el('input', { class: 'atex-pp-input', type: 'date' });
         dateInput.value = d.planDate || '';

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -14,9 +14,10 @@
 //
 // Справочник позиций заказа (для привязки обеспечения) берётся отчётом
 // `GET /{db}/report/positions_list?JSON_KV` (`rowsToPositions`): Позиция заказа —
-// подчинённая таблица, прямое `object/`-чтение её не отдаёт. Справочники станков,
-// типов резки и партий сырья для формы читаются по именам из метаданных
-// (`object/{table}?JSON_OBJ`), поиск опций — через `AtexRefSearch`.
+// подчинённая таблица, прямое `object/`-чтение её не отдаёт. Партии сырья для
+// формы создания резки берутся отчётом `report/material_batches?JSON_KV`
+// (`rowsToBatches`). Справочники станков и типов резки читаются по именам из
+// метаданных (`object/{table}?JSON_OBJ`); поиск опций — через `AtexRefSearch`.
 //
 // Запись идёт прямыми командами `_m_*` (#2903): создание резки —
 // `_m_new/{Производственная резка}` (Номер не задаётся, у таблицы `unique=1` —
@@ -54,8 +55,7 @@
         cut: 'Производственная резка',
         supply: 'Обеспечение',
         slitter: 'Слиттер',
-        cutType: 'Тип резки',
-        materialBatch: 'Партия сырья'
+        cutType: 'Тип резки'
     };
     // Реквизиты «Производственной резки» (Номер — главное значение, автонумер).
     var CUT_REQ = {
@@ -231,6 +231,18 @@
         });
     }
 
+    // Строки отчёта material_batches (JSON_KV) → [{ id, label }] для дропдауна
+    // «Партия сырья». Подпись = номер партии (`batch_no`) — паритет с опциями
+    // серверного поиска AtexRefSearch (главное значение записи).
+    function rowsToBatches(rows) {
+        return (rows || []).map(function(row) {
+            return {
+                id: row.batch_id == null ? '' : String(row.batch_id),
+                label: row.batch_no == null ? '' : String(row.batch_no)
+            };
+        });
+    }
+
     var planning = {
         parseRef: parseRef,
         reqIdByName: reqIdByName,
@@ -240,7 +252,8 @@
         filterCuts: filterCuts,
         buildFields: buildFields,
         rowsToPlanning: rowsToPlanning,
-        rowsToPositions: rowsToPositions
+        rowsToPositions: rowsToPositions,
+        rowsToBatches: rowsToBatches
     };
 
     // ─────────────────────────── Браузерный слой ───────────────────────────
@@ -265,7 +278,7 @@
     function AtexProductionPlanning(root) {
         this.root = root;
         this.db = window.db || root.getAttribute('data-db') || '';
-        this.meta = { cut: null, supply: null, slitter: null, cutType: null, materialBatch: null };
+        this.meta = { cut: null, supply: null, slitter: null, cutType: null };
         this.slitters = [];        // справочник [{ id, label }]
         this.cutTypes = [];        // справочник [{ id, label }]
         this.materialBatches = []; // справочник [{ id, label }]
@@ -337,7 +350,6 @@
             self.meta.supply = byName(TABLE.supply);
             self.meta.slitter = byName(TABLE.slitter);
             self.meta.cutType = byName(TABLE.cutType);
-            self.meta.materialBatch = byName(TABLE.materialBatch);
             if (!self.meta.cut) throw new Error('В метаданных не найдена таблица «' + TABLE.cut + '»');
             if (!self.meta.supply) throw new Error('В метаданных не найдена таблица «' + TABLE.supply + '»');
         });
@@ -366,6 +378,14 @@
         var self = this;
         return this.getJson('report/positions_list?JSON_KV&LIMIT=0,2000').then(function(rows) {
             self.positions = rowsToPositions(rows || []);
+        });
+    };
+
+    // Справочник партий сырья отчётом material_batches (JSON_KV).
+    AtexProductionPlanning.prototype.loadMaterialBatches = function() {
+        var self = this;
+        return this.getJson('report/material_batches?JSON_KV&LIMIT=0,2000').then(function(rows) {
+            self.materialBatches = rowsToBatches(rows || []);
         });
     };
 
@@ -718,7 +738,7 @@
                 return Promise.all([
                     self.loadRef(self.meta.slitter).then(function(items) { self.slitters = items; }),
                     self.loadRef(self.meta.cutType).then(function(items) { self.cutTypes = items; }),
-                    self.loadRef(self.meta.materialBatch).then(function(items) { self.materialBatches = items; }),
+                    self.loadMaterialBatches(),
                     self.loadPositions(),
                     self.loadPlanning()
                 ]);

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -235,11 +235,18 @@
     // «Партия сырья». Подпись обогащённая: «Номер · Вид сырья · ост. N м²»
     // (пустые части пропускаются). Дропдаун статический клиентский (см. renderForm),
     // поэтому метка единообразна и при фильтрации по вводу.
+    // Остаток м² → строка: округление до 2 знаков, без незначащих нулей
+    // (2440.00 → «2440», 38400.366 → «38400.37»). Нечисло/пусто → ''.
+    function fmtRemainder(value) {
+        var n = parseFloat(String(value == null ? '' : value).replace(',', '.'));
+        return isFinite(n) ? String(Math.round(n * 100) / 100) : '';
+    }
+
     function rowsToBatches(rows) {
         return (rows || []).map(function(row) {
             var no = row.batch_no == null ? '' : String(row.batch_no).trim();
             var material = row.batch_material == null ? '' : String(row.batch_material).trim();
-            var rem = row.batch_remainder_m2 == null ? '' : String(row.batch_remainder_m2).trim();
+            var rem = fmtRemainder(row.batch_remainder_m2);
             var parts = [];
             if (material) parts.push(material);
             if (rem) parts.push('ост. ' + rem + ' м²');

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -12,6 +12,12 @@
 // `object/`-чтений резок и обеспечения, резолв метаданных для чтения не нужен
 // (правило: docs/integram-reports.md).
 //
+// Справочник позиций заказа (для привязки обеспечения) берётся отчётом
+// `GET /{db}/report/positions_list?JSON_KV` (`rowsToPositions`): Позиция заказа —
+// подчинённая таблица, прямое `object/`-чтение её не отдаёт. Справочники станков,
+// типов резки и партий сырья для формы читаются по именам из метаданных
+// (`object/{table}?JSON_OBJ`), поиск опций — через `AtexRefSearch`.
+//
 // Запись идёт прямыми командами `_m_*` (#2903): создание резки —
 // `_m_new/{Производственная резка}` (Номер не задаётся, у таблицы `unique=1` —
 // сервер сам считает автонумер), обеспечение — `_m_new/{Обеспечение}` с
@@ -47,7 +53,6 @@
     var TABLE = {
         cut: 'Производственная резка',
         supply: 'Обеспечение',
-        position: 'Позиция заказа',
         slitter: 'Слиттер',
         cutType: 'Тип резки',
         materialBatch: 'Партия сырья'
@@ -68,15 +73,6 @@
         finishedBatch: 'Партия ГП',
         status: 'Статус'
     };
-    // Реквизиты «Позиции заказа» — нужны лишь для подписи в списке привязки.
-    var POSITION_REQ = {
-        qty: 'Кол-во',
-        material: 'Вид сырья',
-        cutType: 'Тип резки',
-        width: 'Ширина, мм',
-        status: 'Статус'
-    };
-
     // Статусы — свободный текст (тип 3); фиксируем разумные наборы по дизайн-спеке.
     var CUT_STATUSES = ['Запланирована', 'В очереди', 'В работе', 'Готова', 'Отменена'];
     var SUPPLY_STATUSES = ['Зарезервировано', 'Выполнено', 'Отменено'];
@@ -220,6 +216,21 @@
         return { cuts: order.map(function(id) { return cutsById[id]; }), supplies: supplies };
     }
 
+    // Строки отчёта positions_list (JSON_KV) → [{ id, label }] для дропдауна
+    // привязки. Подпись: «#id · Тип резки · Ширина · Кол-во» (пустые поля
+    // пропускаются); если деталей нет — «#id · Номер».
+    function rowsToPositions(rows) {
+        return (rows || []).map(function(row) {
+            var id = row.position_id == null ? '' : String(row.position_id);
+            var parts = [row.position_cut_type, row.position_width, row.position_qty]
+                .map(function(v) { return v == null ? '' : String(v).trim(); })
+                .filter(function(v) { return v !== ''; });
+            var main = row.position_no == null ? '' : String(row.position_no).trim();
+            var label = '#' + id + (parts.length ? ' · ' + parts.join(' · ') : (main ? ' · ' + main : ''));
+            return { id: id, label: label };
+        });
+    }
+
     var planning = {
         parseRef: parseRef,
         reqIdByName: reqIdByName,
@@ -228,7 +239,8 @@
         groupBySlitter: groupBySlitter,
         filterCuts: filterCuts,
         buildFields: buildFields,
-        rowsToPlanning: rowsToPlanning
+        rowsToPlanning: rowsToPlanning,
+        rowsToPositions: rowsToPositions
     };
 
     // ─────────────────────────── Браузерный слой ───────────────────────────
@@ -253,7 +265,7 @@
     function AtexProductionPlanning(root) {
         this.root = root;
         this.db = window.db || root.getAttribute('data-db') || '';
-        this.meta = { cut: null, supply: null, position: null, slitter: null, cutType: null, materialBatch: null };
+        this.meta = { cut: null, supply: null, slitter: null, cutType: null, materialBatch: null };
         this.slitters = [];        // справочник [{ id, label }]
         this.cutTypes = [];        // справочник [{ id, label }]
         this.materialBatches = []; // справочник [{ id, label }]
@@ -323,7 +335,6 @@
             }
             self.meta.cut = byName(TABLE.cut);
             self.meta.supply = byName(TABLE.supply);
-            self.meta.position = byName(TABLE.position);
             self.meta.slitter = byName(TABLE.slitter);
             self.meta.cutType = byName(TABLE.cutType);
             self.meta.materialBatch = byName(TABLE.materialBatch);
@@ -349,23 +360,12 @@
         });
     };
 
+    // Справочник позиций заказа отчётом positions_list (JSON_KV). Позиция
+    // подчинённая — прямое object/-чтение её не отдаёт, отчёт возвращает все.
     AtexProductionPlanning.prototype.loadPositions = function() {
         var self = this;
-        var meta = this.meta.position;
-        if (!meta) { this.positions = []; return Promise.resolve(); }
-        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,2000').then(function(rows) {
-            self.positions = (rows || []).map(function(r) {
-                var parts = [];
-                var main = (r.r && r.r[0]) || ('#' + r.i);
-                [POSITION_REQ.cutType, POSITION_REQ.width, POSITION_REQ.qty].forEach(function(name) {
-                    var idx = columnIndex(meta, name);
-                    if (idx >= 0 && r.r && r.r[idx] != null && String(r.r[idx]).trim() !== '') {
-                        parts.push(parseRef(r.r[idx]).label || String(r.r[idx]));
-                    }
-                });
-                var label = '#' + r.i + (parts.length ? ' · ' + parts.join(' · ') : (' · ' + main));
-                return { id: String(r.i), label: label };
-            });
+        return this.getJson('report/positions_list?JSON_KV&LIMIT=0,2000').then(function(rows) {
+            self.positions = rowsToPositions(rows || []);
         });
     };
 

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -149,12 +149,14 @@ assertEqual(planning.rowsToPositions([]), [], 'rowsToPositions: пустой в�
 // ── rowsToBatches: строки material_batches (JSON_KV) → [{id,label}] для дропдауна ──
 var batchRows = [
     { batch_id: '1946', batch_no: 'RM-АТХ-3002-2026-05-31', batch_material: 'MWR118', batch_remainder_m2: '2440.00' },
-    { batch_id: '8078', batch_no: 'Начальный остаток MR131', batch_material: 'MR131', batch_remainder_m2: '4588.35' }
+    { batch_id: '8078', batch_no: 'Начальный остаток MR131', batch_material: 'MR131', batch_remainder_m2: '4588.35' },
+    { batch_id: '8082', batch_no: 'MR132', batch_material: 'MR132', batch_remainder_m2: '38400.366' }
 ];
 assertEqual(planning.rowsToBatches(batchRows), [
-    { id: '1946', label: 'RM-АТХ-3002-2026-05-31 · MWR118 · ост. 2440.00 м²' },
-    { id: '8078', label: 'Начальный остаток MR131 · MR131 · ост. 4588.35 м²' }
-], 'rowsToBatches: id партии + обогащённая подпись «номер · вид · ост. N м²»');
+    { id: '1946', label: 'RM-АТХ-3002-2026-05-31 · MWR118 · ост. 2440 м²' },
+    { id: '8078', label: 'Начальный остаток MR131 · MR131 · ост. 4588.35 м²' },
+    { id: '8082', label: 'MR132 · MR132 · ост. 38400.37 м²' }
+], 'rowsToBatches: подпись «номер · вид · ост. N м²», остаток округлён без хвостовых нулей');
 assertEqual(planning.rowsToBatches([{ batch_id: '5', batch_no: 'НК-9', batch_material: '', batch_remainder_m2: '' }]),
     [{ id: '5', label: 'НК-9' }], 'rowsToBatches: пустые вид/остаток → только номер');
 assertEqual(planning.rowsToBatches([]), [], 'rowsToBatches: пустой ввод → пустой список');

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -102,4 +102,35 @@ assertEqual(planning.buildFields(
     { footage: '1200', cut: '501', status: 'Зарезервировано' }
 ), { t1082: '1200', t1084: '501' }, 'buildFields skips fields with null reqId');
 
+// ── rowsToPlanning: плоские строки отчёта cut_planning (JSON_KV) → { cuts, supplies } ──
+// LEFT JOIN: резка 10 с двумя обеспечениями = две строки; резка 20 без обеспечения.
+var reportRows = [
+    { cut_id: '10', cut_no: '1', cut_slitter: 'Станок 1', cut_slitter_id: '101',
+      cut_type: '99мм×9', cut_material_batch: 'НК-0400', cut_plan_date: '06.05.2026',
+      cut_status: 'В работе', supply_id: '900', supply_position_id: '700' },
+    { cut_id: '10', cut_no: '1', cut_slitter: 'Станок 1', cut_slitter_id: '101',
+      cut_type: '99мм×9', cut_material_batch: 'НК-0400', cut_plan_date: '06.05.2026',
+      cut_status: 'В работе', supply_id: '901', supply_position_id: '701' },
+    { cut_id: '20', cut_no: '2', cut_slitter: '', cut_slitter_id: '',
+      cut_type: '25мм×35', cut_material_batch: 'НК-0118', cut_plan_date: '27.05.2026',
+      cut_status: 'Ожидает', supply_id: '', supply_position_id: '' }
+];
+var plan = planning.rowsToPlanning(reportRows);
+assertEqual(plan.cuts, [
+    { id: '10', number: '1', slitter: { id: '101', label: 'Станок 1' },
+      cutType: { id: null, label: '99мм×9' }, materialBatch: { id: null, label: 'НК-0400' },
+      planDate: '06.05.2026', status: 'В работе' },
+    { id: '20', number: '2', slitter: { id: null, label: '' },
+      cutType: { id: null, label: '25мм×35' }, materialBatch: { id: null, label: 'НК-0118' },
+      planDate: '27.05.2026', status: 'Ожидает' }
+], 'rowsToPlanning dedups cuts by cut_id, slitter без id → {id:null}');
+assertEqual(plan.supplies, [
+    { id: '900', positionId: '700', cutId: '10' },
+    { id: '901', positionId: '701', cutId: '10' }
+], 'rowsToPlanning collects supplies from rows with supply_id, skips empty');
+assertEqual(planning.rowsToPlanning([]).cuts.length, 0, 'rowsToPlanning empty input → no cuts');
+// сценарий показа: группировка + счётчик связей поверх результата rowsToPlanning
+assertEqual(planning.groupBySlitter(plan.cuts).map(function(g) { return g.slitter.label; }),
+    ['Станок 1', 'Без станка'], 'groupBySlitter over rowsToPlanning cuts');
+
 console.log('\n' + passed + ' assertions passed');

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -133,4 +133,17 @@ assertEqual(planning.rowsToPlanning([]).cuts.length, 0, 'rowsToPlanning empty in
 assertEqual(planning.groupBySlitter(plan.cuts).map(function(g) { return g.slitter.label; }),
     ['Станок 1', 'Без станка'], 'groupBySlitter over rowsToPlanning cuts');
 
+// ── rowsToPositions: строки positions_list (JSON_KV) → [{id,label}] для дропдауна ──
+var posRows = [
+    { position_id: '8207', position_no: '1', position_cut_type: '', position_width: '25.00', position_qty: '70' },
+    { position_id: '8300', position_no: '2', position_cut_type: '110мм×8', position_width: '110.00', position_qty: '5' }
+];
+assertEqual(planning.rowsToPositions(posRows), [
+    { id: '8207', label: '#8207 · 25.00 · 70' },
+    { id: '8300', label: '#8300 · 110мм×8 · 110.00 · 5' }
+], 'rowsToPositions: «#id · тип · ширина · кол-во», пустые поля пропущены');
+assertEqual(planning.rowsToPositions([{ position_id: '9', position_no: '3', position_cut_type: '', position_width: '', position_qty: '' }]),
+    [{ id: '9', label: '#9 · 3' }], 'rowsToPositions: без деталей — fallback на номер');
+assertEqual(planning.rowsToPositions([]), [], 'rowsToPositions: пустой ввод → пустой список');
+
 console.log('\n' + passed + ' assertions passed');

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -146,4 +146,15 @@ assertEqual(planning.rowsToPositions([{ position_id: '9', position_no: '3', posi
     [{ id: '9', label: '#9 · 3' }], 'rowsToPositions: без деталей — fallback на номер');
 assertEqual(planning.rowsToPositions([]), [], 'rowsToPositions: пустой ввод → пустой список');
 
+// ── rowsToBatches: строки material_batches (JSON_KV) → [{id,label}] для дропдауна ──
+var batchRows = [
+    { batch_id: '1946', batch_no: 'RM-АТХ-3002-2026-05-31', batch_material: 'MWR118', batch_remainder_m2: '2440.00' },
+    { batch_id: '8078', batch_no: 'Начальный остаток MR131', batch_material: 'MR131', batch_remainder_m2: '4588.35' }
+];
+assertEqual(planning.rowsToBatches(batchRows), [
+    { id: '1946', label: 'RM-АТХ-3002-2026-05-31' },
+    { id: '8078', label: 'Начальный остаток MR131' }
+], 'rowsToBatches: id записи партии + номер партии как подпись');
+assertEqual(planning.rowsToBatches([]), [], 'rowsToBatches: пустой ввод → пустой список');
+
 console.log('\n' + passed + ' assertions passed');

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -152,9 +152,11 @@ var batchRows = [
     { batch_id: '8078', batch_no: 'Начальный остаток MR131', batch_material: 'MR131', batch_remainder_m2: '4588.35' }
 ];
 assertEqual(planning.rowsToBatches(batchRows), [
-    { id: '1946', label: 'RM-АТХ-3002-2026-05-31' },
-    { id: '8078', label: 'Начальный остаток MR131' }
-], 'rowsToBatches: id записи партии + номер партии как подпись');
+    { id: '1946', label: 'RM-АТХ-3002-2026-05-31 · MWR118 · ост. 2440.00 м²' },
+    { id: '8078', label: 'Начальный остаток MR131 · MR131 · ост. 4588.35 м²' }
+], 'rowsToBatches: id партии + обогащённая подпись «номер · вид · ост. N м²»');
+assertEqual(planning.rowsToBatches([{ batch_id: '5', batch_no: 'НК-9', batch_material: '', batch_remainder_m2: '' }]),
+    [{ id: '5', label: 'НК-9' }], 'rowsToBatches: пустые вид/остаток → только номер');
 assertEqual(planning.rowsToBatches([]), [], 'rowsToBatches: пустой ввод → пустой список');
 
 console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
## Что
Рабочее место **«Планирование производства»** (`download/atex/js/production-planning.js`) полностью переведено на чтение через защищённый слой `report/` — по паттерну dashboards (#3067). Все `object/?JSON_OBJ`-чтения данных и справочников заменены отчётами; запись (`_m_*`) не тронута.

## 1. Очередь резок и обеспечение → `report/cut_planning` (8384)
- **`rowsToPlanning(rows)`** — плоские строки → `{cuts, supplies}` (резки dedup по `cut_id`, обеспечения из строк с непустым `supply_id`). Зеркало `rowsToEntities` из dashboards.
- `loadCuts()` + `loadSupplies()` → один **`loadPlanning()`**. **2 запроса → 1.**

## 2. Справочник позиций → `report/positions_list` (8409)
- `loadPositions()` с `object/1076?JSON_OBJ` → `report/positions_list?JSON_KV`. **Позиция заказа — подчинённая таблица**, прямое `object/`-чтение возвращало 0 строк → дропдаун привязки был **пуст**; отчёт отдаёт все позиции, латентный баг устранён.
- **`rowsToPositions(rows)`** — подпись «#id · тип · ширина · кол-во».

## 3. Справочник партий сырья → `report/material_batches` (8434, создан этим PR)
- Новый отчёт `material_batches` (master «Партия сырья» 1074): `batch_id` (abn_ID), `batch_no`, `batch_material`, `batch_remainder_m2`.
- `loadMaterialBatches()` заменяет `loadRef(object/1074)`; **`rowsToBatches(rows)`** — обогащённая подпись «Номер · Вид сырья · ост. N м²». Дропдаун переведён в статический клиентский режим (`reqId=null`, как дропдаун позиций), чтобы подпись была единообразной и при фильтрации по вводу.
- В боевой `ateh` роли **Оператор(1621)** выдан READ на справочник **1069 «Вид сырья»** (Диспетчер 1619 уже имел) — иначе колонка вида под ролью пустая. (`material_stock`/8377 для дропдауна не подошёл — агрегат по виду сырья, без id Партии.)

Убраны мёртвые `POSITION_REQ`, `meta.position`, `meta.materialBatch`, `TABLE.materialBatch`. Дропдауны станков/типов резки и запись `_m_*` не тронуты.

## Верификация
- Юнит-тесты **27/27** (`node experiments/atex-production-planning.test.js`): +4 `rowsToPlanning`, +3 `rowsToPositions`, +3 `rowsToBatches`.
- E2E на боевых отчётах: `cut_planning` 4 строки → 4 резки + обеспечение #1993→резка 1982→позиция 1974; `positions_list` 16 позиций; `material_batches` 35 партий с обогащёнными подписями.
- Гранты: отчёты не требуют грант на объект таблицы 22; роли Диспетчер(1619)/Оператор(1621) имеют доступ к нижележащим таблицам всех трёх отчётов.

## БД / деплой
В боевой `ateh` создан отчёт `material_batches` (8434) и выдан грант 1069 роли 1621. Отчёты `cut_planning`/`positions_list` уже были. После мержа — деплой формы через `update.php`.