### PR TITLE
feat(atex): orders — refs позиций из отчёта, убран per-order запрос loadPositions

### DIFF
--- a/download/atex/js/orders.js
+++ b/download/atex/js/orders.js
@@ -180,6 +180,10 @@
                     qty: s(r.position_qty), raw: s(r.position_raw), cutType: s(r.position_cut_type),
                     width: s(r.position_width), length: s(r.position_length), sleeve: s(r.position_sleeve),
                     winding: s(r.position_winding), status: s(r.position_status)
+                }, refs: {
+                    // id ссылок приходят прямо из отчёта (abn_ID-колонки) — детальная
+                    // догрузка позиций (loadPositions) на каждый заказ больше не нужна.
+                    raw: s(r.position_raw_id), cutType: s(r.position_cut_type_id), sleeve: s(r.position_sleeve_id)
                 } });
             }
         });
@@ -935,14 +939,6 @@
         });
     }
 
-    function loadPositions(orderId) {
-        var url = buildListUrl(getApiBase(), state.positionTable, orderId, null, '');
-        return fetchJson(url).then(function(json) {
-            state.positionsByOrder[orderId] = normalizeObjects(json, state.positionColumns);
-            renderOrders();
-        });
-    }
-
     function createOrder() {
         if (state.creating) return;
         var clientSel = document.getElementById('atex-order-client');
@@ -968,10 +964,7 @@
             setMessage(newId ? 'Заказ №' + newId + ' создан.' : 'Заказ создан.', 'success');
             closeCreateForm();
             return loadOrders().then(function() {
-                if (newId) {
-                    state.expanded[newId] = true;
-                    return loadPositions(newId);
-                }
+                if (newId) state.expanded[newId] = true;
             });
         }).catch(function(error) {
             setMessage('Не удалось создать заказ: ' + (error.message || error), 'error');
@@ -1064,22 +1057,8 @@
         var posId = td.getAttribute('data-position-id');
         var found = posId ? findPositionById(posId) : null;
         if (!found) return;
-        // Ref-полям (raw/cutType/sleeve) нужны id из refs; в данных отчёта их нет —
-        // догружаем позиции заказа детально, затем открываем ячейку.
-        var col = getColumn(state.positionColumns, key);
-        var isRef = col && col.ref;
-        if (isRef && !found.position.refs) {
-            setMessage('Загрузка позиции…', 'info');
-            loadPositions(found.orderId).then(function() {
-                setMessage('');
-                var fresh = document.querySelector('td.atex-orders-cell[data-cell="' + cssEscape(key) +
-                    '"][data-position-id="' + cssEscape(posId) + '"]');
-                if (fresh) activateCell(fresh);
-            }).catch(function(error) {
-                setMessage('Не удалось загрузить позицию: ' + (error.message || error), 'error');
-            });
-            return;
-        }
+        // id ссылок (raw/cutType/sleeve) приходят прямо из отчёта orders_list —
+        // отдельная догрузка позиций заказа больше не требуется.
         // Прежняя активная ячейка возвращается в отображение (без сохранения).
         if (state.editingCell && state.editingCell !== td) deactivateCell();
         state.editingCell = td;
@@ -1599,11 +1578,7 @@
                 if (toggle) {
                     var orderId = toggle.getAttribute('data-toggle');
                     state.expanded[orderId] = !state.expanded[orderId];
-                    if (state.expanded[orderId] && !state.positionsByOrder[orderId]) {
-                        loadPositions(orderId);
-                    } else {
-                        renderOrders();
-                    }
+                    renderOrders();   // позиции уже загружены отчётом orders_list
                     return;
                 }
 

--- a/experiments/test-issue-orders-enh.js
+++ b/experiments/test-issue-orders-enh.js
@@ -13,7 +13,7 @@ function eq(a, e, name){ const ok = JSON.stringify(a) === JSON.stringify(e); con
 // заказ без позиций (пустой position_id) остаётся с positions: [].
 const rows = [
   { order_id:'10', order_no:'1', order_client:'ООО Ромашка', order_manager:'Иванов', order_created:'01.06.2026', order_approved:'', order_status:'Новый',
-    position_id:'100', position_qty:'5', position_raw:'MWR118', position_cut_type:'25мм×35 / MWR118', position_width:'25', position_length:'910', position_sleeve:'25', position_winding:'IN', position_status:'Новая' },
+    position_id:'100', position_qty:'5', position_raw:'MWR118', position_raw_id:'1237', position_cut_type:'25мм×35 / MWR118', position_cut_type_id:'1308', position_width:'25', position_length:'910', position_sleeve:'25', position_sleeve_id:'8190', position_winding:'IN', position_status:'Новая' },
   { order_id:'10', order_no:'1', order_client:'ООО Ромашка', order_manager:'Иванов', order_created:'01.06.2026', order_approved:'', order_status:'Новый',
     position_id:'101', position_qty:'3', position_raw:'MW308', position_cut_type:'110мм×8 / MW308', position_width:'110', position_length:'910', position_sleeve:'40', position_winding:'OUT', position_status:'В работе' },
   { order_id:'20', order_no:'2', order_client:'ИП Петров', order_manager:'Сидоров', order_created:'02.06.2026', order_approved:'02.06.2026', order_status:'Согласован',
@@ -26,6 +26,7 @@ eq(out[0].values.client, 'ООО Ромашка', 'rowsToOrders: значени�
 eq(out[0].positions.length, 2, 'rowsToOrders: 2 позиции у заказа 10');
 eq(out[0].positions[0].id, '100', 'rowsToOrders: id позиции');
 eq(out[0].positions[1].values.cutType, '110мм×8 / MW308', 'rowsToOrders: значения позиции');
+eq(out[0].positions[0].refs, { raw:'1237', cutType:'1308', sleeve:'8190' }, 'rowsToOrders: id ссылок (refs) из отчёта');
 eq(out[1].positions.length, 0, 'rowsToOrders: заказ без позиций → пустой список');
 
 // searchOrders: заказ виден, если запрос совпал с любым полем заказа ИЛИ любой позиции


### PR DESCRIPTION
id ссылок (вид сырья/тип резки/втулка) теперь приходят в отчёте orders_list (abn_ID-колонки), rowsToOrders заполняет refs. Убрана догрузка loadPositions (object/ на каждый заказ при правке ref-ячейки/раскрытии) — все данные одним отчётом. Юнит 18/18 + регрессы. E2E: refs из живого отчёта.