### PR TITLE
fix(atex): validate generated cut timing before save

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
-# Updated: 2026-06-08T06:37:11.719Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
+# Updated: 2026-06-08T06:37:11.719Z

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -647,7 +647,7 @@
 
     // Строки отчёта positions_list (JSON_KV) → [{ id, materialId, width, qty, length, sleeveDiameter, dueKey }]
     // для генерации резок. position_material_id (добавлен в отчёт), position_width,
-    // position_qty, position_length → числа; пустые значения → 0/'' но объект всегда
+    // position_qty, position_length/wind_length → числа; пустые значения → 0/'' но объект всегда
     // присутствует. length — «Длина, м» позиции (длина прогона джамбо = «Метраж, м»
     // создаваемого обеспечения, #3155); нет колонки в отчёте → 0 (длительность намотки 0).
     // dueKey — числовой ключ «Срока изготовления» (position_due_date) через
@@ -658,10 +658,11 @@
             // ИЛИ утверждена сама позиция (item_approval_date).
             var orderApproved = !!(String(row.order_approval_date || row.order_approved || '').trim());
             var itemApproved = !!(String(row.item_approval_date || row.position_approved || row.position_approval_date || '').trim());
-            var length = stripNum(row.position_length);
+            var lengthRaw = rowFirstValue(row, ['position_length', 'position_length_m', 'position_wind_length', 'wind_length']);
+            var length = stripNum(lengthRaw);
             var windLengthRaw = (row.wind_length != null && String(row.wind_length).trim() !== '')
                 ? row.wind_length
-                : ((row.position_wind_length != null && String(row.position_wind_length).trim() !== '') ? row.position_wind_length : row.position_length);
+                : ((row.position_wind_length != null && String(row.position_wind_length).trim() !== '') ? row.position_wind_length : lengthRaw);
             return {
                 id: row.position_id == null ? '' : String(row.position_id),
                 materialId: row.position_material_id == null ? '' : String(row.position_material_id),
@@ -736,6 +737,58 @@
         var out = {};
         (genPositions || []).forEach(function(p) {
             if (p && p.id != null && String(p.id) !== '') out[String(p.id)] = Number(p.length) || 0;
+        });
+        return out;
+    }
+
+    function cutGenerationTimingDiagnostics(layouts, positions, opTimes) {
+        var byId = positionMap(positions);
+        var windPoints = windingPointsFromTimes(opTimes || {});
+        var out = [];
+        (layouts || []).forEach(function(layout, index) {
+            var covered = (layout && layout.positionsCovered) || [];
+            var plannedRuns = plannedRunsForLayout(layout, byId);
+            var runLength = layoutRunLength(layout, byId);
+            var layoutNo = index + 1;
+            if (!(plannedRuns > 0)) {
+                out.push({
+                    key: 'plannedRuns',
+                    label: CUT_REQ.plannedRuns,
+                    reason: 'value',
+                    layoutIndex: index,
+                    message: 'Не рассчитано поле «' + CUT_REQ.plannedRuns + '» для резки ' + layoutNo
+                });
+                return;
+            }
+            if (!(runLength > 0)) {
+                var missingIds = covered.filter(function(positionId) {
+                    var p = byId[String(positionId)];
+                    return !(Number(p && p.length) > 0);
+                }).map(function(positionId) { return String(positionId); });
+                out.push({
+                    key: 'length',
+                    label: CUT_REQ.length,
+                    reason: 'value',
+                    layoutIndex: index,
+                    positionIds: missingIds,
+                    message: 'Не рассчитано поле «' + CUT_REQ.length + '» для резки ' + layoutNo +
+                        (missingIds.length ? ': нет длины у позиций ' + missingIds.join(', ') : ': нет длины прогона') +
+                        '. Проверьте positions_list: position_length / wind_length'
+                });
+                return;
+            }
+            if (!(plannedCutDurationMinutes(runLength, plannedRuns, opTimes) > 0)) {
+                out.push({
+                    key: 'duration',
+                    label: CUT_REQ.duration,
+                    reason: 'value',
+                    layoutIndex: index,
+                    runLength: runLength,
+                    plannedRuns: plannedRuns,
+                    message: 'Не рассчитано поле «' + CUT_REQ.duration + '» для резки ' + layoutNo +
+                        (windPoints.length ? ': длительность 0 при метраже ' + runLength + ' м и проходах ' + plannedRuns : ': нет норм WIND_* в «Время операции, мин»')
+                });
+            }
         });
         return out;
     }
@@ -1564,6 +1617,7 @@
         nextCutMainValue: nextCutMainValue,
         addMainValueField: addMainValueField,
         cutWriteDiagnostics: cutWriteDiagnostics,
+        cutGenerationTimingDiagnostics: cutGenerationTimingDiagnostics,
         supplyCutRelation: supplyCutRelation,
         buildSupplyFieldsForCut: buildSupplyFieldsForCut,
         layoutPositionGroups: layoutPositionGroups,
@@ -2793,6 +2847,16 @@
                 self.notify('Нет необеспеченных позиций для генерации (пропущено ' + skipped.length + ')', 'info');
                 return;
             }
+            var timingDiagnostics = cutGenerationTimingDiagnostics(allLayouts, self.genPositions, self.opTimes);
+            if (timingDiagnostics.length) {
+                console.error('[pp] ❌ generateCuts: ошибка подготовки полей резки — ' + cutWriteDiagnosticSummary(timingDiagnostics), {
+                    diagnostics: timingDiagnostics,
+                    layouts: allLayouts.slice(0, 5)
+                });
+                self.notify('Ошибка подготовки резок: ' + cutWriteDiagnosticSummary(timingDiagnostics.slice(0, 3)) +
+                    (timingDiagnostics.length > 3 ? '; …' : ''), 'error');
+                return;
+            }
 
             // Счётчики для подтверждения: полос = число записей «Полоса» (как в итоговой
             // нотификации), ножей = суммарное Количество (Σ qty).
@@ -2871,6 +2935,15 @@
         var nSleeves = 0;
         var nCuts = layouts.length;
         var doneCuts = 0;
+        var timingDiagnostics = cutGenerationTimingDiagnostics(layouts, this.genPositions, this.opTimes);
+        if (timingDiagnostics.length) {
+            console.error('[pp] ❌ runGenerateCuts: ошибка подготовки полей резки — ' + cutWriteDiagnosticSummary(timingDiagnostics), {
+                diagnostics: timingDiagnostics
+            });
+            this.notify('Ошибка подготовки резок: ' + cutWriteDiagnosticSummary(timingDiagnostics.slice(0, 3)) +
+                (timingDiagnostics.length > 3 ? '; …' : ''), 'error');
+            return Promise.resolve();
+        }
 
         this.setBusy(true);
         // Окно прогресса (#3148): генерация идёт последовательными зависимыми

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -645,12 +645,12 @@ var grp3219 = planning.rowsToGenPositions([
   { position_id:'not-approved', position_material_id:'2086', position_width:'25', position_qty:'35', position_winding:'OUT' }
 ]);
 assertEqual(grp3219.map(function(p) {
-  return { id:p.id, windDir:p.windDir, windLength:p.windLength, approved:p.approved };
+  return { id:p.id, length:p.length, windDir:p.windDir, windLength:p.windLength, approved:p.approved };
 }), [
-  { id:'o-approved', windDir:'OUT', windLength:450, approved:true },
-  { id:'p-approved', windDir:'IN', windLength:600, approved:true },
-  { id:'not-approved', windDir:'OUT', windLength:0, approved:false }
-], 'rowsToGenPositions #3219: order/position approval plus winding direction/length');
+  { id:'o-approved', length:450, windDir:'OUT', windLength:450, approved:true },
+  { id:'p-approved', length:600, windDir:'IN', windLength:600, approved:true },
+  { id:'not-approved', length:0, windDir:'OUT', windLength:0, approved:false }
+], 'rowsToGenPositions #3234: wind_length fallback feeds length for generated cut payloads');
 assertEqual(planning.groupPositionsByPlanningProfile([
   { id:'p1', materialId:'2086', windDir:'OUT', windLength:600 },
   { id:'p2', materialId:'2086', windDir:'OUT', windLength:600 },
@@ -676,6 +676,23 @@ assertEqual(planning.positionLengthMap([
   { id:'12' }                            // нет length → 0
 ]), { '10':1200, '11':0, '12':0 }, 'positionLengthMap: id→длина, пустой id пропущен');
 assertEqual(planning.positionLengthMap(null), {}, 'positionLengthMap: null → {}');
+var timingOpTimes = { WIND_600:4 };
+var missingTiming = planning.cutGenerationTimingDiagnostics([
+  { positionsCovered:['p-no-length'], strips:[{ width:25, qty:1, purpose:'Заказ' }] }
+], [{ id:'p-no-length', width:25, qty:1, length:0 }], timingOpTimes);
+assertEqual(missingTiming.map(function(d) { return d.key + ':' + d.reason + ':' + d.layoutIndex; }),
+  ['length:value:0'], 'cutGenerationTimingDiagnostics #3234: ловит отсутствующий метраж до сохранения резки');
+assertEqual(missingTiming[0].message.indexOf('p-no-length') >= 0, true,
+  'cutGenerationTimingDiagnostics #3234: сообщение указывает позицию без метража');
+var missingWindTime = planning.cutGenerationTimingDiagnostics([
+  { positionsCovered:['p-no-time'], strips:[{ width:25, qty:1, purpose:'Заказ' }] }
+], [{ id:'p-no-time', width:25, qty:1, length:600 }], {});
+assertEqual(missingWindTime.map(function(d) { return d.key + ':' + d.reason + ':' + d.layoutIndex; }),
+  ['duration:value:0'], 'cutGenerationTimingDiagnostics #3234: ловит отсутствующие нормы WIND_* до сохранения резки');
+assertEqual(planning.cutGenerationTimingDiagnostics([
+  { positionsCovered:['p-ok'], strips:[{ width:25, qty:1, purpose:'Заказ' }] }
+], [{ id:'p-ok', width:25, qty:1, length:600 }], timingOpTimes), [],
+  'cutGenerationTimingDiagnostics #3234: валидная раскладка не даёт ошибок подготовки');
 
 // ── aggregateStrips: строки отчёта cut_strips (JSON_KV) → { cutId: {knifeCount, knifeWidths:[...]} } ──
 var agg = planning.aggregateStrips([


### PR DESCRIPTION
Fixes #3234.

## Summary
- Read generated-position run length from `positions_list` aliases (`position_length`, `position_length_m`, `position_wind_length`, `wind_length`) so generated cuts can write `Метраж, м`.
- Add pre-save generated cut timing diagnostics that stop generation before `_m_new` when `Метраж, м` or `Длительность, минут` cannot be calculated.
- Surface the preparation error in the UI and console with the affected layout and position ids instead of only failing at payload save time.

## Reproduction / Regression Coverage
- Added a regression assertion for `wind_length` feeding generated cut `length`.
- Added pure diagnostics coverage for missing position length and missing `WIND_*` operation-time norms before save.

## Tests
- `node experiments/atex-production-planning.test.js` — 279 assertions passed
- `for f in experiments/atex-*.test.js; do node "$f" || exit $?; done`
- `node --check download/atex/js/production-planning.js`
- `node -e "require('./download/atex/js/production-planning.js'); console.log('loads ok')"`
- `git diff --check`
