### PR TITLE
feat(upload): загрузка файла по ссылке через серверный прокси (#3308)

### DIFF
--- a/index.php
+++ b/index.php
@@ -4496,6 +4496,76 @@ function build_post_fields($data){
     trace("dataArray ".print_r($dataArray, true));
     return $dataArray;
 }
+# Issue #3308: проверка, что хост ссылки указывает на публичный адрес (защита от SSRF).
+# Резолвим имя в IP и отбраковываем приватные/служебные/loopback/link-local адреса,
+# чтобы через прокси нельзя было ходить во внутреннюю сеть сервера.
+function fetchUrlHostIsPublic($host){
+    if(!is_string($host) || $host === "")
+        return false;
+    if(filter_var($host, FILTER_VALIDATE_IP))
+        $ips = array($host);
+    else{
+        $ips = @gethostbynamel($host);
+        if($ips === false || count($ips) === 0)
+            return false;
+    }
+    foreach($ips as $ip)
+        if(!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE))
+            return false; # приватный/служебный адрес — запрещаем
+    return true;
+}
+# Issue #3308: безопасное серверное скачивание файла по ссылке для рабочего места
+# templates/upload.html (обход CORS). Только http(s); каждый редирект проверяется
+# повторно на SSRF; ограничение размера и таймаут. Возвращает строку-содержимое
+# или false при ошибке.
+function fetchUrlSafe($url, $maxBytes = 10485760, $timeout = 15){
+    $redirects = 0;
+    while(true){
+        if(!is_string($url) || !preg_match('#^https?://#i', $url))
+            return false;
+        $host = parse_url($url, PHP_URL_HOST);
+        if(!fetchUrlHostIsPublic($host))
+            return false;
+        if(!function_exists("curl_init")){
+            # Запасной путь без curl: редиректы выключены (их некому перепроверить).
+            $ctx = stream_context_create(array("http" => array(
+                "timeout" => $timeout, "follow_location" => 0, "user_agent" => "Integram",
+            )));
+            $data = @file_get_contents($url, false, $ctx, 0, $maxBytes + 1);
+            if($data === false)
+                return false;
+            return strlen($data) > $maxBytes ? false : $data;
+        }
+        $ch = curl_init($url);
+        curl_setopt_array($ch, array(
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => false,   # редиректы ведём вручную с повторной проверкой хоста
+            CURLOPT_CONNECTTIMEOUT => $timeout,
+            CURLOPT_TIMEOUT        => $timeout,
+            CURLOPT_PROTOCOLS      => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_USERAGENT      => "Integram",
+            CURLOPT_HEADER         => false,
+            CURLOPT_NOPROGRESS     => false,
+            CURLOPT_BUFFERSIZE     => 16384,
+            CURLOPT_PROGRESSFUNCTION => function($ch, $dlTotal, $dlNow, $ulTotal, $ulNow) use ($maxBytes){
+                return ($dlTotal > $maxBytes || $dlNow > $maxBytes) ? 1 : 0; # прерываем при превышении размера
+            },
+        ));
+        $data = curl_exec($ch);
+        $code = (int)curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $redir = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
+        curl_close($ch);
+        if($data === false)
+            return false;
+        if($code >= 300 && $code < 400 && $redir){
+            if(++$redirects > 5)
+                return false;
+            $url = $redir;
+            continue; # повторно проверяем новый адрес на SSRF
+        }
+        return strlen($data) > $maxBytes ? false : $data;
+    }
+}
 function getJsonVal($jsonKey, $val){
     $seek=TRUE;
     if((strlen($jsonKey) > 0) && (mb_strpos(strtoupper($val), strtoupper($jsonKey)) !== FALSE)){
@@ -9615,6 +9685,23 @@ if(Validate_Token())
         case "ai":
             handleAiChatRequest($com);
             break;
+
+		# Issue #3308: серверный прокси для загрузки файла по ссылке в рабочем месте
+		# templates/upload.html. Качает URL на сервере (обход CORS) и отдаёт содержимое
+		# в base64. XSRF уже проверен выше (префикс _m_ → check()).
+		case "_m_fetchurl":
+			$fetchUrl = isset($_REQUEST["url"]) ? trim($_REQUEST["url"]) : "";
+			if($fetchUrl === "" || !preg_match('#^https?://#i', $fetchUrl)){
+				api_dump(json_encode(array("status" => "error", "error" => "Допустимы только http(s) ссылки.")), "fetchurl.json");
+				break;
+			}
+			$fetchData = fetchUrlSafe($fetchUrl);
+			if($fetchData === false){
+				api_dump(json_encode(array("status" => "error", "error" => "Не удалось загрузить файл по ссылке (недоступный адрес, превышен размер 10 МБ или таймаут).")), "fetchurl.json");
+				break;
+			}
+			api_dump(json_encode(array("status" => "ok", "content" => base64_encode($fetchData), "length" => strlen($fetchData))), "fetchurl.json");
+			break;
 
 		case "_m_up":
 			Check_Grant($id);

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -158,10 +158,10 @@ input[type="checkbox"] {
         <label class="btn btn-outline-secondary upload-file-label mb-2"><i class="pi pi-upload"></i> Выберите файл<input type="file" id="selectFiles" style="display:none" /></label>
         <span id="selectedFileName" style="margin-left: 0.5rem; color: var(--text-secondary);"></span>
 		</div>
-        <!--
-        можно загрузить этот файл по ссылке:
-        <input class="form-control" type="text" id="selectLink" /><br />
-        -->
+        <div class="mt-2">
+            <label for="selectLink" class="mb-1" style="color: var(--text-secondary);">…или укажите ссылку на файл:</label>
+            <input class="form-control" type="text" id="selectLink" placeholder="https://example.com/data.csv" />
+        </div>
 		<br />
         <div class="d-inline-block pb-3" id="try"><button onclick="importParse()" class="btn btn-primary">Проверить</button></div>
         <div class="d-inline-block pb-3"><button onclick="$('#tune').toggle()" id="tune-btn" class="btn btn-outline-secondary">Настроить</button></div>
@@ -996,6 +996,31 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                     if(parseInt(lastS)&&index===undefined)
                         intApi('GET',searchUrl+'@'+parseInt(lastS),'searchDb',undefined,'by ID');
                 $('.search-results').html(h).show();
+                break;
+
+            // Issue #3308: ответ серверного прокси загрузки файла по ссылке.
+            // content приходит в base64, декодируем байты и читаем выбранной кодировкой
+            // (как FileReader.readAsText для выбранного файла), затем парсим как обычно.
+            case 'fetchLink':
+                if(json&&json.status==='ok'){
+                    var text;
+                    try{
+                        var bin=atob(json.content||''),bytes=new Uint8Array(bin.length);
+                        for(var bi=0;bi<bin.length;bi++)bytes[bi]=bin.charCodeAt(bi);
+                        text=new TextDecoder($('#encoding').val()||'utf-8').decode(bytes);
+                    }catch(err){
+                        $('#errors').html(escape('Не удалось прочитать содержимое по ссылке.')).show();
+                        break;
+                    }
+                    parseUploadText(text,{delimiter:$('#delim').val(),linebreak:$('#caret').val(),skipEmptyLines:true
+                        ,LocalChunkSize:1048024
+                        ,RemoteChunkSize:1048024
+                        ,chunk:(results,parser)=>{importDoParse(results);}
+                    });
+                }
+                else
+                    $('#errors').html(escape((json&&json.error)?json.error:'Не удалось загрузить файл по ссылке.')).show();
+                break;
         }
     }
     obj.send(vars); // отправили запрос и теперь будем ждать ответ, а пока - выходим
@@ -1089,17 +1114,20 @@ function importParse(){
             ,chunk: (results, parser) =>{importDoParse(results);}
         });
     else{
-    	var selectFiles=document.getElementById('selectFiles'),file,files=selectFiles?selectFiles.files:null;
-    	if(!files||files.length <= 0)
-    	    if(($('#selectLink').val()||'').length>0){
-    	        fetch($('#selectLink').val(),{mode:'no-cors'}).then(res=>file=new File([res.blob()],'filename'));
-    	        console.log(file);
-    	        var dt=new DataTransfer();
-                dt.items.add(file);
-                files=dt.files;
+    	var selectFiles=document.getElementById('selectFiles'),files=selectFiles?selectFiles.files:null;
+    	if(!files||files.length <= 0){
+    	    var link=($('#selectLink').val()||'').trim();
+    	    if(link.length>0){
+    	        // Issue #3308: скачиваем файл по ссылке через серверный прокси (_m_fetchurl),
+    	        // т.к. fetch из браузера блокирует CORS для чужих доменов. Парсинг — в ветке
+    	        // 'fetchLink' колбэка intApi, когда придёт ответ.
+    	        $('#errors').hide();
+    	        intApi('POST','_m_fetchurl/?JSON','fetchLink','url='+encodeURIComponent(link));
+    	        $('#refresh').hide();
+    	        return false;
     	    }
-    	if(!files||files.length <= 0)
-    		return false;
+    	    return false;
+    	}
 	    var fr = new FileReader();
 	    fr.onload = function(e){
 	        parseUploadText(e.target.result,{delimiter:$('#delim').val(),linebreak:$('#caret').val(),skipEmptyLines:true


### PR DESCRIPTION
Закрывает #3308.

## Что было
В `templates/upload.html` ввод «загрузить файл по ссылке» был закомментирован, а под него лежала нерабочая JS-логика: `fetch(url,{mode:'no-cors'})` даёт opaque-ответ без читаемого тела; код после `.then()` выполнялся синхронно (`file` ещё `undefined`); `new File([res.blob()],...)` оборачивал Promise, а не blob.

## Что сделано
Ссылка качается **на сервере** в обход CORS.

**`index.php`**
- Команда `_m_fetchurl` в главном `switch` — XSRF проверяется автоматически (префикс `_m_` → `check()`).
- Хелперы `fetchUrlSafe()` / `fetchUrlHostIsPublic()` рядом с `build_post_fields`.
- Защита от SSRF: только `http(s)`; отбраковка приватных/служебных/loopback/link-local IP; каждый редирект (до 5) проверяется повторно; лимит 10 МБ и таймаут 15 с; запасной путь без curl с выключенными редиректами.
- Содержимое отдаётся в base64.

**`templates/upload.html`**
- Раскомментирован и оформлен ввод ссылки (label + placeholder).
- Ветка ссылки в `importParse` вызывает прокси через `intApi('POST','_m_fetchurl/?JSON','fetchLink',...)`.
- Ответ декодируется выбранной кодировкой через `TextDecoder` (как `FileReader.readAsText`) и парсится штатно.
- Ошибки показываются в блоке `#errors`.

## Проверки
- `php -l` чист на 7.4 и 8.2.
- Изолированные тесты хелпера: loopback / `localhost` / `10.x` / `169.254.169.254` → отклонены; `example.com` → скачан; `ftp://` → отклонён; лимит размера прерывает загрузку; редирект на `127.0.0.1` блокируется.
- Синтаксис изменённого JS проверен.

🤖 Generated with [Claude Code](https://claude.com/claude-code)