### PR TITLE
fix(atex): persist winding on generated cuts

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
-# Updated: 2026-06-08T16:12:29.826Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
+# Updated: 2026-06-08T16:12:29.826Z

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -80,7 +80,8 @@
         duration: 'Длительность, минут',
         timing: 'Тайминг',
         actualRuns: 'Кол-во факт',
-        length: 'Метраж, м'
+        length: 'Метраж, м',
+        winding: 'Тип намотки'
     };
     var CUT_PLANNED_RUN_COLUMNS = [
         'cut_planned_runs',
@@ -105,7 +106,8 @@
         planDate: CUT_REQ.planDate,
         status: CUT_REQ.status,
         notes: CUT_REQ.notes,
-        sequence: CUT_REQ.sequence
+        sequence: CUT_REQ.sequence,
+        winding: CUT_REQ.winding
     };
     // Реквизиты «Обеспечения» (up = позиция заказа).
     var SUPPLY_REQ = {
@@ -3195,6 +3197,7 @@
             duration: reqIdByName(cutMeta, CUT_REQ.duration),
             timing: reqIdByName(cutMeta, CUT_REQ.timing),
             length: reqIdByName(cutMeta, CUT_REQ.length),
+            winding: reqIdByName(cutMeta, CUT_REQ.winding),
             status: reqIdByName(cutMeta, CUT_REQ.status),
             sequence: reqIdByName(cutMeta, CUT_REQ.sequence)
         };
@@ -3326,6 +3329,7 @@
                     duration: duration > 0 ? duration : '',
                     timing: timing,
                     length: runLength > 0 ? runLength : '',
+                    winding: normWinding(lay && lay.windDir),
                     sequence: sequence
                 });
                 cutFields = addMainValueField(cutMeta, cutFields, cutMainValue);

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1174,6 +1174,7 @@ function runGenerateCutsDeferredGpTest() {
             req('24305', 'Метраж, м'),
             req('26584', 'Длительность, минут'),
             req('26990', 'Тайминг'),
+            req('27172', 'Тип намотки'),
             req('1162', 'Статус')
         ] },
         // #3242: «Обеспечение» ссылается на «Партию ГП» (t15016), не на резку.
@@ -1215,6 +1216,8 @@ function runGenerateCutsDeferredGpTest() {
 
     var result = controller.runGenerateCuts([{
         mat: 'M',
+        windDir: 'OUT',
+        windLength: 1200,
         positionsCovered: ['p1'],
         strips: [
             { width: 110, qty: 1, purpose: 'Заказ', positionIds: ['p1'] },
@@ -1241,6 +1244,8 @@ function runGenerateCutsDeferredGpTest() {
             'runGenerateCuts #3223: t26584 пишет Длительность, минут при планировании');
         assertEqual(cutPost.fields.t26990, planning.cutTimingDetails(1200, 1, opT),
             'runGenerateCuts #3238: t26990 пишет Тайминг с деталями расчёта');
+        assertEqual(cutPost.fields.t27172, 'OUT',
+            'runGenerateCuts #3266: t27172 пишет Тип намотки Производственной резки');
         // #3242: состав резки создаётся как «Партия ГП» (по ширинам: 110 и 55), не «Полоса».
         var gpPosts = posts.filter(function(p) { return p.path.indexOf('_m_new/1081') === 0; });
         assertEqual(gpPosts.length, 2, 'runGenerateCuts #3242: создаются «Партии ГП» по каждой ширине');


### PR DESCRIPTION
Fixes #3266

## What changed
- Add the `Тип намотки` req mapping for `Производственная резка` payloads in production planning.
- When cuts are generated from a planning profile, write normalized `lay.windDir` (`IN`/`OUT`) into the new cut field if the current metadata contains it.
- Keep the behavior backward-compatible for metadata that does not have the field: `buildFields` skips the missing req id.

## Reproduction and verification
The regression is covered in `experiments/atex-production-planning.test.js`: the generated-cut fixture exposes `Производственная резка.Тип намотки` as `t27172`, passes `windDir: 'OUT'`, and asserts that `_m_new/1078?JSON&up=1` includes `t27172='OUT'`. Before the fix this assertion failed because the field was absent from the payload.

## Tests
- `node experiments/atex-production-planning.test.js` (`343 assertions passed`)
- `for f in experiments/atex-*.test.js; do node "$f"; done` (all Atex experiment tests passed; full local log at `/tmp/atex-tests.log`)
- `git diff --check`

No screenshots: this is a request payload fix, not a visual UI change.
