### PR TITLE
fix(atex): очередь не по убыванию ножей — из-за unix-штампа даты в сортировке (#3258)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -345,7 +345,10 @@
         function seqKey(c) { var s = c && c.sequence; var n = Number(s); return (s == null || isNaN(n)) ? Infinity : n; }
         function knifeKey(c) { var n = Number(c && c.knifeCount); return isFinite(n) ? n : 0; }
         function cmpCutPlanDay(a, b) {
-            var ak = batchDateKey(a && a.planDate), bk = batchDateKey(b && b.planDate);
+            // #3258: planDate — unix-штамп DATETIME (с секундами). Сравниваем по
+            // КАЛЕНДАРНОМУ дню (planDateDayKey), иначе резки одного дня различаются по
+            // моменту создания и сортировка «ножи по убыванию» (#3130) не срабатывает.
+            var ak = planDateDayKey(a && a.planDate), bk = planDateDayKey(b && b.planDate);
             if (ak === Infinity && bk !== Infinity) return 1;
             if (bk === Infinity && ak !== Infinity) return -1;
             if (ak < bk) return -1;

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -314,6 +314,14 @@ var gKnives = planning.groupBySlitter([
 ])[0];
 assertEqual(gKnives.cuts.map(function(c){ return c.id; }), ['high-seq','mid-seq','low-seq'],
     'groupBySlitter #3236: внутри дня видимая очередь сортирует ножи по убыванию, даже если sequence старый');
+// #3258: planDate — unix-штамп DATETIME (с секундами): резки одного дня различаются
+// по моменту создания, но должны сортироваться по ножам убыв., а не по штампу.
+var gKnivesTs = planning.groupBySlitter([
+    { id:'few', slitter:{id:'20',label:'Станок 2'}, planDate:'1780919776', sequence:1, knifeCount:5 },
+    { id:'many', slitter:{id:'20',label:'Станок 2'}, planDate:'1780919777', sequence:2, knifeCount:15 }
+])[0];
+assertEqual(gKnivesTs.cuts.map(function(c){ return c.id; }), ['many','few'],
+    'groupBySlitter #3258: одинаковый день (unix-штампы с секундами) → ножи по убыванию (15 раньше 5)');
 var gDays = planning.groupBySlitter([
     { id:'d2-1', slitter:{id:'10',label:'Станок 1'}, planDate:'2026-06-08', sequence:1 },
     { id:'d1-2', slitter:{id:'10',label:'Станок 1'}, planDate:'2026-06-07', sequence:2 },


### PR DESCRIPTION
Closes #3258 (повтор #3130, #3213).

### Причина
`groupBySlitter` сортирует резки внутри станка: **день плана → ножи по убыванию (#3130/#3236) → sequence**. Но `cmpCutPlanDay` сравнивал `planDate` через `batchDateKey`, а после #3242 `planDate` — это **unix-штамп DATETIME с точностью до секунд**. У резок одного дня штампы различаются (момент создания: `…776` vs `…777`), поэтому шаг сортировки «по дню» уже разводил их по порядку создания, и тай-брейк «ножи по убыванию» **никогда не срабатывал**.

На скрине: Станок 2 → «Полосы (5)» раньше «Полосы (15)» вместо 15 → 5.

### Решение
`cmpCutPlanDay` сравнивает по **календарному дню** (`planDateDayKey`), а не по сырому штампу. Резки одного дня теперь дают равенство по дню → тай-брейк «ножи по убыванию» работает. Это тот же класс бага, что #3249, но в `cmpCutPlanDay` (там я тогда поправил `isCutVisible`/`cutPlanDayKey`, а эту сортировку пропустил).

### Тесты
`node experiments/atex-production-planning.test.js` → **340 assertions passed** (добавлен кейс: один день, разные unix-штампы с секундами → 15 ножей раньше 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)