### PR TITLE
fix(atex): очередь сгенерированных резок по убыванию ножей (#3263)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
-# Updated: 2026-06-08T14:41:38.627Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
+# Updated: 2026-06-08T14:41:38.627Z

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3241,6 +3241,64 @@
             return Promise.resolve();
         }
 
+        var layoutPlans = [];
+        layouts.forEach(function(lay, layIdx) {
+            var plannedRuns = plannedRunsForLayout(lay, posById);
+            var runLength = layoutRunLength(lay, posById);
+            var batchId = pickBatchFIFOForRun(self.genBatches, lay.mat, runLength, batchRemainingById);
+            var setupKey = slitterAffinityKey(lay.mat, lay.windDir, lay.windLength, batchId);
+            var slitterId = slitterBySetupKey[setupKey] || pickSlitter(self.slitters, lay.mat, loadBySlitterId);
+            if (slitterId != null) {
+                slitterId = String(slitterId);
+                slitterBySetupKey[setupKey] = slitterId;
+                loadBySlitterId[slitterId] = (loadBySlitterId[slitterId] || 0) + 1;
+            }
+            layoutPlans.push({
+                plannedRuns: plannedRuns,
+                runLength: runLength,
+                duration: plannedCutDurationMinutes(runLength, plannedRuns, self.opTimes),
+                timing: cutTimingDetails(runLength, plannedRuns, self.opTimes),
+                batchId: batchId,
+                slitterId: slitterId,
+                cutMainValue: nextCutMainValue(sequenceCuts, controllerNowMs(self), cutMainState),
+                knifeCount: stripsTotalKnives(lay && lay.strips),
+                sequence: '',
+                index: layIdx
+            });
+        });
+        if (layoutPlans.length) self.lastCutMainValue = cutMainState.last;
+
+        // #3263: create requests stay in layout order, but queue numbers for
+        // same-day generated cuts must follow knife count descending.
+        var sequenceGroups = {};
+        var sequenceGroupOrder = [];
+        layoutPlans.forEach(function(plan) {
+            var slitterId = String(plan.slitterId == null ? '' : plan.slitterId);
+            if (slitterId === '') return;
+            var day = cutPlanDayKey({ planDate: plan.cutMainValue });
+            var key = slitterId + '\u0000' + day;
+            if (!sequenceGroups[key]) {
+                sequenceGroups[key] = { slitterId: slitterId, planDate: plan.cutMainValue, plans: [] };
+                sequenceGroupOrder.push(key);
+            }
+            sequenceGroups[key].plans.push(plan);
+        });
+        sequenceGroupOrder.forEach(function(key) {
+            var group = sequenceGroups[key];
+            group.plans.slice().sort(function(a, b) {
+                return ((Number(b.knifeCount) || 0) - (Number(a.knifeCount) || 0)) || (a.index - b.index);
+            }).forEach(function(plan) {
+                plan.sequence = nextSequenceForCuts(sequenceCuts, group.slitterId, group.planDate);
+                sequenceCuts.push({
+                    id: 'generated-' + plan.index,
+                    number: plan.cutMainValue,
+                    slitter: { id: group.slitterId, label: '' },
+                    planDate: plan.cutMainValue,
+                    sequence: plan.sequence
+                });
+            });
+        });
+
         this.setBusy(true);
         // Окно прогресса (#3148): генерация идёт последовательными зависимыми
         // запросами, может занять заметное время.
@@ -3251,25 +3309,15 @@
         layouts.forEach(function(lay, layIdx) {
             chain = chain.then(function() {
                 self.updateProgress(doneCuts, 'Создаётся резка ' + (layIdx + 1) + ' из ' + nCuts + '…');
-                var plannedRuns = plannedRunsForLayout(lay, posById);
-                var runLength = layoutRunLength(lay, posById);
-                var duration = plannedCutDurationMinutes(runLength, plannedRuns, self.opTimes);
-                var timing = cutTimingDetails(runLength, plannedRuns, self.opTimes);
-
-                var batchId = pickBatchFIFOForRun(self.genBatches, lay.mat, runLength, batchRemainingById);
-                var setupKey = slitterAffinityKey(lay.mat, lay.windDir, lay.windLength, batchId);
-                var slitterId = slitterBySetupKey[setupKey] || pickSlitter(self.slitters, lay.mat, loadBySlitterId);
-                if (slitterId != null) {
-                    slitterId = String(slitterId);
-                    slitterBySetupKey[setupKey] = slitterId;
-                    loadBySlitterId[slitterId] = (loadBySlitterId[slitterId] || 0) + 1;
-                }
-                var sequence = nextSequenceForCuts(sequenceCuts, slitterId, '');
-                var cutMainValue = nextCutMainValue(sequenceCuts, controllerNowMs(self), cutMainState);
-                self.lastCutMainValue = cutMainState.last;
-                if (sequence !== '') {
-                    sequenceCuts.push({ id: 'generated-' + layIdx, number: cutMainValue, slitter: { id: slitterId, label: '' }, planDate: '', sequence: sequence });
-                }
+                var layoutPlan = layoutPlans[layIdx];
+                var plannedRuns = layoutPlan.plannedRuns;
+                var runLength = layoutPlan.runLength;
+                var duration = layoutPlan.duration;
+                var timing = layoutPlan.timing;
+                var batchId = layoutPlan.batchId;
+                var slitterId = layoutPlan.slitterId;
+                var sequence = layoutPlan.sequence;
+                var cutMainValue = layoutPlan.cutMainValue;
                 var cutFields = buildFields(cutReqIds, {
                     status: CUT_STATUSES[0],
                     slitter: slitterId,

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1324,6 +1324,70 @@ function runGenerateCutsSlitterAffinityTest() {
     });
 }
 
+function runGenerateCutsSequenceByKnivesTest() {
+    var controller = Object.create(api.Controller.prototype);
+    var posts = [];
+    var cutNo = 0;
+    controller.meta = {
+        cut: { id: '1078', val: 'Производственная резка', reqs: [
+            req('1156', 'Слиттер'),
+            req('15018', 'Партия сырья'),
+            req('16403', 'Кол-во план'),
+            req('24308', 'Очередность'),
+            req('24305', 'Метраж, м'),
+            req('26584', 'Длительность, минут'),
+            req('26990', 'Тайминг'),
+            req('1162', 'Статус')
+        ] },
+        supply: { id: '1077', val: 'Обеспечение', reqs: [
+            req('1149', 'Метраж, м'),
+            req('1154', 'В работе'),
+            req('15016', 'Партия ГП', { ref: '1081' }),
+            req('16424', 'Кол-во рулонов')
+        ] },
+        finishedBatch: { id: '1081', val: 'Партия ГП', reqs: [
+            req('1186', 'Ширина, мм'),
+            req('1188', 'Кол-во рулонов'),
+            req('1189', 'Метраж, м'),
+            req('1192', 'В работе')
+        ] },
+        sleeveTask: null
+    };
+    controller.genPositions = [
+        { id: 'p-few', materialId: 'M', width: 60, qty: 5, length: 600, windDir: 'IN', windLength: 600 },
+        { id: 'p-many', materialId: 'M', width: 40, qty: 15, length: 600, windDir: 'IN', windLength: 600 }
+    ];
+    controller.genBatches = [{ id: 'b1', materialId: 'M', dateKey: 20260601, remainder: 999, remainderLinear: 5000, active: true }];
+    controller.cuts = [];
+    controller.slitters = [{ id: '20', label: 'Станок 2', stopMaterialIds: [] }];
+    controller.opTimes = opT;
+    controller.nowMs = function() { return 1780919700000; };
+    controller.setBusy = function() {};
+    controller.showProgress = function() {};
+    controller.updateProgress = function() {};
+    controller.hideProgress = function() {};
+    controller.render = function() {};
+    controller.reload = function() { return Promise.resolve(); };
+    controller.notify = function() {};
+    controller.post = function(path, fields) {
+        posts.push({ path: path, fields: fields || {} });
+        if (path.indexOf('_m_new/1078') === 0) {
+            cutNo += 1;
+            return Promise.resolve({ obj: 'cut-' + cutNo });
+        }
+        return Promise.resolve({ obj: 'obj-' + posts.length });
+    };
+
+    return controller.runGenerateCuts([
+        { mat: 'M', windDir: 'IN', windLength: 600, positionsCovered: ['p-few'], strips: [{ width: 60, qty: 5, purpose: 'Заказ', positionIds: ['p-few'] }] },
+        { mat: 'M', windDir: 'IN', windLength: 600, positionsCovered: ['p-many'], strips: [{ width: 40, qty: 15, purpose: 'Заказ', positionIds: ['p-many'] }] }
+    ], []).then(function() {
+        var cutPosts = posts.filter(function(p) { return p.path.indexOf('_m_new/1078') === 0; });
+        assertEqual(cutPosts.map(function(p) { return p.fields.t24308; }), [2, 1],
+            'runGenerateCuts #3263: новые резки одного станка получают очередь по ножам убыв. (15 раньше 5)');
+    });
+}
+
 function runCreateCutPayloadDiagnosticsTest() {
     var controller = Object.create(api.Controller.prototype);
     var posts = [];
@@ -1428,6 +1492,7 @@ function runCreateCutMainValueTest() {
 runPreferredWidthsFilterTest()
     .then(runGenerateCutsDeferredGpTest)
     .then(runGenerateCutsSlitterAffinityTest)
+    .then(runGenerateCutsSequenceByKnivesTest)
     .then(runCreateCutPayloadDiagnosticsTest)
     .then(runCreateCutMainValueTest)
     .then(function() {


### PR DESCRIPTION
Closes #3263.

### Воспроизведение
Сгенерировать две новые резки на один станок и один день, где первая раскладка имеет 5 ножей, а вторая — 15. До фикса `runGenerateCuts` проставлял «Очередность» сразу в порядке создания: 5 ножей → `1`, 15 ножей → `2`.

### Причина
После #3259 отображение уже сравнивает плановую дату по календарному дню, но новые записи всё равно получали `sequence` до того, как генератор мог сравнить их по количеству ножей. Кроме того, временная запись для расчёта очереди добавлялась с пустой `planDate`, хотя сама резка создаётся с DATETIME-значением.

### Решение
`runGenerateCuts` сначала собирает план создаваемых резок: партия, станок, DATETIME-значение, длительность и количество ножей. Затем внутри каждой группы `станок + день` назначает номера очереди по `knifeCount` по убыванию, а сами `_m_new` запросы остаются последовательными в исходном порядке.

### Тесты
- `node experiments/atex-production-planning.test.js` → **342 assertions passed**
- `node -e \"require('./download/atex/js/production-planning.js'); console.log('loads ok')\"` → `loads ok`

🤖 Generated with OpenAI Codex