### PR TITLE
fix(integram-table): отлепить число счётчика от текста (issue #3108)

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -860,6 +860,18 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     align-items: center;
 }
 
+/*
+ * Restore the space before the total-count number (issue #3108).
+ * Making .scroll-counter a flex container (#3103) turned the trailing
+ * text node "Показано N из " and the <span> counter into separate flex
+ * items, collapsing the literal space between them ("из258"). A small
+ * left margin re-introduces that visual gap without breaking the
+ * vertical centering added in #3103.
+ */
+.scroll-counter-total {
+    margin-left: 0.25em;
+}
+
 /* Make semi-transparent when table rows are beneath it (issue #1922) */
 .scroll-counter.rows-beneath {
     opacity: 0.7;


### PR DESCRIPTION
## Проблема

После PR #3103 `.scroll-counter` стал flex-контейнером (`display: flex; align-items: center`) для вертикального выравнивания. Побочный эффект: текстовый узел `«Показано N из »` и `<span class="scroll-counter-total">` превратились в **отдельные flex-элементы**, и литеральный пробел между ними схлопнулся — число прилипло к тексту: «Показано 40 **из258**».

## Решение

Добавлено правило `.scroll-counter-total { margin-left: 0.25em; }` — возвращает визуальный отступ перед числом, не трогая вертикальное центрирование из #3103.

## Проверка (headless Chrome, before/after)

- **BEFORE:** `Показано 40 из258`
- **AFTER:** `Показано 40 из 258` (центрирование сохранено)

## Файлы

- `css/integram-table.css` — +8 строк (правило + комментарий) в секции `.scroll-counter`

Fixes #3108