### PR TITLE
fix(atex): «Итого ножей» в панели полос = число полос + 1

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3634,7 +3634,9 @@
             var stripsBtn = card && card.querySelector('.atex-pp-strips');
             if (stripsBtn) stripsBtn.textContent = stripsButtonLabel(knives);
             summaryEl.innerHTML = '';
-            summaryEl.appendChild(metric('Итого ножей', knives));
+            // «Итого ножей» = число полос + 1 (крайний нож): N полос режутся N+1 ножом.
+            // knives здесь — число полос (Σ qty), оно же метка кнопки «Полосы (N)».
+            summaryEl.appendChild(metric('Итого ножей', knives > 0 ? knives + 1 : 0));
             summaryEl.appendChild(metric('Занято, мм', used));
             // Ширина джамбо неизвестна (нет вида сырья / ширины) → остаток посчитать
             // нельзя. Не показываем ложный отрицательный «вне допуска» (#3116 п.5),


### PR DESCRIPTION
## Задача
«Итого ножей» должно быть на 1 больше количества полос.

## Что было
В панели полос (`openStrips`) метрика «Итого ножей» показывала `stripsTotalKnives(strips)` = Σ количеств полос — то есть само число полос. Это же число — метка кнопки карточки «Полосы (N)».

## Что стало
«Итого ножей» = число полос + 1 (крайний нож: N полос режутся N+1 ножом). При 0 полос — 0.

Изменён только показ метрики «Итого ножей» (одна строка). Не тронуты: `knifeCount` (метка кнопки «Полосы (N)»), расчёт переналадки «смена ножей» (бинарный, по равенству/разнице — нечувствителен к равномерному +1) и хранение.

## Проверка
`node --check` — OK. Прошу глянуть на живой панели полос: «Итого ножей» = «Полосы (N)» + 1.