### PR TITLE
fix(atex): спланированные резки не видны — фильтр даты по unix-штампу (#3249)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -393,6 +393,25 @@
     // cut_planning резки считаются рабочей очередью (#3209: очищенная новая модель).
     // Форматы дат разные («ДД.ММ.ГГГГ» из отчёта, «ГГГГ-ММ-ДД» из <input type=date>) —
     // нормализуем общим batchDateKey.
+    // Календарный день плановой даты как YYYYMMDD (#3249). «Дата план» — первая колонка
+    // «Производственной резки» (DATETIME) и приходит unix-штампом (секунды/мс), а фильтр
+    // <input type=date> даёт «ГГГГ-ММ-ДД». batchDateKey сводит дату-строку к YYYYMMDD, но
+    // unix-штамп (≈1.7e9) к нему несравним — приводим штамп к календарному дню той же шкалы.
+    function planDateDayKey(value) {
+        var s = String(value == null ? '' : value).trim();
+        if (s === '') return Infinity;
+        if (/^\d{9,13}$/.test(s)) {
+            var num = Number(s);
+            var ms = num >= 1e12 ? num : num * 1000;
+            var d = new Date(ms);
+            var year = d.getFullYear();
+            if (!isNaN(d.getTime()) && year >= 2001 && year <= 2100) {
+                return year * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+            }
+        }
+        return batchDateKey(s);
+    }
+
     function isCutVisible(cut, selectedDate) {
         if (!cut) return false;
         if (String(cut.status || '').trim() === 'Завершён') return false;
@@ -400,7 +419,9 @@
         if (pd === '') return true;
         var sd = String(selectedDate == null ? '' : selectedDate).trim();
         if (sd === '') return true;
-        return batchDateKey(pd) === batchDateKey(sd);
+        // #3249: сравниваем по календарному дню (planDate — unix-штамп DATETIME,
+        // selectedDate — «ГГГГ-ММ-ДД»); раньше batchDateKey давал несравнимые шкалы.
+        return planDateDayKey(pd) === planDateDayKey(sd);
     }
 
     // Текущая дата как «ГГГГ-ММ-ДД» для <input type=date> (только браузер).
@@ -1813,7 +1834,8 @@
     }
 
     function cutPlanDayKey(c) {
-        var key = batchDateKey(c && c.planDate);
+        // #3249: planDate приходит unix-штампом (DATETIME) — группируем по календарному дню.
+        var key = planDateDayKey(c && c.planDate);
         return key === Infinity ? '' : String(key);
     }
 
@@ -1891,6 +1913,7 @@
         groupBySlitter: groupBySlitter,
         filterCuts: filterCuts,
         isCutVisible: isCutVisible,
+        planDateDayKey: planDateDayKey,
         buildFields: buildFields,
         maxNumericCutNumber: maxNumericCutNumber,
         nextCutMainValue: nextCutMainValue,
@@ -3881,7 +3904,7 @@
                 el('span', { class: 'atex-pp-cut-winding', text: formatCutWindingLabel(c) }),
                 el('span', { class: 'atex-pp-cut-runs', text: formatCutRuns(c.plannedRuns, runLenByCut[String(c.id)]) }),
                 el('span', { class: 'atex-pp-cut-batch', title: c.materialBatch.label || '', text: c.materialBatch.label || '' }),
-                el('span', { class: 'atex-pp-cut-date', text: c.planDate || '' }),
+                el('span', { class: 'atex-pp-cut-date', text: formatCutNumber(c.planDate) || '' }),   // #3249: planDate — unix-штамп → дата
                 el('span', { class: 'atex-pp-cut-status', text: c.status || '' }),
                 el('span', { class: 'atex-pp-cut-supplies', text: supplies ? ('связей: ' + supplies) : 'нет связей' })
             ]);

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -814,6 +814,20 @@ assertEqual(planning.isCutVisible(vc({planDate:''}), '2026-06-02'), true, 'isCut
 assertEqual(planning.isCutVisible(vc({planDate:'02.06.2026'}), ''), true, 'isCutVisible: дата не выбрана → по дате не фильтруем');
 assertEqual(planning.isCutVisible(vc({planDate:''}), ''), true, 'isCutVisible: обе пусты → видна');
 assertEqual(planning.isCutVisible(null, '2026-06-02'), false, 'isCutVisible: null → false');
+// #3249: «Дата план» приходит unix-штампом (DATETIME) — фильтр по дню должен совпасть.
+var ts3249 = 1780919776;
+var dt3249 = new Date(ts3249 * 1000);
+var pad3249 = function(n){ return String(n).length < 2 ? '0' + n : String(n); };
+var sameDayIso3249 = dt3249.getFullYear() + '-' + pad3249(dt3249.getMonth() + 1) + '-' + pad3249(dt3249.getDate());
+var dayKey3249 = dt3249.getFullYear() * 10000 + (dt3249.getMonth() + 1) * 100 + dt3249.getDate();
+assertEqual(planning.isCutVisible(vc({planDate:String(ts3249)}), sameDayIso3249), true,
+    'isCutVisible #3249: unix-штамп planDate совпадает с днём фильтра → видна');
+assertEqual(planning.isCutVisible(vc({planDate:String(ts3249)}), '2000-01-02'), false,
+    'isCutVisible #3249: unix-штамп planDate ≠ день фильтра → скрыта');
+assertEqual(planning.planDateDayKey('2026-06-08'), 20260608, 'planDateDayKey: ISO-дата → YYYYMMDD');
+assertEqual(planning.planDateDayKey(String(ts3249)), dayKey3249, 'planDateDayKey #3249: unix-штамп → календарный день YYYYMMDD');
+assertEqual(planning.planDateDayKey('') === Infinity, true, 'planDateDayKey: пусто → Infinity');
+assertEqual(planning.planDateDayKey('01.06.2026'), 20260601, 'planDateDayKey: ДД.ММ.ГГГГ → YYYYMMDD');
 
 // ── Сводка по полосам редактора (stripsUsedWidth/stripsTotalKnives/stripsRemainder) ──
 // Полосы [{width:110,qty:2},{width:70,qty:1}] при джамбо 910:


### PR DESCRIPTION
Closes #3249.

### Симптом
Спланированные резки приходят с API (`cut_planning` отдаёт строки — видно в панели отладки), но в очереди «Резок по станкам» их нет (Станок 1: 0).

### Причина
После #3242 «Дата план» резки — это первая колонка «Производственной резки» (DATETIME), и API отдаёт её **unix-штампом в секундах** (подтверждено на `ateh`: `cut_plan_date: "1780919776"`). 

`isCutVisible` / `cutPlanDayKey` сравнивали `batchDateKey(planDate)` с `batchDateKey(выбранной даты)`. Но `batchDateKey` сводит дату-строку к `YYYYMMDD` (≈2e7), а unix-штамп (≈1.7e9) к нему несравним → **равенства никогда нет → все резки скрываются** фильтром «Дата плана».

### Решение
- `planDateDayKey(value)`: unix-штамп → календарный день `YYYYMMDD` (та же шкала, что даёт `batchDateKey` для строки-даты); пусто → `Infinity`.
- `isCutVisible` и `cutPlanDayKey` теперь используют `planDateDayKey` — фильтр по дате и группировка по дням снова работают.
- Карточка резки показывает дату плана **отформатированной** (`formatCutNumber`), а не сырой штамп.

### Тесты
`node experiments/atex-production-planning.test.js` → **337 assertions passed** (добавлены кейсы: unix-штамп `planDate` совпадает/не совпадает с днём фильтра; `planDateDayKey` для штампа/ISO/ДД.ММ.ГГГГ).

> Независимый фикс от `main`; с открытым PR #3246 не пересекается (разные функции).

🤖 Generated with [Claude Code](https://claude.com/claude-code)