### PR TITLE
#3130 production-planning: число ножей убывает к концу дня (сортировка очереди станка)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -553,11 +553,22 @@
         }
         return result;
     }
-    // Упорядочить резки станка: не-Фольга жадно, затем Фольга жадно; проставить sequence; вход не мутировать.
+    // Внутри последовательности станка число ножей должно убывать к концу дня
+    // (ideav/crm#3130): в начале смены ножей много, к вечеру меньше — переналаживать
+    // тяжелее. Стабильная сортировка по knifeCount ↓; равные — в порядке жадной
+    // последовательности (минимизация переналадок остаётся вторичным критерием).
+    function byKnifeCountDesc(seq){
+        return (seq || []).map(function(c, i){ return { c: c, i: i }; })
+            .sort(function(a, b){ return ((Number(b.c.knifeCount) || 0) - (Number(a.c.knifeCount) || 0)) || (a.i - b.i); })
+            .map(function(x){ return x.c; });
+    }
+
+    // Упорядочить резки станка: не-Фольга, затем Фольга; внутри каждой группы — жадно
+    // (переналадки), затем по убыванию ножей (#3130); проставить sequence; вход не мутировать.
     function orderCuts(cuts, weights){
         var rest = [], foil = [];
         (cuts || []).forEach(function(c){ (c && c.isFoil ? foil : rest).push(c); });
-        var seq = greedySequence(rest, weights).concat(greedySequence(foil, weights));
+        var seq = byKnifeCountDesc(greedySequence(rest, weights)).concat(byKnifeCountDesc(greedySequence(foil, weights)));
         return seq.map(function(c, i){
             var copy = {}; for (var k in c){ if (Object.prototype.hasOwnProperty.call(c, k)) copy[k] = c[k]; }
             copy.sequence = i + 1;
@@ -627,6 +638,7 @@
         changeoverCost: changeoverCost,
         greedySequence: greedySequence,
         orderCuts: orderCuts,
+        byKnifeCountDesc: byKnifeCountDesc,
         planQueues: planQueues,
         moveInQueue: moveInQueue,
         unsuppliedPositions: unsuppliedPositions,

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -245,6 +245,15 @@ var res = planning.orderCuts(src);
 assertEqual(res.map(function(c){return c.sequence;}), [1,2], 'sequence 1..N');
 assertEqual(src[0].sequence, undefined, 'вход не мутируется');
 
+// #3130: число ножей убывает по очереди станка (внутри не-Фольга группы)
+var knifeCuts = [
+    { id: '1', materialId: 'M', knifeCount: 3, knifeWidths: [], rollerWidth: 0 },
+    { id: '2', materialId: 'M', knifeCount: 7, knifeWidths: [], rollerWidth: 0 },
+    { id: '3', materialId: 'M', knifeCount: 5, knifeWidths: [], rollerWidth: 0 }
+];
+assertEqual(planning.orderCuts(knifeCuts).map(function(c){ return c.knifeCount; }), [7, 5, 3], 'orderCuts: ножи убывают к концу дня (7,5,3)');
+assertEqual(planning.byKnifeCountDesc([{ knifeCount: 2, id: 'a' }, { knifeCount: 2, id: 'b' }, { knifeCount: 9, id: 'c' }]).map(function(x){ return x.id; }), ['c', 'a', 'b'], 'byKnifeCountDesc: ↓, равные стабильно');
+
 // ── rowsToPlanning строит дескриптор движка из колонок отчёта ──
 var rpd = planning.rowsToPlanning([{
   cut_id:'9', cut_no:'1', cut_slitter_id:'10', cut_slitter:'Станок 1',


### PR DESCRIPTION
Фикс #3130: число ножей в резке должно **убывать к концу дня**, а не расти (к вечеру оператору тяжелее налаживать ножи).

### Изменение
В `orderCuts` после жадной последовательности (минимизация переналадок) каждая группа станка (не-Фольга, затем Фольга) **стабильно сортируется по `knifeCount` ↓**. Равные по числу ножей сохраняют порядок жадной последовательности (минимизация переналадок остаётся **вторичным** критерием). Чистая `byKnifeCountDesc` + тесты.

Результат: по очереди станка число ножей не возрастает (напр. 7 → 5 → 3).

### Важно (компромисс)
Раньше первичной была группировка по сырью/намотке (минимизация переналадок). Теперь **первично убывание ножей** (как просит #3130), а группировка по сырью — вторична: при разнице в числе ножей резки разного сырья могут чередоваться. Это прямое следствие требования «ножи должны убывать».

Если нужен баланс (сохранить группировку по сырью, а ножи лишь «не увеличивать» внутри сырьевого блока) — вместо первичной сортировки сделаю **асимметричный штраф** в `changeoverCost` (рост ножей дороже снижения). Скажи, если предпочтительнее этот вариант.

### Проверка
`node experiments/atex-production-planning.test.js` — **127 assertions OK** (ножи убывают 7,5,3; стабильность для равных; прежние тесты группировки целы). Поведение очереди — браузерная проверка после деплоя.
