### PR TITLE
#3120 (Группа C, Фаза 1a) подсветка резки без подходящей партии сырья (п.4)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -123,6 +123,8 @@
 }
 .atex-pp-cut:hover { background: var(--pp-surface); }
 .atex-pp-cut.is-active { border-color: var(--pp-accent); box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
+/* Нет подходящей партии сырья — резку нельзя обеспечить (#3120 п.4, Фаза 1a). */
+.atex-pp-cut.is-unreserved { background: rgba(185, 28, 28, .07); border-color: var(--pp-warn); }
 
 /* Информационная строка — клик выбирает резку. */
 .atex-pp-cut-info {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -491,6 +491,15 @@
         return String(avail[0].id);
     }
 
+    // #3120 группа C (Фаза 1a, п.4): у резки задан материал, но нет ни одной подходящей
+    // партии сырья с остатком (pickBatchFIFO === null) → резку нельзя обеспечить сырьём.
+    // Резки без материала (materialId пуст) не помечаем. genBatches — [{id,materialId,...,remainder}].
+    function cutMissingBatch(cut, genBatches){
+        var mat = cut && cut.materialId != null ? String(cut.materialId) : '';
+        if (mat === '') return false;
+        return pickBatchFIFO(genBatches || [], mat) === null;
+    }
+
     // Потребность резки в погонных метрах (#3120 группа C): длина прогона джамбо =
     // самая длинная обеспечиваемая позиция (параллельный слиттинг — все полосы режутся
     // за один прогон). supplyFootages — массив «Метраж, м» обеспечений резки.
@@ -623,6 +632,7 @@
         unsuppliedPositions: unsuppliedPositions,
         pickSlitter: pickSlitter,
         pickBatchFIFO: pickBatchFIFO,
+        cutMissingBatch: cutMissingBatch,
         requiredRunLengthM: requiredRunLengthM,
         reserveFifo: reserveFifo,
         aggregateStrips: aggregateStrips,
@@ -1777,7 +1787,10 @@
             // информация (клик = выбор резки) и контролы (↑/↓/Полосы). Панель полос
             // (#3120 п.8) openStrips добавляет внутрь этой же карточки (контейнер —
             // cardPanel), а не внизу всей очереди — поэтому она строго одна на карточку.
-            var cardPanel = el('div', { class: 'atex-pp-cut' + (active ? ' is-active' : ''), dataset: { cutId: String(c.id) } });
+            // #3120 п.4 (Фаза 1a): подсветка резки, у которой задан материал, но нет
+            // подходящей партии сырья с остатком (обеспечить нечем).
+            var unreserved = cutMissingBatch(c, self.genBatches);
+            var cardPanel = el('div', { class: 'atex-pp-cut' + (active ? ' is-active' : '') + (unreserved ? ' is-unreserved' : ''), dataset: { cutId: String(c.id) } });
 
             var info = el('div', { class: 'atex-pp-cut-info' }, [
                 el('span', { class: 'atex-pp-cut-num', text: '№ ' + (c.number || c.id) }),

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -398,6 +398,13 @@ assertEqual([r3.allocations.length, r3.reservedLinearM, r3.shortfallLinearM, r3.
 var r4 = planning.reserveFifo(fifoBatches, 0, 0.9);
 assertEqual([r4.allocations.length, r4.fullyReserved], [0, true], 'reserveFifo: N=0 → пусто, fullyReserved');
 
+// cutMissingBatch (#3120 п.4): материал задан, но нет партии с остатком → true.
+var gb = [{ id: '1', materialId: '2126', dateKey: 1, remainder: 100 }, { id: '2', materialId: '900', dateKey: 1, remainder: 0 }];
+assertEqual(planning.cutMissingBatch({ materialId: '2126' }, gb), false, 'cutMissingBatch: есть партия с остатком → false');
+assertEqual(planning.cutMissingBatch({ materialId: '900' }, gb), true, 'cutMissingBatch: партия есть, но остаток 0 → true');
+assertEqual(planning.cutMissingBatch({ materialId: '777' }, gb), true, 'cutMissingBatch: нет партий материала → true');
+assertEqual(planning.cutMissingBatch({ materialId: '' }, gb), false, 'cutMissingBatch: материал не задан → false');
+
 // вход не мутируется (порядок исходного массива сохранён).
 assertEqual(fifoBatches[0].id, '10', 'reserveFifo: вход не мутируется (сортировка на копии)');
 


### PR DESCRIPTION
**Группа C, Фаза 1a (из #3120):** подсветка резок без обеспечения сырьём — безопасная, без записи в БД.

### Что в этом PR
- **п.4 (часть «нет подходящей партии»):** карточка резки `.atex-pp-cut` подсвечивается светло-красным (`is-unreserved`), если у резки **задан материал**, но **нет ни одной партии сырья этого вида с остатком** (`pickBatchFIFO === null`). Резки без материала не помечаются.
- Чистая функция `cutMissingBatch(cut, genBatches)` + тесты (125 assertions OK). Использует уже загружаемые `genBatches` — **никаких новых запросов и записей**.
- CSS `.atex-pp-cut.is-unreserved`.

Это сразу подсвечивает класс проблем «резка на сырьё, которого нет на складе» (как была резка №32 до заведения партии MR377).

### Дальше — Фаза 1b (отдельным PR, нужна твоя проверка на live)
FIFO-**резерв** (создание записей «Расход сырья» 1079 по приходу) и вторая часть п.4 («не удалось зарезервировать полностью»). Требует:
- подгрузки **«Метраж, м»** обеспечений в клиент (сейчас `cut_planning` его не отдаёт) — для потребности `N = max(Метраж)`;
- живых записей в БД на создании/планировании — это write-логика, которую корректнее проверить в браузере перед мержем.

Ядро FIFO (`reserveFifo`, `requiredRunLengthM`) уже в main (#3123) и покрыто тестами.

### Фаза 2 (схема, с бэкапом) — позже
Удаление req 1159 «Партия сырья», переисточнение `cut_planning`, поле формы.
