### PR TITLE
fix(atex): .atex-pp-cut-time показывает начало окна (setup), как «Тайминг окна» (#3262)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1573,7 +1573,13 @@
             if (!hasWindingPoints) return '⏱ ошибка: нет норм WIND_*; длительность не рассчитана';
             return '⏱ ошибка: длительность 0 мин; проверьте проходы и нормы намотки';
         }
-        return '⏱ ' + formatClock(sc.startMin) + ' – ' + formatClock(sc.finishMin) + ' · ' + dur + ' мин';
+        // #3262: показываем всё ОКНО (setup + резка), как «Тайминг окна» в модалке —
+        // старт = начало setup (startMin − setupMin), длительность = setup + резка
+        // (диапазон совпадает с числом минут, как у блока уборки). Так начало в карточке
+        // равно первому шагу тайминга окна, а не старту самой резки.
+        var setup = stripNum(sc.setupMin);
+        var windowStart = stripNum(sc.startMin) - setup;
+        return '⏱ ' + formatClock(windowStart) + ' – ' + formatClock(sc.finishMin) + ' · ' + round3(setup + dur) + ' мин';
     }
 
     // Допуск остатка джамбо (мм): если задан (непустая строка) — берём его (терпимо

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1013,12 +1013,19 @@ var schedStoredDuration = planning.buildSchedule([
 ], { windPoints: pts, runLengthByCut: {}, shiftStartMin: 480 });
 assertEqual(schedStoredDuration[0], { cutId:'D', startMin:482, finishMin:494.5, setupMin:2, durationMin:12.5 },
     'buildSchedule #3229: cut_duration используется как fallback, если метраж отчёта отсутствует');
+// #3262: строка показывает ВСЁ окно (setup+резка): старт = startMin−setupMin (08:00),
+// длительность = setup(2)+12.5 = 14.5 (диапазон совпадает с числом минут).
 assertEqual(planning.formatScheduleLine(schedStoredDuration[0], 0, true),
-    '⏱ 08:02 – 08:15 · 12.5 мин',
-    'formatScheduleLine #3229: сохранённая длительность отображается без 0 мин');
+    '⏱ 08:00 – 08:15 · 14.5 мин',
+    'formatScheduleLine #3262: окно от начала setup; длительность = setup + резка');
 assertEqual(planning.formatScheduleLine({ startMin:482, finishMin:482, durationMin:0 }, 0, true),
     '⏱ ошибка: нет метража прохода; длительность не рассчитана',
     'formatScheduleLine #3229: нулевая длительность без метража отображается как ошибка');
+// #3262: пример из тикета — setup 47 мин, резка 12 мин → окно 10:34–11:33 · 59 мин
+// (совпадает с первым шагом «Тайминг окна», а не со стартом резки 11:21).
+assertEqual(planning.formatScheduleLine({ startMin:681, finishMin:693, setupMin:47, durationMin:12 }, 0, true),
+    '⏱ 10:34 – 11:33 · 59 мин',
+    'formatScheduleLine #3262: старт окна (10:34) совпадает с таймингом окна, не со стартом резки (11:21)');
 assertEqual(planning.formatClock(482), '08:02', 'formatClock: 482 → 08:02');
 assertEqual(planning.formatClock(1440 + 90), '01:30 +1д', 'formatClock: за сутки → +1д');
 assertEqual(planning.formatCutStartTime({ startMin:482 }), '08:02',


### PR DESCRIPTION
Closes #3262.

### Проблема
Строка времени резки `.atex-pp-cut-time` показывала старт самой **резки** (после setup): `⏱ 11:21 – 11:33 · 12 мин`. А модалка «Тайминг окна» начинается с **начала setup** (10:34: лидер → смена сырья → смена ножей → резка). Начала не совпадали.

### Решение
`formatScheduleLine` теперь показывает всё **окно** (setup + резка):
- старт = `startMin − setupMin` (= 10:34, первый шаг «Тайминг окна»);
- длительность = `setup + резка` (диапазон совпадает с числом минут — как у блока «Уборка»).

Пример из тикета: `⏱ 10:34 – 11:33 · 59 мин` (было `11:21 – 11:33 · 12 мин`). Разбивка setup/резка по-прежнему в модалке.

> `.atex-pp-cut-num` (жирное время слева) — отдельный элемент, остаётся **плановым стартом самой резки** (#3236). Если нужно и его сделать = началу окна — скажите.

### Тесты
`node experiments/atex-production-planning.test.js` → **341 assertions passed** (formatScheduleLine: окно от начала setup; добавлен кейс из тикета 10:34–11:33·59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)