### PR TITLE
feat(atex): dashboards — остатки сырья по логарифмической шкале

### DIFF
--- a/download/atex/js/dashboards.js
+++ b/download/atex/js/dashboards.js
@@ -364,8 +364,20 @@
         };
     }
 
+    // Ширина бара по логарифмической шкале: диапазон [min..max] → [2..100]%.
+    // Равные ОТНОШЕНИЯ значений дают равные расстояния, поэтому рядом с огромными
+    // остатками видно и соотношение маленьких. v<=0 или min<=0 → минимум (2%).
+    function logBarWidth(v, min, max) {
+        v = toNumber(v); min = toNumber(min); max = toNumber(max);
+        if (v <= 0 || min <= 0) return 2;
+        if (max <= min) return 100;
+        var pct = Math.round((Math.log(v) - Math.log(min)) / (Math.log(max) - Math.log(min)) * 98) + 2;
+        return Math.max(2, Math.min(100, pct));
+    }
+
     var agg = {
         toNumber: toNumber,
+        logBarWidth: logBarWidth,
         round3: round3,
         groupBy: groupBy,
         sumBy: sumBy,
@@ -478,16 +490,29 @@
     }
 
     // Горизонтальная гистограмма по строкам [{ key, count, ... }].
-    function bars(rows, valueFn, formatFn) {
+    function bars(rows, valueFn, formatFn, opts) {
         if (!rows.length) return el('div', { class: 'atex-db-empty', text: 'Нет данных' });
+        opts = opts || {};
         var max = rows.reduce(function(m, r) { return Math.max(m, toNumber(valueFn(r))); }, 0) || 1;
-        var box = el('div', { class: 'atex-db-bars' });
+        // Для лог-шкалы нижняя граница диапазона — минимальное положительное значение.
+        var minPos = 1;
+        if (opts.logScale) {
+            minPos = rows.reduce(function(m, r) {
+                var x = toNumber(valueFn(r));
+                return x > 0 ? Math.min(m, x) : m;
+            }, Infinity);
+            if (!isFinite(minPos)) minPos = 1;
+        }
+        function widthPct(v) {
+            return opts.logScale ? logBarWidth(v, minPos, max) : Math.max(2, Math.round(v / max * 100));
+        }
+        var box = el('div', { class: 'atex-db-bars' + (opts.logScale ? ' atex-db-bars-log' : '') });
         rows.forEach(function(r) {
             var v = toNumber(valueFn(r));
             var row = el('div', { class: 'atex-db-bar-row' }, [
                 el('span', { class: 'atex-db-bar-key', text: r.key, title: r.key }),
                 el('span', { class: 'atex-db-bar-track' }, [
-                    el('span', { class: 'atex-db-bar-fill', style: 'width:' + Math.max(2, Math.round(v / max * 100)) + '%' })
+                    el('span', { class: 'atex-db-bar-fill', style: 'width:' + widthPct(v) + '%' })
                 ]),
                 el('span', { class: 'atex-db-bar-val', text: (formatFn ? formatFn(r) : fmt(v)) })
             ]);
@@ -619,10 +644,10 @@
             metrics([
                 { label: 'остаток, м²', value: data.totalRemainder }
             ]),
-            el('h3', { class: 'atex-db-subhead', text: 'По видам сырья (остаток, м²)' }),
+            el('h3', { class: 'atex-db-subhead', text: 'По видам сырья (остаток, м² — лог. шкала)', title: 'Длина бара — по логарифмической шкале: видно соотношение и маленьких остатков рядом с огромными. Число справа — точный остаток.' }),
             bars(data.rows, function(r) { return r.remainder; }, function(r) {
                 return fmt(r.remainder) + ' м²';
-            })
+            }, { logScale: true })
         ]));
     };
 

--- a/experiments/atex-dashboards.test.js
+++ b/experiments/atex-dashboards.test.js
@@ -182,3 +182,13 @@ msRound.rows.forEach(function(r) { byMat[r.key] = r.remainder; });
 assertEqual(byMat['MR132'], 38401, 'materialStock: остаток MR132 = round(38400.366+0.5)=38401');
 assertEqual(byMat['MR194'], 414115, 'materialStock: остаток MR194 = round(414115.10)=414115');
 assertEqual(msRound.totalRemainder, 452516, 'materialStock: totalRemainder округлён до целых');
+
+// logBarWidth: логарифмическая шкала остатков [min..max] → [2..100]%.
+assertEqual(dashboards.logBarWidth(100, 100, 10000), 2, 'logBarWidth: минимум диапазона → 2%');
+assertEqual(dashboards.logBarWidth(10000, 100, 10000), 100, 'logBarWidth: максимум → 100%');
+assertEqual(dashboards.logBarWidth(1000, 100, 10000), 51, 'logBarWidth: середина по log (10×min) → 51%');
+assertEqual(dashboards.logBarWidth(0, 100, 10000), 2, 'logBarWidth: v<=0 → 2%');
+assertEqual(dashboards.logBarWidth(5, 5, 5), 100, 'logBarWidth: max<=min → 100%');
+// Маленькое значение (10×min) на лог-шкале заметно шире, чем было бы линейно.
+var linW = Math.round(1000 / 10000 * 100);            // линейно = 10%
+assert(dashboards.logBarWidth(1000, 100, 10000) > linW, 'logBarWidth: мелкое значение видимее, чем линейно (51% > 10%)');


### PR DESCRIPTION
## Что и зачем
В РМ «Дашборды и отчёты» бары «Остатки сырья» были линейными — при разбросе остатков (2 440 … 414 115 м²) мелкие виды почти не видны. Лог-шкала уравнивает: равные ОТНОШЕНИЯ значений → равные расстояния, видно соотношение маленьких остатков рядом с огромными. Доработка к #3093/#3073.

## Изменения
- Чистая `logBarWidth(v, min, max)` — диапазон [min..max] → [2..100]% по натуральному логарифму (экспортирована, покрыта тестом).
- `bars()` получил опцию `logScale`; включена только для остатков. Другие графики (статусы, слиттеры, ГП) — линейные, без изменений.
- Подзаголовок помечен «лог. шкала» + tooltip. Точное число остатка остаётся справа от бара.

## Проверки
- `node experiments/atex-dashboards.test.js` — ok (logBarWidth: min→2%, max→100%, 10×min→51% vs линейных 10%, v≤0→2%, max≤min→100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)