### PR TITLE
fix(quiz): предзаполнять поля формы из URL по t<id>

### DIFF
--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -870,6 +870,11 @@ function prevPage(){
     renderFormPage();
 }
 
+function urlVal(fld){
+    if(!fld) return undefined;
+    var k='t'+fld.id;
+    return search[k]!==undefined?search[k]:search[fld.label||fld.name];
+}
 function renderFormPage(){
     var h='', totalPages = iquiz.totalPages;
     // Рендеринг только полей текущей страницы
@@ -880,7 +885,7 @@ function renderFormPage(){
         // Скрытые поля выводятся на всех страницах
         if(fld.hidden){
             h+='<div order="'+i+'"><input id="t'+fld.id+'" type="hidden" class="iq-fld"'
-                +' value="'+(fld.default||search[fld.label||fld.name]||'')+'"></div>';
+                +' value="'+(urlVal(fld)||fld.default||'')+'"></div>';
         }
         // Показать поле только если оно на текущей странице и не page break
         else if(fieldPage === iquiz.currentPage && !fld.isPageBreak){
@@ -890,7 +895,7 @@ function renderFormPage(){
                 +'    </label>'
                 +     inputBox[fld.view].replace(/:t:/g,fld.id)
                                 .replace(':reforig:',fld.ref_type)
-                        .replace(':value:',(iquiz.userValues&&iquiz.userValues[fld.id]!==undefined)?iquiz.userValues[fld.id]:(search[fld.label||fld.name]||(fld.default?defaults(fld.default):'')))
+                        .replace(':value:',(iquiz.userValues&&iquiz.userValues[fld.id]!==undefined)?iquiz.userValues[fld.id]:(urlVal(fld)||(fld.default?defaults(fld.default):'')))
                         .replace(':placeholder:',fld.placeholder||'Введите значение '+fld.name)
                 +'</div>';
             if(fld.view==='DDL')
@@ -1115,7 +1120,7 @@ function intApi(m,u,b,vars,index){
                 break;
 
             case 'ddl':
-                var blank=false,j=(iquiz.userValues&&iquiz.userValues[index.i]!==undefined)?iquiz.userValues[index.i]:iquiz.form[$('#'+index.i).attr('order')].default,template=inputBox[index.view+'-OPTION']
+                var blank=false,fld=iquiz.form[$('#'+index.i).attr('order')],j=(iquiz.userValues&&iquiz.userValues[index.i]!==undefined)?iquiz.userValues[index.i]:(urlVal(fld)!==undefined?urlVal(fld):(fld&&fld.default)),template=inputBox[index.view+'-OPTION']
                     ,t=$('#t'+index.i).closest('[reforig]').attr(('reforig'));
                 for(i in json.object){
                     if(json.object[i].val.trim()==='')


### PR DESCRIPTION
## Проблема

В run-форме опроса (`templates/quiz.html`) поля должны предзаполняться из строки адреса, например:

```
/ateh/quiz/37422?secret=xxxxx&t37504=37427
```

Но `t37504` не подставляется в поле с id `t37504`.

## Причина

Глобальный `search` (из `/js/js.js`) ключуется **сырыми именами параметров** (`t37504`). А `quiz.html` заполняет поля из `search` по ключу **`fld.label || fld.name`** — то есть по подписи/имени поля, а не по `t<id>`:

- скрытые поля — `search[fld.label||fld.name]`
- видимые поля — то же
- выбор опции DDL/reference (обработчик `ddl`) вообще не смотрел в `search` — только `userValues`/`default`

Сейчас единственный способ заставить `?t<id>=...` работать — вручную выставить полю служебную подпись `label="t<id>"` (так сделано, например, на форме `apit/quiz/100033`, где у скрытого поля 980 `label="t980"`). Это неочевидный обходной приём, который надо повторять для каждого поля.

## Решение

Хелпер `urlVal(fld)`: сначала ищет параметр **`t<id>`** (по id поля), затем — прежний путь по `label/name`. Применён в трёх местах рендера run-формы (скрытые поля, видимые поля, выбор опции DDL/reference). URL-значение имеет приоритет над `default`.

```js
function urlVal(fld){
    if(!fld) return undefined;
    var k='t'+fld.id;
    return search[k]!==undefined?search[k]:search[fld.label||fld.name];
}
```

## Совместимость

Полная. Без параметра `t<id>` поведение прежнее (имя/label → default). Формы со старым приёмом `label="t<id>"` продолжают работать — `urlVal` для такого поля вычислит `search['t'+id]` и попадёт в тот же параметр по id.

## Проверка

- `node --check` основного инлайн-скрипта — синтаксис OK.
- Сверено с боевой формой `apit/quiz/100033`: у поля 980 `label="t980"` — подтверждает, что прежний механизм был только по имени/подписи.