### PR TITLE
fix: массовое удаление по фильтру серверно (_m_del_select), без выгрузки строк (#3260)

### DIFF
--- a/experiments/test-issue-2749-delete-by-filter.js
+++ b/experiments/test-issue-2749-delete-by-filter.js
@@ -1,28 +1,27 @@
 /*
- * Test for issue #2749: js/integram-table.js
- * "Кнопка «Удалить по фильтру»: добавить кнопку, видимую только пользователям,
- *  у которых есть метаданное delete:"1", и реализовать удаление через отдельный
- *  метод (не через _m_del_select)."
+ * Test for issues #2749 + #3260: js/integram-table/23-bulk-export.js
  *
- * The test exercises bulkDeleteByFilter() and fetchFilterMatchCount() from
- * js/integram-table/23-bulk-export.js against a mocked server. It verifies:
+ * "Удалить по фильтру" deletes every record matching the current filter.
  *
- *   1. fetchFilterMatchCount() hits the JSON_OBJ&_count=1 endpoint with the
- *      current filters/parent forwarded so the user sees the correct number
- *      of records before confirming.
- *   2. bulkDeleteByFilter() sends ONE POST per chunk to /_m_del_batch/{tableId}
- *      — NOT one POST per record. For N matching records and chunk size 500
- *      it sends ceil(N/500) requests, which is the whole point of the fix.
- *   3. Per-record server errors returned in the chunk response surface in
- *      the bulk-delete errors panel.
- *   4. The legacy _m_del_select endpoint is NOT touched.
+ * #2749 first implemented this by fetching all matching ids client-side and
+ * deleting them in chunks via /_m_del_batch. On large tables that meant loading
+ * up to 1,000,000 rows, which exhausted PHP memory (#3260). #3260 switches the
+ * delete to the server-side _m_del_select path: the server SELECTs and deletes
+ * matching rows in one request, returning {deleted:N} — no row payload fetched.
+ *
+ * This test verifies the #3260 behaviour:
+ *   1. fetchFilterMatchCount() hits /object/{id}/?JSON_OBJ&_count=1 with the
+ *      current filters/parent forwarded (the confirm popup count).
+ *   2. bulkDeleteByFilter() sends ONE POST to /object/{id}/?JSON carrying
+ *      _m_del_select=1 + the same filter — NOT a 1,000,000-row export, NOT
+ *      _m_del_batch, NOT per-record _m_del/{id}.
+ *   3. The {deleted:N} count is surfaced to the user and the table reloads.
+ *   4. A server error (JSON {error} or non-JSON body) is shown, not swallowed.
  */
 
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-
-// --- Load just the methods we need straight from the source module ----------
 
 const moduleSource = fs.readFileSync(
     path.join(__dirname, '..', 'js', 'integram-table', '23-bulk-export.js'),
@@ -40,9 +39,7 @@ function extractMethod(name) {
         if (ch === '{') depth++;
         else if (ch === '}') {
             depth--;
-            if (depth === 0) {
-                return moduleSource.slice(match.index + 1, i + 1);
-            }
+            if (depth === 0) return moduleSource.slice(match.index + 1, i + 1);
         }
     }
     throw new Error(`Could not find matching closing brace for ${name}`);
@@ -51,14 +48,13 @@ function extractMethod(name) {
 const methodSources = [
     extractMethod('bulkDeleteByFilter'),
     extractMethod('fetchFilterMatchCount'),
+    extractMethod('appendCurrentFilters'),
 ].join('\n');
 
 const Host = new Function('fetchRef', 'documentRef', `
     const fetch = (...args) => fetchRef(...args);
-    const document = new Proxy({}, {
-        get(_, prop) { return documentRef()[prop]; },
-    });
-    const xsrf = undefined; // typeof xsrf !== 'undefined' will be false
+    const document = new Proxy({}, { get(_, prop) { return documentRef()[prop]; } });
+    const xsrf = 'XSRFTOKEN';
     class Host {
         constructor(opts) { Object.assign(this, opts); }
         getApiBase() { return this._apiBase; }
@@ -68,23 +64,9 @@ const Host = new Function('fetchRef', 'documentRef', `
         }
         appendPageUrlParams() {}
         escapeHtml(s) { return String(s); }
-        sanitizeInlineMessageHtml(s) { return String(s); }
-        showToast(msg, level) {
-            (this.toasts = this.toasts || []).push({ msg, level });
-        }
-        loadData() {
-            this.reloadCalls = (this.reloadCalls || 0) + 1;
-            return Promise.resolve();
-        }
-        loadDataFromTableForExport(offset, limit) {
-            this.loadCalls = (this.loadCalls || []);
-            this.loadCalls.push({ offset, limit });
-            return Promise.resolve({
-                columns: this.columns,
-                rows: this._rawDataResponse.map(r => r.r),
-                rawData: this._rawDataResponse,
-            });
-        }
+        showToast(msg, level) { (this.toasts = this.toasts || []).push({ msg, level }); }
+        loadData() { this.reloadCalls = (this.reloadCalls || 0) + 1; return Promise.resolve(); }
+        loadDataFromTableForExport() { this.exportCalled = true; return Promise.resolve({ rawData: [] }); }
         ${methodSources}
     }
     return Host;
@@ -94,176 +76,14 @@ const Host = new Function('fetchRef', 'documentRef', `
 );
 
 function defaultDocument() {
+    const errorsNode = { style: {}, innerHTML: '', appendChild() {} };
     return {
-        body: { insertAdjacentHTML() {} },
-        getElementById() {
-            return {
-                querySelector() { return { style: {}, textContent: '', innerHTML: '', appendChild() {} }; },
-                remove() {},
-            };
-        },
-        createElement() {
-            return { className: '', style: {}, textContent: '', addEventListener() {} };
-        },
-    };
-}
-
-function makeFetch(routes) {
-    return async function fetch(url, init) {
-        for (const route of routes) {
-            const match = route.match(url, init);
-            if (match) {
-                route.calls.push({ url, init, match });
-                return route.respond(match);
-            }
-        }
-        throw new Error(`Unexpected fetch to ${url}`);
-    };
-}
-
-function jsonResponse(status, body) {
-    const text = typeof body === 'string' ? body : JSON.stringify(body);
-    return {
-        ok: status >= 200 && status < 300,
-        status,
-        async text() { return text; },
-        async json() { return JSON.parse(text); },
-    };
-}
-
-const API = 'https://example.test/db';
-
-async function testFetchFilterMatchCount() {
-    // The button must show how many records currently match the filter
-    // BEFORE asking for confirmation. fetchFilterMatchCount() must hit
-    // /object/{id}/?JSON_OBJ&_count=1 with current filters forwarded.
-    global.document = defaultDocument();
-    const routes = [
-        {
-            calls: [],
-            match: (url) => {
-                const m = url.match(/^https:\/\/example\.test\/db\/object\/3596\/\?JSON_OBJ&(.+)$/);
-                return m ? { qs: new URLSearchParams(m[1]) } : null;
-            },
-            respond: () => jsonResponse(200, { count: 7 }),
-        },
-    ];
-    global.fetch = makeFetch(routes);
-
-    const tbl = new Host({
-        _apiBase: API,
-        objectTableId: '3596',
-        columns: [{ id: '3597' }],
-        filters: { '3597': { type: '=', value: 'foo' } },
-        options: { parentId: '999' },
-    });
-
-    const count = await tbl.fetchFilterMatchCount();
-    assert.strictEqual(count, 7);
-    assert.strictEqual(routes[0].calls.length, 1);
-
-    const qs = routes[0].calls[0].match.qs;
-    assert.strictEqual(qs.get('_count'), '1');
-    assert.strictEqual(qs.get('F_3597'), 'foo');
-    assert.strictEqual(qs.get('F_U'), '999');
-    console.log('PASS fetchFilterMatchCount forwards filters and parent to the _count endpoint');
-}
-
-async function testBulkDeleteByFilterUsesBatchEndpoint() {
-    // The core fix: bulkDeleteByFilter must POST chunks to /_m_del_batch/{tableId}
-    // — one request per chunk, NOT one request per record. Legacy _m_del_select
-    // and per-record _m_del/{id} endpoints must NOT be touched.
-    global.document = defaultDocument();
-    const batchCalls = [];
-    const routes = [
-        {
-            calls: [],
-            match: (url, init) => {
-                const m = url.match(/^https:\/\/example\.test\/db\/_m_del_batch\/(\d+)\?JSON$/);
-                return (m && init && init.method === 'POST') ? { tableId: m[1] } : null;
-            },
-            respond: ({ tableId }, ctx) => {
-                // body should contain ids=...
-                return null; // sentinel — actual respond set below
-            },
-        },
-        {
-            calls: [],
-            match: (url) => url.includes('/_m_del_select') ? {} : null,
-            respond: () => { throw new Error('legacy _m_del_select must NOT be used'); },
-        },
-        {
-            calls: [],
-            match: (url) => /\/_m_del\/\d+/.test(url) ? {} : null,
-            respond: () => { throw new Error('per-record _m_del/{id} must NOT be used for filter delete'); },
-        },
-    ];
-    // Replace batch respond so it parses the body and answers
-    routes[0].respond = (match) => {
-        const init = routes[0].calls[routes[0].calls.length - 1].init;
-        const body = new URLSearchParams(init.body);
-        const ids = (body.get('ids') || '').split(',').filter(Boolean).map(s => parseInt(s, 10));
-        batchCalls.push({ tableId: match.tableId, ids });
-        return jsonResponse(200, { deleted: ids, errors: {} });
-    };
-    global.fetch = makeFetch(routes);
-
-    // 1234 records — exercises chunking (FILTER_DELETE_CHUNK = 500 in source)
-    const N = 1234;
-    const raw = [];
-    for (let i = 1; i <= N; i++) raw.push({ i, u: 1, o: i - 1, r: ['v' + i] });
-
-    const tbl = new Host({
-        _apiBase: API,
-        objectTableId: '3596',
-        columns: [{ id: '3597' }],
-        filters: {},
-        options: { tableTypeId: '3596' },
-        rawObjectData: [],
-        selectedRows: new Set(),
-        data: [],
-        loadedRecords: 0,
-        hasMore: true,
-        totalRows: null,
-        _rawDataResponse: raw,
-    });
-
-    await tbl.bulkDeleteByFilter();
-
-    // 1234 records / chunk size 500 = 3 chunks
-    assert.strictEqual(routes[0].calls.length, 3, `expected 3 batch calls, got ${routes[0].calls.length}`);
-    assert.strictEqual(routes[1].calls.length, 0, 'legacy _m_del_select must not be called');
-    assert.strictEqual(routes[2].calls.length, 0, 'per-record _m_del/{id} must not be called');
-    assert.strictEqual(batchCalls[0].ids.length, 500);
-    assert.strictEqual(batchCalls[1].ids.length, 500);
-    assert.strictEqual(batchCalls[2].ids.length, 234);
-    assert.strictEqual(batchCalls[0].tableId, '3596', 'tableId in URL must equal objectTableId');
-    // No overlap, full coverage
-    const allIds = new Set([...batchCalls[0].ids, ...batchCalls[1].ids, ...batchCalls[2].ids]);
-    assert.strictEqual(allIds.size, N, 'every record id must be sent exactly once');
-    for (let i = 1; i <= N; i++) assert.ok(allIds.has(i), `id ${i} missing from batches`);
-    assert.strictEqual(tbl.reloadCalls, 1, 'table must reload once at the end');
-    console.log(`PASS bulkDeleteByFilter sends ${routes[0].calls.length} batch requests for ${N} records (was ${N} per-record requests)`);
-}
-
-async function testBulkDeleteByFilterSurfacesPerRecordErrors() {
-    // The server's _m_del_batch response carries {deleted, errors} per chunk.
-    // Per-record errors must be reported in the bulk-delete errors panel —
-    // not silently swallowed and not aggregated into a single "chunk failed".
-    const capturedErrors = [];
-    global.document = {
+        _errorsNode: errorsNode,
         body: { insertAdjacentHTML() {} },
         getElementById() {
             return {
                 querySelector(sel) {
-                    if (sel === '.bulk-delete-errors') {
-                        return {
-                            style: {},
-                            set innerHTML(v) { capturedErrors.push(v); },
-                            get innerHTML() { return capturedErrors[capturedErrors.length - 1] || ''; },
-                            appendChild() {},
-                        };
-                    }
+                    if (sel === '.bulk-delete-errors') return errorsNode;
                     return { style: {}, textContent: '', innerHTML: '', appendChild() {} };
                 },
                 remove() {},
@@ -271,144 +91,94 @@ async function testBulkDeleteByFilterSurfacesPerRecordErrors() {
         },
         createElement() { return { className: '', style: {}, textContent: '', addEventListener() {} }; },
     };
-
-    const routes = [
-        {
-            calls: [],
-            match: (url, init) => /\/_m_del_batch\/\d+\?JSON$/.test(url) && init.method === 'POST' ? {} : null,
-            respond: () => jsonResponse(200, {
-                deleted: [101, 103],
-                errors: { '102': 'Запись используется как ссылка' },
-            }),
-        },
-    ];
-    global.fetch = makeFetch(routes);
-
-    const tbl = new Host({
-        _apiBase: API,
-        objectTableId: '3596',
-        columns: [{ id: '3597' }],
-        filters: {},
-        options: {},
-        rawObjectData: [],
-        selectedRows: new Set(),
-        data: [],
-        loadedRecords: 0,
-        hasMore: true,
-        totalRows: null,
-        _rawDataResponse: [
-            { i: 101, u: 1, o: 0, r: ['Alpha'] },
-            { i: 102, u: 1, o: 1, r: ['Beta'] },
-            { i: 103, u: 1, o: 2, r: ['Gamma'] },
-        ],
-    });
-
-    await tbl.bulkDeleteByFilter();
-
-    const allErrorHtml = capturedErrors.join('\n');
-    assert.ok(/102/.test(allErrorHtml), 'error report must include failing record id 102');
-    assert.ok(/Beta/.test(allErrorHtml), 'error report must include the failing record value');
-    assert.ok(/Запись используется как ссылка/.test(allErrorHtml),
-        'error report must include the server-side error message');
-    console.log('PASS bulkDeleteByFilter surfaces per-record server errors');
 }
 
-async function testBulkDeleteByFilterHandlesChunkLevelFailure() {
-    // If a chunk itself fails (network error, HTTP 5xx, top-level {error}),
-    // every id in that chunk must be reported — not silently lost.
+function jsonResponse(status, body) {
+    const text = typeof body === 'string' ? body : JSON.stringify(body);
+    return { ok: status >= 200 && status < 300, status, async text() { return text; }, async json() { return JSON.parse(text); } };
+}
+
+const API = 'https://example.test/db';
+
+async function testFetchFilterMatchCount() {
     global.document = defaultDocument();
-    let callCount = 0;
-    const routes = [
-        {
-            calls: [],
-            match: (url, init) => /\/_m_del_batch\/\d+\?JSON$/.test(url) && init.method === 'POST' ? {} : null,
-            respond: () => {
-                callCount++;
-                if (callCount === 2) {
-                    return jsonResponse(403, [{ error: 'forbidden' }]);
-                }
-                // chunk 1 + chunk 3 succeed
-                const init = routes[0].calls[routes[0].calls.length - 1].init;
-                const ids = new URLSearchParams(init.body).get('ids').split(',').map(Number);
-                return jsonResponse(200, { deleted: ids, errors: {} });
-            },
-        },
-    ];
-    global.fetch = makeFetch(routes);
-
-    // 3 chunks of 500 each
-    const raw = [];
-    for (let i = 1; i <= 1500; i++) raw.push({ i, u: 1, o: i - 1, r: ['v' + i] });
-
-    let errorAccumulator = [];
-    // Spy on what the impl puts into errorsDiv. Easier: monkey-patch escapeHtml
-    // to fold every error string through us.
+    const calls = [];
+    global.fetch = async (url) => {
+        calls.push(url);
+        const m = url.match(/^https:\/\/example\.test\/db\/object\/3596\/\?JSON_OBJ&(.+)$/);
+        assert.ok(m, `unexpected count url ${url}`);
+        const qs = new URLSearchParams(m[1]);
+        assert.strictEqual(qs.get('_count'), '1');
+        assert.strictEqual(qs.get('F_3597'), 'foo');
+        assert.strictEqual(qs.get('F_U'), '999');
+        return jsonResponse(200, { count: 7 });
+    };
     const tbl = new Host({
-        _apiBase: API,
-        objectTableId: '3596',
-        columns: [{ id: '3597' }],
-        filters: {},
-        options: {},
-        rawObjectData: [],
-        selectedRows: new Set(),
-        data: [],
-        loadedRecords: 0,
-        hasMore: true,
-        totalRows: null,
-        _rawDataResponse: raw,
+        _apiBase: API, objectTableId: '3596',
+        columns: [{ id: '3597' }], filters: { '3597': { type: '=', value: 'foo' } },
+        options: { parentId: '999' },
     });
-    const origEscape = tbl.escapeHtml.bind(tbl);
-    tbl.escapeHtml = (s) => { errorAccumulator.push(String(s)); return origEscape(s); };
-
-    await tbl.bulkDeleteByFilter();
-
-    assert.strictEqual(routes[0].calls.length, 3, 'three chunks issued');
-    const joined = errorAccumulator.join('|');
-    // Chunk 2 covers ids 501..1000 — at least the first and last should be there
-    assert.ok(/#501\b/.test(joined), 'failed chunk start id (#501) must appear in errors');
-    assert.ok(/#1000\b/.test(joined), 'failed chunk end id (#1000) must appear in errors');
-    // Successful chunks (1 and 3) should NOT appear in errors
-    assert.ok(!/#1\b/.test(joined), 'successful chunk ids must not appear in errors');
-    assert.ok(!/#1500\b/.test(joined), 'successful chunk ids must not appear in errors');
-    console.log('PASS chunk-level failures surface every id of the failed chunk');
+    const count = await tbl.fetchFilterMatchCount();
+    assert.strictEqual(count, 7);
+    assert.strictEqual(calls.length, 1);
+    console.log('PASS fetchFilterMatchCount forwards filters + parent to the _count endpoint');
 }
 
-async function testReproducesLegacyBehaviourBeforeFix() {
-    // Before issue #2749 was filed, the legacy flow was a server-side form POST
-    // to {tableId}/_m_del_select. Re-implement it locally so we can document
-    // what is being replaced.
-    async function legacyDeleteByFilter(tableId, filterParams) {
-        const params = new URLSearchParams(filterParams);
-        params.set('_m_del_select', '1');
-        const resp = await fetch(`${API}/${tableId}`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: params.toString(),
-        });
-        return { ok: resp.ok };
-    }
-    let legacyCalled = false;
+async function testBulkDeleteUsesServerSideSelect() {
+    // #3260: ONE POST to /object/{id}/?JSON with _m_del_select=1 + filter.
+    // No 1M export, no _m_del_batch, no per-record _m_del.
+    global.document = defaultDocument();
+    let delCall = null;
     global.fetch = async (url, init) => {
-        if (url === `${API}/3596` && init && init.body && init.body.includes('_m_del_select=1')) {
-            legacyCalled = true;
-            return jsonResponse(200, { ok: true });
+        if (/\/_m_del_batch\//.test(url)) throw new Error('_m_del_batch must NOT be used (#3260)');
+        if (/\/_m_del\/\d+/.test(url)) throw new Error('per-record _m_del must NOT be used');
+        if (/object\/3596\/\?JSON$/.test(url) && init && init.method === 'POST') {
+            delCall = { url, body: new URLSearchParams(init.body) };
+            return jsonResponse(200, { deleted: 22462 });
         }
-        throw new Error(`unexpected ${url}`);
+        throw new Error(`Unexpected fetch ${url}`);
     };
-    await legacyDeleteByFilter('3596', { F_3597: 'foo' });
-    assert.strictEqual(legacyCalled, true,
-        'the legacy flow that this PR replaces relied on _m_del_select');
-    console.log('PASS reproduces the pre-fix _m_del_select flow that this issue replaces');
+    const tbl = new Host({
+        _apiBase: API, objectTableId: '3596',
+        columns: [{ id: '3597' }], filters: { '3597': { type: '=', value: 'foo' } },
+        options: {},
+        selectedRows: new Set(), data: [], rawObjectData: [], loadedRecords: 0, hasMore: true, totalRows: null,
+    });
+    await tbl.bulkDeleteByFilter();
+
+    assert.ok(delCall, 'a server-side delete request must be sent');
+    assert.strictEqual(delCall.body.get('_m_del_select'), '1', '_m_del_select trigger must be present');
+    assert.strictEqual(delCall.body.get('F_3597'), 'foo', 'the current filter must be forwarded');
+    assert.strictEqual(delCall.body.get('JSON'), '1', 'JSON flag makes the server answer JSON, not a redirect');
+    assert.strictEqual(delCall.body.get('_xsrf'), 'XSRFTOKEN', 'xsrf must be sent');
+    assert.strictEqual(tbl.exportCalled, undefined, 'must NOT fetch all rows for export (no OOM)');
+    const toast = (tbl.toasts || []).find(t => t.level === 'success');
+    assert.ok(toast && /22462/.test(toast.msg), 'deleted count must be reported to the user');
+    assert.strictEqual(tbl.reloadCalls, 1, 'table reloads once after delete');
+    console.log('PASS bulkDeleteByFilter deletes server-side via _m_del_select (one request, no export)');
+}
+
+async function testBulkDeleteSurfacesServerError() {
+    global.document = defaultDocument();
+    global.fetch = async (url, init) => {
+        if (/object\/3596\/\?JSON$/.test(url) && init.method === 'POST')
+            return jsonResponse(403, { error: 'У вас нет прав на массовое удаление' });
+        throw new Error(`Unexpected fetch ${url}`);
+    };
+    const tbl = new Host({
+        _apiBase: API, objectTableId: '3596', columns: [], filters: {}, options: {},
+        selectedRows: new Set(), data: [], rawObjectData: [], loadedRecords: 0, hasMore: true, totalRows: null,
+    });
+    await tbl.bulkDeleteByFilter();
+    const errHtml = global.document._errorsNode.innerHTML;
+    assert.ok(/нет прав на массовое удаление/.test(errHtml), 'server error must be shown to the user');
+    assert.ok(!(tbl.toasts || []).some(t => t.level === 'success'), 'no success toast on error');
+    console.log('PASS bulkDeleteByFilter surfaces a server-side delete error');
 }
 
 (async function run() {
-    await testReproducesLegacyBehaviourBeforeFix();
     await testFetchFilterMatchCount();
-    await testBulkDeleteByFilterUsesBatchEndpoint();
-    await testBulkDeleteByFilterSurfacesPerRecordErrors();
-    await testBulkDeleteByFilterHandlesChunkLevelFailure();
-    console.log('\nAll issue #2749 tests passed.');
-})().catch((err) => {
-    console.error(err);
-    process.exit(1);
-});
+    await testBulkDeleteUsesServerSideSelect();
+    await testBulkDeleteSurfacesServerError();
+    console.log('\nAll issue #2749/#3260 tests passed.');
+})().catch((err) => { console.error(err); process.exit(1); });

--- a/index.php
+++ b/index.php
@@ -6847,6 +6847,10 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 				while($row = mysqli_fetch_array($data_set))
 					BatchDelete($row["id"]);
 				BatchDelete(""); // Flush batch
+				# #3260: API/новый UI зовёт _m_del_select напрямую (без выгрузки строк) —
+				# отдаём число удалённых JSON-ом вместо HTML-редиректа.
+				if(isApi())
+					api_dump(json_encode(array("deleted"=>(int)$deleted), JSON_UNESCAPED_UNICODE), "deleted.json");
 				header("Location: /$z/object/$id/?deleted=$deleted&".$GLOBALS["FILTER"]);
 				myexit();
 			}

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -17822,7 +17822,21 @@ class IntegramTable{
             }
             const apiBase = this.getApiBase();
             const params = new URLSearchParams({ _count: '1' });
+            this.appendCurrentFilters(params);
 
+            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
+            const response = await fetch(url);
+            const result = await response.json();
+            return parseInt(result.count, 10);
+        }
+
+        /**
+         * Append the current filter (per-column conditions + parent F_U + page
+         * URL params) to `params`. Shared by count and server-side delete so the
+         * "delete N matching" count and the actual deletion use the exact same
+         * filter (issue #3260).
+         */
+        appendCurrentFilters(params) {
             const filters = this.filters || {};
             Object.keys(filters).forEach(colId => {
                 const filter = filters[colId];
@@ -17833,34 +17847,21 @@ class IntegramTable{
                     }
                 }
             });
-
             if (this.options.parentId) {
                 params.set('F_U', this.options.parentId);
             }
             this.appendPageUrlParams(params);
-
-            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
-            const response = await fetch(url);
-            const result = await response.json();
-            return parseInt(result.count, 10);
+            return params;
         }
 
         /**
-         * Delete all records matching the current filter (issue #2749).
+         * Delete all records matching the current filter (issues #2749, #3260).
          *
-         * Replaces both the legacy POST {table_id}/_m_del_select form flow
-         * (templates/object.html) AND the naive "POST /_m_del/{id} per record"
-         * approach. Instead this method:
-         *   1. Fetches matching record IDs from the JSON_OBJ endpoint
-         *      (loadDataFromTableForExport already honours filters/sort/F_U).
-         *   2. Splits the IDs into chunks of FILTER_DELETE_CHUNK records.
-         *   3. POSTs each chunk to /_m_del_batch/{tableId}?JSON in ONE request
-         *      per chunk. The server runs them in a single transaction via
-         *      BatchDelete() — the same path the legacy _m_del_select used.
-         *   4. Updates the progress bar per-chunk and reports per-record
-         *      server errors (reference constraints, missing rights, etc.).
-         *
-         * For a 100k delete this is ~100-200 HTTP requests instead of 100k.
+         * Server-side delete via _m_del_select: the server SELECTs matching ids
+         * (honouring the same filter as the count) and BatchDelete()s them in a
+         * single request — no row payload is fetched. Replaces the old approach
+         * of loading up to 1,000,000 full rows just to collect ids, which
+         * exhausted PHP memory on large tables (#3260).
          */
         async bulkDeleteByFilter() {
             if (!this.objectTableId) {
@@ -17868,191 +17869,76 @@ class IntegramTable{
                 return;
             }
 
-            // Chunk size — bounded to keep individual DB transactions reasonable
-            // and to give the progress bar useful granularity. The server caps
-            // _m_del_batch at 10000 ids per request anyway.
-            const FILTER_DELETE_CHUNK = 500;
-
-            // Load all matching record IDs through the existing export pathway.
-            let records = [];
-            try {
-                const savedTableTypeId = this.options.tableTypeId;
-                if (!this.options.tableTypeId && this.objectTableId) {
-                    this.options.tableTypeId = this.objectTableId;
-                }
-                const json = await this.loadDataFromTableForExport(0, 1000000);
-                this.options.tableTypeId = savedTableTypeId;
-
-                const rawData = (json && json.rawData) || [];
-                records = rawData
-                    .filter(item => item && item.i)
-                    .map(item => ({
-                        id: item.i,
-                        value: (item.r && item.r[0]) || ''
-                    }));
-            } catch (err) {
-                console.error('filter-delete load failed:', err);
-                this.showToast(`Ошибка загрузки записей: ${ err.message }`, 'error');
-                return;
-            }
-
-            if (records.length === 0) {
-                this.showToast('Нет записей, удовлетворяющих фильтру', 'error');
-                return;
-            }
-
             const apiBase = this.getApiBase();
-            const total = records.length;
-            let completed = 0;
-            const errors = [];
-            const warnings = [];
+            // Same filter as the count, plus the server-side bulk-delete trigger.
+            const params = this.appendCurrentFilters(new URLSearchParams());
+            params.set('_m_del_select', '1');
+            params.set('JSON', '1');   // isApi() -> сервер вернёт {deleted:N}, а не HTML-редирект
+            if (typeof xsrf !== 'undefined') {
+                params.set('_xsrf', xsrf);
+            }
 
-            // Map id -> first-column value, for human-readable error rows.
-            const valueById = new Map();
-            for (const r of records) valueById.set(String(r.id), r.value);
-
+            // Single, possibly long-running request - show a simple progress modal.
             const progressId = `filter-delete-progress-${ Date.now() }`;
-            const progressHtml = `
+            document.body.insertAdjacentHTML('beforeend', `
                 <div class="integram-modal-overlay" id="${ progressId }">
                     <div class="integram-modal" style="max-width: 500px;">
-                        <div class="integram-modal-header">
-                            <h3>Удаление записей по фильтру</h3>
-                        </div>
+                        <div class="integram-modal-header"><h3>Удаление записей по фильтру</h3></div>
                         <div class="integram-modal-body">
-                            <div class="bulk-delete-progress-bar-container">
-                                <div class="bulk-delete-progress-bar" style="width: 0%"></div>
-                            </div>
-                            <div class="bulk-delete-progress-text">Удалено: 0 / ${ total }</div>
-                            <div class="bulk-delete-errors" style="display: none;"></div>
+                            <div class="bulk-delete-progress-text">Удаление…</div>
+                            <div class="bulk-delete-errors" style="display:none; margin-top:10px;"></div>
                         </div>
                     </div>
                 </div>
-            `;
-            document.body.insertAdjacentHTML('beforeend', progressHtml);
+            `);
+            const overlay = document.getElementById(progressId);
+            const textEl = overlay.querySelector('.bulk-delete-progress-text');
+            const errorsDiv = overlay.querySelector('.bulk-delete-errors');
 
-            const progressOverlay = document.getElementById(progressId);
-            const progressBar = progressOverlay.querySelector('.bulk-delete-progress-bar');
-            const progressText = progressOverlay.querySelector('.bulk-delete-progress-text');
-            const errorsDiv = progressOverlay.querySelector('.bulk-delete-errors');
-
-            const updateProgress = () => {
-                const pct = Math.round((completed / total) * 100);
-                progressBar.style.width = `${ pct }%`;
-                progressText.textContent = `Удалено: ${ completed } / ${ total }`;
+            const showClose = () => {
+                const btn = document.createElement('button');
+                btn.className = 'btn btn-sm btn-primary';
+                btn.style.marginTop = '10px';
+                btn.textContent = 'Закрыть';
+                btn.addEventListener('click', () => overlay.remove());
+                overlay.querySelector('.integram-modal-body').appendChild(btn);
             };
 
-            // Send chunks sequentially — we want to update progress between
-            // chunks, and parallelising large server-side transactions just
-            // moves the contention from network to MySQL.
-            for (let i = 0; i < records.length; i += FILTER_DELETE_CHUNK) {
-                const chunk = records.slice(i, i + FILTER_DELETE_CHUNK);
-                const chunkIds = chunk.map(r => r.id);
+            try {
+                const response = await fetch(`${ apiBase }/object/${ this.objectTableId }/?JSON`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: params.toString()
+                });
+                const responseText = await response.text();
+                let result = null;
+                try { result = JSON.parse(responseText); } catch (e) { result = null; }
 
-                const params = new URLSearchParams();
-                params.append('ids', chunkIds.join(','));
-                if (typeof xsrf !== 'undefined') {
-                    params.append('_xsrf', xsrf);
+                const errMsg = result && (result.error || (Array.isArray(result) && result[0] && result[0].error));
+                if (errMsg) {
+                    textEl.textContent = 'Удаление не выполнено';
+                    errorsDiv.style.display = 'block';
+                    errorsDiv.innerHTML = `<div class="alert alert-danger">${ this.escapeHtml(String(errMsg)) }</div>`;
+                    showClose();
+                } else if (!result || result.deleted == null) {
+                    // Non-JSON / unexpected response (e.g. permission die() text).
+                    textEl.textContent = 'Удаление не выполнено';
+                    errorsDiv.style.display = 'block';
+                    errorsDiv.innerHTML = `<div class="alert alert-danger">${ this.escapeHtml(responseText.slice(0, 300)) }</div>`;
+                    showClose();
+                } else {
+                    const deleted = parseInt(result.deleted, 10) || 0;
+                    overlay.remove();
+                    this.showToast(`Удалено записей: ${ deleted }`, 'success');
                 }
-
-                try {
-                    const response = await fetch(`${ apiBase }/_m_del_batch/${ this.objectTableId }?JSON`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                        body: params.toString()
-                    });
-
-                    const text = await response.text();
-                    let result;
-                    try {
-                        result = JSON.parse(text);
-                    } catch (parseErr) {
-                        // Non-JSON response (e.g. PHP fatal) — record as a warning
-                        // for the whole chunk so the user can see what happened.
-                        warnings.push(`chunk ${ i / FILTER_DELETE_CHUNK + 1 } : ${ text.slice(0, 200) }`);
-                        completed += chunk.length;
-                        updateProgress();
-                        continue;
-                    }
-
-                    // Top-level error from the endpoint (e.g. 403): mark all ids
-                    // in this chunk as failed.
-                    if (result && Array.isArray(result) && result[0] && result[0].error) {
-                        const msg = result[0].error;
-                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ msg }`);
-                        completed += chunk.length;
-                        updateProgress();
-                        continue;
-                    }
-                    if (result && result.error) {
-                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ result.error }`);
-                        completed += chunk.length;
-                        updateProgress();
-                        continue;
-                    }
-
-                    const deletedIds = (result && Array.isArray(result.deleted)) ? result.deleted : [];
-                    const chunkErrors = (result && result.errors && typeof result.errors === 'object') ? result.errors : {};
-
-                    for (const rid of deletedIds) completed++;
-                    for (const rid of Object.keys(chunkErrors)) {
-                        const value = valueById.get(String(rid)) || '';
-                        errors.push(`#${ rid } : ${ value } : ${ chunkErrors[rid] }`);
-                    }
-                    updateProgress();
-                } catch (err) {
-                    // Network/transport failure — surface every id in the chunk
-                    for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ err.message }`);
-                    completed += chunk.length;
-                    updateProgress();
-                }
-            }
-
-            if (errors.length > 0 || warnings.length > 0) {
+            } catch (err) {
+                textEl.textContent = 'Ошибка удаления';
                 errorsDiv.style.display = 'block';
-                let html = '';
-                if (errors.length > 0) {
-                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
-                        <strong>Ошибки (блокирующие):</strong><br>
-                        ${ errors.map(e => {
-                            const parts = e.split(' : ');
-                            if (parts.length >= 3) {
-                                const recordId = this.escapeHtml(parts[0]);
-                                const recordValue = this.escapeHtml(parts[1]);
-                                const errorMsg = parts.slice(2).join(' : ');
-                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
-                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
-                            }
-                            return this.escapeHtml(e);
-                        }).join('<br>') }
-                    </div>`;
-                }
-                if (warnings.length > 0) {
-                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
-                        <strong>Предупреждения:</strong><br>
-                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
-                    </div>`;
-                }
-                errorsDiv.innerHTML = html;
+                errorsDiv.innerHTML = `<div class="alert alert-danger">${ this.escapeHtml(err.message) }</div>`;
+                showClose();
             }
 
-            if (errors.length > 0) {
-                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
-            } else {
-                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
-            }
-
-            if (errors.length === 0 && warnings.length === 0) {
-                setTimeout(() => progressOverlay.remove(), 1500);
-            } else {
-                const closeBtn = document.createElement('button');
-                closeBtn.className = 'btn btn-sm btn-primary';
-                closeBtn.style.marginTop = '10px';
-                closeBtn.textContent = 'Закрыть';
-                closeBtn.addEventListener('click', () => progressOverlay.remove());
-                progressOverlay.querySelector('.integram-modal-body').appendChild(closeBtn);
-            }
-
-            // Reset state and reload (mirrors bulkDelete())
+            // Reset state and reload the table (mirrors bulkDelete()).
             this.selectedRows.clear();
             this.data = [];
             this.rawObjectData = [];

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -375,7 +375,8 @@
             // If we have parent info, show breadcrumb-style title
             if (this.parentInfo) {
                 const parentTypeName = this.escapeHtml(this.parentInfo.type || '');
-                const parentVal = this.escapeHtml(this.parentInfo.val || '');
+                // #3247: первая колонка-DATETIME родителя приходит unix-штампом — форматируем.
+                const parentVal = this.escapeHtml(this.formatRecordTitleValue(this.parentInfo.val || ''));
                 const parentObjId = this.parentInfo.obj || '';
                 const parentUp = parseInt(this.parentInfo.up, 10) || 0;
                 const parentRecordId = this.options.parentId || '';

--- a/js/integram-table/05-date-utils.js
+++ b/js/integram-table/05-date-utils.js
@@ -125,3 +125,14 @@
             return `${ day }.${ month }.${ year } ${ hours }:${ minutes }:${ seconds }`;
         }
 
+        // Значение «главного» поля записи для заголовка/ссылок (.integram-title-link,
+        // .integram-parent-record-link). Если первая колонка таблицы — DATETIME, API
+        // отдаёт её unix-штампом (секунды) — показываем как дату-время с секундами
+        // (issue #3247). Не-штампы (DATE «20260601», числа, текст, уже форматированные
+        // строки) остаются как есть: parseUnixTimestamp строго требует >= 1e9 и год 2001–2100.
+        formatRecordTitleValue(value) {
+            const raw = String(value == null ? '' : value);
+            const ts = this.parseUnixTimestamp(raw);
+            return ts ? this.formatDateTimeDisplay(ts) : raw;
+        }
+

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -305,7 +305,21 @@
             }
             const apiBase = this.getApiBase();
             const params = new URLSearchParams({ _count: '1' });
+            this.appendCurrentFilters(params);
 
+            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
+            const response = await fetch(url);
+            const result = await response.json();
+            return parseInt(result.count, 10);
+        }
+
+        /**
+         * Append the current filter (per-column conditions + parent F_U + page
+         * URL params) to `params`. Shared by count and server-side delete so the
+         * "delete N matching" count and the actual deletion use the exact same
+         * filter (issue #3260).
+         */
+        appendCurrentFilters(params) {
             const filters = this.filters || {};
             Object.keys(filters).forEach(colId => {
                 const filter = filters[colId];
@@ -316,34 +330,21 @@
                     }
                 }
             });
-
             if (this.options.parentId) {
                 params.set('F_U', this.options.parentId);
             }
             this.appendPageUrlParams(params);
-
-            const url = `${ apiBase }/object/${ this.objectTableId }/?JSON_OBJ&${ params }`;
-            const response = await fetch(url);
-            const result = await response.json();
-            return parseInt(result.count, 10);
+            return params;
         }
 
         /**
-         * Delete all records matching the current filter (issue #2749).
+         * Delete all records matching the current filter (issues #2749, #3260).
          *
-         * Replaces both the legacy POST {table_id}/_m_del_select form flow
-         * (templates/object.html) AND the naive "POST /_m_del/{id} per record"
-         * approach. Instead this method:
-         *   1. Fetches matching record IDs from the JSON_OBJ endpoint
-         *      (loadDataFromTableForExport already honours filters/sort/F_U).
-         *   2. Splits the IDs into chunks of FILTER_DELETE_CHUNK records.
-         *   3. POSTs each chunk to /_m_del_batch/{tableId}?JSON in ONE request
-         *      per chunk. The server runs them in a single transaction via
-         *      BatchDelete() — the same path the legacy _m_del_select used.
-         *   4. Updates the progress bar per-chunk and reports per-record
-         *      server errors (reference constraints, missing rights, etc.).
-         *
-         * For a 100k delete this is ~100-200 HTTP requests instead of 100k.
+         * Server-side delete via _m_del_select: the server SELECTs matching ids
+         * (honouring the same filter as the count) and BatchDelete()s them in a
+         * single request — no row payload is fetched. Replaces the old approach
+         * of loading up to 1,000,000 full rows just to collect ids, which
+         * exhausted PHP memory on large tables (#3260).
          */
         async bulkDeleteByFilter() {
             if (!this.objectTableId) {
@@ -351,191 +352,76 @@
                 return;
             }
 
-            // Chunk size — bounded to keep individual DB transactions reasonable
-            // and to give the progress bar useful granularity. The server caps
-            // _m_del_batch at 10000 ids per request anyway.
-            const FILTER_DELETE_CHUNK = 500;
-
-            // Load all matching record IDs through the existing export pathway.
-            let records = [];
-            try {
-                const savedTableTypeId = this.options.tableTypeId;
-                if (!this.options.tableTypeId && this.objectTableId) {
-                    this.options.tableTypeId = this.objectTableId;
-                }
-                const json = await this.loadDataFromTableForExport(0, 1000000);
-                this.options.tableTypeId = savedTableTypeId;
-
-                const rawData = (json && json.rawData) || [];
-                records = rawData
-                    .filter(item => item && item.i)
-                    .map(item => ({
-                        id: item.i,
-                        value: (item.r && item.r[0]) || ''
-                    }));
-            } catch (err) {
-                console.error('filter-delete load failed:', err);
-                this.showToast(`Ошибка загрузки записей: ${ err.message }`, 'error');
-                return;
-            }
-
-            if (records.length === 0) {
-                this.showToast('Нет записей, удовлетворяющих фильтру', 'error');
-                return;
-            }
-
             const apiBase = this.getApiBase();
-            const total = records.length;
-            let completed = 0;
-            const errors = [];
-            const warnings = [];
+            // Same filter as the count, plus the server-side bulk-delete trigger.
+            const params = this.appendCurrentFilters(new URLSearchParams());
+            params.set('_m_del_select', '1');
+            params.set('JSON', '1');   // isApi() -> сервер вернёт {deleted:N}, а не HTML-редирект
+            if (typeof xsrf !== 'undefined') {
+                params.set('_xsrf', xsrf);
+            }
 
-            // Map id -> first-column value, for human-readable error rows.
-            const valueById = new Map();
-            for (const r of records) valueById.set(String(r.id), r.value);
-
+            // Single, possibly long-running request - show a simple progress modal.
             const progressId = `filter-delete-progress-${ Date.now() }`;
-            const progressHtml = `
+            document.body.insertAdjacentHTML('beforeend', `
                 <div class="integram-modal-overlay" id="${ progressId }">
                     <div class="integram-modal" style="max-width: 500px;">
-                        <div class="integram-modal-header">
-                            <h3>Удаление записей по фильтру</h3>
-                        </div>
+                        <div class="integram-modal-header"><h3>Удаление записей по фильтру</h3></div>
                         <div class="integram-modal-body">
-                            <div class="bulk-delete-progress-bar-container">
-                                <div class="bulk-delete-progress-bar" style="width: 0%"></div>
-                            </div>
-                            <div class="bulk-delete-progress-text">Удалено: 0 / ${ total }</div>
-                            <div class="bulk-delete-errors" style="display: none;"></div>
+                            <div class="bulk-delete-progress-text">Удаление…</div>
+                            <div class="bulk-delete-errors" style="display:none; margin-top:10px;"></div>
                         </div>
                     </div>
                 </div>
-            `;
-            document.body.insertAdjacentHTML('beforeend', progressHtml);
+            `);
+            const overlay = document.getElementById(progressId);
+            const textEl = overlay.querySelector('.bulk-delete-progress-text');
+            const errorsDiv = overlay.querySelector('.bulk-delete-errors');
 
-            const progressOverlay = document.getElementById(progressId);
-            const progressBar = progressOverlay.querySelector('.bulk-delete-progress-bar');
-            const progressText = progressOverlay.querySelector('.bulk-delete-progress-text');
-            const errorsDiv = progressOverlay.querySelector('.bulk-delete-errors');
-
-            const updateProgress = () => {
-                const pct = Math.round((completed / total) * 100);
-                progressBar.style.width = `${ pct }%`;
-                progressText.textContent = `Удалено: ${ completed } / ${ total }`;
+            const showClose = () => {
+                const btn = document.createElement('button');
+                btn.className = 'btn btn-sm btn-primary';
+                btn.style.marginTop = '10px';
+                btn.textContent = 'Закрыть';
+                btn.addEventListener('click', () => overlay.remove());
+                overlay.querySelector('.integram-modal-body').appendChild(btn);
             };
 
-            // Send chunks sequentially — we want to update progress between
-            // chunks, and parallelising large server-side transactions just
-            // moves the contention from network to MySQL.
-            for (let i = 0; i < records.length; i += FILTER_DELETE_CHUNK) {
-                const chunk = records.slice(i, i + FILTER_DELETE_CHUNK);
-                const chunkIds = chunk.map(r => r.id);
+            try {
+                const response = await fetch(`${ apiBase }/object/${ this.objectTableId }/?JSON`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: params.toString()
+                });
+                const responseText = await response.text();
+                let result = null;
+                try { result = JSON.parse(responseText); } catch (e) { result = null; }
 
-                const params = new URLSearchParams();
-                params.append('ids', chunkIds.join(','));
-                if (typeof xsrf !== 'undefined') {
-                    params.append('_xsrf', xsrf);
+                const errMsg = result && (result.error || (Array.isArray(result) && result[0] && result[0].error));
+                if (errMsg) {
+                    textEl.textContent = 'Удаление не выполнено';
+                    errorsDiv.style.display = 'block';
+                    errorsDiv.innerHTML = `<div class="alert alert-danger">${ this.escapeHtml(String(errMsg)) }</div>`;
+                    showClose();
+                } else if (!result || result.deleted == null) {
+                    // Non-JSON / unexpected response (e.g. permission die() text).
+                    textEl.textContent = 'Удаление не выполнено';
+                    errorsDiv.style.display = 'block';
+                    errorsDiv.innerHTML = `<div class="alert alert-danger">${ this.escapeHtml(responseText.slice(0, 300)) }</div>`;
+                    showClose();
+                } else {
+                    const deleted = parseInt(result.deleted, 10) || 0;
+                    overlay.remove();
+                    this.showToast(`Удалено записей: ${ deleted }`, 'success');
                 }
-
-                try {
-                    const response = await fetch(`${ apiBase }/_m_del_batch/${ this.objectTableId }?JSON`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                        body: params.toString()
-                    });
-
-                    const text = await response.text();
-                    let result;
-                    try {
-                        result = JSON.parse(text);
-                    } catch (parseErr) {
-                        // Non-JSON response (e.g. PHP fatal) — record as a warning
-                        // for the whole chunk so the user can see what happened.
-                        warnings.push(`chunk ${ i / FILTER_DELETE_CHUNK + 1 } : ${ text.slice(0, 200) }`);
-                        completed += chunk.length;
-                        updateProgress();
-                        continue;
-                    }
-
-                    // Top-level error from the endpoint (e.g. 403): mark all ids
-                    // in this chunk as failed.
-                    if (result && Array.isArray(result) && result[0] && result[0].error) {
-                        const msg = result[0].error;
-                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ msg }`);
-                        completed += chunk.length;
-                        updateProgress();
-                        continue;
-                    }
-                    if (result && result.error) {
-                        for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ result.error }`);
-                        completed += chunk.length;
-                        updateProgress();
-                        continue;
-                    }
-
-                    const deletedIds = (result && Array.isArray(result.deleted)) ? result.deleted : [];
-                    const chunkErrors = (result && result.errors && typeof result.errors === 'object') ? result.errors : {};
-
-                    for (const rid of deletedIds) completed++;
-                    for (const rid of Object.keys(chunkErrors)) {
-                        const value = valueById.get(String(rid)) || '';
-                        errors.push(`#${ rid } : ${ value } : ${ chunkErrors[rid] }`);
-                    }
-                    updateProgress();
-                } catch (err) {
-                    // Network/transport failure — surface every id in the chunk
-                    for (const r of chunk) errors.push(`#${ r.id } : ${ r.value } : ${ err.message }`);
-                    completed += chunk.length;
-                    updateProgress();
-                }
-            }
-
-            if (errors.length > 0 || warnings.length > 0) {
+            } catch (err) {
+                textEl.textContent = 'Ошибка удаления';
                 errorsDiv.style.display = 'block';
-                let html = '';
-                if (errors.length > 0) {
-                    html += `<div class="alert alert-danger" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px; background-color: #f8d7da; border: 2px solid #f5c6cb; border-radius: 4px; padding: 10px;">
-                        <strong>Ошибки (блокирующие):</strong><br>
-                        ${ errors.map(e => {
-                            const parts = e.split(' : ');
-                            if (parts.length >= 3) {
-                                const recordId = this.escapeHtml(parts[0]);
-                                const recordValue = this.escapeHtml(parts[1]);
-                                const errorMsg = parts.slice(2).join(' : ');
-                                const sanitizedMsg = this.sanitizeInlineMessageHtml(errorMsg);
-                                return `${recordId} : ${recordValue} : ${sanitizedMsg}`;
-                            }
-                            return this.escapeHtml(e);
-                        }).join('<br>') }
-                    </div>`;
-                }
-                if (warnings.length > 0) {
-                    html += `<div class="alert alert-warning" style="max-height: 200px; overflow-y: auto; font-size: 0.75rem; margin-top: 10px;">
-                        <strong>Предупреждения:</strong><br>
-                        ${ warnings.map(w => this.escapeHtml(w)).join('<br>') }
-                    </div>`;
-                }
-                errorsDiv.innerHTML = html;
+                errorsDiv.innerHTML = `<div class="alert alert-danger">${ this.escapeHtml(err.message) }</div>`;
+                showClose();
             }
 
-            if (errors.length > 0) {
-                progressText.textContent = `Удаление завершено с ошибками: ${ completed } / ${ total }`;
-            } else {
-                progressText.textContent = `Удаление завершено: ${ completed } / ${ total }`;
-            }
-
-            if (errors.length === 0 && warnings.length === 0) {
-                setTimeout(() => progressOverlay.remove(), 1500);
-            } else {
-                const closeBtn = document.createElement('button');
-                closeBtn.className = 'btn btn-sm btn-primary';
-                closeBtn.style.marginTop = '10px';
-                closeBtn.textContent = 'Закрыть';
-                closeBtn.addEventListener('click', () => progressOverlay.remove());
-                progressOverlay.querySelector('.integram-modal-body').appendChild(closeBtn);
-            }
-
-            // Reset state and reload (mirrors bulkDelete())
+            // Reset state and reload the table (mirrors bulkDelete()).
             this.selectedRows.clear();
             this.data = [];
             this.rawObjectData = [];


### PR DESCRIPTION
Closes #3260.

### Причина
Кнопка «Удалить по фильтру» в новом UI грузила до **1 000 000 строк** (`object/{type}/?JSON_OBJ&LIMIT=0,1000000`), чтобы собрать id и удалять чанками через `_m_del_batch`. На больших таблицах (десятки миллионов) сервер падал:
> PHP Fatal error: Allowed memory size of 134217728 bytes exhausted (index.php:8190)

В старом интерфейсе работает через серверный `_m_del_select` — на него и переходим (как и предложено в issue).

### Сервер (`index.php`)
`_m_del_select` для API-вызова (`isApi()`) возвращает JSON `{deleted:N}` вместо HTML-редиректа. Само удаление как и раньше: один `SELECT` id по фильтру (референсные пропускаются) → `BatchDelete` — **без выгрузки строк**.

### Фронтенд (`js/integram-table/23-bulk-export.js`)
`bulkDeleteByFilter` теперь шлёт **один POST** `object/{type}/?JSON` с `_m_del_select=1` + текущий фильтр (тот же, что у `_count`) + `_xsrf`. Больше нет загрузки 1М строк, нет `_m_del_batch`, нет пер-записного `_m_del`. Вынесен общий `appendCurrentFilters` — счётчик и удаление строят фильтр одинаково. `js/integram-table.js` пересобран (`build.sh`).

> ⚠️ Также перенёс фикс #3247 (`formatRecordTitleValue`) из **сгенерированного** `js/integram-table.js` в исходные модули (`01-core.js`, `05-date-utils.js`) — он был только в сгенерированном файле, и этот ребилд его бы затёр. Теперь модули = источник истины.

### Компромисс
Серверный `_m_del_select` не возвращает пер-записные ошибки (референсные записи просто не удаляются — `$deleted` считает реально удалённые). Это цена работы на больших объёмах; ровно то, что делает проверенный старый UI.

### Тесты
`node experiments/test-issue-2749-delete-by-filter.js` → переписан под `_m_del_select` (3 кейса: count, серверное удаление одним запросом без экспорта, показ ошибки); `test-issue-3247` — зелёный. Серверную часть (PHP) автотестами не покрыть — проверена разбором; на живом стенде проверить не мог (issue на `xcom`, токен только к `ateh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)