### PR TITLE
fix(atex): состав резки — полосы за проход, а не рулоны ×проходов (#3253)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -320,12 +320,14 @@
 .atex-pp-strip-table { margin-bottom: 10px; }
 .atex-pp-strip-row {
     display: grid;
-    grid-template-columns: 1fr 1fr 40px;   /* #3242: Ширина · Кол-во рулонов · удалить (без «Назначения») */
+    grid-template-columns: 1fr 1fr 1fr 40px;   /* #3253: Ширина · Кол-во полос · Рулонов(read-only) · удалить */
     gap: 8px;
     align-items: center;
     margin-bottom: 6px;
 }
 .atex-pp-strip-head { font-size: 12px; color: var(--pp-muted); font-weight: 600; }
+/* #3253: read-only вычисляемое поле «Рулонов» (полос × проходов) — справочно. */
+.atex-pp-strip-rolls { color: var(--pp-muted); text-align: center; font-variant-numeric: tabular-nums; }
 .atex-pp-strip-del { padding: 6px 0; text-align: center; }
 .atex-pp-strip-add { margin-bottom: 12px; }
 

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1176,13 +1176,12 @@
         return out;
     }
 
-    // #3242: состав резки = «Партия ГП» по каждой РАЗЛИЧНОЙ ширине (Σ рулонов всех полос
-    // этой ширины × прогоны). Покрывает и заказ, и склад: излишек (произведено −
-    // Σ обеспечений этой ширины) остаётся складом той же Партией ГП, отдельной записи не нужно.
-    // → [{ width, rolls, length }] по порядку первого появления ширины.
-    function producedBatchesForLayout(layout, runLength, plannedRuns) {
-        var runs = Number(plannedRuns) || 0;
-        if (runs <= 0) runs = plannedRunsForLayout(layout, {});
+    // #3242/#3253: состав резки = «Партия ГП» по каждой РАЗЛИЧНОЙ ширине. Храним
+    // «количество ПОЛОС за один проход» (Σ полос этой ширины), БЕЗ умножения на проходы —
+    // это геометрия раскроя (Σ ширина×полос ≤ ширина джамбо). Число рулонов (полос ×
+    // проходов) — производная величина, отдельно не храним. → [{ width, strips, length }]
+    // по порядку первого появления ширины.
+    function producedBatchesForLayout(layout, runLength) {
         var len = Number(runLength) || 0;
         var byWidth = {};
         var order = [];
@@ -1191,8 +1190,8 @@
             var qty = Number(s.qty) || 0;
             if (width <= 0 || qty <= 0) return;
             var key = stripWidthKey(width);
-            if (!(key in byWidth)) { byWidth[key] = { width: width, rolls: 0, length: len }; order.push(key); }
-            byWidth[key].rolls = round3(byWidth[key].rolls + qty * runs);
+            if (!(key in byWidth)) { byWidth[key] = { width: width, strips: 0, length: len }; order.push(key); }
+            byWidth[key].strips = round3(byWidth[key].strips + qty);
         });
         return order.map(function(k) { return byWidth[k]; });
     }
@@ -2816,9 +2815,13 @@
 
         // Таблица полос.
         var table = el('div', { class: 'atex-pp-strip-table' });
+        // #3253: редактируем «Кол-во полос» (за проход); «Рулонов» (полос × проходов) —
+        // справочно, read-only. Геометрия (Занято/Остаток/Ножи) считается по полосам.
+        var passes = stripNum(cut.plannedRuns) > 0 ? stripNum(cut.plannedRuns) : 1;
         table.appendChild(el('div', { class: 'atex-pp-strip-row atex-pp-strip-head' }, [
             el('span', { text: 'Ширина, мм' }),
-            el('span', { text: 'Кол-во рулонов' }),   // #3242: «Партия ГП» — рулоны, не «Назначение»
+            el('span', { text: 'Кол-во полос' }),
+            el('span', { text: 'Рулонов (×' + passes + ')' }),
             el('span', { text: '' })
         ]));
         var body = el('div', { class: 'atex-pp-strip-body' });
@@ -2877,13 +2880,20 @@
                 w.addEventListener('change', function() { self.persistStrip(cut.id, s); });  // авто-сейв (#3127)
                 row.appendChild(w);
 
+                // #3253: read-only «Рулонов» = полос × проходов (справочно).
+                var rollsCell = el('span', { class: 'atex-pp-strip-rolls', text: String(round3((stripNum(s.qty) || 0) * passes)) });
+
                 var q = el('input', { class: 'atex-pp-input', type: 'number', min: '0', step: '1', placeholder: '0' });
                 q.value = s.qty;
-                q.addEventListener('input', function() { s.qty = q.value; recalc(); });
+                q.addEventListener('input', function() {
+                    s.qty = q.value;
+                    rollsCell.textContent = String(round3((stripNum(s.qty) || 0) * passes));
+                    recalc();
+                });
                 q.addEventListener('change', function() { self.persistStrip(cut.id, s); });  // авто-сейв (#3127)
                 row.appendChild(q);
 
-                // #3242: у «Партии ГП» нет «Назначения» — колонка убрана.
+                row.appendChild(rollsCell);   // #3253: вычисляемое поле «Рулонов», read-only
 
                 var del = el('button', { class: 'atex-pp-btn atex-pp-strip-del', type: 'button', title: 'Удалить полосу', text: '×' });
                 del.addEventListener('click', function() {
@@ -3278,11 +3288,12 @@
                 var widthToBatchId = {};
                 function createFinishedBatches(cutId) {
                     var batchChain = Promise.resolve();
-                    producedBatchesForLayout(lay, runLength, plannedRuns).forEach(function(batch) {
+                    producedBatchesForLayout(lay, runLength).forEach(function(batch) {
                         batchChain = batchChain.then(function() {
+                            // #3253: «Кол-во рулонов» «Партии ГП» = число полос за проход (без ×проходов).
                             var fields = buildFinishedBatchFields(finishedBatchMeta, {
                                 width: batch.width,
-                                rolls: batch.rolls,
+                                rolls: batch.strips,
                                 footage: batch.length > 0 ? batch.length : '',
                                 active: '1'
                             });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -541,12 +541,12 @@ assertEqual(planning.finishedBatchesForLayout(layout3185, 'cut777', 1200, 3), [
   { cutId: 'cut777', width: 44, rolls: 3, length: 1200 }
 ], 'finishedBatchesForLayout: stock strips become GP batches');
 // #3242: состав резки — «Партия ГП» по КАЖДОЙ ширине (заказ+склад), Σ рулонов × прогоны.
-assertEqual(planning.producedBatchesForLayout(layout3185, 1200, 3), [
-  { width: 110, rolls: 6, length: 1200 },
-  { width: 70, rolls: 3, length: 1200 },
-  { width: 55, rolls: 6, length: 1200 },
-  { width: 44, rolls: 3, length: 1200 }
-], 'producedBatchesForLayout #3242: Партия ГП по каждой ширине (рулоны × прогоны)');
+assertEqual(planning.producedBatchesForLayout(layout3185, 1200), [
+  { width: 110, strips: 2, length: 1200 },
+  { width: 70, strips: 1, length: 1200 },
+  { width: 55, strips: 2, length: 1200 },
+  { width: 44, strips: 1, length: 1200 }
+], 'producedBatchesForLayout #3253: Партия ГП по ширине — число ПОЛОС за проход (без ×проходов)');
 // #3242: план обеспечений — позиция → Партия ГП своей ширины, рулоны и метраж позиции.
 assertEqual(planning.supplyPlanForLayout(layout3185, pos3185, 3), [
   { positionId: 'p110', width: 110, rolls: 6, footage: 1200 },


### PR DESCRIPTION
Closes #3253. Дефекты из #3246.

### Что было не так
Число полос ошибочно **умножалось на число проходов**. Поэтому в редакторе состава резки:
- колонка показывала «Кол-во рулонов» (= полос × проходов) вместо «Кол-во полос»;
- «Итого ножей», «Занято, мм», «Остаток, мм» считались по раздутому числу (на скрине: ширина 25 × 108 = «Занято 2700», «Остаток −1790»).

Подтверждено на `ateh`: резка 27180, проходов = 3, «Партия ГП» хранит «Кол-во рулонов» = 108 (= 36 полос/проход × 3).

### Исправлено
- **`producedBatchesForLayout`** хранит «Кол-во полос» за **один проход** (Σ полос ширины), **без ×проходов** — это геометрия раскроя (Σ ширина × полос ≤ ширина джамбо).
- **Редактор**: колонка «**Кол-во полос**» (вместо «Кол-во рулонов»); геометрия (Занято / Остаток / Итого ножей) теперь по полосам за проход — не раздута.
- Добавлено **справочное read-only поле «Рулонов (×проходов)»** = полос × проходов (как и просили — «нередактируемым вычисляемым полем»).
- CSS-сетка строки: 4 колонки (ширина · полос · рулонов · удалить).

### Заметки
- «Итого ножей» теперь фиксирован независимо от проходов (считается по полосам).
- **Обеспечение** остаётся в рулонах-выпуске (×проходов) — это покрытие позиции заказа (сколько готовых рулонов идёт под заказ), а не геометрия раскроя. Если нужно иначе — скажите, поправлю.
- Записи «Партия ГП», созданные **до** этого фикса (раздутые ×проходов), останутся такими до перегенерации резки.

### Тесты
`node experiments/atex-production-planning.test.js` → **339 assertions passed** (`producedBatchesForLayout` теперь отдаёт полосы за проход); cut-map 21, cut-layout 22 — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)