### PR TITLE
#3118 main.html: токен AI-сервиса не делаем type=password (ложный промпт «Сохранить пароль»)

### DIFF
--- a/templates/atex/main.html
+++ b/templates/atex/main.html
@@ -315,7 +315,11 @@
                     </div>
                     <div class="database-field-group">
                         <label for="ai-service-token" class="database-field-label">API token</label>
-                        <input id="ai-service-token" class="database-field-input" type="password" autocomplete="off">
+                        <!-- Токен AI-сервиса — секрет, но не пароль входа. type="text" + маска
+                             text-security вместо type="password": иначе менеджер паролей браузера
+                             принимает пару «Модель + Токен» за логин и предлагает «Сохранить пароль»
+                             при любом submit-подобном событии (например, применении фильтра) — #3118. -->
+                        <input id="ai-service-token" class="database-field-input" type="text" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other" spellcheck="false" style="-webkit-text-security:disc; text-security:disc;">
                     </div>
                     <div class="database-field-group">
                         <label for="ai-target-db" class="database-field-label">База данных</label>

--- a/templates/main.html
+++ b/templates/main.html
@@ -314,7 +314,11 @@
                     </div>
                     <div class="database-field-group">
                         <label for="ai-service-token" class="database-field-label">API token</label>
-                        <input id="ai-service-token" class="database-field-input" type="password" autocomplete="off">
+                        <!-- Токен AI-сервиса — секрет, но не пароль входа. type="text" + маска
+                             text-security вместо type="password": иначе менеджер паролей браузера
+                             принимает пару «Модель + Токен» за логин и предлагает «Сохранить пароль»
+                             при любом submit-подобном событии (например, применении фильтра) — #3118. -->
+                        <input id="ai-service-token" class="database-field-input" type="text" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other" spellcheck="false" style="-webkit-text-security:disc; text-security:disc;">
                     </div>
                     <div class="database-field-group">
                         <label for="ai-target-db" class="database-field-label">База данных</label>

--- a/templates/ru/main.html
+++ b/templates/ru/main.html
@@ -148,7 +148,11 @@
                     </div>
                     <div class="database-field-group">
                         <label for="ai-service-token" class="database-field-label">API token</label>
-                        <input id="ai-service-token" class="database-field-input" type="password" autocomplete="off">
+                        <!-- Токен AI-сервиса — секрет, но не пароль входа. type="text" + маска
+                             text-security вместо type="password": иначе менеджер паролей браузера
+                             принимает пару «Модель + Токен» за логин и предлагает «Сохранить пароль»
+                             при любом submit-подобном событии (например, применении фильтра) — #3118. -->
+                        <input id="ai-service-token" class="database-field-input" type="text" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other" spellcheck="false" style="-webkit-text-security:disc; text-security:disc;">
                     </div>
                     <div class="database-field-group">
                         <label for="ai-target-db" class="database-field-label">База данных</label>


### PR DESCRIPTION
Фикс #3118: при применении фильтра браузер предлагал «Сохранить пароль».

### Причина
В панели настроек AI-сервиса (`main.html`) поле **API token** было `type="password"`, а прямо перед ним — текстовое поле **Модель** (`ai-service-model`). Менеджер паролей Chrome принимает пару «текстовое поле + password» за логин/пароль и при любом submit-подобном событии (в т.ч. применении фильтра в рабочем месте) предлагает сохранить токен как пароль (на скрине: «Имя пользователя: deepseek/deepseek-v4-pro», «Пароль: <токен>»). `autocomplete="off"` Chrome для password-полей игнорирует.

Модалка смены пароля ни при чём — её поля `disabled` (Chrome их не учитывает).

### Фикс
Токен AI-сервиса — секрет, но **не пароль входа**. Поле переведено с `type="password"` на `type="text"` с визуальной маской `-webkit-text-security: disc` (Chrome/Safari) + `data-lpignore`/`data-1p-ignore`/`data-form-type="other"`. Браузерный менеджер паролей больше не видит password-поле и не предлагает сохранение; значение поля (`.value`) и логика чтения не меняются.

Исправлено во всех трёх копиях шаблона:
- `templates/main.html` (база),
- `templates/atex/main.html` (**деплоится на live ateh** через `templates/atex` → `templates/custom/ateh`),
- `templates/ru/main.html` (ru-локаль).

### Проверка
- Активных password-полей, образующих «логин-пару», не осталось; password остаются только у модалки смены пароля (`disabled`, открывается явно) и у honeypot (`readonly`).
- ⚠️ Маска `text-security` поддерживается Chrome/Safari; в Firefox токен отобразится открытым текстом (поле админ-настроек) — при необходимости добавим show/hide-кнопку.
- Браузерную проверку (применить фильтр → промпт не появляется) прогнать после мержа/деплоя.
