### PR TITLE
feat(atex): ре-планирование тоже строит план от даты фильтра (.atex-pp-input)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -437,6 +437,15 @@
         return d.getFullYear() + '-' + m + '-' + day;
     }
 
+    // Полночь (мс) базовой даты планирования: дата из фильтра «.atex-pp-input»
+    // («ГГГГ-ММ-ДД»), даже если в прошлом; без выбранной даты — сегодня (nowMs).
+    function planBaseMidnightFrom(dateStr, nowMs) {
+        var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim());
+        var d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0)
+                  : new Date(Number(nowMs) || Date.now());
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0).getTime();
+    }
+
     // Сборка полей `t{reqId}` для записи. reqIds — { ключ: числовойId },
     // values — { ключ: значение }. Пустые значения (''/null/undefined) опускаются,
     // чтобы не перетирать данные и не плодить пустые реквизиты.
@@ -4158,8 +4167,9 @@
         (function() {
             var windPoints = windingPointsFromTimes(self.opTimes || {});
             var dayWindow = self.workingWindow();
-            var nowD = new Date(controllerNowMs(self));
-            var planBaseMidnightMs = new Date(nowD.getFullYear(), nowD.getMonth(), nowD.getDate(), 0, 0, 0, 0).getTime();
+            // #(gen-from-date): план строим от даты, выбранной в фильтре
+            // (.atex-pp-input), даже если она в прошлом; без даты — от сегодня.
+            var planBaseMidnightMs = planBaseMidnightFrom(self.filter && self.filter.date, controllerNowMs(self));
             var bySlitter = {};
             layoutPlans.forEach(function(plan) {
                 var s = String(plan.slitterId == null ? '' : plan.slitterId);

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -4713,8 +4713,9 @@
 
             // #3280: план разбиения по дням + плановое время старта (t1078).
             var dayWindow = self.workingWindow();
-            var nowD = new Date(controllerNowMs(self));
-            var planBaseMidnightMs = new Date(nowD.getFullYear(), nowD.getMonth(), nowD.getDate(), 0, 0, 0, 0).getTime();
+            // #(replan-from-date): ре-планирование строим от даты, выбранной в
+            // фильтре (.atex-pp-input), даже если в прошлом; без даты — от сегодня.
+            var planBaseMidnightMs = planBaseMidnightFrom(self.filter && self.filter.date, controllerNowMs(self));
             var windPoints = windingPointsFromTimes(self.opTimes || {});
             var perPassByCut = {};
             self.cuts.forEach(function(c) {


### PR DESCRIPTION
Продолжение #3311 (распространить «от выбранной даты» на ре-планирование).

## Что
Кнопка «Запланировать» (`runPlanning`) пересчитывала план от полуночи **сегодня**. Теперь, как и генерация (#3311), база берётся из даты фильтра `.atex-pp-input` (`this.filter.date`), **даже если она в прошлом**; без выбранной даты — от сегодня.

Переиспользует хелпер `planBaseMidnightFrom`, введённый в #3311.

## Зависимость
Ветка построена поверх #3311 (там вводится `planBaseMidnightFrom`). **Мержить после #3311** — тогда здесь останется ровно одна правка (строка базы планирования в `runPlanning`). До мержа #3311 в диффе видны и его изменения.

## Область
- ✅ Генерация (`runGenerateCuts`) — в #3311.
- ✅ Ре-планирование (`runPlanning`) — этот PR.
- Без изменений: ручное создание одной резки (`freeSlotForCut`) и отрисовка очереди (`renderQueue`, только отображение).

## Проверка
- `node --check` — OK; `nowD` в `doRun` больше не используется (удалён).
- Прошу проверить на живой форме: выбрать прошлую дату в фильтре → «Запланировать» → резки пересчитываются на выбранную дату.