### PR TITLE
fix(atex): показывать резки с timestamp cut_no

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-06T20:26:11.642Z for PR creation at branch issue-3189-83819542298d for issue https://github.com/ideav/crm/issues/3189
+# Updated: 2026-06-07T14:38:15.699Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-06T20:26:11.642Z for PR creation at branch issue-3189-83819542298d for issue https://github.com/ideav/crm/issues/3189
-# Updated: 2026-06-07T14:38:15.699Z

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -76,7 +76,8 @@
         notes: 'Примечания',
         sequence: 'Очередность',
         plannedRuns: 'Кол-во план',
-        actualRuns: 'Кол-во факт'
+        actualRuns: 'Кол-во факт',
+        length: 'Метраж, м'
     };
     // Реквизиты «Обеспечения» (up = позиция заказа).
     var SUPPLY_REQ = {
@@ -293,16 +294,15 @@
     // Видимость резки в очереди диспетчера (за сегодня и позже / по выбранной дате).
     // Резка показывается, если ВСЕ условия выполнены:
     //  1) статус не «Завершён» (выполненные резки в очередь не показываем);
-    //  2) заказ резки согласован — «Дата согласования» заказа не пустая
-    //     (orderApprovalDate из отчёта cut_planning, через Позиция→Заказ);
-    //  3) «Дата план» совпадает с выбранной датой ИЛИ пустая (ещё не запланирована —
+    //  2) «Дата план» совпадает с выбранной датой ИЛИ пустая (ещё не запланирована —
     //     напр. только что сгенерированная резка). selectedDate пустая → дата не фильтрует.
+    // Согласование заказа/позиции фильтрует создание новых резок, но уже попавшие в
+    // cut_planning резки считаются рабочей очередью (#3209: очищенная новая модель).
     // Форматы дат разные («ДД.ММ.ГГГГ» из отчёта, «ГГГГ-ММ-ДД» из <input type=date>) —
     // нормализуем общим batchDateKey.
     function isCutVisible(cut, selectedDate) {
         if (!cut) return false;
         if (String(cut.status || '').trim() === 'Завершён') return false;
-        if (!String(cut.orderApprovalDate || '').trim()) return false;
         var pd = String(cut.planDate || '').trim();
         if (pd === '') return true;
         var sd = String(selectedDate == null ? '' : selectedDate).trim();
@@ -346,6 +346,15 @@
         var order = [];
         var supplies = [];
         function str(v) { return v == null ? '' : String(v); }
+        function rowValue(row, names) {
+            for (var i = 0; i < names.length; i++) {
+                if (row && row[names[i]] != null && row[names[i]] !== '') return row[names[i]];
+            }
+            return '';
+        }
+        function rowNum(row, names) {
+            return stripNum(rowValue(row, names));
+        }
         (rows || []).forEach(function(row) {
             var cutId = str(row.cut_id);
             if (cutId && !cutsById[cutId]) {
@@ -366,9 +375,10 @@
                     knifeWidths: [],
                     winding: normWinding(row.cut_winding),
                     rollerWidth: (row.cut_roller_width == null || row.cut_roller_width === '') ? 0 : Number(row.cut_roller_width),
+                    length: rowNum(row, ['cut_length', 'cut_footage', 'cut_footage_m']),
                     isFoil: /фольг/i.test(str(row.cut_material)),
                     orderId: str(row.order_id),
-                    orderApprovalDate: str(row.order_approval_date)
+                    orderApprovalDate: str(row.order_approval_date || row.item_approval_date)
                 };
                 order.push(cutId);
             }
@@ -377,7 +387,9 @@
                 supplies.push({
                     id: supplyId,
                     positionId: row.supply_position_id ? String(row.supply_position_id) : null,
-                    cutId: cutId
+                    cutId: cutId,
+                    footage: rowNum(row, ['supply_footage', 'supply_length', 'supply_length_m']),
+                    rolls: rowNum(row, ['supply_rolls', 'supply_qty', 'supply_quantity', 'supply_roll_count'])
                 });
             }
         });
@@ -903,6 +915,22 @@
         return (supplyFootages || []).reduce(function(m, f){ var n = stripNum(f); return n > m ? n : m; }, 0);
     }
 
+    function supplyFootage(supply, footageBySupply){
+        var direct = stripNum(supply && supply.footage);
+        if (direct > 0) return direct;
+        return stripNum(footageBySupply && supply && footageBySupply[String(supply.id)]);
+    }
+
+    function cutRunLength(cut, supplies, footageBySupply){
+        var maxF = stripNum(cut && cut.length);
+        (supplies || []).forEach(function(s) {
+            if (String(s.cutId) !== String(cut && cut.id)) return;
+            var f = supplyFootage(s, footageBySupply);
+            if (f > maxF) maxF = f;
+        });
+        return maxF;
+    }
+
     // FIFO-резерв сырья из партий (#3120 группа C). batches — [{id, label, arrivalKey, freeLinearM}]
     // (freeLinearM — СВОБОДНЫЙ погонный остаток партии: Остаток,м − Σ чужих резервов); сортируются
     // внутри по приходу (arrivalKey ↑, тай-брейк меньший id). requiredLinearM — потребность, пог.м;
@@ -1100,6 +1128,8 @@
         sleeveMinutes: sleeveMinutes,
         cutMissingBatch: cutMissingBatch,
         requiredRunLengthM: requiredRunLengthM,
+        supplyFootage: supplyFootage,
+        cutRunLength: cutRunLength,
         reserveFifo: reserveFifo,
         fifoBatchesForMaterial: fifoBatchesForMaterial,
         materialByCut: materialByCut,
@@ -1387,11 +1417,7 @@
         var materialId = cut.materialId ? String(cut.materialId) : '';
         if (materialId === '') { this.notify('У резки не задано сырьё — резерв невозможен', 'error'); return Promise.resolve(); }
         var widthM = (Number(this.jumboWidthByMaterial[materialId]) || 0) / 1000;
-        var foot = [];
-        (this.supplies || []).forEach(function(s) {
-            if (String(s.cutId) === String(cut.id)) foot.push(Number(self.footageBySupply && self.footageBySupply[String(s.id)]) || 0);
-        });
-        var requiredLin = requiredRunLengthM(foot);
+        var requiredLin = cutRunLength(cut, this.supplies, this.footageBySupply);
         // свободный остаток без учёта собственных прежних резервов этой резки (их перезапишем)
         var existing = (this.consumptionByCut && this.consumptionByCut[String(cut.id)]) || [];
         var reservedExcl = {};
@@ -1447,18 +1473,20 @@
 
     // Метраж обеспечений: this.footageBySupply = { supplyId: «Метраж, м» }. Нужен для
     // длины прогона резки (макс по её обеспечениям) → длительность намотки (расписание).
-    // Читаем object/ напрямую — колонка отчёта cut_planning поле подчинённой таблицы не
-    // подтянула (reverse-join), а object/ по «Обеспечение» отдаёт «Метраж, м» штатно.
+    // cut_planning может отдавать supply_footage; object/ по «Обеспечение» остаётся
+    // полным источником и мержится, потому загрузки идут параллельно.
     AtexProductionPlanning.prototype.loadSupplyFootage = function() {
         var self = this;
         var meta = this.meta.supply;
-        if (!meta) { this.footageBySupply = {}; return Promise.resolve(); }
+        if (!meta) { this.footageBySupply = this.footageBySupply || {}; return Promise.resolve(); }
         var footIdx = columnIndex(meta, SUPPLY_REQ.footage);
         return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,5000').then(function(rows) {
-            var map = {};
+            var map = self.footageBySupply || {};
             (rows || []).forEach(function(rec) {
                 var r = rec.r || [];
-                map[String(rec.i)] = footIdx >= 0 ? (Number(r[footIdx]) || 0) : 0;
+                var key = String(rec.i);
+                var value = footIdx >= 0 ? (Number(r[footIdx]) || 0) : 0;
+                if (value > 0 || stripNum(map[key]) <= 0) map[key] = value;
             });
             self.footageBySupply = map;
         });
@@ -1561,6 +1589,11 @@
                 cut.knifeCount = a.knifeCount || 0;
                 cut.knifeWidths = a.knifeWidths || [];
             });
+            if (!self.footageBySupply) self.footageBySupply = {};
+            p.supplies.forEach(function(supply) {
+                var f = supplyFootage(supply, null);
+                if (f > 0) self.footageBySupply[String(supply.id)] = f;
+            });
             self.cuts = p.cuts;
             self.supplies = p.supplies;
             console.log('[pp] 📅 loadPlanning: загружено резок:', p.cuts.length, ', обеспечений:', p.supplies.length);
@@ -1599,6 +1632,9 @@
         var d = this.draft;
         console.log('[pp] 🔪 createCut: начало. станок=', d.slitterId, 'план.прогонов=', d.plannedRuns, 'статус=', d.status, 'выбрано позиций:', (d.selectedPositions||[]).length);
         if (!d.slitterId) { this.notify('Выберите станок', 'error'); return; }
+        var selectedPositions = d.selectedPositions || [];
+        var posById = positionMap(this.genPositions);
+        var runLength = layoutRunLength({ positionsCovered: selectedPositions }, posById);
 
         // Стоп-лист станка: сырьё выбранной партии не должно быть запрещено на станке.
         if (d.materialBatchId) {
@@ -1616,6 +1652,7 @@
             slitter: reqIdByName(meta, CUT_REQ.slitter),
             materialBatch: reqIdByName(meta, CUT_REQ.materialBatch),
             plannedRuns: reqIdByName(meta, CUT_REQ.plannedRuns),
+            length: reqIdByName(meta, CUT_REQ.length),
             planDate: reqIdByName(meta, CUT_REQ.planDate),
             status: reqIdByName(meta, CUT_REQ.status),
             notes: reqIdByName(meta, CUT_REQ.notes)
@@ -1624,6 +1661,7 @@
             slitter: d.slitterId,
             materialBatch: d.materialBatchId,
             plannedRuns: d.plannedRuns,
+            length: runLength > 0 ? runLength : '',
             planDate: d.planDate,
             status: d.status,
             notes: d.notes
@@ -1631,12 +1669,14 @@
 
         function finishCreatedCut(id) {
             if (!id) throw new Error('Сервер не вернул id новой резки');
-            var selectedPositions = d.selectedPositions || [];
             console.log('[pp] 🔪 createCut: резка #' + id + ' создана. создаём обеспечения для ' + selectedPositions.length + ' позиций:', selectedPositions);
             // Создать обеспечения для выбранных позиций (#3194)
             var supplyPromises = selectedPositions.map(function(positionId) {
+                var position = posById[String(positionId)] || {};
+                var footage = Number(position.length) || 0;
                 var supplyFields = buildSupplyFieldsForCut(self.meta.supply, self.meta.cut, {
                     cutId: String(id),
+                    footage: footage > 0 ? footage : '',
                     status: SUPPLY_STATUSES[0]
                 });
                 return self.post('_m_new/' + self.meta.supply.id + '?JSON&up=' + encodeURIComponent(positionId), supplyFields)
@@ -2175,6 +2215,7 @@
             slitter: reqIdByName(cutMeta, CUT_REQ.slitter),
             materialBatch: reqIdByName(cutMeta, CUT_REQ.materialBatch),
             plannedRuns: reqIdByName(cutMeta, CUT_REQ.plannedRuns),
+            length: reqIdByName(cutMeta, CUT_REQ.length),
             status: reqIdByName(cutMeta, CUT_REQ.status)
         };
         var stripReqIds = {
@@ -2239,7 +2280,8 @@
                     status: CUT_STATUSES[0],
                     slitter: slitterId,
                     materialBatch: batchId,
-                    plannedRuns: plannedRuns
+                    plannedRuns: plannedRuns,
+                    length: runLength > 0 ? runLength : ''
                 });
 
                 function createStrips(cutId) {
@@ -2713,7 +2755,7 @@
         filters.appendChild(field('Статус', statusFilter));
         box.appendChild(filters);
 
-        // Базовая видимость очереди: не «Завершён», заказ согласован, дата плана = выбранной/пустая.
+        // Базовая видимость очереди: не «Завершён», дата плана = выбранной/пустая.
         var visible = (this.cuts || []).filter(function(c) { return isCutVisible(c, self.filter.date); });
         var filtered = filterCuts(visible, this.filter);
         var groups = groupBySlitter(filtered);
@@ -2770,14 +2812,7 @@
         var windPoints = windingPointsFromTimes(self.opTimes || {});
         var runLenByCut = {};
         activeGroup.cuts.forEach(function(c) {
-            var maxF = 0;
-            (self.supplies || []).forEach(function(s) {
-                if (String(s.cutId) === String(c.id)) {
-                    var f = Number(self.footageBySupply && self.footageBySupply[String(s.id)]) || 0;
-                    if (f > maxF) maxF = f;
-                }
-            });
-            runLenByCut[String(c.id)] = maxF;
+            runLenByCut[String(c.id)] = cutRunLength(c, self.supplies, self.footageBySupply);
         });
         var schedById = {};
         var schedule = buildSchedule(activeGroup.cuts, { windPoints: windPoints, times: self.changeTimes, runLengthByCut: runLenByCut });
@@ -2940,7 +2975,7 @@
             this.positions.forEach(function(p) { posById[p.id] = p.label; });
             linked.forEach(function(s) {
                 var label = posById[s.positionId] || ('позиция #' + s.positionId);
-                var foot = Number(self.footageBySupply && self.footageBySupply[String(s.id)]) || 0;
+                var foot = supplyFootage(s, self.footageBySupply);
                 if (foot > 0) label += ' · ' + foot + ' м';
                 var children = [el('span', { class: 'atex-pp-linked-label', text: label })];
                 var del = el('button', { class: 'atex-pp-linked-del', type: 'button', text: '×', title: 'Убрать из резки' });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -175,23 +175,62 @@ assertEqual(plan.cuts, [
       materialBatch: { id: null, label: 'НК-0400' },
       planDate: '06.05.2026', status: 'В работе', sequence: null,
       materialId: '', materialName: '', batchId: '',
-      jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, isFoil: false,
+      jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, length: 0, isFoil: false,
       orderId: '', orderApprovalDate: '' },
     { id: '20', number: '2', slitter: { id: null, label: '' },
       materialBatch: { id: null, label: 'НК-0118' },
       planDate: '27.05.2026', status: 'Ожидает', sequence: null,
       materialId: '', materialName: '', batchId: '',
-      jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, isFoil: false,
+      jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, length: 0, isFoil: false,
       orderId: '', orderApprovalDate: '' }
 ], 'rowsToPlanning dedups cuts by cut_id, slitter без id → {id:null}');
 assertEqual(plan.supplies, [
-    { id: '900', positionId: '700', cutId: '10' },
-    { id: '901', positionId: '701', cutId: '10' }
+    { id: '900', positionId: '700', cutId: '10', footage: 0, rolls: 0 },
+    { id: '901', positionId: '701', cutId: '10', footage: 0, rolls: 0 }
 ], 'rowsToPlanning collects supplies from rows with supply_id, skips empty');
 assertEqual(planning.rowsToPlanning([]).cuts.length, 0, 'rowsToPlanning empty input → no cuts');
 // сценарий показа: группировка + счётчик связей поверх результата rowsToPlanning
 assertEqual(planning.groupBySlitter(plan.cuts).map(function(g) { return g.slitter.label; }),
     ['Станок 1', 'Без станка'], 'groupBySlitter over rowsToPlanning cuts');
+
+// #3209: новая модель cut_planning отдаёт cut_no как штамп времени, а метраж
+// резки/обеспечения отдельными колонками. Существующая резка должна попадать в
+// пульт даже без старой order_approval_date: отчёт уже является источником очереди.
+var issue3209Rows = [
+    { cut_id: '23316', cut_no: '1780837651', cut_slitter: 'Станок 1', cut_slitter_id: '1277',
+      cut_plan_date: '', cut_status: '', supply_id: '23352', supply_position_id: '21101',
+      cut_sequence: '1', cut_material: 'MR194', cut_jumbo_remaining: '13260.00',
+      cut_winding: 'OUT', cut_roller_width: '60.00', cut_material_id: '2086',
+      order_approval_date: '', order_id: '17990', supply_footage: '800', supply_rolls: '6',
+      cut_length: '1200' },
+    { cut_id: '23316', cut_no: '1780837651', cut_slitter: 'Станок 1', cut_slitter_id: '1277',
+      cut_plan_date: '', cut_status: '', supply_id: '23353', supply_position_id: '21102',
+      cut_sequence: '1', cut_material: 'MR194', cut_jumbo_remaining: '13260.00',
+      cut_winding: 'OUT', cut_roller_width: '60.00', cut_material_id: '2086',
+      order_approval_date: '', order_id: '17990', supply_footage: '600', supply_rolls: '3',
+      cut_length: '1200' },
+    { cut_id: '23370', cut_no: '1780837653', cut_slitter: 'Станок 2', cut_slitter_id: '1279',
+      cut_plan_date: '', cut_status: '', supply_id: '', supply_position_id: '',
+      cut_sequence: '2', cut_material: 'MR194', cut_material_id: '2086',
+      order_approval_date: '', order_id: '17991', cut_length: '700' }
+];
+var issue3209Plan = planning.rowsToPlanning(issue3209Rows);
+assertEqual(issue3209Plan.cuts.map(function(cut) {
+    return { id: cut.id, number: cut.number, length: cut.length, visible: planning.isCutVisible(cut, '') };
+}), [
+    { id: '23316', number: '1780837651', length: 1200, visible: true },
+    { id: '23370', number: '1780837653', length: 700, visible: true }
+], 'rowsToPlanning #3209: timestamp cut_no, cut_length, and blank approval still produce visible cuts');
+assertEqual(issue3209Plan.supplies, [
+    { id: '23352', positionId: '21101', cutId: '23316', footage: 800, rolls: 6 },
+    { id: '23353', positionId: '21102', cutId: '23316', footage: 600, rolls: 3 }
+], 'rowsToPlanning #3209: carries supply footage and roll count from report rows');
+assertEqual(planning.cutRunLength(issue3209Plan.cuts[0], issue3209Plan.supplies, {}), 1200,
+    'cutRunLength #3209: cut_length is available as run-length fallback');
+assertEqual(planning.supplyFootage(issue3209Plan.supplies[0], { '23352': 0 }), 800,
+    'supplyFootage #3209: direct report footage wins over empty object fallback');
+assertEqual(planning.cutRunLength({ id: 'c1', length: 0 }, [{ id: 's1', cutId: 'c1', footage: 0 }], { s1: 500 }), 500,
+    'cutRunLength #3209: object footage remains fallback when report row has no footage');
 
 // ── rowsToPositions: строки positions_list (JSON_KV) → [{id,label}] для дропдауна ──
 var posRows = [
@@ -487,8 +526,8 @@ var grp = planning.rowsToGenPositions([
   { position_id:'11', position_material_id:'5', position_width:'', position_qty:'', position_length:'' }
 ]);
 assertEqual(grp, [
-  { id:'10', materialId:'5', width:60, qty:30, length:1200, sleeveDiameter:76, dueKey: Infinity },
-  { id:'11', materialId:'5', width:0, qty:0, length:0, sleeveDiameter:0, dueKey: Infinity }
+  { id:'10', materialId:'5', width:60, qty:30, length:1200, sleeveDiameter:76, dueKey: Infinity, approved:false },
+  { id:'11', materialId:'5', width:0, qty:0, length:0, sleeveDiameter:0, dueKey: Infinity, approved:false }
 ], 'rowsToGenPositions: маппинг + пустые ширина/кол-во/длина → 0, dueKey без срока → Infinity');
 
 // rowsToGenPositions читает срок изготовления → dueKey (batchDateKey)
@@ -537,7 +576,7 @@ assertEqual(planning.batchDateKey('2026-01-05') < planning.batchDateKey('2026-02
 function vc(over){ return Object.assign({ status:'Ожидает', orderApprovalDate:'31.05.2026', planDate:'02.06.2026' }, over||{}); }
 assertEqual(planning.isCutVisible(vc(), '2026-06-02'), true, 'isCutVisible: согласован, не завершён, дата совпадает → видна');
 assertEqual(planning.isCutVisible(vc({status:'Завершён'}), '2026-06-02'), false, 'isCutVisible: «Завершён» → скрыта');
-assertEqual(planning.isCutVisible(vc({orderApprovalDate:''}), '2026-06-02'), false, 'isCutVisible: заказ не согласован → скрыта');
+assertEqual(planning.isCutVisible(vc({orderApprovalDate:''}), '2026-06-02'), true, 'isCutVisible: пустое согласование не скрывает существующую резку');
 assertEqual(planning.isCutVisible(vc({planDate:'01.06.2026'}), '2026-06-02'), false, 'isCutVisible: дата плана ≠ выбранной → скрыта');
 assertEqual(planning.isCutVisible(vc({planDate:''}), '2026-06-02'), true, 'isCutVisible: дата плана пустая → видна (ещё не запланирована)');
 assertEqual(planning.isCutVisible(vc({planDate:'02.06.2026'}), ''), true, 'isCutVisible: дата не выбрана → по дате не фильтруем');


### PR DESCRIPTION
Fixes #3209

## What changed
- Treat existing `cut_planning` rows as the production queue source, so blank legacy `order_approval_date` no longer hides already-created cuts.
- Parse timestamp `cut_no`, `cut_length`, `supply_footage`, and supply roll counts from `cut_planning` rows.
- Use cut/supply metrage for run length in scheduling, linked-position display, and material reserve calculations.
- Write cut-level `Метраж, м` and supply metrage when manual or generated cuts are created.

## Reproduction and verification
- Issue sample `cut_planning.1.json`: 77 report rows, 18 unique cuts, blank `order_approval_date` for all rows.
- Before the fix, the queue visibility filter hid all of them.
- After the fix, the same sample parses to 18 visible cuts: `Станок 1` = 5, `Станок 2` = 5, `Станок 3` = 4, `Станок 4` = 4.

## Tests
- `node experiments/atex-production-planning.test.js` (`212 assertions passed`)
- `node experiments/atex-slitter.test.js` (`45 assertions passed`)
- `node experiments/atex-cut-layout.test.js` (`22 assertions passed`)
