### PR TITLE
fix(atex): resolve issues #3170, #3168, #3167, #3154

### DIFF
--- a/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
+++ b/docs/WORKSPACE_DEVELOPMENT_GUIDE.md
@@ -9,13 +9,16 @@
 Правила собраны из кода и закрытых тикетов
 (<https://github.com/ideav/crm/issues?q=is%3Aissue%20state%3Aclosed>). По соглашению,
 принятому в `js/integram-table.js`, каждое правило снабжено ссылкой на источник:
-номер задачи `(issue #NNN)` и/или путь к файлу с номером строки `file:line`. Это
-позволяет проверить корректность каждого утверждения и проследить его происхождение.
+номер задачи `(issue #NNN)` и/или путь к файлу с идентифицирующим фрагментом кода
+(имя функции, класса или уникальная строка). Это позволяет проверить корректность
+каждого утверждения и проследить его происхождение.
 
 > **Как читать ссылки.** `issue #NNN` — закрытый тикет ideav/crm, в котором правило
-> появилось. `file:line` — место в коде, подтверждающее правило. Номера задач вида
-> `#6451`, встречающиеся в `mcp-server/`, относятся к отдельному трекеру MCP-сервера, а
-> не к ideav/crm; в таких случаях указан путь к файлу как источник истины.
+> появилось. Путь к файлу с именем функции или идентифицирующим фрагментом — место
+> в коде, подтверждающее правило (номера строк не используются, так как они
+> постоянно меняются). Номера задач вида `#6451`, встречающиеся в `mcp-server/`,
+> относятся к отдельному трекеру MCP-сервера, а не к ideav/crm; в таких случаях
+> указан путь к файлу как источник истины.
 
 ## Где включается это правило (подсказка)
 
@@ -54,10 +57,20 @@
 
 ### 1.1. Подстановка переменных
 
+> **⚠️ Точки вставки обрабатываются во всём тексте шаблона, включая комментарии.**
+> Если в HTML-комментарии написать `надо использовать {_global_.*} для обращения`,
+> шаблонизатор попытается разрешить `{_global_.*}` как точку вставки и, скорее
+> всего, не найдёт переменную — блок будет пропущен целиком. Регулярное выражение
+> шаблонизатора, которое захватывает точки вставки (функция `Parse_block` в `index.php`):
+> `/{([A-ZА-Я0-9\.&_ \-]*?[^ ;\r\n])}/gmiu`
+> Всё, что подпадает под этот шаблон, трактуется как точка вставки — даже
+> в комментариях. **Не пишите `{_global_.*}` и похожие конструкции
+> в комментариях HTML-шаблона.**
+
 - Синтаксис подстановки: `{_global_.ИМЯ}`. **Пробелы внутри фигурных скобок
   недопустимы** — пишите `{_global_.version}`, а не `{ _global_.version }`
-  (`README.md:77`).
-- Доступные глобальные переменные (объявлены в `templates/main.html:130-139`):
+  (`README.md`, раздел «Подстановка переменных»).
+- Доступные глобальные переменные (объявлены в `templates/main.html` (блок `<script>` с `var db, xsrf, ...`)):
 
   | Переменная | Значение |
   |------------|----------|
@@ -68,7 +81,7 @@
   | `{_global_.token}` | токен сессии |
   | `{_global_.xsrf}` | XSRF-токен для POST-запросов (см. раздел 4) |
   | `{_global_.id}` | ID текущего объекта/ресурса |
-  | `{_global_.grants}` | base64-JSON прав доступа: `JSON.parse(atob('{_global_.grants}'))` (`templates/main.html:138`) |
+  | `{_global_.grants}` | base64-JSON прав доступа: `JSON.parse(atob('{_global_.grants}'))` (`templates/main.html` (строка `grants=JSON.parse(atob(...))`)) |
   | `{_global_.version}` | версия приложения для cache-busting (см. раздел 2) |
 
 - Кроме `_global_`, шаблонизатор понимает префиксы `{_request_.X}` (значение из
@@ -80,33 +93,33 @@
 ### 1.2. Блоки и встраивание рабочего места
 
 - Повторяемые и условные секции размечаются парами комментариев
-  `<!-- Begin: ИМЯ -->` … `<!-- End: ИМЯ -->` (`templates/main.html:192,198,385,387`).
+  `<!-- Begin: ИМЯ -->` … `<!-- End: ИМЯ -->` (`templates/main.html` (маркеры `<!-- Begin: ... -->` / `<!-- End: ... -->`)).
 - Условный блок проверяет инлайн-комментарий вида `<!--{_global_.z}-->`: если
-  переменная не разрешается, блок пропускается (`templates/main.html:192`).
-- Маркер `<!-- File: a -->` (`templates/main.html:379`) динамически подключает шаблон
+  переменная не разрешается, блок пропускается (`templates/main.html` (условный блок `<!--{_global_.z}-->`)).
+- Маркер `<!-- File: a -->` (`templates/main.html` (маркер `<!-- File: a -->`)) динамически подключает шаблон
   рабочего места по имени `{_global_.action}.html` (например `dict.html`,
   `forms.html`). Если файла нет — подставляется `info.html`. Так рабочее место и
   встраивается в `main.html`.
 - Имена блоков могут начинаться с `&`, например `<!-- Begin:&Uni_Report -->`
-  (`templates/report.html:1`).
+  (`templates/report.html` (блок `<!-- Begin:&Uni_Report -->`)).
 
 ---
 
 ## 2. Подключение CSS/JS и версионирование ресурсов
 
 - **Стили — только в `.css`, скрипты — только в `.js`.** Инлайн-стили и инлайн-скрипты
-  в шаблонах не используются (`README.md:78`). Исключение — короткая логика
+  в шаблонах не используются (`README.md` (правило «стили в .css, скрипты в .js»)). Исключение — короткая логика
   инициализации (например, вызов `initHints`, см. раздел 9);
   пример применения исключения — блоки `<style>` и `<script>` для логики подсказок
-  в `templates/table.html:15-260`.
+  в `templates/table.html` (блоки `<style>` и `<script>` для подсказок).
 - **URL ресурсов рекомендуется снабжать версией** для сброса кэша:
   `href="/css/file.css?{_global_.version}"`, `src="/js/file.js?{_global_.version}"`
-  (`templates/dash.html:1,73`; `README.md:79`).
+  (`templates/dash.html`, `<link>` с `?{_global_.version}`; `README.md`, раздел «Версионирование ресурсов»).
   Правило применяется в новых шаблонах (`dash.html`, `migr.html`); часть
   старых шаблонов (`table.html`, `query.html`, `info.html` и др.) версию не указывает —
   это техдолг, а не допустимое исключение.
 - Порядок подключения для рабочего места с таблицей: сначала CSS компонента, затем
-  его JS, затем `hints.js` (`templates/table.html:10-13`).
+  его JS, затем `hints.js` (`templates/table.html` (порядок `<link>`/`<script>` в `<head>`)).
 
 ---
 
@@ -121,25 +134,23 @@
 | `_m_save/{objectId}` | сохранить **первую колонку** (имя/идентификатор объекта) |
 | `_m_set/{objectId}` | задать значения **остальных реквизитов** (не первой колонки) |
 | `_m_del/{objectId}` | удалить объект (каскадно с подчинёнными) |
-| `_m_del_select` | массовое удаление выбранных записей (`templates/object.html:545`) |
+| `_m_del_select` | массовое удаление выбранных записей (`templates/object.html` (вызов `_m_del_select`)) |
 | `_m_ord/{objectId}` | установить позицию в порядке сортировки (`issue #1617`) |
-| `_m_up/{objectId}` | сдвинуть запись вверх среди равных (`templates/forms.html:2479`) |
+| `_m_up/{objectId}` | сдвинуть запись вверх среди равных (`templates/forms.html` (вызов `_m_up`)) |
 | `_m_move/{objectId}` | сменить родителя (параметр `up={newParentId}`) |
 | `_m_id/{objectId}` | переименовать ID объекта (параметр `new_id`; административная команда) |
 
 - **`_m_save` — только для первой колонки**, для всех прочих реквизитов используйте
-  `_m_set` (`issue #775`; `js/integram-table.js:5633`).
+  `_m_set` (`issue #775`; `js/integram-table.js` (функция сохранения ячейки, проверка `colIndex === 0`)).
 - Частые параметры строки запроса:
   - `JSON` — получить ответ в формате JSON;
   - `up={parentId}` — родитель создаваемого объекта; для корневого объекта `up=1`
     (`issue #1658`);
   - `t{reqId}={value}` — значение реквизита по его ID; можно несколько:
-    `&t271=...&t273=...` (`templates/upload.html:959-961`);
+    `&t271=...&t273=...` (`templates/upload.html` (функция `createSet`, вызов `_m_new` с `t{reqId}`));
   - `full=1` — **обязателен** при записи длинных/HTML-полей, иначе значение
-    обрезается до 127 символов (`index.php:49` — константа `VAL_LIM=127`,
-    `index.php:6821,7215` — проверка обрезки; комментарии в
-    `mcp-server/index.js:2122`).
-- Пример (создание + установка реквизитов из `templates/upload.html:959-961`):
+    обрезается до 127 символов (`index.php`, константа `VAL_LIM=127` и проверка обрезки в `Parse_block`; комментарии в `mcp-server/index.js`, функция `setField`).
+- Пример (создание + установка реквизитов из `templates/upload.html` (функция `createSet`, вызов `_m_new` с `t{reqId}`)):
 
   ```js
   // создать набор: тип 269, родитель up=1, реквизиты t271, t269, t273
@@ -154,21 +165,21 @@
 
 - **Каждый POST-запрос обязан содержать токен `_xsrf`.** GET-запросы токен не требуют.
 - Токен берётся из шаблонной переменной: `var xsrf = '{_global_.xsrf}'`
-  (`templates/main.html:131`).
+  (`templates/main.html` (строка `var xsrf = ...`)).
 - В рабочих местах используется хелпер `intApi(method, url, branch, vars, index)`,
-  который **сам подставляет токен** (`templates/upload.html:821-832`):
+  который **сам подставляет токен** (`templates/upload.html` (функция `intApi`)):
   - если `vars` — объект `FormData`: `vars.append('_xsrf', xsrf)`;
   - если `vars` — строка: `vars = '_xsrf=' + xsrf + '&' + vars` и заголовок
     `Content-Type: application/x-www-form-urlencoded`.
 - Для обычной HTML-формы добавляйте скрытое поле:
   `<input type="hidden" name="_xsrf" value="{_global_.xsrf}">`
-  (`templates/edit_obj.html:77`).
+  (`templates/edit_obj.html` (скрытое поле `<input name="_xsrf">`)).
 - Аналогичные хелперы используют ту же логику инжекта токена:
-  - `newApi` (с поддержкой `FormData`) — глобальный хелпер в `js/main.js:2-13`;
-  - `myApi` (только строка) — локальный хелпер в `templates/sql.html:691` и
-    `templates/form.html:217`;
+  - `newApi` (с поддержкой `FormData`) — глобальный хелпер в `js/main.js` (функция `newApi`);
+  - `myApi` (только строка) — локальный хелпер в `templates/sql.html` (функция `myApi`) и
+    `templates/form.html` (функция `myApi`);
   - `intApi` (с поддержкой `FormData`) — локальный хелпер в
-    `templates/quiz.html:952` и `templates/object.html:1526`.
+    `templates/quiz.html` (функция `intApi`) и `templates/object.html` (функция `intApi`).
 - Не дублируйте логику XSRF вручную, если хелпер уже есть.
 
 ---
@@ -176,7 +187,7 @@
 ## 5. Чтение данных из отчётов
 
 - Источник `report`: данные берутся из готового отчёта по
-  `GET /{_global_.z}/report/{id}?JSON` (`templates/query.html:4`).
+  `GET /{_global_.z}/report/{id}?JSON` (`templates/query.html` (атрибут `data-api-url` блока `data-integram-table`)).
 - Формат ответа: `{ columns: [...], data: [...], header: "..." }`, где `columns` —
   описания колонок (`id`, `type`, `format`, `name`, `granted`, `ref`), а `data` —
   колонко-ориентированный массив (компонент сам преобразует его в строки).
@@ -193,7 +204,7 @@
 
 - Источник `table`: сначала метаданные `GET /{_global_.z}/metadata/{typeId}`, затем
   данные `GET /{_global_.z}/object/{typeId}/?JSON_OBJ&F_U={parentId}&LIMIT=…`
-  (`templates/table.html:4`).
+  (`templates/table.html` (атрибут `data-api-url` блока `data-integram-table`)).
 - Формат `JSON_OBJ` — массив записей `[{ "i": …, "u": …, "o": …, "r": [...] }]`:
   - `i` — ID записи, `u` — ID родителя, `o` — порядок, `r` — массив значений колонок.
 - Метаданные содержат список реквизитов (`reqs`) и поле `granted`: значение `WRITE`
@@ -266,18 +277,18 @@
        data-instance-name="tasksTable"></div>
   ```
 
-  (`templates/query.html:1-8`, `templates/table.html:1-8`)
+  (`templates/query.html` и `templates/table.html`, блоки `<div data-integram-table>`)
 - **Программно**: `new IntegramTable('container-id', { apiUrl, dataSource, tableTypeId,
   parentId, recordId, pageSize, cookiePrefix, title, instanceName, onCellClick,
-  onDataLoad, debug })` (`templates/calendar.html:1328`).
+  onDataLoad, debug })` (`templates/calendar.html` (вызов `new IntegramTable(...)`)).
 - `parentId` берётся из опции или из URL (`parentId` / `F_U` / `up`); `recordId` —
   фильтр по записи, берётся из опции или из GET-параметра `F_I` (`issue #563`).
-- `debug: false` — включить трассировку в консоль (`js/integram-table/01-core.js:22`).
+- `debug: false` — включить трассировку в консоль (`js/integram-table/01-core.js` (опция `debug` в конструкторе)).
 
 ### 7.2. Правило сборки бандла
 
 - `js/integram-table.js` — **автогенерируемый бандл, его НЕЛЬЗЯ редактировать напрямую**
-  (`CLAUDE.md:1-7`).
+  (`CLAUDE.md` (правило «не редактировать бандл напрямую»)).
 - Исходники — модули `js/integram-table/*.js`. После правки модуля запустите
   `bash build.sh` из корня и закоммитьте оба файла: изменённый модуль и пересобранный
   `js/integram-table.js` (`build.sh`).
@@ -287,15 +298,15 @@
 ## 8. Модальные окна и запрет `alert`/`confirm`/`prompt`
 
 - **Никогда не используйте** `alert()`, `confirm()`, `prompt()`. Вместо них —
-  модальные методы (`README.md:41,73-76`):
+  модальные методы (`README.md` (правило «модальные окна вместо alert/confirm/prompt»)):
   - `showDeleteConfirmModal()` — подтверждение удаления (в `IntegramTable`, без
-    параметра — текст фиксированный; `js/integram-table/21-form-field-settings.js:893`);
+    параметра — текст фиксированный; `js/integram-table/21-form-field-settings.js` (функция `showDeleteConfirmModal`));
   - `showErrorModal(message)` — ошибки (в `MainAppController`;
-    `js/main-app.js:1607`);
+    `js/main-app.js` (метод `showErrorModal` класса `MainAppController`));
   - `showWarningModal(message, objId = null)` — предупреждения во время сохранения
-    (в `IntegramTable`; `js/integram-table/22-utils.js:430`);
+    (в `IntegramTable`; `js/integram-table/22-utils.js` (функция `showWarningModal`));
   - `showWarningsModal(message)` — информационные предупреждения **после** сохранения,
-    не блокирует операцию (в `IntegramTable`; `js/integram-table/22-utils.js:491`;
+    не блокирует операцию (в `IntegramTable`; `js/integram-table/22-utils.js` (функция `showWarningsModal`);
     `issue #610`).
 
 ---
@@ -316,5 +327,5 @@
 *Документ создан по issue #2797; ссылка на первоисточник
 ([`integram-app-workflow.md`](integram-app-workflow.md)) добавлена по issue #2808, а сам
 первоисточник заархивирован в репозиторий по issue #2810. Источники правил — код
-репозитория и закрытые тикеты ideav/crm; см. ссылки `issue #NNN` и `file:line` в каждом
-разделе.*
+репозитория и закрытые тикеты ideav/crm; см. ссылки `issue #NNN` и пути к файлам
+с идентифицирующими фрагментами кода в каждом разделе.*

--- a/download/atex/js/orders.js
+++ b/download/atex/js/orders.js
@@ -34,7 +34,7 @@
         { key: 'created', label: 'Дата создания', names: ['Дата создания'] },
         { key: 'approved', label: 'Дата согласования', names: ['Дата согласования'] },
         { key: 'dueDate', label: 'Срок изготовления', names: ['Срок изготовления'] },
-        { key: 'status', label: 'Статус', names: ['Статус'], status: true },
+        { key: 'status', label: 'Статус', names: ['Статус заказа', 'Статус'], ref: true },
         { key: 'lead', label: 'Лидер', names: ['Лидер'] },
         { key: 'notes', label: 'Примечания', names: ['Примечания'] },
         // Счётчик подчинённых позиций (ROLLUP-колонка «Позиция заказа») — приходит
@@ -50,7 +50,7 @@
         { key: 'length', label: 'Длина, м', names: ['Длина, м', 'Длина'] },
         { key: 'sleeve', label: 'Диаметр втулки', names: ['Диаметр втулки'], ref: true },
         { key: 'winding', label: 'Тип намотки', names: ['Тип намотки'] },
-        { key: 'status', label: 'Статус', names: ['Статус'], status: true },
+        { key: 'status', label: 'Статус', names: ['Статус позиции', 'Статус'], ref: true },
         // Срок изготовления — только для отображения (read-only), как «Дата согласования».
         { key: 'dueDate', label: 'Срок изготовления', names: ['Срок изготовления'] }
     ];
@@ -661,9 +661,11 @@
     function renderFilter() {
         var sel = document.getElementById('atex-orders-filter');
         if (!sel) return;
-        sel.innerHTML = ['<option value="">Все статусы</option>'].concat(state.orderStatuses.map(function(status) {
-            var selected = status === state.statusFilter ? ' selected' : '';
-            return '<option value="' + escapeHtml(status) + '"' + selected + '>' + escapeHtml(status) + '</option>';
+        var statusCol = getColumn(state.orderColumns, 'status');
+        var options = (statusCol && statusCol.reqId) ? (state.refOptions[statusCol.reqId] || []) : [];
+        sel.innerHTML = ['<option value="">Все статусы</option>'].concat(options.map(function(opt) {
+            var selected = String(opt.id) === state.statusFilter ? ' selected' : '';
+            return '<option value="' + escapeHtml(opt.id) + '">' + escapeHtml(opt.text) + '</option>';
         })).join('');
     }
 
@@ -802,12 +804,14 @@
     function renderCreateForm() {
         var clientCol = getColumn(state.orderColumns, 'client');
         var clientOptions = clientCol && clientCol.reqId ? state.refOptions[clientCol.reqId] : null;
+        var statusCol = getColumn(state.orderColumns, 'status');
+        var statusOptions = statusCol && statusCol.reqId ? (state.refOptions[statusCol.reqId] || []) : [];
         var panel = document.getElementById('atex-order-create-form');
         if (!panel) return;
         panel.innerHTML =
             '<div class="atex-orders-fields">' +
             '<label>Клиент' + refSelectHtml('atex-order-client', clientOptions, '', 'Выберите клиента', clientCol && clientCol.reqId) + '</label>' +
-            '<label>Статус' + statusSelectHtml(state.orderStatuses, state.orderStatuses[0], ' id="atex-order-status"') + '</label>' +
+            '<label>Статус' + refSelectHtml('atex-order-status', statusOptions, '', 'Выберите статус', statusCol && statusCol.reqId) + '</label>' +
             '<label>Срок изготовления<input type="date" class="atex-orders-input" id="atex-order-due-date"></label>' +
             '<label class="atex-orders-field-wide">Примечания<textarea class="atex-orders-input" id="atex-order-notes" rows="2"></textarea></label>' +
             '</div>' +
@@ -1504,7 +1508,7 @@
                         approveBtn._atexApproveTimer = setTimeout(function() {
                             approveBtn.removeAttribute('data-confirm');
                             approveBtn.classList.remove('is-confirm');
-                            approveBtn.textContent = 'Согласовано';
+                            approveBtn.textContent = 'Согласовать';
                         }, 4000);
                     }
                     return;
@@ -1572,7 +1576,7 @@
             if (btn._atexApproveTimer) clearTimeout(btn._atexApproveTimer);
             btn.removeAttribute('data-confirm');
             btn.classList.remove('is-confirm');
-            btn.textContent = 'Согласовано';
+            btn.textContent = 'Согласовать';
         });
     }
 
@@ -1623,12 +1627,16 @@
 
                 // Предзагрузка справочников для форм.
                 var clientCol = getColumn(state.orderColumns, 'client');
+                var orderStatusCol = getColumn(state.orderColumns, 'status');
                 var rawCol = getColumn(state.positionColumns, 'raw');
                 var sleeveCol = getColumn(state.positionColumns, 'sleeve');
+                var positionStatusCol = getColumn(state.positionColumns, 'status');
                 return Promise.all([
                     clientCol && clientCol.reqId ? loadRefOptions(clientCol.reqId) : Promise.resolve([]),
+                    orderStatusCol && orderStatusCol.reqId ? loadRefOptions(orderStatusCol.reqId) : Promise.resolve([]),
                     rawCol && rawCol.reqId ? loadRefOptions(rawCol.reqId) : Promise.resolve([]),
-                    sleeveCol && sleeveCol.reqId ? loadRefOptions(sleeveCol.reqId) : Promise.resolve([])
+                    sleeveCol && sleeveCol.reqId ? loadRefOptions(sleeveCol.reqId) : Promise.resolve([]),
+                    positionStatusCol && positionStatusCol.reqId ? loadRefOptions(positionStatusCol.reqId) : Promise.resolve([])
                 ]);
             })
             .then(function() {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2172,10 +2172,6 @@
         planBtn.addEventListener('click', function() { self.runPlanning(actions); });
         actions.appendChild(planBtn);
 
-        var genBtn = el('button', { class: 'atex-pp-btn', type: 'button', text: 'Сгенерировать резки' });
-        genBtn.addEventListener('click', function() { self.generateCuts(actions); });
-        actions.appendChild(genBtn);
-
         form.appendChild(actions);
     };
 
@@ -2201,7 +2197,25 @@
         var groups = groupBySlitter(filtered);
 
         if (!groups.length) {
-            box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Резок в очереди нет' }));
+            // Показываем вкладки всех станков, даже если резок нет (#3168).
+            if (this.slitters.length) {
+                var allKeys = this.slitters.map(function(s) { return String(s.id); });
+                if (allKeys.indexOf(self.activeSlitter) === -1) self.activeSlitter = allKeys[0];
+                var tabs = el('div', { class: 'atex-pp-tabs' });
+                this.slitters.forEach(function(s) {
+                    var key = String(s.id);
+                    var tab = el('button', { class: 'atex-pp-tab' + (key === self.activeSlitter ? ' is-active' : ''), type: 'button' }, [
+                        el('span', { class: 'atex-pp-tab-label', text: s.label }),
+                        el('span', { class: 'atex-pp-tab-count', text: '0' })
+                    ]);
+                    tab.addEventListener('click', function() { self.activeSlitter = key; self.renderQueue(); });
+                    tabs.appendChild(tab);
+                });
+                box.appendChild(tabs);
+                box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Резок в очереди нет' }));
+            } else {
+                box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Резок в очереди нет' }));
+            }
             return;
         }
 
@@ -2495,11 +2509,14 @@
         // Форма новой резки живёт в модалке (#3116 п.1), открывается кнопкой «+».
         this.formEl = el('section', { class: 'atex-pp-form', 'data-submit-scope': '' });
 
-        // Шапка очереди: заголовок слева + кнопка «+ Новая резка» справа вверху.
+        // Шапка очереди: заголовок слева, затем кнопка «Сгенерировать резки» и «+ Новая резка» справа вверху.
+        var genBtn = el('button', { class: 'atex-pp-btn', type: 'button', text: 'Сгенерировать резки' });
+        genBtn.addEventListener('click', function() { self.generateCuts(null); });
         var addBtn = el('button', { class: 'atex-pp-btn atex-pp-btn-primary atex-pp-add', type: 'button', text: '+ Новая резка' });
         addBtn.addEventListener('click', function() { self.openForm(); });
         var queueHead = el('div', { class: 'atex-pp-panel-head' }, [
             el('h2', { class: 'atex-pp-form-title', text: 'Очередь резок по станкам' }),
+            genBtn,
             addBtn
         ]);
         var queueWrap = el('section', { class: 'atex-pp-panel atex-pp-queue-panel' }, [queueHead]);

--- a/templates/atex/intake.html
+++ b/templates/atex/intake.html
@@ -1,4 +1,4 @@
-<!-- Рабочее место atex «Приёмка сырья» (роль Кладовщик). -->
+<!-- Рабочее место atex «Приёмка сырья» (роли: Кладовщик, Диспетчер РМ). -->
 <!-- Решение ideav/crm#2914 (часть #2903). См. docs/atex_workplaces.md §3.4 -->
 <!-- и docs/WORKSPACE_DEVELOPMENT_GUIDE.md. URL: /atex/intake -->
 <link rel="stylesheet" href="/download/{_global_.z}/css/atex-brand.css?0{_global_.version}">


### PR DESCRIPTION
## Что сделано

### #3170 — WORKSPACE_DEVELOPMENT_GUIDE.md
- Добавлено предупреждение о regex шаблонизатора (`Parse_block`), который обрабатывает точки вставки даже в комментариях HTML-шаблона
- Убраны все ссылки на номера строк (`file:line`), заменены на имена функций и идентифицирующие фрагменты кода

### #3168 — production-planning.js
- Кнопка «Сгенерировать резки» вынесена в шапку очереди резок, левее кнопки «+ Новая резка»
- Убран дубликат кнопки «Сгенерировать резки» из модальной формы
- Вкладки станков показываются даже при отсутствии резок (отображаются все слиттеры с счётчиком 0)

### #3167 — orders.js
- Обновлены имена полей статуса в соответствии с новой структурой метаданных: «Статус» → «Статус заказа» / «Статус позиции»
- Статус переведён из текстового поля в ref-поле (`status: true` → `ref: true`)
- Кнопка «Согласовано» переименована в «Согласовать»
- Фильтр по статусу и форма создания заказа используют ref-опции, загружаемые с сервера

### #3154 — templates/atex/intake.html
- Обновлён комментарий: рабочее место «Приёмка сырья» теперь документировано как доступное ролям Кладовщик и Диспетчер РМ

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)