### PR TITLE
#3124 production-planning: «×» полосы сразу шлёт _m_del (удаление не сохранялось)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1163,9 +1163,24 @@
 
                 var del = el('button', { class: 'atex-pp-btn atex-pp-strip-del', type: 'button', title: 'Удалить полосу', text: '×' });
                 del.addEventListener('click', function() {
-                    strips.splice(idx, 1);
+                    if (self.busy) return;
+                    var removed = strips.splice(idx, 1)[0];
                     renderRows();
                     recalc();
+                    // Уже сохранённую полосу (есть id) удаляем на сервере сразу (#3124):
+                    // раньше _m_del уходил только по «Сохранить полосы», поэтому при
+                    // обновлении страницы удалённые полосы возвращались. Убираем и из
+                    // original, чтобы последующее «Сохранить» не пыталось удалить повторно.
+                    if (removed && removed.id) {
+                        for (var i = 0; i < original.length; i++) {
+                            if (String(original[i].id) === String(removed.id)) { original.splice(i, 1); break; }
+                        }
+                        self.post('_m_del/' + encodeURIComponent(removed.id) + '?JSON', {}).then(function() {
+                            self.notify('Полоса удалена', 'info');
+                        }).catch(function(err) {
+                            self.notify('Ошибка удаления полосы: ' + err.message, 'error');
+                        });
+                    }
                 });
                 row.appendChild(del);
 


### PR DESCRIPTION
Фикс #3124: `.atex-pp-strip-del` («×») не слал `_m_del` — удаление полосы не сохранялось.

### Причина
Кнопка «×» удаляла полосу **только локально** (`strips.splice` + `renderRows` + `recalc`). Запрос `_m_del` уходил лишь при «Сохранить полосы» (дифф `original↔strips`). Если пользователь жал «×» и не нажимал «Сохранить», на сервер ничего не уходило, и после обновления страницы полосы возвращались.

### Фикс
Клик по «×» для **уже сохранённой полосы** (есть `id`) сразу шлёт `_m_del/{id}` (как «×» в «Связанных позициях»), плюс убирает её из `original`, чтобы последующее «Сохранить» не пыталось удалить повторно. Новые (несохранённые, `id=null`) полосы — как и раньше, удаляются только из локального состояния. Сводка (`recalc`) пересчитывается сразу.

### Проверка
`node experiments/atex-production-planning.test.js` — 121 assertion OK; модуль грузится. Поведение «×» (немедленный `_m_del` + пересчёт) — браузерная проверка после деплоя.
