### PR TITLE
feat(atex): клик по строке времени резки тоже показывает «Связанные позиции»

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5197,8 +5197,10 @@
                     title: 'Показать тайминг резки',
                     text: scheduleText
                 });
-                timeEl.addEventListener('click', function(e) {
-                    e.stopPropagation();
+                // Клик по строке времени открывает тайминг И выбирает резку: событие
+                // всплывает к обработчику карточки (selectedCutId → renderLink покажет
+                // «Связанные позиции»). Поэтому здесь НЕ останавливаем всплытие.
+                timeEl.addEventListener('click', function() {
                     self.openCutTiming(c);
                 });
                 timeEl.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Задача
Клик в любом месте карточки резки `.atex-pp-cut` должен показывать её «Связанные позиции».

## Что было
Клик по телу карточки уже выбирает резку → боковая панель показывает «Связанные позиции» (#3149). Но строка времени `.atex-pp-cut-time` вызывала `e.stopPropagation()` и только открывала модалку тайминга — клик по ней связанные позиции не показывал. Это единственное место тела карточки, где «клик в любом месте» не срабатывал (кнопки ↑/↓/Полосы намеренно сохраняют свои действия).

## Что стало
Убран `stopPropagation` у обработчика строки времени: клик по ней теперь **и** открывает тайминг, **и** всплывает к обработчику карточки (`selectedCutId` → `renderLink` показывает «Связанные позиции»). Модалка тайминга — отдельный оверлей, `render()` её не закрывает.

Кнопки ↑/↓/Полосы и панель полос — без изменений.

## Проверка
- `node --check` — OK.
- Прошу проверить на живой форме: клик по строке времени резки → открывается тайминг и в боковой панели появляются «Связанные позиции» выбранной резки; клик по остальному телу карточки — как прежде.