### PR TITLE
#3120 (Группа A) production-planning: карточка-панель, панель полос под карточкой, блок стрелок при busy

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -113,24 +113,25 @@
 
 .atex-pp-queue-group { margin-bottom: 16px; }
 
+/* Карточка резки — панель (#3120 п.1): информация + контролы + панель полос внутри. */
 .atex-pp-cut {
+    padding: 9px 12px;
+    margin-bottom: 8px;
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+}
+.atex-pp-cut:hover { background: var(--pp-surface); }
+.atex-pp-cut.is-active { border-color: var(--pp-accent); box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
+
+/* Информационная строка — клик выбирает резку. */
+.atex-pp-cut-info {
     display: grid;
     grid-template-columns: 70px 1.4fr 1fr 100px 110px 110px;
     gap: 10px;
     align-items: center;
-    width: 100%;
-    text-align: left;
-    padding: 9px 10px;
-    margin-bottom: 6px;
-    border: 1px solid var(--pp-border);
-    border-radius: 6px;
-    background: var(--pp-bg);
     cursor: pointer;
-    font: inherit;
-    color: inherit;
 }
-.atex-pp-cut:hover { background: var(--pp-surface); }
-.atex-pp-cut.is-active { border-color: var(--pp-accent); box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
 .atex-pp-cut-num { font-weight: 700; }
 .atex-pp-cut-type { font-weight: 600; }
 .atex-pp-cut-batch,
@@ -146,8 +147,33 @@
 }
 .atex-pp-cut-supplies { font-size: 12px; color: var(--pp-muted); text-align: right; }
 
+/* Контролы внутри карточки: вверх/вниз/Полосы (#3120 п.1). */
+.atex-pp-cut-controls {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    margin-top: 8px;
+}
+.atex-pp-move {
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    padding: 5px 11px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    line-height: 1;
+}
+.atex-pp-move:hover { background: var(--pp-surface); }
+.atex-pp-move:disabled { opacity: .4; cursor: default; }
+/* Пока идёт перемещение (setBusy) — все стрелки неактивны (#3120 п.5). */
+.atex-pp.is-busy .atex-pp-move { pointer-events: none; opacity: .4; }
+
+/* Панель полос — под своей карточкой (#3120 п.8). */
+.atex-pp-cut > .atex-pp-strip-panel { margin: 10px 0 2px; }
+
 @media (max-width: 720px) {
-    .atex-pp-cut { grid-template-columns: 1fr 1fr; }
+    .atex-pp-cut-info { grid-template-columns: 1fr 1fr; }
     .atex-pp-filters { grid-template-columns: 1fr; }
 }
 

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1735,7 +1735,14 @@
         activeGroup.cuts.forEach(function(c, idx) {
             var active = String(self.selectedCutId) === String(c.id);
             var supplies = self.supplyCount(c.id);
-            var card = el('button', { class: 'atex-pp-cut' + (active ? ' is-active' : ''), type: 'button' }, [
+
+            // Карточка-панель (#3120 п.1): div-панель вместо кнопки. Внутри —
+            // информация (клик = выбор резки) и контролы (↑/↓/Полосы). Панель полос
+            // (#3120 п.8) openStrips добавляет внутрь этой же карточки (контейнер —
+            // cardPanel), а не внизу всей очереди — поэтому она строго одна на карточку.
+            var cardPanel = el('div', { class: 'atex-pp-cut' + (active ? ' is-active' : ''), dataset: { cutId: String(c.id) } });
+
+            var info = el('div', { class: 'atex-pp-cut-info' }, [
                 el('span', { class: 'atex-pp-cut-num', text: '№ ' + (c.number || c.id) }),
                 el('span', { class: 'atex-pp-cut-seq', text: 'Очер.: ' + (c.sequence != null && !isNaN(c.sequence) ? c.sequence : '—') }),
                 el('span', { class: 'atex-pp-cut-batch', text: c.materialBatch.label || '' }),
@@ -1743,11 +1750,12 @@
                 el('span', { class: 'atex-pp-cut-status', text: c.status || '' }),
                 el('span', { class: 'atex-pp-cut-supplies', text: supplies ? ('связей: ' + supplies) : 'нет связей' })
             ]);
-            card.addEventListener('click', function() { self.selectedCutId = c.id; self.render(); });
+            info.addEventListener('click', function() { self.selectedCutId = c.id; self.render(); });
+            cardPanel.appendChild(info);
 
-            var row = el('div', { class: 'atex-pp-cut-row' });
-            var up = el('button', { class: 'atex-pp-move', type: 'button', text: '↑' });
-            var down = el('button', { class: 'atex-pp-move', type: 'button', text: '↓' });
+            var controls = el('div', { class: 'atex-pp-cut-controls' });
+            var up = el('button', { class: 'atex-pp-move', type: 'button', text: '↑', title: 'Выше' });
+            var down = el('button', { class: 'atex-pp-move', type: 'button', text: '↓', title: 'Ниже' });
             if (idx === 0) up.disabled = true;
             if (idx === activeGroup.cuts.length - 1) down.disabled = true;
             up.addEventListener('click', function() {
@@ -1763,13 +1771,14 @@
             var strips = el('button', { class: 'atex-pp-strips', type: 'button', text: 'Полосы' });
             strips.addEventListener('click', function() {
                 if (self.busy) return;
-                self.openStrips(c, box);
+                self.openStrips(c, cardPanel);
             });
-            row.appendChild(up);
-            row.appendChild(card);
-            row.appendChild(down);
-            row.appendChild(strips);
-            groupEl.appendChild(row);
+            controls.appendChild(up);
+            controls.appendChild(down);
+            controls.appendChild(strips);
+            cardPanel.appendChild(controls);
+
+            groupEl.appendChild(cardPanel);
         });
         box.appendChild(groupEl);
     };


### PR DESCRIPTION
Доработки рабочего места «Планирование производства» по #3120 — **Группа A (UI-баги 1, 5, 8)**.
Группа C (архитектура «Расход сырья» FIFO — пп.2,3,4) выделена в отдельный дизайн (решение по задаче: резерв авто при создании/планировании). Ниже — что сделано и диагнозы по остальным пунктам.

### Сделано
- **П.1 — карточка `.atex-pp-cut` → панель.** Вместо `<button>` — `<div>`-панель: внутри информационная строка (клик = выбор резки) и контролы (↑/↓/«Полосы»).
- **П.8 — панель полос под своей карточкой.** `openStrips` добавляет `.atex-pp-strip-panel` внутрь карточки резки (контейнер — сама карточка), а не внизу всей очереди. Панель строго одна на карточку.
- **П.5 — блокировка стрелок при перемещении.** Пока идёт `saveSequences` (`setBusy`), все `.atex-pp-move` неактивны (CSS `.atex-pp.is-busy .atex-pp-move { pointer-events:none; opacity:.4 }`).

### Диагнозы (пп.6, 7, 9, 10)
- **П.7 (Остаток −50, cut 13132 = №28):** сырьё MWR200, джамбо в справочнике = 910 мм. Полосы: 80×10 + 60×1 + 25×2 + **25×2** = 960 → 910−960 = −50. Расчёт верный — **полосы превышают джамбо**.
- **П.10 («2 идентичные строки»):** это **дублирующая запись Полосы** `25×2 Склад` (редактор читает записи напрямую и показывает реально две). Без дубля сумма = 910 = джамбо ровно. Таблица рисует один заголовок + по строке на запись — это не баг рендера, а данные. **П.7 и П.10 — одна причина.**
- **П.6 («ширина джамбо не задана» при наличии ширины):** для резок с привязанным сырьём джамбо резолвится из справочника корректно (13132 → 910). Бейдж появляется только когда у резки не определён материал (нет партии). Нужен конкретный пример резки, где сырьё есть, а бейдж «не задана».
- **П.9 (`strip-del` не сохраняет/не пересчитывает):** по коду `del` делает splice+renderRows+recalc, а `saveStrips` шлёт `_m_del` для удалённых id — логика корректна. Перенос панели в карточку (п.8) устраняет «протухшую» панель в общем контейнере. Если баг воспроизводится — нужны шаги.

### Не вошло (требует решения/данных)
- Удаление дублирующей Полосы у резки 13132 (данные) — по подтверждению.
- Предотвращение дублей полос при генерации/добавлении ходовых — кандидат в Группу C.
- Тесты пуро-функций: 112 assertions OK. DOM-поведение (панель/вкладки/стрелки) — браузерная проверка после деплоя.
