### PR TITLE
fix(atex): расшифровка тайминга резки — setup, релевантная норма, жирный итог (#3240)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -906,25 +906,46 @@
     // Неудобный остаток джамбо: 0 < m < REMAINDER_OK_M (не дорезан до ≈0 и не оставлен крупным).
     function awkwardRemainder(m){ var x = Number(m); return !isNaN(x) && x > 1e-6 && x < REMAINDER_OK_M; }
 
-    // Стоимость перехода prev→next в МИНУТАХ переналадки (times по кодам, иначе дефолт):
+    // Компоненты переналадки prev→next (МИНУТЫ, БЕЗ лидера BETWEEN_CUTS) — те операции,
+    // что реально применились, для расшифровки тайминга (#3240):
     //   смена сырья ИЛИ намотки ИЛИ партии → MATERIAL_WINDING (одна операция «смена
     //   сырья/намотки»; неудобный остаток — её же частный случай, отдельно не считаем);
-    //   смена набора ножей ИЛИ сужение ролика → KNIFE. Минуты суммируются (две операции —
-    //   обе вычитают время смены). Бинарно (изменилось/нет), без нормировок.
-    function changeoverCost(prev, next, times){
+    //   смена набора ножей ИЛИ сужение ролика → KNIFE. Бинарно (изменилось/нет), без
+    //   нормировок. prev/next отсутствует → [] (первой резке переналадка не нужна).
+    //   → [{ code, label, minutes }] (только применившиеся, с minutes > 0).
+    function changeoverParts(prev, next, times){
         var t = times || DEFAULT_OP_TIMES;
         var matWind = Number(t.MATERIAL_WINDING != null ? t.MATERIAL_WINDING : DEFAULT_OP_TIMES.MATERIAL_WINDING) || 0;
         var knife = Number(t.KNIFE != null ? t.KNIFE : DEFAULT_OP_TIMES.KNIFE) || 0;
-        var cost = 0;
+        var parts = [];
+        if (!prev || !next) return parts;
         var matWindChange = String(prev.materialId) !== String(next.materialId)
             || normWinding(prev.winding) !== normWinding(next.winding)
             || String(prev.batchId) !== String(next.batchId);
-        if (matWindChange) cost += matWind;
+        if (matWindChange && matWind > 0) parts.push({ code: 'MATERIAL_WINDING', label: 'смена сырья / намотки / партии', minutes: round3(matWind) });
         var knifeChange = (Number(prev.knifeCount) || 0) !== (Number(next.knifeCount) || 0)
             || widthSetDistance(prev.knifeWidths, next.knifeWidths) > 0
             || (Number(prev.rollerWidth) || 0) > (Number(next.rollerWidth) || 0);   // сужение ролика
-        if (knifeChange) cost += knife;
-        return cost;
+        if (knifeChange && knife > 0) parts.push({ code: 'KNIFE', label: 'смена ножей / сужение ролика', minutes: round3(knife) });
+        return parts;
+    }
+
+    // Стоимость перехода prev→next в МИНУТАХ переналадки (Σ компонентов changeoverParts;
+    // две операции — обе вычитают время смены).
+    function changeoverCost(prev, next, times){
+        return round3(changeoverParts(prev, next, times).reduce(function(sum, p){ return sum + (Number(p.minutes) || 0); }, 0));
+    }
+
+    // Полный setup перед резкой (#3240): лидер между резками (BETWEEN_CUTS, база) +
+    // переналадка с предыдущей (changeoverParts). prev=null (первая резка очереди/дня) →
+    // только лидер. Σ minutes == setupMin расписания buildSchedule. → [{ code, label, minutes }].
+    function setupBreakdown(prev, next, times){
+        var t = times || DEFAULT_OP_TIMES;
+        var leader = Number(t.BETWEEN_CUTS != null ? t.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS) || 0;
+        var parts = [];
+        if (leader > 0) parts.push({ code: 'BETWEEN_CUTS', label: 'лидер между резками', minutes: round3(leader) });
+        Array.prototype.push.apply(parts, changeoverParts(prev, next, times));
+        return parts;
     }
 
     // ───────────────────── Хелперы генерации резок ─────────────────────
@@ -1155,6 +1176,30 @@
         return round3(windingMinutes(runMeters, windingPointsFromTimes(opTimes || {})) * runs);
     }
 
+    // Норма(ы) намотки, реально применённые для метража runMeters (зеркало windingMinutes,
+    // #3240 «привести только ту, которая здесь подходит»):
+    //   точное совпадение точки → [та точка]; ниже первой → [первая] (пропорция от 0);
+    //   между точками → [нижняя, верхняя] (интерполяция); выше последней → [предпоследняя,
+    //   последняя] (экстраполяция). Нет точек / runMeters≤0 → []. → подмножество points.
+    function relevantWindingNorms(runMeters, points){
+        var x = Number(runMeters) || 0;
+        var p = (points || []).slice().sort(function(a, b){ return a.m - b.m; });
+        if (!p.length || x <= 0) return [];
+        for (var k = 0; k < p.length; k++){ if (p[k].m === x) return [p[k]]; }
+        if (x <= p[0].m) return [p[0]];
+        for (var i = 1; i < p.length; i++){ if (x <= p[i].m) return [p[i-1], p[i]]; }
+        return p.length >= 2 ? [p[p.length-2], p[p.length-1]] : [p[p.length-1]];
+    }
+
+    // norms → строка «Норма намотки: WIND_600=4 мин» (одна) либо «Нормы намотки:
+    // WIND_600=4 мин; WIND_900=5 мин (интерполяция)» (две). Пусто → ''.
+    function formatWindingNorms(norms){
+        var items = (norms || []).map(function(n){ return 'WIND_' + formatTimingNumber(n.m) + '=' + formatTimingNumber(n.min) + ' мин'; });
+        if (!items.length) return '';
+        if (items.length === 1) return 'Норма намотки: ' + items[0];
+        return 'Нормы намотки: ' + items.join('; ') + ' (интерполяция)';
+    }
+
     function formatTimingNumber(value) {
         return String(round3(Number(value) || 0));
     }
@@ -1173,15 +1218,89 @@
             'Плановых проходов: ' + formatTimingNumber(runs),
             'Намотка 1 прохода: ' + formatTimingNumber(oneRun) + ' мин',
             'Итого резка: ' + formatTimingNumber(oneRun) + ' * ' + formatTimingNumber(runs) + ' = ' + formatTimingNumber(total) + ' мин',
-            'Нормы намотки: ' + points.map(function(p) {
-                return 'WIND_' + formatTimingNumber(p.m) + '=' + formatTimingNumber(p.min) + ' мин';
-            }).join('; ')
+            formatWindingNorms(relevantWindingNorms(length, points))
         ].join('\n');
     }
 
     function cutTimingModalText(cut) {
         var text = String(cut && cut.timing != null ? cut.timing : '').trim();
         return text || 'Тайминг резки не заполнен';
+    }
+
+    // Заголовок модалки тайминга (#3240). Авто-номер резки = метка времени создания
+    // («08.06.2026 11:37») — для пользователя это шум, поэтому такой номер не показываем;
+    // вместо него — сырьё и намотка для опознания резки. Человекочитаемый номер (не
+    // timestamp) оставляем. → «Тайминг резки · MW308 · намотка IN».
+    function cutTimingModalTitle(cut) {
+        var rawNo = cut && cut.number;
+        var s = rawNo == null ? '' : String(rawNo).trim();
+        var no = (s !== '' && !isTimestampCutNumber(s)) ? formatCutNumber(rawNo) : '';
+        var material = (cut && (cut.materialName || (cut.materialId ? '#' + cut.materialId : ''))) || '';
+        var winding = normWinding(cut && cut.winding);
+        var parts = ['Тайминг резки'];
+        if (no) parts.push('№ ' + no);
+        if (material) parts.push(material);
+        if (winding) parts.push('намотка ' + winding);
+        return parts.join(' · ');
+    }
+
+    // Строки тайминга окна резки для модалки (#3240, DOM-независимо — рендер в openCutTiming).
+    // Включает время на смену сырья/типа/ножи и лидер (setupParts) хронологически от старта
+    // окна, «Итого резка» выделяется жирным (bold). ctx: { length, runs, oneRun, total,
+    // setupParts:[{label,minutes}], norms:[{m,min}], startMin, finishMin }. → [{ text, bold }].
+    function cutTimingTimelineLines(ctx) {
+        ctx = ctx || {};
+        var length = stripNum(ctx.length);
+        var runs = stripNum(ctx.runs);
+        var oneRun = round3(Number(ctx.oneRun) || 0);
+        var total = round3(Number(ctx.total) || 0);
+        var setupParts = ctx.setupParts || [];
+        var lines = [];
+        lines.push({ text: 'Метраж прохода: ' + formatTimingNumber(length) + ' м' });
+        lines.push({ text: 'Плановых проходов: ' + formatTimingNumber(runs) });
+        lines.push({ text: 'Намотка 1 прохода: ' + formatTimingNumber(oneRun) + ' мин' });
+        var normLine = formatWindingNorms(ctx.norms);
+        if (normLine) lines.push({ text: normLine });
+        lines.push({ text: '' });
+        lines.push({ text: 'Тайминг окна:' });
+        var setupTotal = setupParts.reduce(function(sum, p){ return sum + (Number(p.minutes) || 0); }, 0);
+        var hasStart = ctx.startMin != null && isFinite(Number(ctx.startMin));
+        var clock = hasStart ? round3(Number(ctx.startMin) - setupTotal) : null;
+        setupParts.forEach(function(p){
+            var mins = round3(Number(p.minutes) || 0);
+            var prefix = clock != null ? (formatClock(clock) + ' · ') : '';
+            lines.push({ text: prefix + p.label + ' — ' + formatTimingNumber(mins) + ' мин' });
+            if (clock != null) clock += mins;
+        });
+        var cutPrefix = hasStart ? (formatClock(ctx.startMin) + ' · ') : '';
+        lines.push({
+            text: cutPrefix + 'Итого резка: ' + formatTimingNumber(oneRun) + ' * ' + formatTimingNumber(runs) + ' = ' + formatTimingNumber(total) + ' мин',
+            bold: true
+        });
+        if (ctx.finishMin != null && isFinite(Number(ctx.finishMin))) {
+            lines.push({ text: formatClock(ctx.finishMin) + ' · готово' });
+        }
+        return lines;
+    }
+
+    // Контекст тайминга одной резки для модалки (#3240): метраж/проходы/намотка, разбивка
+    // setup (prevCut — предыдущая резка очереди или null для первой), релевантные нормы и
+    // старт/финиш из расписания sc. → объект для cutTimingTimelineLines.
+    function buildCutTimingCtx(cut, prevCut, sc, runMeters, windPoints, times) {
+        var length = stripNum(runMeters);
+        var runs = stripNum(cut && cut.plannedRuns);
+        var oneRun = windingMinutes(length, windPoints || []);
+        var total = runs > 0 ? round3(oneRun * runs) : oneRun;
+        return {
+            length: length,
+            runs: runs,
+            oneRun: round3(oneRun),
+            total: round3(total),
+            setupParts: setupBreakdown(prevCut, cut, times),
+            norms: relevantWindingNorms(length, windPoints || []),
+            startMin: sc ? sc.startMin : null,
+            finishMin: sc ? sc.finishMin : null
+        };
     }
 
     function scheduleDurationMinutes(cut, runMeters, windPoints) {
@@ -1697,7 +1816,9 @@
         normWinding: normWinding,
         widthSetDistance: widthSetDistance,
         awkwardRemainder: awkwardRemainder,
+        changeoverParts: changeoverParts,
         changeoverCost: changeoverCost,
+        setupBreakdown: setupBreakdown,
         greedySequence: greedySequence,
         orderCuts: orderCuts,
         byKnifeCountDesc: byKnifeCountDesc,
@@ -1729,9 +1850,14 @@
         materialByCut: materialByCut,
         windingPointsFromTimes: windingPointsFromTimes,
         windingMinutes: windingMinutes,
+        relevantWindingNorms: relevantWindingNorms,
+        formatWindingNorms: formatWindingNorms,
         plannedCutDurationMinutes: plannedCutDurationMinutes,
         cutTimingDetails: cutTimingDetails,
         cutTimingModalText: cutTimingModalText,
+        cutTimingModalTitle: cutTimingModalTitle,
+        cutTimingTimelineLines: cutTimingTimelineLines,
+        buildCutTimingCtx: buildCutTimingCtx,
         scheduleDurationMinutes: scheduleDurationMinutes,
         parseClockMinutes: parseClockMinutes,
         resolveWorkingWindow: resolveWorkingWindow,
@@ -1812,6 +1938,7 @@
         this.timingModalEl = null;
         this.timingModalTitleEl = null;
         this.timingModalBodyEl = null;
+        this._timingByCut = {};     // #3240: контекст тайминга на резку (setup+нормы+старт) для модалки
         this.daySettings = {};      // DAY_START_HOUR/DAY_END_HOUR из таблицы «Настройка»
         this._lastCutPlanningDiagnosticKey = '';
     }
@@ -3325,10 +3452,24 @@
 
     AtexProductionPlanning.prototype.openCutTiming = function(cut) {
         if (this.timingModalTitleEl) {
-            var no = formatCutNumber(cut && cut.number) || (cut && cut.id ? ('#' + cut.id) : '');
-            this.timingModalTitleEl.textContent = 'Тайминг резки' + (no ? ' ' + no : '');
+            this.timingModalTitleEl.textContent = cutTimingModalTitle(cut);
         }
-        if (this.timingModalBodyEl) this.timingModalBodyEl.textContent = cutTimingModalText(cut);
+        if (this.timingModalBodyEl) {
+            var body = this.timingModalBodyEl;
+            while (body.firstChild) body.removeChild(body.firstChild);
+            // #3240: тайминг окна с разбивкой setup и жирным «Итого резка». Контекст
+            // (старт/setup/нормы) собран в renderQueue; нет контекста → сохранённый текст.
+            var ctx = this._timingByCut && this._timingByCut[String(cut && cut.id)];
+            if (ctx) {
+                cutTimingTimelineLines(ctx).forEach(function(ln, i) {
+                    if (i > 0) body.appendChild(document.createTextNode('\n'));
+                    if (ln.bold) body.appendChild(el('strong', { text: ln.text }));
+                    else body.appendChild(document.createTextNode(ln.text));
+                });
+            } else {
+                body.textContent = cutTimingModalText(cut);
+            }
+        }
         if (this.timingModalEl) this.timingModalEl.classList.add('is-open');
     };
 
@@ -3594,6 +3735,7 @@
             shiftEndMin: dayWindow.cutEndMin
         });
         schedule.forEach(function(sc) { schedById[sc.cutId] = sc; });
+        self._timingByCut = {};   // #3240: пересобираем контекст тайминга модалки для активного станка
         var dayCutsByKey = {};
         activeGroup.cuts.forEach(function(c) {
             var key = cutPlanDayKey(c);
@@ -3633,6 +3775,11 @@
 
             var materialText = c.materialName || (c.materialId ? ('#' + c.materialId) : '—');
             var sc = schedById[String(c.id)];
+            // #3240: контекст тайминга резки для модалки (setup с предыдущей + нормы + старт).
+            self._timingByCut[String(c.id)] = buildCutTimingCtx(
+                c, idx > 0 ? activeGroup.cuts[idx - 1] : null, sc,
+                runLenByCut[String(c.id)], windPoints, self.changeTimes
+            );
             var cutNumberTitle = 'Резка № ' + (formatCutNumber(c.number) || c.id);
             var info = el('div', { class: 'atex-pp-cut-info' }, [
                 el('span', { class: 'atex-pp-cut-num', title: cutNumberTitle, text: formatCutStartTime(sc) }),

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -854,8 +854,76 @@ assertEqual(plannedCutDuration(600, 3, opT), 12,
 assertEqual(plannedCutDuration(600, 0, opT), 0,
     'plannedCutDurationMinutes #3223: без плановых проходов длительность 0');
 assertEqual(planning.cutTimingDetails(600, 3, opT),
-    'Метраж прохода: 600 м\nПлановых проходов: 3\nНамотка 1 прохода: 4 мин\nИтого резка: 4 * 3 = 12 мин\nНормы намотки: WIND_300=1.2 мин; WIND_600=4 мин; WIND_900=5 мин; WIND_1100=5.6 мин',
-    'cutTimingDetails #3238: сохраняет понятную расшифровку длительности резки');
+    'Метраж прохода: 600 м\nПлановых проходов: 3\nНамотка 1 прохода: 4 мин\nИтого резка: 4 * 3 = 12 мин\nНорма намотки: WIND_600=4 мин',
+    'cutTimingDetails #3240: расшифровка длительности с релевантной нормой (точное совпадение метража)');
+assertEqual(planning.cutTimingDetails(750, 1, opT),
+    'Метраж прохода: 750 м\nПлановых проходов: 1\nНамотка 1 прохода: 4.5 мин\nИтого резка: 4.5 * 1 = 4.5 мин\nНормы намотки: WIND_600=4 мин; WIND_900=5 мин (интерполяция)',
+    'cutTimingDetails #3240: интерполяция показывает обе окружающие нормы');
+
+// #3240: relevantWindingNorms — какие WIND_* реально применяются для метража.
+assertEqual(planning.relevantWindingNorms(600, pts), [{m:600,min:4}], 'relevantWindingNorms: точное совпадение → одна точка');
+assertEqual(planning.relevantWindingNorms(750, pts), [{m:600,min:4},{m:900,min:5}], 'relevantWindingNorms: между точками → нижняя+верхняя');
+assertEqual(planning.relevantWindingNorms(150, pts), [{m:300,min:1.2}], 'relevantWindingNorms: ниже первой → первая (пропорция от 0)');
+assertEqual(planning.relevantWindingNorms(1200, pts), [{m:900,min:5},{m:1100,min:5.6}], 'relevantWindingNorms: выше последней → последний отрезок (экстраполяция)');
+assertEqual(planning.relevantWindingNorms(0, pts), [], 'relevantWindingNorms: 0 м → []');
+assertEqual(planning.formatWindingNorms([{m:600,min:4}]), 'Норма намотки: WIND_600=4 мин', 'formatWindingNorms: одна норма');
+assertEqual(planning.formatWindingNorms([{m:600,min:4},{m:900,min:5}]), 'Нормы намотки: WIND_600=4 мин; WIND_900=5 мин (интерполяция)', 'formatWindingNorms: две нормы — пометка интерполяции');
+assertEqual(planning.formatWindingNorms([]), '', 'formatWindingNorms: пусто → пустая строка');
+
+// #3240: changeoverParts/setupBreakdown — расшифровка переналадки и полного setup.
+var toBase = { materialId:'1', winding:'IN', batchId:'b', knifeCount:4, knifeWidths:[60], rollerWidth:60 };
+function toClone(extra){ var o = {}; Object.keys(toBase).forEach(function(k){ o[k] = toBase[k]; }); if (extra) Object.keys(extra).forEach(function(k){ o[k] = extra[k]; }); return o; }
+assertEqual(planning.changeoverParts(toBase, toClone(), null), [], 'changeoverParts: идентичные → нет операций');
+assertEqual(planning.changeoverParts(toBase, toClone({materialId:'2'}), null),
+    [{code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}],
+    'changeoverParts: смена сырья → MATERIAL_WINDING 15');
+assertEqual(planning.changeoverParts(toBase, toClone({materialId:'2', knifeCount:9, knifeWidths:[10,10,10,10,10,10,10,10,10]}), null),
+    [{code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}, {code:'KNIFE', label:'смена ножей / сужение ролика', minutes:30}],
+    'changeoverParts: сырьё+ножи → две операции (15+30)');
+assertEqual(planning.changeoverParts(null, toBase, null), [], 'changeoverParts: нет предыдущей → []');
+assertEqual(planning.setupBreakdown(null, toBase, null),
+    [{code:'BETWEEN_CUTS', label:'лидер между резками', minutes:2}],
+    'setupBreakdown: первая резка → только лидер');
+assertEqual(planning.setupBreakdown(toBase, toClone({materialId:'2'}), null),
+    [{code:'BETWEEN_CUTS', label:'лидер между резками', minutes:2}, {code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}],
+    'setupBreakdown: лидер + смена сырья');
+// Σ minutes setupBreakdown == setupMin расписания (лидер 2 + переналадка 15 = 17).
+var sbSched = planning.buildSchedule([toBase, toClone({materialId:'2'})], { windPoints: pts, runLengthByCut: {}, shiftStartMin: 480 });
+assertEqual(sbSched[1].setupMin, planning.setupBreakdown(toBase, toClone({materialId:'2'}), null).reduce(function(s,p){return s+p.minutes;},0),
+    'setupBreakdown #3240: Σ minutes == setupMin расписания');
+
+// #3240: заголовок модалки не показывает авто-номер (timestamp), а показывает сырьё/намотку.
+assertEqual(planning.cutTimingModalTitle({ number:'1749375420', materialName:'MW308', winding:'IN' }),
+    'Тайминг резки · MW308 · намотка IN',
+    'cutTimingModalTitle #3240: timestamp-номер скрыт, показаны сырьё и намотка');
+assertEqual(planning.cutTimingModalTitle({ number:'42', materialName:'MW308', winding:'OUT' }),
+    'Тайминг резки · № 42 · MW308 · намотка OUT',
+    'cutTimingModalTitle #3240: человекочитаемый номер сохраняется');
+assertEqual(planning.cutTimingModalTitle({ materialId:5 }),
+    'Тайминг резки · #5',
+    'cutTimingModalTitle #3240: без номера/намотки — fallback на материал');
+
+// #3240: buildCutTimingCtx + cutTimingTimelineLines — хронология окна с setup и жирным итогом.
+var tlPrev = { materialId:'1', winding:'IN', batchId:'b', knifeCount:4, knifeWidths:[60], rollerWidth:60 };
+var tlCut = { id:'X', materialId:'2', winding:'IN', batchId:'b', knifeCount:4, knifeWidths:[60], rollerWidth:60, plannedRuns:1 };
+var tlSched = planning.buildSchedule([tlPrev, tlCut], { windPoints: pts, runLengthByCut: { X:600 }, shiftStartMin: 480 });
+var tlSc = tlSched[1];   // вторая резка: setup = лидер 2 + смена сырья 15 = 17
+var tlCtx = planning.buildCutTimingCtx(tlCut, tlPrev, tlSc, 600, pts, null);
+assertEqual([tlCtx.length, tlCtx.runs, tlCtx.oneRun, tlCtx.total], [600, 1, 4, 4], 'buildCutTimingCtx: метраж/проходы/намотка/итого');
+assertEqual(tlCtx.setupParts.length, 2, 'buildCutTimingCtx: setup = лидер + смена сырья');
+assertEqual(tlCtx.norms, [{m:600,min:4}], 'buildCutTimingCtx: релевантная норма 600');
+var tlLines = planning.cutTimingTimelineLines(tlCtx);
+var tlBold = tlLines.filter(function(l){ return l.bold; });
+assertEqual(tlBold.length, 1, 'cutTimingTimelineLines: ровно одна жирная строка');
+assertEqual(/^.*Итого резка: 4 \* 1 = 4 мин$/.test(tlBold[0].text), true, 'cutTimingTimelineLines: жирная строка — «Итого резка»');
+var tlStart = planning.formatClock(tlSc.startMin);
+var tlSetupStart = planning.formatClock(tlSc.startMin - 17);
+assertEqual(tlBold[0].text.indexOf(tlStart + ' · ') === 0, true, 'cutTimingTimelineLines: «Итого резка» начинается со старта резки');
+var tlText = tlLines.map(function(l){ return l.text; }).join('\n');
+assertEqual(tlText.indexOf(tlSetupStart + ' · лидер между резками — 2 мин') >= 0, true, 'cutTimingTimelineLines: setup начинается от старта окна');
+assertEqual(tlText.indexOf('смена сырья / намотки / партии — 15 мин') >= 0, true, 'cutTimingTimelineLines: показано время смены сырья');
+assertEqual(/Норма намотки: WIND_600=4 мин/.test(tlText), true, 'cutTimingTimelineLines: только релевантная норма');
+assertEqual(tlLines[tlLines.length-1].text, planning.formatClock(tlSc.finishMin) + ' · готово', 'cutTimingTimelineLines: финальная строка — готово');
 
 // Расписание очереди: старт/финиш от 08:00 (480 мин) + лидер 2 + намотка по метражу.
 var schedCuts = [


### PR DESCRIPTION
Closes #3240. Доработка модалки «Тайминг резки» (продолжение #3239).

### Что было (по скриншоту из issue)
Модалка показывала только намотку и **весь** список норм `WIND_*`, а в очереди между резками был «пустой» зазор (`09:12 → 09:59`), который ничем не объяснялся. Заголовок содержал авто-номер резки `08.06.2026 11:37`, смысл которого был непонятен.

### Что сделано
1. **Время на смену сырья/типа/ножей включено в тайминг.** Модалка теперь строит хронологию окна от его старта: лидер между резками + переналадка с предыдущей (смена сырья/намотки/партии — 15 мин; смена ножей/сужение ролика — 30 мин) → затем сама резка → готово. Это объясняет зазор в очереди (`а что было между 09:12 и 09:59`).
2. **«Итого резка» выделена жирным** — основная суть окна.
3. **«Нормы намотки» — только релевантная(ые).** Для метража прохода показывается точка точного совпадения (`Норма намотки: WIND_600=4 мин`) либо две окружающие при интерполяции (`… (интерполяция)`), а не весь справочник.
4. **Заголовок модалки больше не показывает «11:37».** Авто-номер резки — это метка времени её создания (Integram), для пользователя это шум. Вместо него показываются сырьё и намотка: `Тайминг резки · MW308 · намотка IN`. Человекочитаемый номер (не timestamp) сохраняется.

### Реализация
Новые чистые (DOM-независимые) функции, экспортируются и покрыты юнит-тестами:
`changeoverParts`, `setupBreakdown`, `relevantWindingNorms`, `formatWindingNorms`, `cutTimingModalTitle`, `cutTimingTimelineLines`, `buildCutTimingCtx`.
`changeoverCost` переписан как сумма `changeoverParts` (числовое поведение не изменилось — старые тесты зелёные). Σ `setupBreakdown` == `setupMin` расписания.
`openCutTiming` рендерит строки тайминга в `<pre>` с `<strong>` для жирного итога; контекст резки собирается в `renderQueue`.

### Тесты
`node experiments/atex-production-planning.test.js` → **320 assertions passed** (было 291 + 29 новых).

🤖 Generated with [Claude Code](https://claude.com/claude-code)