### PR TITLE
fix(atex): timing traces for generateCuts/renderQueue + approval filter fix

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -418,6 +418,10 @@
     // batchDateKey (для оконного отбора по сроку при генерации); нет срока → Infinity.
     function rowsToGenPositions(rows) {
         return (rows || []).map(function(row) {
+            // Позиция считается согласованной, если утверждён заказ (order_approval_date)
+            // ИЛИ утверждена сама позиция (item_approval_date).
+            var orderApproved = !!(String(row.order_approval_date || '').trim());
+            var itemApproved = !!(String(row.item_approval_date || '').trim());
             return {
                 id: row.position_id == null ? '' : String(row.position_id),
                 materialId: row.position_material_id == null ? '' : String(row.position_material_id),
@@ -425,7 +429,8 @@
                 qty: Number(row.position_qty) || 0,
                 length: Number(row.position_length) || 0,
                 sleeveDiameter: sleeveDiameterFromRow(row),
-                dueKey: batchDateKey(row.position_due_date)
+                dueKey: batchDateKey(row.position_due_date),
+                approved: orderApproved || itemApproved
             };
         });
     }
@@ -1296,7 +1301,8 @@
         return this.getJson('report/positions_list?JSON_KV&LIMIT=0,2000').then(function(rows) {
             self.positions = rowsToPositions(rows || []);
             self.genPositions = rowsToGenPositions(rows || []);
-            console.log('[pp] 📋 loadPositions: загружено позиций для дропдауна:', self.positions.length, ', для генерации:', self.genPositions.length);
+            var approvedCnt = self.genPositions.filter(function(p) { return p.approved; }).length;
+            console.log('[pp] 📋 loadPositions: загружено позиций для дропдауна:', self.positions.length, ', для генерации:', self.genPositions.length, ', согласованных:', approvedCnt);
         });
     };
 
@@ -2080,8 +2086,9 @@
         }
 
         // Необеспеченные позиции, сгруппированные по сырью.
-        var unsup = unsuppliedPositions(this.genPositions, this.supplies);
-        console.log('[pp] ⚙️ generateCuts: всего позиций:', this.genPositions.length, ', необеспеченных:', unsup.length);
+        // Только согласованные (order_approval_date или item_approval_date).
+        var unsup = unsuppliedPositions(this.genPositions, this.supplies).filter(function(p) { return p.approved; });
+        console.log('[pp] ⚙️ generateCuts: всего позиций:', this.genPositions.length, ', необеспеченных согласованных:', unsup.length);
         if (!unsup.length) {
             this.notify('Нет необеспеченных позиций для генерации', 'info');
             return;
@@ -2560,7 +2567,8 @@
         // Выбор позиций заказа для обеспечения (#3194) — только согласованные,
         // ещё не обеспеченные позиции, сгруппированные по виду сырья и ширине.
         var unsup = unsuppliedPositions(this.genPositions, this.supplies);
-        var approvedOnly = unsup.filter(function(p) { return p.dueKey > 0; });
+        // Только согласованные: заказ (order_approval_date) или позиция (item_approval_date)
+        var approvedOnly = unsup.filter(function(p) { return p.approved; });
         // Группировка по сырью для компактного отображения
         var byMat = {};
         approvedOnly.forEach(function(p) {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2221,8 +2221,10 @@
         this.setBusy(true);
         // Окно прогресса (#3148): генерация идёт последовательными зависимыми
         // запросами, может занять заметное время.
+        console.log('[pp] 🔧 runGenerateCuts: начало создания ' + nCuts + ' резок...');
         this.showProgress('Генерация резок…', nCuts);
         var chain = Promise.resolve();
+        var startTime = Date.now();
         layouts.forEach(function(lay, layIdx) {
             chain = chain.then(function() {
                 self.updateProgress(doneCuts, 'Создаётся резка ' + (layIdx + 1) + ' из ' + nCuts + '…');
@@ -2333,15 +2335,25 @@
             });
         });
 
+        var genStartTime = Date.now();
         chain.then(function() {
+            var elapsed = ((Date.now() - genStartTime) / 1000).toFixed(1);
+            console.log('[pp] 🔧 runGenerateCuts: все записи созданы за ' + elapsed + 'с. загружаем свежие данные...');
             self.updateProgress(nCuts, 'Обновление очереди…');
             return self.reload();
         }).then(function() {
+            var elapsed = ((Date.now() - genStartTime) / 1000).toFixed(1);
+            console.log('[pp] 🔧 runGenerateCuts: данные загружены за ' + elapsed + 'с. рендерим...');
             self.hideProgress();
             self.setBusy(false);
+            var renderStart = Date.now();
             self.render();
+            var renderMs = Date.now() - renderStart;
+            console.log('[pp] 🔧 runGenerateCuts: render занял ' + renderMs + 'мс');
+            var totalElapsed = ((Date.now() - genStartTime) / 1000).toFixed(1);
             var reasons = self.groupSkipReasons(skipped);
             var sleeveMin = sleeveMinutes(nSleeves, self.opTimes || {});
+            console.log('[pp] 🔧 runGenerateCuts: ГОТОВО за ' + totalElapsed + 'с. резок:', layouts.length, 'полос:', nStrips, 'партийГП:', nFinishedBatches, 'втулок:', nSleeveTasks, 'пропущено:', skipped.length);
             self.notify('Создано ' + layouts.length + ' резок, полос ' + nStrips +
                 ', партий ГП ' + nFinishedBatches + ', заданий на втулки ' + nSleeveTasks +
                 (sleeveMin > 0 ? ' (' + sleeveMin + ' мин)' : '') +
@@ -2349,6 +2361,7 @@
         }).catch(function(err) {
             self.hideProgress();
             self.setBusy(false);
+            console.error('[pp] 🔧 runGenerateCuts: ОШИБКА', err.message, err.stack);
             self.notify('Ошибка генерации резок: ' + err.message, 'error');
         });
     };
@@ -2660,6 +2673,7 @@
 
     AtexProductionPlanning.prototype.renderQueue = function() {
         var self = this;
+        var t0 = Date.now();
         var box = this.queueEl;
         box.innerHTML = '';
 
@@ -2842,6 +2856,7 @@
             }
         });
         box.appendChild(groupEl);
+        console.log('[pp] 📊 renderQueue: отрисовано за ' + (Date.now() - t0) + 'мс. групп:', groups.length, 'резок:', self.cuts.length);
     };
 
     AtexProductionPlanning.prototype.renderLink = function() {


### PR DESCRIPTION
Add timing traces for generateCuts and renderQueue. Fix approval filter to use order_approval_date/item_approval_date. Help diagnose #3197.