### PR TITLE
fix(integram-table): выравнивание .scroll-counter-total по вертикали (issue #3100)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T19:17:58.861Z for PR creation at branch issue-3100-c7b1bcb1f071 for issue https://github.com/ideav/crm/issues/3100

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T19:17:58.861Z for PR creation at branch issue-3100-c7b1bcb1f071 for issue https://github.com/ideav/crm/issues/3100

--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -856,6 +856,8 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     z-index: 100;
     letter-spacing: 0.25px;
     transition: opacity 0.2s ease;
+    display: flex;
+    align-items: center;
 }
 
 /* Make semi-transparent when table rows are beneath it (issue #1922) */


### PR DESCRIPTION
## Проблема

Счётчик `.scroll-counter-total` (число «258» в «Показано 40 из 258») отображался выше остального текста — из-за того, что кнопки «+» и «вставить данные» с `height: 22px` сдвигали базовую линию строки, а вложенный `<span>` внутри `.scroll-counter-total` прилипал к сдвинутому baseline.

## Решение

Добавлены `display: flex; align-items: center` к `.scroll-counter` (css/integram-table.css). Flexbox центрирует все дочерние элементы (кнопки, текст, span со счётчиком) по вертикальной оси, устраняя проблему с выравниванием.

## Файлы

- `css/integram-table.css` — 2 строки в `.scroll-counter`


Fixes #3100