### PR TITLE
fix(atex): генерация пишет плановое время старта в t1078 (#3280)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3867,6 +3867,42 @@
             });
         });
 
+        // #3280: главное значение резки (t1078) = ПЛАНОВОЕ ВРЕМЯ СТАРТА, а не время
+        // создания. По каждому станку строим расписание (buildSchedule в порядке
+        // очерёдности) и берём начало окна (startMin − setupMin) как Unix-штамп.
+        // buildSchedule сам переносит не влезающие резки на след. день → их штамп
+        // попадает на следующий день, и они отображаются в следующем дне.
+        (function() {
+            var windPoints = windingPointsFromTimes(self.opTimes || {});
+            var dayWindow = self.workingWindow();
+            var nowD = new Date(controllerNowMs(self));
+            var planBaseMidnightMs = new Date(nowD.getFullYear(), nowD.getMonth(), nowD.getDate(), 0, 0, 0, 0).getTime();
+            var bySlitter = {};
+            layoutPlans.forEach(function(plan) {
+                var s = String(plan.slitterId == null ? '' : plan.slitterId);
+                if (s === '') return;
+                (bySlitter[s] = bySlitter[s] || []).push(plan);
+            });
+            Object.keys(bySlitter).forEach(function(s) {
+                var plans = bySlitter[s].slice().sort(function(a, b) { return (Number(a.sequence) || 0) - (Number(b.sequence) || 0); });
+                var runLenByCut = {};
+                plans.forEach(function(p) { runLenByCut[String(p.id)] = p.runLength; });
+                var sched = buildSchedule(plans, {
+                    windPoints: windPoints, times: self.changeTimes, runLengthByCut: runLenByCut,
+                    shiftStartMin: dayWindow.startMin, shiftEndMin: dayWindow.cutEndMin
+                });
+                var scById = {};
+                sched.forEach(function(sc) { scById[sc.cutId] = sc; });
+                plans.forEach(function(p) {
+                    var sc = scById[String(p.id)];
+                    if (!sc) return;
+                    var ws = stripNum(sc.startMin) - stripNum(sc.setupMin);
+                    var ts = scheduleStartTimestamp(planBaseMidnightMs, ws);
+                    if (ts > 0) p.cutMainValue = ts;
+                });
+            });
+        })();
+
         this.setBusy(true);
         // Окно прогресса (#3148): генерация идёт последовательными зависимыми
         // запросами, может занять заметное время.

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1279,8 +1279,8 @@ function runGenerateCutsDeferredGpTest() {
         var cutPost = posts.filter(function(p) { return p.path.indexOf('_m_new/1078') === 0; })[0];
         assertEqual(cutPost.path, '_m_new/1078?JSON&up=1',
             'runGenerateCuts #3225: _m_new резки не передаёт бессмысленный full=1');
-        assertEqual(cutPost.fields.t1078, 1780895994,
-            'runGenerateCuts #3225: t1078 пишет главное значение Производственной резки');
+        assertEqual(cutPost.fields.t1078, 1780905600,
+            'runGenerateCuts #3280: t1078 = плановое время старта (08:00 дня), а не время создания');
         assertEqual(cutPost.fields.t16403, 1,
             'runGenerateCuts #3215: t16403 пишет Кол-во план');
         assertEqual(cutPost.fields.t24308, 1,


### PR DESCRIPTION
Корень жалобы #3280 п.2: «Сгенерировать резки» писало в первую колонку время создания (nextCutMainValue, +1 сек). Теперь runGenerateCuts после назначения очерёдности считает расписание по каждому станку (buildSchedule) и пишет в t1078 плановое время старта; переполняющие день резки переносятся расписанием на след. день → отображаются в следующем дне. Тесты 396/396.