### PR TITLE
fix(atex): убрать подсчёт полос/ножей из подтверждения генерации резок (#3253)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3156,16 +3156,10 @@
                 return;
             }
 
-            // Счётчики для подтверждения: полос = число записей «Полоса» (как в итоговой
-            // нотификации), ножей = суммарное Количество (Σ qty).
+            // #3253: в подтверждении не считаем полосы/ножи — только число резок.
             var nCuts = allLayouts.length;
-            var nStrips = 0, nKnives = 0;
-            allLayouts.forEach(function(lay) {
-                (lay.strips || []).forEach(function(s) { nStrips += 1; nKnives += (Number(s.qty) || 0); });
-            });
             var msg = 'Не обеспечено резками и складом позиций: ' + unsup.length +
-                '. Создать ' + nCuts + ' резок (полос ' + nStrips +
-                ', ножей ' + nKnives + ')? Пропущено ' + skipped.length + '.';
+                '. Создать ' + nCuts + ' резок? Пропущено ' + skipped.length + '.';
 
             self.confirmAction(msg, actionsEl, 'Да, создать', function() {
                 self.runGenerateCuts(allLayouts, skipped);


### PR DESCRIPTION
Доработка по #3253.

В диалоге подтверждения генерации было:
> Не обеспечено резками и складом позиций: 7. Создать 7 резок **(полос 9, ножей 111)**? Пропущено N.

Подсчёт полос и ножей тут не нужен (и вводил в заблуждение). Оставляем только число резок:
> Не обеспечено резками и складом позиций: 7. Создать 7 резок? Пропущено N.

Удалён ненужный цикл подсчёта `nStrips`/`nKnives`. Тесты: 339 — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)