### PR TITLE
fix(integram-table): корректное разделение имён таблицы и первой колонки (#3157)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-05T12:43:11.967Z for PR creation at branch issue-3157-c71ad9c39a85 for issue https://github.com/ideav/crm/issues/3157

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-05T12:43:11.967Z for PR creation at branch issue-3157-c71ad9c39a85 for issue https://github.com/ideav/crm/issues/3157

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -7905,7 +7905,7 @@ class IntegramTable{
             const uniqueKeyTitle = 'Система контролирует уникальность комбинации первой колонки и всех ключей';
 
             colEditModal.innerHTML = `
-                <h3 style="margin: 0 0 16px 0; font-weight: 500; font-size: 1.125rem;">Редактирование колонки: <em style="font-style: normal; color: var(--md-primary, #1976d2);">${ this.escapeHtml(col.name) }</em></h3>
+                <h3 style="margin: 0 0 16px 0; font-weight: 500; font-size: 1.125rem;">Редактирование колонки: <em style="font-style: normal; color: var(--md-primary, #1976d2);">${ this.escapeHtml(currentName) }</em></h3>
                 <div class="col-edit-section">
                     <div class="col-edit-row">
                         <label class="col-edit-label">Название:</label>

--- a/js/integram-table/11-column-settings.js
+++ b/js/integram-table/11-column-settings.js
@@ -358,7 +358,7 @@
             const uniqueKeyTitle = 'Система контролирует уникальность комбинации первой колонки и всех ключей';
 
             colEditModal.innerHTML = `
-                <h3 style="margin: 0 0 16px 0; font-weight: 500; font-size: 1.125rem;">Редактирование колонки: <em style="font-style: normal; color: var(--md-primary, #1976d2);">${ this.escapeHtml(col.name) }</em></h3>
+                <h3 style="margin: 0 0 16px 0; font-weight: 500; font-size: 1.125rem;">Редактирование колонки: <em style="font-style: normal; color: var(--md-primary, #1976d2);">${ this.escapeHtml(currentName) }</em></h3>
                 <div class="col-edit-section">
                     <div class="col-edit-row">
                         <label class="col-edit-label">Название:</label>


### PR DESCRIPTION
Fixes #3157

## Проблема

При редактировании **первой колонки** в диалоге «Настройки колонок таблицы» заголовок диалога показывал **псевдоним таблицы** («Задание на втулки») вместо настоящего имени колонки («К-во план»).

Причина: у объекта первой колонки (формируется в `01-core.js` / `02-format-helpers.js`, issue #2967):
- `col.name` — отображаемое имя таблицы (псевдоним), напр. `Задание на втулки`;
- `col.val` — сырое имя первой колонки, напр. `К-во план`;
- `col.alias` — псевдоним таблицы.

Заголовок диалога `Редактирование колонки: …` в `11-column-settings.js` использовал `col.name`, поэтому для первой колонки показывал псевдоним таблицы.

## Решение

Заголовок диалога теперь использует `currentName` (`col.val || col.name`) — то же значение, что и поле **«Название»**. Для первой колонки это сырое имя `К-во план`, для остальных — их имя (без изменений).

Псевдоним таблицы по-прежнему отображается:
- в `.integram-table-title` (заголовок таблицы) — без изменений;
- в поле **«Псевдоним таблицы»** диалога — без изменений.

## Изменения
- `js/integram-table/11-column-settings.js` — заголовок диалога использует `currentName` вместо `col.name`.
- `js/integram-table.js` — пересобранный бандл (`bash build.sh`).

## Как воспроизвести
1. Открыть таблицу с псевдонимом (напр. «Задание на втулки»), у которой первая колонка названа иначе (напр. «К-во план»).
2. Открыть «Настройки колонок таблицы» → редактировать первую колонку.
3. **До:** в заголовке диалога — «Задание на втулки». **После:** «К-во план».

## Проверка
- Синтаксис бандла: `node --check js/integram-table.js` — OK.
- Логика заголовка проверена изолированным тестом (`col.val || col.name` → `К-во план`).