### PR TITLE
feat(atex): учитывает усталость при очереди резок

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
-# Updated: 2026-06-08T17:02:10.951Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
+# Updated: 2026-06-08T17:02:10.951Z

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -981,6 +981,9 @@
     var KNIFE_SCALE = 8;     // нормировка ножевой компоненты (переставленных ножей до «максимума»)
     var WIDTH_SCALE = 100;   // нормировка ширины (мм «сужения» до «максимума»)
     var REMAINDER_OK_M = 600;
+    var FATIGUE_MACHINE_WIDTH_MM = 1600;  // базовая ширина вала для оценки числа ножей (#3270)
+    var FATIGUE_FACTOR = 2.0;             // alpha: штраф последней позиции = 1 + alpha
+    var FATIGUE_START_COST_MIN = 45;      // условная стоимость старта маршрута, мин
 
     function normWinding(v){ var s = String(v == null ? '' : v).trim().toUpperCase(); return (s === 'IN' || s === 'OUT') ? s : ''; }
 
@@ -1037,6 +1040,73 @@
         if (leader > 0) parts.push({ code: 'BETWEEN_CUTS', label: 'лидер между резками', minutes: round3(leader) });
         Array.prototype.push.apply(parts, changeoverParts(prev, next, times));
         return parts;
+    }
+
+    function fatigueOptionNumber(options, keys, fallback){
+        var opts = options || {};
+        for (var i = 0; i < keys.length; i++) {
+            var n = Number(opts[keys[i]]);
+            if (isFinite(n) && n > 0) return n;
+        }
+        return fallback;
+    }
+
+    function fatigueChangeTimes(options){
+        if (!options) return null;
+        if (options.times) return options.times;
+        if (options.changeTimes) return options.changeTimes;
+        if (options.opTimes) return options.opTimes;
+        if (options.MATERIAL_WINDING != null || options.KNIFE != null || options.BETWEEN_CUTS != null) return options;
+        return null;
+    }
+
+    function fatigueJobWidth(cut){
+        var candidates = cut ? [cut.width, cut.rollerWidth, cut.widthMm, cut.rollerWidthMm] : [];
+        for (var i = 0; i < candidates.length; i++) {
+            var n = stripNum(candidates[i]);
+            if (isFinite(n) && n > 0) return n;
+        }
+        return 0;
+    }
+
+    // Оценка сложности резки по ножам. Если strip-агрегация ещё не влита в очередь,
+    // используем приближение из задачи: N_j ≈ Wmax / W_j.
+    function estimatedKnifeCount(cut, machineWidth){
+        var explicit = Number(cut && cut.knifeCount);
+        if (isFinite(explicit) && explicit > 0) return explicit;
+        var width = fatigueJobWidth(cut);
+        if (!(width > 0)) return 999;
+        var maxWidth = Number(machineWidth);
+        if (!isFinite(maxWidth) || maxWidth <= 0) maxWidth = FATIGUE_MACHINE_WIDTH_MM;
+        return Math.max(1, Math.floor(maxWidth / width));
+    }
+
+    function fatiguePositionWeight(positionIndex, totalPositions, fatigueFactor){
+        var total = Number(totalPositions) || 0;
+        if (total <= 1) return 1;
+        var alpha = Number(fatigueFactor);
+        if (!isFinite(alpha)) alpha = FATIGUE_FACTOR;
+        var idx = Number(positionIndex) || 0;
+        if (idx < 0) idx = 0;
+        if (idx > total - 1) idx = total - 1;
+        return round3(1 + alpha * (idx / (total - 1)));
+    }
+
+    function fatigueRouteScore(route, options){
+        var list = route || [];
+        if (!list.length) return 0;
+        var opts = options || {};
+        var machineWidth = fatigueOptionNumber(opts, ['machineWidth', 'machineWidthMm', 'Wmax'], FATIGUE_MACHINE_WIDTH_MM);
+        var alpha = fatigueOptionNumber(opts, ['fatigueFactor', 'alpha'], FATIGUE_FACTOR);
+        var startCost = fatigueOptionNumber(opts, ['startCost', 'startCostMin'], FATIGUE_START_COST_MIN);
+        var times = fatigueChangeTimes(opts);
+        var total = 0;
+        for (var i = 0; i < list.length; i++) {
+            var transitionCost = i === 0 ? startCost : changeoverCost(list[i - 1], list[i], times);
+            var knifeFactor = 1 + estimatedKnifeCount(list[i], machineWidth) / 100;
+            total += transitionCost * fatiguePositionWeight(i, list.length, alpha) * knifeFactor;
+        }
+        return round3(total);
     }
 
     // ───────────────────── Хелперы генерации резок ─────────────────────
@@ -1603,6 +1673,16 @@
         return (strips || []).reduce(function(sum, s) { return sum + stripNum(s.qty); }, 0);
     }
 
+    function stripsKnifeWidths(strips) {
+        var out = [];
+        (strips || []).forEach(function(s) {
+            var width = stripNum(s && s.width);
+            var qty = stripNum(s && s.qty);
+            for (var i = 0; i < qty; i++) out.push(width);
+        });
+        return out;
+    }
+
     // «Остаток, мм» — ширина джамбо минус занятая полосами ширина.
     function stripsRemainder(jumboWidth, strips) {
         return round3(stripNum(jumboWidth) - stripsUsedWidth(strips));
@@ -1792,6 +1872,15 @@
 
     function startKey(c){ return [Number(c.rollerWidth) || 0, -(Number(c.knifeCount) || 0), String(c.id)]; }
     function cmpKey(a, b){ for (var i = 0; i < a.length; i++){ if (a[i] < b[i]) return -1; if (a[i] > b[i]) return 1; } return 0; }
+
+    function fatigueComplexityKey(c, machineWidth){
+        var width = fatigueJobWidth(c);
+        return [
+            -estimatedKnifeCount(c, machineWidth),
+            width > 0 ? width : Number.MAX_VALUE
+        ];
+    }
+
     // Жадная последовательность: старт — argmin startKey (узкая/много-ножевая); далее argmin changeoverCost, tie-break startKey.
     function greedySequence(cuts, weights){
         var pool = (cuts || []).slice();
@@ -1818,12 +1907,30 @@
             .map(function(x){ return x.c; });
     }
 
-    // Упорядочить резки станка: не-Фольга, затем Фольга; внутри каждой группы — жадно
-    // (переналадки), затем по убыванию ножей (#3130); проставить sequence; вход не мутировать.
+    // #3270: штраф усталости растёт к концу очереди. Сначала получаем устойчивую
+    // жадную базу по переналадкам, затем ставим более сложные (много ножей / узкая
+    // ширина) резки раньше и проверяем этот маршрут против обратного через weighted cost.
+    function fatigueAwareSequence(cuts, options){
+        var input = (cuts || []).slice();
+        if (input.length <= 1) return input;
+        var opts = options || {};
+        var times = fatigueChangeTimes(opts);
+        var machineWidth = fatigueOptionNumber(opts, ['machineWidth', 'machineWidthMm', 'Wmax'], FATIGUE_MACHINE_WIDTH_MM);
+        var base = greedySequence(input, times);
+        var complexFirst = base.map(function(c, i){ return { c: c, i: i, key: fatigueComplexityKey(c, machineWidth) }; })
+            .sort(function(a, b){ return cmpKey(a.key, b.key) || (a.i - b.i); })
+            .map(function(x){ return x.c; });
+        var simpleFirst = complexFirst.slice().reverse();
+        return fatigueRouteScore(complexFirst, opts) <= fatigueRouteScore(simpleFirst, opts)
+            ? complexFirst : simpleFirst;
+    }
+
+    // Упорядочить резки станка: не-Фольга, затем Фольга; внутри каждой группы —
+    // fatigue-aware порядок (#3270); проставить sequence; вход не мутировать.
     function orderCuts(cuts, weights){
         var rest = [], foil = [];
         (cuts || []).forEach(function(c){ (c && c.isFoil ? foil : rest).push(c); });
-        var seq = byKnifeCountDesc(greedySequence(rest, weights)).concat(byKnifeCountDesc(greedySequence(foil, weights)));
+        var seq = fatigueAwareSequence(rest, weights).concat(fatigueAwareSequence(foil, weights));
         return seq.map(function(c, i){
             var copy = {}; for (var k in c){ if (Object.prototype.hasOwnProperty.call(c, k)) copy[k] = c[k]; }
             copy.sequence = i + 1;
@@ -1952,12 +2059,19 @@
         KNIFE_SCALE: KNIFE_SCALE,
         WIDTH_SCALE: WIDTH_SCALE,
         REMAINDER_OK_M: REMAINDER_OK_M,
+        FATIGUE_MACHINE_WIDTH_MM: FATIGUE_MACHINE_WIDTH_MM,
+        FATIGUE_FACTOR: FATIGUE_FACTOR,
+        FATIGUE_START_COST_MIN: FATIGUE_START_COST_MIN,
         normWinding: normWinding,
         widthSetDistance: widthSetDistance,
         awkwardRemainder: awkwardRemainder,
         changeoverParts: changeoverParts,
         changeoverCost: changeoverCost,
         setupBreakdown: setupBreakdown,
+        estimatedKnifeCount: estimatedKnifeCount,
+        fatiguePositionWeight: fatiguePositionWeight,
+        fatigueRouteScore: fatigueRouteScore,
+        fatigueAwareSequence: fatigueAwareSequence,
         greedySequence: greedySequence,
         orderCuts: orderCuts,
         byKnifeCountDesc: byKnifeCountDesc,
@@ -3254,6 +3368,9 @@
                 loadBySlitterId[slitterId] = (loadBySlitterId[slitterId] || 0) + 1;
             }
             layoutPlans.push({
+                id: 'generated-' + layIdx,
+                materialId: lay && lay.mat,
+                winding: lay && lay.windDir,
                 plannedRuns: plannedRuns,
                 runLength: runLength,
                 duration: plannedCutDurationMinutes(runLength, plannedRuns, self.opTimes),
@@ -3262,14 +3379,16 @@
                 slitterId: slitterId,
                 cutMainValue: nextCutMainValue(sequenceCuts, controllerNowMs(self), cutMainState),
                 knifeCount: stripsTotalKnives(lay && lay.strips),
+                knifeWidths: stripsKnifeWidths(lay && lay.strips),
+                rollerWidth: stripsUsedWidth(lay && lay.strips),
                 sequence: '',
                 index: layIdx
             });
         });
         if (layoutPlans.length) self.lastCutMainValue = cutMainState.last;
 
-        // #3263: create requests stay in layout order, but queue numbers for
-        // same-day generated cuts must follow knife count descending.
+        // #3263/#3270: create requests stay in layout order, but queue numbers for
+        // same-day generated cuts follow the fatigue-aware planner.
         var sequenceGroups = {};
         var sequenceGroupOrder = [];
         layoutPlans.forEach(function(plan) {
@@ -3285,12 +3404,10 @@
         });
         sequenceGroupOrder.forEach(function(key) {
             var group = sequenceGroups[key];
-            group.plans.slice().sort(function(a, b) {
-                return ((Number(b.knifeCount) || 0) - (Number(a.knifeCount) || 0)) || (a.index - b.index);
-            }).forEach(function(plan) {
+            fatigueAwareSequence(group.plans, self.changeTimes).forEach(function(plan) {
                 plan.sequence = nextSequenceForCuts(sequenceCuts, group.slitterId, group.planDate);
                 sequenceCuts.push({
-                    id: 'generated-' + plan.index,
+                    id: plan.id,
                     number: plan.cutMainValue,
                     slitter: { id: group.slitterId, label: '' },
                     planDate: plan.cutMainValue,

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -439,6 +439,33 @@ var knifeCuts = [
 assertEqual(planning.orderCuts(knifeCuts).map(function(c){ return c.knifeCount; }), [7, 5, 3], 'orderCuts: ножи убывают к концу дня (7,5,3)');
 assertEqual(planning.byKnifeCountDesc([{ knifeCount: 2, id: 'a' }, { knifeCount: 2, id: 'b' }, { knifeCount: 9, id: 'c' }]).map(function(x){ return x.id; }), ['c', 'a', 'b'], 'byKnifeCountDesc: ↓, равные стабильно');
 
+// #3270: если ножей нет в данных, сложность резки оценивается по ширине рулона
+// (1600 мм / ширина), а штраф усталости растёт к концу очереди.
+var fatiguePositionWeight = typeof planning.fatiguePositionWeight === 'function'
+    ? planning.fatiguePositionWeight : function(){ return undefined; };
+var estimatedKnifeCount = typeof planning.estimatedKnifeCount === 'function'
+    ? planning.estimatedKnifeCount : function(){ return undefined; };
+var fatigueRouteScore = typeof planning.fatigueRouteScore === 'function'
+    ? planning.fatigueRouteScore : function(){ return undefined; };
+assertEqual(fatiguePositionWeight(0, 3, 2), 1, 'fatiguePositionWeight #3270: первая позиция без штрафа');
+assertEqual(fatiguePositionWeight(2, 3, 2), 3, 'fatiguePositionWeight #3270: последняя позиция = 1 + alpha');
+assertEqual(estimatedKnifeCount({ rollerWidth: 25 }, 1600), 64, 'estimatedKnifeCount #3270: Wmax / width');
+assertEqual(estimatedKnifeCount({ knifeCount: 7, rollerWidth: 25 }, 1600), 7, 'estimatedKnifeCount #3270: явное число ножей важнее оценки по ширине');
+var fatigueNarrowFirst = [
+    { id: 'narrow', materialId: 'M', winding: 'IN', batchId: 'b', rollerWidth: 25, knifeCount: 0, knifeWidths: [] },
+    { id: 'wide', materialId: 'M', winding: 'IN', batchId: 'b', rollerWidth: 200, knifeCount: 0, knifeWidths: [] }
+];
+assertEqual(fatigueRouteScore(fatigueNarrowFirst, { machineWidth: 1600, fatigueFactor: 2, startCost: 45 }) <
+            fatigueRouteScore(fatigueNarrowFirst.slice().reverse(), { machineWidth: 1600, fatigueFactor: 2, startCost: 45 }),
+    true, 'fatigueRouteScore #3270: узкая/многоножевая резка дешевле в начале очереди');
+var fatigueWidthCuts = [
+    { id: 'wideA', materialId: 'A', winding: 'IN', batchId: 'A', rollerWidth: 200, knifeCount: 0, knifeWidths: [] },
+    { id: 'narrowA', materialId: 'A', winding: 'IN', batchId: 'A', rollerWidth: 25, knifeCount: 0, knifeWidths: [] },
+    { id: 'midB', materialId: 'B', winding: 'IN', batchId: 'B', rollerWidth: 60, knifeCount: 0, knifeWidths: [] }
+];
+assertEqual(planning.orderCuts(fatigueWidthCuts).map(function(c){ return c.id; }),
+    ['narrowA', 'midB', 'wideA'], 'orderCuts #3270: оценка ножей по ширине ставит узкие резки раньше широких');
+
 // ── rowsToPlanning строит дескриптор движка из колонок отчёта ──
 // #3242: cut_batch_id и cut_knives упразднены в cut_planning. batchId (Партия сырья) в
 // отчёте больше нет → ''; число ножей теперь из cut_strips (Партия ГП), мёрджится в


### PR DESCRIPTION
Fixes #3270

## Что изменилось
- Добавлен fatigue-aware score для маршрута: позиционный вес `1 + alpha * k/(K-1)`, стартовая стоимость 45 мин, множитель сложности `1 + knives/100`.
- Если число ножей ещё не известно, сложность оценивается через ширину: `1600 мм / ширина резки`.
- `orderCuts` сохраняет существующую жадную минимизацию переналадок как стабильную базу, но ставит более сложные/узкие резки раньше и сравнивает этот маршрут с обратным.
- Очередность новых сгенерированных резок теперь назначается тем же fatigue-aware планнером, при этом сами create-запросы остаются в исходном порядке раскладок.

## Как воспроизвести
- До исправления очередь без `knifeCount` могла сгруппировать резки по сырью так, что широкая резка вставала раньше более узкой.
- Регрессия покрыта примером `narrowA / midB / wideA`: при ширинах 25, 60 и 200 мм порядок теперь становится от более сложной узкой резки к более простой широкой.

## Проверка
- `node --check download/atex/js/production-planning.js`
- `node experiments/atex-production-planning.test.js` — 348 assertions passed
