### PR TITLE
feat(atex): dashboards — счётчик завершённых/отменённых заказов

### DIFF
--- a/download/atex/js/dashboards.js
+++ b/download/atex/js/dashboards.js
@@ -167,6 +167,19 @@
         return statusIn(status, TERMINAL_STATUSES);
     }
 
+    // Счётчики завершённых/отменённых заказов из отчёта orders_status_count
+    // (строки {order_status, cnt}). Эти заказы НЕ грузятся в order_pipeline (там
+    // только активные), поэтому их количество берём отдельным лёгким запросом.
+    function terminalOrderCounts(statusRows) {
+        var done = 0, cancelled = 0;
+        (statusRows || []).forEach(function(r) {
+            var n = toNumber(r.cnt != null ? r.cnt : r.count);
+            if (statusIn(r.order_status, ['Выполнен'])) done += n;
+            else if (statusIn(r.order_status, ['Отменён'])) cancelled += n;
+        });
+        return { done: done, cancelled: cancelled, total: done + cancelled };
+    }
+
     // Дата (ISO YYYY-MM-DD) в диапазоне [from, to] включительно; пустые границы
     // открыты, пустая дата не входит ни в какой непустой диапазон.
     function dateInRange(date, from, to) {
@@ -391,6 +404,7 @@
         buildSummaries: buildSummaries,
         selectOrders: selectOrders,
         isTerminalStatus: isTerminalStatus,
+        terminalOrderCounts: terminalOrderCounts,
         dateInRange: dateInRange,
         TERMINAL_STATUSES: TERMINAL_STATUSES,
         UNSET: UNSET
@@ -461,9 +475,12 @@
         var self = this;
         return Promise.all([
             this.getJson('report/order_pipeline?JSON_KV&FR_order_active=%25'),
-            this.getJson('report/material_stock?JSON_KV')
+            this.getJson('report/material_stock?JSON_KV'),
+            // Лёгкий агрегат: завершённые/отменённые заказы (их нет в order_pipeline).
+            this.getJson('report/orders_status_count?JSON_KV')
         ]).then(function(res) {
             self.raw = { pipelineRows: res[0] || [], materialRows: res[1] || [] };
+            self.statusCounts = res[2] || [];
             return buildSummaries(self.raw.pipelineRows, self.raw.materialRows, self.filter);
         });
     };
@@ -611,7 +628,15 @@
     };
 
     AtexDashboards.prototype.cardOrders = function(count, data) {
+        // Завершённые/отменённые заказы на дашборд не грузятся (только активные),
+        // поэтому их счётчики берём из отдельного отчёта orders_status_count.
+        var term = terminalOrderCounts(this.statusCounts || []);
         return card('Заказы по статусам', count, el('div', {}, [
+            metrics([
+                { label: 'завершено', value: term.done },
+                { label: 'отменено', value: term.cancelled }
+            ]),
+            el('h3', { class: 'atex-db-subhead', text: 'Активные по статусам' }),
             ordersBars(data.rows)
         ]));
     };

--- a/experiments/atex-dashboards.test.js
+++ b/experiments/atex-dashboards.test.js
@@ -120,12 +120,18 @@ controller.getJson = function(pathname) {
     if (pathname === 'report/material_stock?JSON_KV') return Promise.resolve([
         { material: 'Полиэтилен', material_received_m2: '500', material_remainder_m2: '200' }
     ]);
+    if (pathname === 'report/orders_status_count?JSON_KV') return Promise.resolve([
+        { order_status: 'Выполнен', cnt: '7' },
+        { order_status: 'Отменён', cnt: '3' },
+        { order_status: 'Новый', cnt: '1' }
+    ]);
     throw new Error('Unexpected getJson call: ' + pathname);
 };
 
 controller.collect().then(function(result) {
-    assertEqual(collectCalls.sort(), ['report/material_stock?JSON_KV', 'report/order_pipeline?JSON_KV&FR_order_active=%25'],
-        'collect() запрашивает ровно два отчёта (order_pipeline — только активные)');
+    assertEqual(collectCalls.sort(), ['report/material_stock?JSON_KV', 'report/order_pipeline?JSON_KV&FR_order_active=%25', 'report/orders_status_count?JSON_KV'],
+        'collect() запрашивает три отчёта (order_pipeline активные + остатки + счётчик статусов)');
+    assert.strictEqual(controller.statusCounts.length, 3, 'collect(): statusCounts сохранён');
     // #3073: пустой диапазон дат → только актуальные заказы (Выполнен 'A-2' отфильтрован).
     assert.strictEqual(result.counts.order, 1, 'collect(): пустой диапазон → только актуальные заказы');
     assert.strictEqual(result.counts.rawBatch, 1, 'collect(): counts.rawBatch = строки material_stock');
@@ -192,3 +198,16 @@ assertEqual(dashboards.logBarWidth(5, 5, 5), 100, 'logBarWidth: max<=min → 100
 // Маленькое значение (10×min) на лог-шкале заметно шире, чем было бы линейно.
 var linW = Math.round(1000 / 10000 * 100);            // линейно = 10%
 assert(dashboards.logBarWidth(1000, 100, 10000) > linW, 'logBarWidth: мелкое значение видимее, чем линейно (51% > 10%)');
+
+// terminalOrderCounts: завершённые/отменённые из отчёта статусов.
+var tc = dashboards.terminalOrderCounts([
+    { order_status: 'Выполнен', cnt: '7' },
+    { order_status: 'Отменён', cnt: '3' },
+    { order_status: 'Новый', cnt: '120' }
+]);
+assertEqual(tc.done, 7, 'terminalOrderCounts: завершено = 7');
+assertEqual(tc.cancelled, 3, 'terminalOrderCounts: отменено = 3');
+assertEqual(tc.total, 10, 'terminalOrderCounts: всего терминальных = 10');
+// ё/регистр и пустой ввод
+assertEqual(dashboards.terminalOrderCounts([{ order_status: 'отменен', cnt: '5' }]).cancelled, 5, 'terminalOrderCounts: нормализация ё/регистра');
+assertEqual(dashboards.terminalOrderCounts([]).total, 0, 'terminalOrderCounts: пустой ввод → 0');


### PR DESCRIPTION
## Что и зачем
После PR #3102 на дашборд грузятся только активные заказы (терминальные исключены сервером). Чтобы видеть, сколько заказов **завершено/отменено**, считаем их **отдельным лёгким запросом** (без выгрузки всех строк).

## Как
- Новый отчёт-агрегат **`orders_status_count`** на live: group by Заказ.Статус + COUNT (t104=74) → ~5 строк `{order_status, cnt}`.
- `collect()` тянет его третьим запросом, сохраняет `statusCounts`.
- Карточка «Заказы по статусам»: метрики **«завершено» / «отменено»** сверху, ниже — активные по статусам.
- Чистая `terminalOrderCounts(statusRows)` (экспорт, тест).

## Проверено на боевом
- Отчёт группирует и считает: при 1 Выполнен + 1 Отменён → `[{Выполнен:1},{Отменён:1},{Новый:272}]`; после возврата → `[{Новый:274}]` (тестовые правки откатил).
- `node experiments/atex-dashboards.test.js` — ok (3 отчёта в моке + тест terminalOrderCounts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)