### PR TITLE
fix(upload): восстанавливать #createParent рано (вместе с header/trim) — #3304

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -758,6 +758,13 @@ function doSaveSet(){
         else
             showNotification('Недопустимый символ " в имени настройки!', 'error');
 }
+// Восстанавливает галку «Создавать родителя, если его нет» из выбранной настройки.
+// Без выбранной настройки — снимает (chosenSet===undefined). Вызывается рано в
+// case 'type' (вместе с header/trim), чтобы состояние не терялось, если на
+// промежуточных шагах рендера произойдёт ошибка до позднего восстановления.
+function setCreateParentFromSet(){
+    $('#createParent').prop('checked',!!(chosenSet!==undefined&&uploadSets[chosenSet]&&uploadSets[chosenSet].createParent));
+}
 function applySet(v){
     chosenSet=v;
     $('#chosenType').val(uploadSets[v].type);
@@ -893,6 +900,7 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                     $('#delim').val(uploadSets[chosenSet].delimiter);
                     $('#caret').val(uploadSets[chosenSet].newline);
                 }
+                setCreateParentFromSet();
                 h+='<div class="pl-2 pt-1 h3" title="'+'Добавить пропуск — пустое поле'+'" onclick="$(addSortable(\'\',\'\',\'--\',\'--\')).insertBefore(this)"><a>+</a></div>';
                 $('#sortable').html(h);
                 j=getParent(chosenType);
@@ -915,7 +923,7 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                     $('.auto-parent').val(uploadSets[chosenSet].autoParent);
                     setAutoParent(uploadSets[chosenSet].autoParent);
                 }
-                $('#createParent').prop('checked',!!(uploadSets[chosenSet]&&uploadSets[chosenSet].createParent));
+                setCreateParentFromSet();
                 if(uploadSets[chosenSet]&&uploadSets[chosenSet].searchParent)
                     selectItem(uploadSets[chosenSet].searchParent,'#'+uploadSets[chosenSet].searchParent);
                 break;


### PR DESCRIPTION
Closes #3304

## Диагностика (по факту с живой формы)
В консоли при выбранной настройке:
- `$('#createParent').length` → **1** — элемент в DOM есть.
- `uploadSets[chosenSet].createParent` → **true** — сохранённое значение есть и истинно.

То есть данные и элемент в порядке, а галка всё равно не вставала. Ключевой признак: **остальные настройки (header/trim/разделитель) восстанавливаются, а галка — нет.**

## Причина
В `case 'type'` (`templates/upload.html`) восстановление `#createParent` стояло **последним** — уже после `$('#sortable').html()`, показа `#up`, `gatherSet()` и `setAutoParent()`. А `header`/`trim` восстанавливаются рано (в начале ветки выбранной настройки).

Если на одном из промежуточных шагов (например, внутри `setAutoParent()` → `importParse()`) для конкретной настройки происходит ошибка, обработчик прерывается **до** строки восстановления галки: `header`/`trim` уже применились, а `#createParent` — нет. Это в точности симптом из #3304, и он не воспроизводился в изолированном harness #3300/#3302, где промежуточных шагов нет.

## Фикс
Восстановление вынесено в идемпотентный хелпер `setCreateParentFromSet()` и вызывается:
1. **рано** — сразу после восстановления `header`/`trim`/разделителя, до промежуточных шагов рендера (основная правка);
2. повторно — после показа `#up` (как было), как страховка.

Хелпер снимает галку, если настройка не выбрана (`chosenSet===undefined`) — поведение #3302 (фикс «залипания») сохранено.

```js
function setCreateParentFromSet(){
    $('#createParent').prop('checked',!!(chosenSet!==undefined&&uploadSets[chosenSet]&&uploadSets[chosenSet].createParent));
}
```

## Проверка
- `node --check` инлайн-скрипта — OK.
- Прошу подтвердить на живой форме: выбрать проблемную настройку → галка восстановлена; выбрать настройку с выключенной галкой → снята; без настройки → снята.