### PR TITLE
fix(atex): дропдаун «Тип резки» — bounded ref-search вместо тяжёлой выборки 501 записи

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -16,8 +16,11 @@
 // `GET /{db}/report/positions_list?JSON_KV` (`rowsToPositions`): Позиция заказа —
 // подчинённая таблица, прямое `object/`-чтение её не отдаёт. Партии сырья для
 // формы создания резки берутся отчётом `report/material_batches?JSON_KV`
-// (`rowsToBatches`). Справочники станков и типов резки читаются по именам из
-// метаданных (`object/{table}?JSON_OBJ`); поиск опций — через `AtexRefSearch`.
+// (`rowsToBatches`). Справочник станков читается по имени из метаданных
+// (`object/{table}?JSON_OBJ`, записей мало). «Тип резки» — большой справочник:
+// полная выборка упирается в серверный потолок размера ответа, поэтому первая
+// порция грузится ограниченным ref-search `_ref_reqs` (`loadCutTypes`), остальное
+// — поиском по вводу через `AtexRefSearch`.
 //
 // Запись идёт прямыми командами `_m_*` (#2903): создание резки —
 // `_m_new/{Производственная резка}` (Номер не задаётся, у таблицы `unique=1` —
@@ -54,8 +57,7 @@
     var TABLE = {
         cut: 'Производственная резка',
         supply: 'Обеспечение',
-        slitter: 'Слиттер',
-        cutType: 'Тип резки'
+        slitter: 'Слиттер'
     };
     // Реквизиты «Производственной резки» (Номер — главное значение, автонумер).
     var CUT_REQ = {
@@ -292,7 +294,7 @@
     function AtexProductionPlanning(root) {
         this.root = root;
         this.db = window.db || root.getAttribute('data-db') || '';
-        this.meta = { cut: null, supply: null, slitter: null, cutType: null };
+        this.meta = { cut: null, supply: null, slitter: null };
         this.slitters = [];        // справочник [{ id, label }]
         this.cutTypes = [];        // справочник [{ id, label }]
         this.materialBatches = []; // справочник [{ id, label }]
@@ -363,7 +365,6 @@
             self.meta.cut = byName(TABLE.cut);
             self.meta.supply = byName(TABLE.supply);
             self.meta.slitter = byName(TABLE.slitter);
-            self.meta.cutType = byName(TABLE.cutType);
             if (!self.meta.cut) throw new Error('В метаданных не найдена таблица «' + TABLE.cut + '»');
             if (!self.meta.supply) throw new Error('В метаданных не найдена таблица «' + TABLE.supply + '»');
         });
@@ -400,6 +401,22 @@
         var self = this;
         return this.getJson('report/material_batches?JSON_KV&LIMIT=0,2000').then(function(rows) {
             self.materialBatches = rowsToBatches(rows || []);
+        });
+    };
+
+    // Справочник «Тип резки» — большой (сотни записей); полная выборка
+    // (`object/?JSON_OBJ` или отчёт) упирается в серверный потолок размера ответа
+    // и виснет. Поэтому предзагружаем только первую порцию через ограниченный
+    // ref-search `_ref_reqs/{reqId}?JSON&LIMIT` (как в остальных РМ); остальные
+    // типы доступны поиском по вводу в самом поле (reqId передаётся в selectRef).
+    AtexProductionPlanning.prototype.loadCutTypes = function() {
+        var self = this;
+        var reqId = reqIdByName(this.meta.cut, CUT_REQ.cutType);
+        if (!reqId) { this.cutTypes = []; return Promise.resolve(); }
+        return this.loadRefOptions(reqId, '', 50).then(function(payload) {
+            var helper = (typeof window !== 'undefined' && window.AtexRefSearch) || null;
+            self.cutTypes = (helper && typeof helper.parseOptionsData === 'function')
+                ? helper.parseOptionsData(payload) : [];
         });
     };
 
@@ -754,7 +771,7 @@
             .then(function() {
                 return Promise.all([
                     self.loadRef(self.meta.slitter).then(function(items) { self.slitters = items; }),
-                    self.loadRef(self.meta.cutType).then(function(items) { self.cutTypes = items; }),
+                    self.loadCutTypes(),
                     self.loadMaterialBatches(),
                     self.loadPositions(),
                     self.loadPlanning()


### PR DESCRIPTION
## Проблема
После перевода production-planning на отчёты (#3068) страница на проде висла на «Загрузка…». Браузер-диагностика показала: 3 отчёта (cut_planning/positions_list/material_batches) отдают 200 быстро, а `Promise.all` в `start()` не резолвится из-за **`loadRef(«Тип резки»)`**.

«Тип резки» (таблица 1072) разрослась до **501 записи**. `loadRef` тянет их все: `object/1072?JSON_OBJ&LIMIT=0,1000` → ответ **>27 КБ**, на котором сервер ideav.ru виснет (бисекция: `0,450`≈27КБ — 0.44с, `0,475`≈28КБ — таймаут; окна по offset — мгновенно). Полная выборка через отчёт упирается в тот же потолок размера ответа.

Это **пред-существующий баг**: `loadRef(cutType)` — неизменённый код, он вешал бы страницу независимо от миграции на отчёты, как только справочник перерос ~450 записей.

## Фикс
`loadCutTypes()` предзагружает только первую порцию (~50-80) через штатный ограниченный ref-search `_ref_reqs/{reqId}?JSON&LIMIT=50` (тот же механизм, что в slitter/intake/sleeve-cutter/cut-calc) и парсит её `AtexRefSearch.parseOptionsData`. Остальные типы доступны **поиском по вводу** в самом поле (reqId уже передаётся в `selectRef`). Дропдаун станков (записей мало) оставлен на `object/`. Убраны осевшие `meta.cutType`/`TABLE.cutType`.

## Верификация
- Юнит-тесты ядра **27/27**.
- E2E на бою: `_ref_reqs/1157` → 80 опций `{id,label}`, 0.36с, 614 байт (vs зависание полной выборки).
- Браузер-проверка страницы — после мержа+деплоя.

## БД / деплой
Изменений схемы нет (orphan-отчёт `cut_types_list`, созданный при диагностике, удалён с прода). После мержа — деплой формы через `update.php`.