### PR TITLE
fix: проверять ссылки в подчиненных таблицах при массовом удалении

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
-# Updated: 2026-06-08T19:10:19.791Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
+# Updated: 2026-06-08T19:10:19.791Z

--- a/experiments/test-issue-3274-delete-tree-references.php
+++ b/experiments/test-issue-3274-delete-tree-references.php
@@ -1,0 +1,175 @@
+<?php
+/*
+ * Regression test for issue #3274.
+ *
+ * Bulk delete used to check only incoming references to the selected parent
+ * rows. BatchDelete() then recursively removed child rows, so a parent with a
+ * referenced child row was deleted silently. The delete guard must inspect the
+ * whole delete tree before the parent is accepted for deletion.
+ *
+ * Run: php experiments/test-issue-3274-delete-tree-references.php
+ */
+
+$index = file_get_contents(__DIR__ . '/../index.php');
+
+function extract_function_source($source, $name) {
+    $needle = 'function ' . $name . '(';
+    $pos = strpos($source, $needle);
+    if ($pos === false) {
+        throw new Exception("Function $name not found in index.php");
+    }
+    $open = strpos($source, '{', $pos);
+    if ($open === false) {
+        throw new Exception("Function $name has no opening brace");
+    }
+    $depth = 0;
+    $len = strlen($source);
+    for ($i = $open; $i < $len; $i++) {
+        $ch = $source[$i];
+        if ($ch === '{') {
+            $depth++;
+        } elseif ($ch === '}') {
+            $depth--;
+            if ($depth === 0) {
+                return substr($source, $pos, $i - $pos + 1);
+            }
+        }
+    }
+    throw new Exception("Function $name has no closing brace");
+}
+
+$hasRefsSource = extract_function_source($index, 'DeleteTreeHasRefs');
+$countRefsSource = extract_function_source($index, 'DeleteTreeRefsCount');
+eval($hasRefsSource);
+eval($countRefsSource);
+
+$z = 'objects';
+$pass = 0;
+$fail = 0;
+
+function check($name, $condition) {
+    global $pass, $fail;
+    if ($condition) {
+        $pass++;
+        echo "  PASS  $name\n";
+    } else {
+        $fail++;
+        echo "  FAIL  $name\n";
+    }
+}
+
+function fake_fetch_rows($rows) {
+    return function ($sql, $errMsg) use ($rows) {
+        if (preg_match('/WHERE t=([0-9]+) LIMIT 1/', $sql, $m)) {
+            $id = (int)$m[1];
+            foreach ($rows as $row) {
+                if ((int)$row['t'] === $id) {
+                    return array(array('id' => $row['id']));
+                }
+            }
+            return array();
+        }
+        if (preg_match('/COUNT\(id\) cnt FROM [a-zA-Z0-9_]+ WHERE t=([0-9]+)/', $sql, $m)) {
+            $id = (int)$m[1];
+            $cnt = 0;
+            foreach ($rows as $row) {
+                if ((int)$row['t'] === $id) {
+                    $cnt++;
+                }
+            }
+            return array(array('cnt' => $cnt));
+        }
+        if (preg_match('/WHERE up=([0-9]+)/', $sql, $m)) {
+            $id = (int)$m[1];
+            $children = array();
+            foreach ($rows as $row) {
+                if ((int)$row['up'] === $id) {
+                    $children[] = array('id' => $row['id']);
+                }
+            }
+            return $children;
+        }
+        throw new Exception("Unexpected SQL for $errMsg: $sql");
+    };
+}
+
+function old_direct_only_bulk_delete_roots($roots, $fetchRows) {
+    $out = array();
+    foreach ($roots as $root) {
+        $refs = call_user_func($fetchRows, "SELECT id FROM objects WHERE t=$root LIMIT 1", 'old direct refs');
+        if (!count($refs)) {
+            $out[] = $root;
+        }
+    }
+    return $out;
+}
+
+function fixed_tree_bulk_delete_roots($roots, $fetchRows) {
+    $out = array();
+    foreach ($roots as $root) {
+        if (!DeleteTreeHasRefs($root, $fetchRows)) {
+            $out[] = $root;
+        }
+    }
+    return $out;
+}
+
+echo "=== Scenario A: direct-only bulk check misses a referenced child ===\n";
+$rows = array(
+    array('id' => 100, 'up' => 1,   't' => 10),  // selected parent A
+    array('id' => 101, 'up' => 1,   't' => 10),  // selected parent B
+    array('id' => 200, 'up' => 100, 't' => 20),  // child of A
+    array('id' => 201, 'up' => 101, 't' => 20),  // child of B
+    array('id' => 300, 'up' => 999, 't' => 200), // external reference to child A
+);
+$fetchRows = fake_fetch_rows($rows);
+check(
+    'old direct-only check would delete both selected parents',
+    old_direct_only_bulk_delete_roots(array(100, 101), $fetchRows) === array(100, 101)
+);
+check('tree guard detects reference below parent A', DeleteTreeHasRefs(100, $fetchRows) === true);
+check('tree guard counts the referenced child once', DeleteTreeRefsCount(100, $fetchRows) === 1);
+check('unreferenced sibling parent B remains deletable', DeleteTreeHasRefs(101, $fetchRows) === false);
+check(
+    'fixed bulk check skips only parent A',
+    fixed_tree_bulk_delete_roots(array(100, 101), $fetchRows) === array(101)
+);
+
+echo "=== Scenario B: grandchild references also block the root ===\n";
+$rows = array(
+    array('id' => 500, 'up' => 1,   't' => 50),
+    array('id' => 501, 'up' => 500, 't' => 51),
+    array('id' => 502, 'up' => 501, 't' => 52),
+    array('id' => 900, 'up' => 777, 't' => 502),
+);
+$fetchRows = fake_fetch_rows($rows);
+check('grandchild reference blocks root deletion', DeleteTreeHasRefs(500, $fetchRows) === true);
+check('grandchild reference is included in count', DeleteTreeRefsCount(500, $fetchRows) === 1);
+
+echo "=== Scenario C: direct parent references keep existing behavior ===\n";
+$rows = array(
+    array('id' => 600, 'up' => 1,   't' => 60),
+    array('id' => 601, 'up' => 600, 't' => 61),
+    array('id' => 950, 'up' => 888, 't' => 600),
+);
+$fetchRows = fake_fetch_rows($rows);
+check('direct reference still blocks deletion', DeleteTreeHasRefs(600, $fetchRows) === true);
+check('direct reference count is preserved', DeleteTreeRefsCount(600, $fetchRows) === 1);
+
+echo "=== Scenario D: unreferenced trees are accepted ===\n";
+$rows = array(
+    array('id' => 700, 'up' => 1,   't' => 70),
+    array('id' => 701, 'up' => 700, 't' => 71),
+);
+$fetchRows = fake_fetch_rows($rows);
+check('unreferenced tree has no refs', DeleteTreeHasRefs(700, $fetchRows) === false);
+check('unreferenced tree count is zero', DeleteTreeRefsCount(700, $fetchRows) === 0);
+check('non-positive ids are ignored by guard', DeleteTreeHasRefs(0, $fetchRows) === false);
+check('non-positive ids have zero ref count', DeleteTreeRefsCount(0, $fetchRows) === 0);
+
+if ($fail) {
+    echo "\nFAILED: $fail checks failed, $pass passed\n";
+    exit(1);
+}
+
+echo "\nOK: $pass checks passed\n";

--- a/index.php
+++ b/index.php
@@ -1928,6 +1928,47 @@ function Delete($id, $root=TRUE)  # Delete Obj and its children recursively
 	if($root) # Delete the object in case it's the initially requested one
 		Exec_sql("DELETE FROM $z WHERE id=$id", "Delete obj");
 }
+# BatchDelete removes the whole child tree, so reference checks must cover it too.
+function DeleteTreeFetchRows($sql, $err_msg)
+{
+	$rows = array();
+	$data_set = Exec_sql($sql, $err_msg);
+	while($row = mysqli_fetch_array($data_set))
+		$rows[] = $row;
+	return $rows;
+}
+function DeleteTreeHasRefs($id, $fetchRows=FALSE)
+{
+	global $z;
+	$id = (int)$id;
+	if($id <= 0)
+		return FALSE;
+	if($fetchRows === FALSE)
+		$fetchRows = "DeleteTreeFetchRows";
+	$refs = call_user_func($fetchRows, "SELECT id FROM $z WHERE t=$id LIMIT 1", "Check refs in delete tree");
+	if(count($refs))
+		return TRUE;
+	$children = call_user_func($fetchRows, "SELECT id FROM $z WHERE up=$id", "Get children for delete tree ref check");
+	foreach($children as $child)
+		if(DeleteTreeHasRefs($child["id"], $fetchRows))
+			return TRUE;
+	return FALSE;
+}
+function DeleteTreeRefsCount($id, $fetchRows=FALSE)
+{
+	global $z;
+	$id = (int)$id;
+	if($id <= 0)
+		return 0;
+	if($fetchRows === FALSE)
+		$fetchRows = "DeleteTreeFetchRows";
+	$refs = call_user_func($fetchRows, "SELECT COUNT(id) cnt FROM $z WHERE t=$id", "Count refs in delete tree");
+	$count = count($refs) ? (int)$refs[0]["cnt"] : 0;
+	$children = call_user_func($fetchRows, "SELECT id FROM $z WHERE up=$id", "Get children for delete tree refs count");
+	foreach($children as $child)
+		$count += DeleteTreeRefsCount($child["id"], $fetchRows);
+	return $count;
+}
 function BatchDelete($id, $root=TRUE)  # Delete Obj and its children recursively
 {
 	global $z;
@@ -6843,9 +6884,15 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 										WHERE vals.t=$cur_typ AND vals.t!=vals.up $parent_cond $filter_cond AND refr.id IS NULL"
 										.($cur_typ == 18 ? " AND vals.id!=".$GLOBALS["GLOBAL_VARS"]["user_id"] : "") // The user cannot delete himself
 									, "Get filtered Objs set to delete");
-				$deleted = mysqli_num_rows($data_set);
+				$deleted = 0;
 				while($row = mysqli_fetch_array($data_set))
-					BatchDelete($row["id"]);
+					if(DeleteTreeHasRefs($row["id"]))
+						trace(" _m_del_select skip ".$row["id"]." for refs in delete tree");
+					else
+					{
+						BatchDelete($row["id"]);
+						$deleted++;
+					}
 				BatchDelete(""); // Flush batch
 				# #3260: API/новый UI зовёт _m_del_select напрямую (без выгрузки строк) —
 				# отдаём число удалённых JSON-ом вместо HTML-редиректа.
@@ -10171,6 +10218,9 @@ if(Validate_Token())
 					my_die(t9n("[RU]Нельзя удалить метаданные (реквизит $id типа [EN]You can't delete metadata (the $id type".$row["up"].")!"));
 				if($row[0] > 0)
 					my_die(t9n("[RU]Нельзя удалить объект, на который существует ссылки (всего: [EN]You can't delete an object that has links to it (total:").$row[0].")!", "409 Conflict");
+				$tree_refs = DeleteTreeRefsCount($id);
+				if($tree_refs > 0)
+					my_die(t9n("[RU]Нельзя удалить объект, на который существует ссылки (всего: [EN]You can't delete an object that has links to it (total:").$tree_refs.")!", "409 Conflict");
 				if($row["up"] > 1){ # We'll drop the Array or Reference element, so we need to adjust the order of its peers
 					if($row["tup"] === "0"){ # Array element
     					$arg = "F_U=".$row["up"];
@@ -10260,8 +10310,11 @@ if(Validate_Token())
 					$errors[(string)$rid] = t9n("[RU]Нельзя удалить себя как пользователя[EN]Can't delete yourself");
 					continue;
 				}
-				if($row["ref_cnt"] > 0){
-					$errors[(string)$rid] = t9n("[RU]Нельзя удалить объект, на который существуют ссылки (всего: [EN]Can't delete an object with incoming references (total: ").$row["ref_cnt"].")";
+				$refCnt = (int)$row["ref_cnt"];
+				if($refCnt <= 0)
+					$refCnt = DeleteTreeRefsCount($rid);
+				if($refCnt > 0){
+					$errors[(string)$rid] = t9n("[RU]Нельзя удалить объект, на который существуют ссылки (всего: [EN]Can't delete an object with incoming references (total: ").$refCnt.")";
 					continue;
 				}
 				# Adjust peer order in arrays / multiselect refs (same as case "_m_del")


### PR DESCRIPTION
Fixes #3274

## Что изменено
- Добавлен общий guard для дерева удаления: перед `BatchDelete()` проверяются ссылки не только на корневую запись, но и на все дочерние записи, которые будут удалены рекурсивно.
- `_m_del_select` теперь молча пропускает записи, у которых есть ссылки внутри дерева удаления, и возвращает `deleted` только по реально удаленным корневым записям.
- `_m_del` и `_m_del_batch` используют ту же проверку, чтобы прямые API-удаления не обходили защиту через дочерние записи.

## Как воспроизводится
В `experiments/test-issue-3274-delete-tree-references.php` смоделирован случай: родительская запись проходит старую direct-only проверку, но ее дочерняя запись имеет внешнюю ссылку. Старое поведение удалило бы родителя вместе с дочерней записью; новый guard пропускает такого родителя.

## Проверка
- `php experiments/test-issue-3274-delete-tree-references.php`
- `php -l index.php`
- `php -l experiments/test-issue-3274-delete-tree-references.php`
- `node experiments/test-issue-2749-delete-by-filter.js`