### PR TITLE
fix(atex): force redeploy production-planning.js

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2951,3 +2951,4 @@
 
     return { planning: planning, Controller: AtexProductionPlanning, init: init };
 });
+


### PR DESCRIPTION
Триггер для передеплоя файла через update.php. Файл был повреждён на сервере (23KB вместо 170KB).