### PR TITLE
feat(atex): dashboards — грузить только активные заказы (серверный фильтр)

### DIFF
--- a/download/atex/js/dashboards.js
+++ b/download/atex/js/dashboards.js
@@ -451,10 +451,16 @@
 
     // Сбор сводок из двух отчётов (минимум запросов; агрегации — на клиенте).
     // Сырые строки сохраняются, чтобы фильтр дат перестраивал сводки без перезапроса.
+    //
+    // ⚠️ На дашборд тянем ТОЛЬКО АКТИВНЫЕ заказы (не «Выполнен»/«Отменён») — иначе при
+    // тысячах завершённых заказов выгрузка распухает. Фильтр серверный: в отчёте
+    // order_pipeline есть колонка-формула `order_active` (= '1' для активных, NULL для
+    // терминальных: `IF([THIS] IN ('Выполнен','Отменён'),NULL,'1')` на Заказ.Статус),
+    // а `FR_order_active=%` (LIKE — матчит непустое, отсекает NULL) оставляет только их.
     AtexDashboards.prototype.collect = function() {
         var self = this;
         return Promise.all([
-            this.getJson('report/order_pipeline?JSON_KV'),
+            this.getJson('report/order_pipeline?JSON_KV&FR_order_active=%25'),
             this.getJson('report/material_stock?JSON_KV')
         ]).then(function(res) {
             self.raw = { pipelineRows: res[0] || [], materialRows: res[1] || [] };

--- a/experiments/atex-dashboards.test.js
+++ b/experiments/atex-dashboards.test.js
@@ -116,7 +116,7 @@ var controller = new api.Controller({ getAttribute: function() { return 'atex'; 
 var collectCalls = [];
 controller.getJson = function(pathname) {
     collectCalls.push(pathname);
-    if (pathname === 'report/order_pipeline?JSON_KV') return Promise.resolve(PR);
+    if (pathname === 'report/order_pipeline?JSON_KV&FR_order_active=%25') return Promise.resolve(PR);
     if (pathname === 'report/material_stock?JSON_KV') return Promise.resolve([
         { material: 'Полиэтилен', material_received_m2: '500', material_remainder_m2: '200' }
     ]);
@@ -124,8 +124,8 @@ controller.getJson = function(pathname) {
 };
 
 controller.collect().then(function(result) {
-    assertEqual(collectCalls.sort(), ['report/material_stock?JSON_KV', 'report/order_pipeline?JSON_KV'],
-        'collect() запрашивает ровно два отчёта');
+    assertEqual(collectCalls.sort(), ['report/material_stock?JSON_KV', 'report/order_pipeline?JSON_KV&FR_order_active=%25'],
+        'collect() запрашивает ровно два отчёта (order_pipeline — только активные)');
     // #3073: пустой диапазон дат → только актуальные заказы (Выполнен 'A-2' отфильтрован).
     assert.strictEqual(result.counts.order, 1, 'collect(): пустой диапазон → только актуальные заказы');
     assert.strictEqual(result.counts.rawBatch, 1, 'collect(): counts.rawBatch = строки material_stock');


### PR DESCRIPTION
## Что и зачем
Дашборд тянул ВСЕ заказы из `order_pipeline` и фильтровал на клиенте. При тысячах завершённых заказов это раздувает выгрузку. Теперь активные заказы (не «Выполнен»/«Отменён») отбираются **на сервере**.

## Как
- В отчёт `order_pipeline` добавлена колонка-формула **`order_active`** (на live): `t101 = IF([THIS] IN ('Выполнен','Отменён'),NULL,'1')` поверх Заказ.Статус → '1' для активных, NULL для терминальных.
- `collect()` грузит `report/order_pipeline?JSON_KV&FR_order_active=%25` — LIKE-фильтр матчит непустое и отсекает NULL.

## Проверено на боевом
- Терминальный заказ (Выполнен) → `FR_order_active=%` его исключает (0 строк).
- Активный заказ → проходит, все колонки order_pipeline целы (JOIN не сломан).
- `node experiments/atex-dashboards.test.js` — ok (мок обновлён на новый URL).

## Эффект
На дашборд приходят только активные заказы. Терминальные больше не грузятся (карточка «Заказы по статусам» покажет только активные статусы — это и есть цель).

🤖 Generated with [Claude Code](https://claude.com/claude-code)