### PR TITLE
fix(integram-table): DATETIME-заголовок записи — дата-время с секундами (#3247)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -392,7 +392,8 @@ class IntegramTable{
             // If we have parent info, show breadcrumb-style title
             if (this.parentInfo) {
                 const parentTypeName = this.escapeHtml(this.parentInfo.type || '');
-                const parentVal = this.escapeHtml(this.parentInfo.val || '');
+                // #3247: первая колонка-DATETIME родителя приходит unix-штампом — форматируем.
+                const parentVal = this.escapeHtml(this.formatRecordTitleValue(this.parentInfo.val || ''));
                 const parentObjId = this.parentInfo.obj || '';
                 const parentUp = parseInt(this.parentInfo.up, 10) || 0;
                 const parentRecordId = this.options.parentId || '';
@@ -2173,6 +2174,17 @@ class IntegramTable{
             const minutes = String(dateObj.getMinutes()).padStart(2, '0');
             const seconds = String(dateObj.getSeconds()).padStart(2, '0');
             return `${ day }.${ month }.${ year } ${ hours }:${ minutes }:${ seconds }`;
+        }
+
+        // Значение «главного» поля записи для заголовка/ссылок (.integram-title-link,
+        // .integram-parent-record-link). Если первая колонка таблицы — DATETIME, API
+        // отдаёт её unix-штампом (секунды) — показываем как дату-время с секундами
+        // (issue #3247). Не-штампы (DATE «20260601», числа, текст, уже форматированные
+        // строки) остаются как есть: parseUnixTimestamp строго требует >= 1e9 и год 2001–2100.
+        formatRecordTitleValue(value) {
+            const raw = String(value == null ? '' : value);
+            const ts = this.parseUnixTimestamp(raw);
+            return ts ? this.formatDateTimeDisplay(ts) : raw;
         }
 
         shouldRenderSubordinateRowNumber(rowIndex, colIndex) {


### PR DESCRIPTION
Closes #3247.

### Проблема
Если первая колонка таблицы — **DATETIME** (тип 4, напр. «Партия ГП»), API отдаёт главное значение записи unix-штампом в секундах. В хлебной крошке ссылка на родительскую запись (`.integram-title-link.integram-parent-record-link`) выводила сырой штамп — `1780919776` вместо даты.

### Решение
Добавлен `formatRecordTitleValue(value)` и применён к значению родительской записи в `renderTitleHtml`:
- если значение распознаётся как unix-штамп (`parseUnixTimestamp`, строгая защита: ≥ 1e9 и год 2001–2100) → формат **ДД.ММ.ГГГГ ЧЧ:ММ:СС** (`formatDateTimeDisplay`, с секундами — как просит тикет);
- не-штампы остаются без изменений: числа-автонумера (`42`), DATE (`20260601` — без фейкового `00:00:00`), текст, уже форматированные строки.

Используются существующие проверенные хелперы компонента (`parseUnixTimestamp`, `formatDateTimeDisplay`), поведение ячеек DATETIME не затрагивается.

### Тесты
`node experiments/test-issue-3247-datetime-title.js` → **7 проверок** (форматирование штампа, число/DATE/текст остаются сырыми). Смежные `test-issue-3211` и `test-issue-833` — зелёные.

> Пример из тикета: `1780919776` → `08.06.2026 13:56:16` (локальное время браузера).

🤖 Generated with [Claude Code](https://claude.com/claude-code)