### PR TITLE
fix(atex): форматировать timestamp номера резки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-07T19:27:44.777Z for PR creation at branch issue-3217-816f9642395f for issue https://github.com/ideav/crm/issues/3217

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-07T19:27:44.777Z for PR creation at branch issue-3217-816f9642395f for issue https://github.com/ideav/crm/issues/3217

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -473,6 +473,43 @@
         return isNaN(t) ? Infinity : t;
     }
 
+    // Отображение «Номера» резки: новая модель может отдавать cut_no unix-штампом
+    // (секунды). Короткие автонумера и record id не форматируем как 1970-дату.
+    function isTimestampCutNumber(value) {
+        var s = String(value == null ? '' : value).trim();
+        if (!/^\d+$/.test(s)) return false;
+        var n = Number(s);
+        if (!isFinite(n) || n < 1000000000) return false;
+        var d = new Date(n * 1000);
+        if (isNaN(d.getTime())) return false;
+        var year = d.getFullYear();
+        return year >= 2001 && year <= 2100;
+    }
+
+    function formatDateTimeMinute(date) {
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(date.getDate()) + '.' + pad(date.getMonth() + 1) + '.' + date.getFullYear() +
+            ' ' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+    }
+
+    function refSearchHelper() {
+        if (typeof window !== 'undefined' && window.AtexRefSearch) return window.AtexRefSearch;
+        if (typeof globalThis !== 'undefined' && globalThis.AtexRefSearch) return globalThis.AtexRefSearch;
+        return null;
+    }
+
+    function formatCutNumber(value) {
+        if (value == null || value === '') return '';
+        var s = String(value).trim();
+        if (s === '' || !isTimestampCutNumber(s)) return s;
+        var helper = refSearchHelper();
+        if (helper && typeof helper.formatDateTime === 'function') {
+            var formatted = helper.formatDateTime(s);
+            return formatted == null || formatted === '' ? s : String(formatted);
+        }
+        return formatDateTimeMinute(new Date(Number(s) * 1000));
+    }
+
     // Строки отчёта material_batches (JSON_KV) → [{ id, label }] для дропдауна
     // «Партия сырья». Подпись обогащённая: «Номер · Вид сырья · ост. N м²»
     // (пустые части пропускаются). Дропдаун статический клиентский (см. renderForm),
@@ -1119,6 +1156,7 @@
         rowsToGenPositions: rowsToGenPositions,
         positionLengthMap: positionLengthMap,
         batchDateKey: batchDateKey,
+        formatCutNumber: formatCutNumber,
         rowsToBatches: rowsToBatches,
         DEFAULT_OP_TIMES: DEFAULT_OP_TIMES,
         KNIFE_SCALE: KNIFE_SCALE,
@@ -2844,7 +2882,7 @@
             var cardPanel = el('div', { class: 'atex-pp-cut' + (active ? ' is-active' : '') + (unreserved ? ' is-unreserved' : ''), dataset: { cutId: String(c.id) } });
 
             var info = el('div', { class: 'atex-pp-cut-info' }, [
-                el('span', { class: 'atex-pp-cut-num', text: '№ ' + (c.number || c.id) }),
+                el('span', { class: 'atex-pp-cut-num', text: '№ ' + (formatCutNumber(c.number) || c.id) }),
                 el('span', { class: 'atex-pp-cut-seq', text: 'Очер.: ' + (c.sequence != null && !isNaN(c.sequence) ? c.sequence : '—') }),
                 el('span', { class: 'atex-pp-cut-batch', text: c.materialBatch.label || '' }),
                 el('span', { class: 'atex-pp-cut-date', text: c.planDate || '' }),
@@ -2931,7 +2969,7 @@
             return;
         }
 
-        box.appendChild(el('p', { class: 'atex-pp-hint', text: 'Резка № ' + (cut.number || cut.id) + ' · ' + ((cut.materialBatch && cut.materialBatch.label) || '') }));
+        box.appendChild(el('p', { class: 'atex-pp-hint', text: 'Резка № ' + (formatCutNumber(cut.number) || cut.id) + ' · ' + ((cut.materialBatch && cut.materialBatch.label) || '') }));
 
         var draft = { positionId: '', footage: '', status: SUPPLY_STATUSES[0] };
 

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -10,6 +10,8 @@
 //
 // Run with: node experiments/atex-production-planning.test.js
 
+process.env.TZ = 'UTC';
+
 var api = require('../download/atex/js/production-planning.js');
 var planning = api.planning;
 
@@ -586,6 +588,17 @@ assertEqual(planning.batchDateKey('5/1/2026'), 20260105, 'batchDateKey: D/M/Y');
 assertEqual(planning.batchDateKey('') === Infinity, true, 'batchDateKey: пусто → Infinity');
 assertEqual(planning.batchDateKey('мусор') === Infinity, true, 'batchDateKey: мусор → Infinity');
 assertEqual(planning.batchDateKey('2026-01-05') < planning.batchDateKey('2026-02-01'), true, 'batchDateKey: старше = меньше (FIFO)');
+
+// #3217: cut_no может приходить unix-штампом; в карточке очереди показываем
+// его как дату+время до минут, но обычные номера и id не превращаем в даты.
+assertEqual(planning.formatCutNumber('1780837651'), '07.06.2026 13:07',
+    'formatCutNumber: timestamp cut_no → ДД.ММ.ГГГГ ЧЧ:ММ');
+assertEqual(planning.formatCutNumber('7'), '7',
+    'formatCutNumber: обычный короткий номер не форматируется как дата');
+assertEqual(planning.formatCutNumber('23316'), '23316',
+    'formatCutNumber: numeric record id below timestamp range stays raw');
+assertEqual(planning.formatCutNumber('АТХ-7'), 'АТХ-7',
+    'formatCutNumber: non-numeric number stays raw');
 
 // ── Фильтр видимости очереди isCutVisible (статус + согласование заказа + дата плана) ──
 function vc(over){ return Object.assign({ status:'Ожидает', orderApprovalDate:'31.05.2026', planDate:'02.06.2026' }, over||{}); }


### PR DESCRIPTION
## Что исправлено

Fixes #3217

В рабочем месте `atex/production-planning` значение `cut_no` может приходить unix-штампом в секундах. Раньше `.atex-pp-cut-num` показывал сырой штамп, например `№ 1780837651`. Теперь timestamp-похожие значения отображаются как дата и время до минут: `№ 07.06.2026 13:07` (в локальном времени браузера).

Обычные короткие автонумера (`7`) и numeric record id ниже диапазона unix timestamp (`23316`) остаются без форматирования, чтобы не превратить их в даты 1970 года. Выбранная резка в блоке обеспечения использует тот же формат отображения.

## Как воспроизвести

1. Открыть очередь планирования производства с записью, где `cut_no = 1780837651`.
2. До исправления карточка `.atex-pp-cut-num` показывала `№ 1780837651`.
3. После исправления карточка показывает дату и время: `№ 07.06.2026 13:07` (UTC в тесте; локальное время в браузере).

## Проверка

- `node -c download/atex/js/production-planning.js`
- `node experiments/atex-production-planning.test.js`
- `for f in experiments/atex-*.test.js; do node "$f" || exit $?; done`
- `git diff --check`