### PR TITLE
fix(atex): dashboards — остаток сырья округлять до целых м²

### DIFF
--- a/download/atex/js/dashboards.js
+++ b/download/atex/js/dashboards.js
@@ -128,8 +128,11 @@
     function materialStock(batches) {
         var rows = groupBy(batches, function(b) { return b.material; }, function(acc, b) {
             acc.received = round3((acc.received || 0) + toNumber(b.received));
-            acc.remainder = round3((acc.remainder || 0) + toNumber(b.remainder));
+            // Остаток суммируем точно; округляем до целых м² одним проходом ниже.
+            acc.remainder = (acc.remainder || 0) + toNumber(b.remainder);
         });
+        // Остаток сырья округляем до целых м² — дробные м² на складе это шум.
+        rows.forEach(function(r) { r.remainder = Math.round(r.remainder); });
         // #3073: остатки сырья сортируем по убыванию остатка (а не по count),
         // ключ — вторичный для стабильности.
         rows.sort(function(a, b) {
@@ -139,7 +142,7 @@
         return {
             total: (batches || []).length,
             totalReceived: sumBy(batches, function(b) { return b.received; }),
-            totalRemainder: sumBy(batches, function(b) { return b.remainder; }),
+            totalRemainder: Math.round(sumBy(batches, function(b) { return b.remainder; })),
             rows: rows
         };
     }

--- a/experiments/atex-dashboards.test.js
+++ b/experiments/atex-dashboards.test.js
@@ -170,3 +170,15 @@ var ms = dashboards.materialStock([
 ]);
 assertEqual(ms.rows.map(function(r) { return r.key; }), ['Полиэтилен', 'Лавсан', 'Полипропилен'],
     'materialStock: остатки отсортированы по убыванию');
+
+// materialStock округляет остаток до целых м² (суммируя точно).
+var msRound = dashboards.materialStock([
+    { material: 'MR132', received: '38400.366', remainder: '38400.366' },
+    { material: 'MR132', received: '0', remainder: '0.5' },
+    { material: 'MR194', received: '414115.10', remainder: '414115.10' }
+]);
+var byMat = {};
+msRound.rows.forEach(function(r) { byMat[r.key] = r.remainder; });
+assertEqual(byMat['MR132'], 38401, 'materialStock: остаток MR132 = round(38400.366+0.5)=38401');
+assertEqual(byMat['MR194'], 414115, 'materialStock: остаток MR194 = round(414115.10)=414115');
+assertEqual(msRound.totalRemainder, 452516, 'materialStock: totalRemainder округлён до целых');


### PR DESCRIPTION
## Что и зачем
В РМ «Дашборды и отчёты» карточка «Остатки сырья» показывала остаток с дробями (`38400.366`, `414115.10`) — для склада дробные м² это шум. Доработка к #3093/#3073.

## Изменения
- `materialStock()` суммирует остаток точно, затем округляет до целых м² (`Math.round`) — и по видам сырья, и `totalRemainder`. «Получено» не трогаем.

## Проверки
- `node experiments/atex-dashboards.test.js` — ok (добавлены проверки округления: 38400.366+0.5→38401, 414115.10→414115, total→452516).

🤖 Generated with [Claude Code](https://claude.com/claude-code)