### PR TITLE
feat(quiz): белый список расширений для загружаемых файлов

### DIFF
--- a/templates/quiz.html
+++ b/templates/quiz.html
@@ -577,6 +577,8 @@ function shownAndHidden(i,fld,f){
                         .replace('type="password"','type="text"')
                         .replace(':value:',fld.placeholder||'')
                         .replace(':reforig:',fld.ref_type||'')
+                        .replace(':acceptAttr:',acceptAttr(fld.accept))
+                        .replace(':exts:',escapeHtml(fld.accept||''))
                         .replace(':placeholder:','Введите подсказку к вопросу')
         +'</div>';
     f.hiddens+=hidBadge.replace(':t:',fld.id)
@@ -875,6 +877,17 @@ function urlVal(fld){
     var k='t'+fld.id;
     return search[k]!==undefined?search[k]:search[fld.label||fld.name];
 }
+function parseExts(s){
+    if(!s) return [];
+    return String(s).toLowerCase().split(/[\s,;]+/).map(function(x){return x.replace(/^\.+/,'');}).filter(function(x){return x.length>0;});
+}
+function acceptAttr(s){
+    return parseExts(s).map(function(x){return '.'+x;}).join(',');
+}
+function fileExt(name){
+    var m=String(name).toLowerCase().match(/\.([a-z0-9]+)$/);
+    return m?m[1]:'';
+}
 function renderFormPage(){
     var h='', totalPages = iquiz.totalPages;
     // Рендеринг только полей текущей страницы
@@ -896,6 +909,8 @@ function renderFormPage(){
                 +     inputBox[fld.view].replace(/:t:/g,fld.id)
                                 .replace(':reforig:',fld.ref_type)
                         .replace(':value:',(iquiz.userValues&&iquiz.userValues[fld.id]!==undefined)?iquiz.userValues[fld.id]:(urlVal(fld)||(fld.default?defaults(fld.default):'')))
+                        .replace(':acceptAttr:',acceptAttr(fld.accept))
+                        .replace(':exts:','')
                         .replace(':placeholder:',fld.placeholder||'Введите значение '+fld.name)
                 +'</div>';
             if(fld.view==='DDL')
@@ -924,8 +939,15 @@ function submitForm(){
         if(fld.isPageBreak) continue;
         el=document.getElementById('t'+fld.id);
         if(fld.base==='FILE'){
-            if(el&&el.files[0])
-                vars.append('t'+fld.id,el.files[0]);
+            if(el&&el.files[0]){
+                var allowed=parseExts(fld.accept);
+                if(allowed.length&&allowed.indexOf(fileExt(el.files[0].name))===-1){
+                    e+='Недопустимый тип файла «'+(fld.label||fld.name)+'». Разрешено: '+acceptAttr(fld.accept)+'<br />';
+                    $(el).css('border','2px solid red');
+                }
+                else
+                    vars.append('t'+fld.id,el.files[0]);
+            }
         }
         else if(fld.base==='BOOLEAN'){
             if(!fld.hidden&&fld.required){
@@ -1286,6 +1308,9 @@ var ddlAdd='<div class="input-group pt-2 set:t:" style="display:none;" title="З
             +'    <input type="text" class="form-control form-control-sm" placeholder="Добавить значение в список" onkeyup="if(event.keyCode===13)addItem(:t:)">'
             +'    <div class="input-group-append"><button class="btn btn-primary btn-sm" onclick="addItem(:t:)">Сохранить</button></div>'
             +'</div>'
+    ,fileSet='<div class="input-group pt-2 set:t:" style="display:none;" title="Разрешённые типы файлов">'
+            +'    <input type="text" name="accept" value=":exts:" class="form-control form-control-sm iq-save iq-fld" placeholder="Разрешённые расширения через запятую: jpg, png, pdf (пусто — любые)">'
+            +'</div>'
     ,inputBox={
     'SHORT':'<input type="text" name="placeholder" id="t:t:" value=":value:" class="form-control iq-save iq-fld" placeholder=":placeholder:">',
     'SIGNED':'<input type="text" name="placeholder" id="t:t:" value=":value:" class="form-control iq-save iq-fld" placeholder=":placeholder:">',
@@ -1304,7 +1329,7 @@ var ddlAdd='<div class="input-group pt-2 set:t:" style="display:none;" title="З
     'HTML':'<textarea name="placeholder" id="t:t:" class="form-control iq-save iq-fld" placeholder=":placeholder:">:value:</textarea>',
     'MEMO':'<textarea name="placeholder" id="t:t:" class="form-control iq-save iq-fld" placeholder=":placeholder:">:value:</textarea>',
     'CHARS':'<input type="text" name="placeholder" id="t:t:" value=":value:" class="form-control iq-save iq-fld" placeholder=":placeholder:">',
-    'FILE':'<input type="file" id="t:t:" value=":value:" class="form-control iq-save iq-fld">',
+    'FILE':'<input type="file" id="t:t:" accept=":acceptAttr:" class="form-control iq-save iq-fld">'+fileSet,
     'BOOLEAN':'<div style="width:40px"><input type="checkbox" name="default" id="t:t:" value="1" class="form-control iq-save iq-fld"></div>',
     'PWD':'<input type="password" name="placeholder" id="t:t:" value=":value:" class="form-control iq-save iq-fld" placeholder=":placeholder:">',
     'CALCULATABLE':'<span>:value:</span>',


### PR DESCRIPTION
## Что

Возможность ограничивать расширения файлов, загружаемых через форму опроса — **белый список** для поля типа «Файл».

Кнопка-шестерёнка («Настройки поля») у FILE-полей раньше ничего не открывала. Теперь под ней — панель со списком разрешённых расширений.

## Как пользоваться

1. В конструкторе у поля «Файл» нажать шестерёнку.
2. Ввести разрешённые расширения через запятую: `jpg, png, pdf` (регистр/точки/пробелы не важны). Пусто — разрешены любые.

## Поведение

- Значение хранится в `fld.accept` и сохраняется вместе с формой (`JSON.stringify(iquiz)` → `t273`).
- На боевой форме `<input type="file">` получает `accept=".jpg,.png,.pdf"` — диалог выбора файла по умолчанию показывает только нужные типы.
- **Жёсткая проверка при отправке:** если расширение выбранного файла не из списка — выводится ошибка «Недопустимый тип файла …», поле подсвечивается, файл не отправляется. Это гарантия даже если пользователь обойдёт фильтр диалога.

## Реализация

- Хелперы `parseExts` / `acceptAttr` / `fileExt` нормализуют список (нижний регистр, срез ведущих точек, разделители `,` `;` пробел/таб).
- Панель настроек `fileSet` (класс `set<id>`, как у `ddlAdd` для списков) тогглится той же шестерёнкой. Поле `name="accept"` сохраняется штатным `iqSave` (как `placeholder`, `required` и пр.).
- `accept`-атрибут и значение настройки подставляются в рендере и редактора (`shownAndHidden`), и боевой формы (`renderFormPage`).

## Совместимость

Полная. Поля без списка расширений (`fld.accept` пусто) ведут себя как раньше — принимают любые файлы. Никакой схемы/таблиц не затрагивает.

## Проверка

- `node --check` инлайн-скрипта — синтаксис OK.
- Юнит-тесты `parseExts`/`acceptAttr`/`fileExt` и симуляция рендера FILE (редактор + боевая форма): корректный `accept`, класс `set<id>` для шестерёнки, нет «протёкших» плейсхолдеров — все прошли.