### PR TITLE
feat(atex): генерировать резки от даты из фильтра (.atex-pp-input), а не от сегодня

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -437,6 +437,15 @@
         return d.getFullYear() + '-' + m + '-' + day;
     }
 
+    // Полночь (мс) базовой даты планирования: дата из фильтра «.atex-pp-input»
+    // («ГГГГ-ММ-ДД»), даже если в прошлом; без выбранной даты — сегодня (nowMs).
+    function planBaseMidnightFrom(dateStr, nowMs) {
+        var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim());
+        var d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0)
+                  : new Date(Number(nowMs) || Date.now());
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0).getTime();
+    }
+
     // Сборка полей `t{reqId}` для записи. reqIds — { ключ: числовойId },
     // values — { ключ: значение }. Пустые значения (''/null/undefined) опускаются,
     // чтобы не перетирать данные и не плодить пустые реквизиты.
@@ -4158,8 +4167,9 @@
         (function() {
             var windPoints = windingPointsFromTimes(self.opTimes || {});
             var dayWindow = self.workingWindow();
-            var nowD = new Date(controllerNowMs(self));
-            var planBaseMidnightMs = new Date(nowD.getFullYear(), nowD.getMonth(), nowD.getDate(), 0, 0, 0, 0).getTime();
+            // #(gen-from-date): план строим от даты, выбранной в фильтре
+            // (.atex-pp-input), даже если она в прошлом; без даты — от сегодня.
+            var planBaseMidnightMs = planBaseMidnightFrom(self.filter && self.filter.date, controllerNowMs(self));
             var bySlitter = {};
             layoutPlans.forEach(function(plan) {
                 var s = String(plan.slitterId == null ? '' : plan.slitterId);


### PR DESCRIPTION
## Задача
Генерировать резки нужно от даты, выбранной в `.atex-pp-input` (дата-фильтр очереди), даже если она в прошлом, а не от текущей даты.

## Что было
В `runGenerateCuts` база планирования `planBaseMidnightMs` = полночь **сегодня** (`controllerNowMs`). От неё считаются плановое время старта сегментов (запись в `t1078` — главное значение резки = плановая дата начала, #3242/#3280), разбиение длинных резок по дням и очерёдность. Поэтому сгенерированные резки всегда попадали на сегодня.

## Что стало
База берётся из выбранной даты фильтра `this.filter.date` (значение `.atex-pp-input type=date`), **даже если она в прошлом**; если дата не выбрана — от сегодня.

```js
function planBaseMidnightFrom(dateStr, nowMs) {
    var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim());
    var d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0)
              : new Date(Number(nowMs) || Date.now());
    return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0).getTime();
}
```

От этой базы автоматически следуют корректные: плановые даты/время старта (`t1078`), разбиение по дням (спилл на следующий день — уже от выбранной даты) и пересчёт очерёдности по `(станок, день)`.

## Область
Затронут **только** поток генерации (`runGenerateCuts`). Без изменений: ручное создание резки (`freeSlotForCut`), ре-планирование «Запланировать» и отрисовка очереди — там по-прежнему сегодня. Если нужно распространить «от выбранной даты» и на ре-планирование — скажите, добавлю.

## Проверка
- `node --check` — OK.
- Юнит-тест `planBaseMidnightFrom`: парсинг `ГГГГ-ММ-ДД`, прошлая дата (ts положительный и в прошлом), пусто/мусор → сегодня — пройдены.
- Прошу проверить на живой форме: выбрать в фильтре прошлую дату → «Сгенерировать резки» → сгенерированные резки появляются на выбранной дате (а не на сегодня).