### PR TITLE
feat(atex): не дробить позиции по сроку, если просрочки нет

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3874,6 +3874,13 @@
         if (this.busy) return;
         console.log('[pp] ⚙️ generateCuts: начало генерации резок...');
 
+        // #(no-srok-when-on-time): срок учитываем (дробим позиции по окну) только если
+        // есть просроченные относительно даты планирования. Если все позиции укладываются
+        // в свой срок (dueKey ≥ planDateKey), окно не нужно — объединяем в один кластер.
+        var planBaseMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
+        var pbmD = new Date(planBaseMs);
+        var planDateKey = pbmD.getFullYear() * 10000 + (pbmD.getMonth() + 1) * 100 + pbmD.getDate();
+
         var layoutCore = (typeof window !== 'undefined' && window.AtexCutLayout && window.AtexCutLayout.layout) || null;
         if (!layoutCore || typeof layoutCore.planLayouts !== 'function') {
             console.error('[pp] ⚙️ generateCuts: модуль cut-layout не загружен');
@@ -3919,13 +3926,18 @@
                     return;
                 }
                 layoutPositionGroups(group.positions).forEach(function(positionGroup) {
+                    // Нет просроченных позиций (всё в рамках срока) → окно срока не нужно,
+                    // объединяем все позиции сырья (windowDays=Infinity); иначе дробим по WINDOW_DAYS.
+                    var hasOverdue = positionGroup.some(function(p) {
+                        return isFinite(p.dueKey) && p.dueKey < planDateKey;
+                    });
                     var res = layoutCore.planLayouts({
                         jumboWidth: jw,
                         positions: positionGroup.map(function(p) {
                             return { id: p.id, width: p.width, qty: p.qty, dueKey: p.dueKey };
                         }),
                         preferred: self.preferredByMaterial[group.key] || [],
-                        options: { windowDays: WINDOW_DAYS, tolerance: self.resolveToleranceMm(mat) }
+                        options: { windowDays: hasOverdue ? WINDOW_DAYS : Infinity, tolerance: self.resolveToleranceMm(mat) }
                     });
                     (res.layouts || []).forEach(function(lay) {
                         lay.mat = mat;


### PR DESCRIPTION
## Задача
Не учитывать приоритет по сроку для того, что делается в срок: сейчас позиции выстраиваются по сроку изготовления, но если всё успевается в рамках срока — дробить не нужно.

## Что было
В `generateCuts` позиции одного сырья передавались в раскладку с `windowDays = WINDOW_DAYS (3)`. Ядро `cut-layout.dueWindowGroups` дробит позиции на кластеры по окну срока → под разные сроки строятся отдельные резки даже когда всё успевается, что плодит лишние переналадки.

## Что стало (правило «нет просрочки → не дробить»)
Для каждой группы сырья проверяем, есть ли просроченные позиции относительно **даты планирования** (`dueKey < planDateKey`):
- **нет просроченных** → `windowDays = Infinity`: все позиции сырья объединяются в один кластер (оптимальный раскрой / минимум переналадок), срок не дробит;
- **есть просроченные** → прежнее окно `WINDOW_DAYS (3)` сохраняется, чтобы срочное приоритезировалось.

`planDateKey` (YYYYMMDD) берётся от даты планирования — из фильтра `.atex-pp-input` (через `planBaseMidnightFrom`, как в генерации #3311 и ре-планировании #3312).

## Область
- Меняется только выбор `windowDays` в `generateCuts` (production-planning.js). Ядро `cut-layout.js` не трогается (оно уже корректно сливает всё при больших `windowDays`).
- Нюанс: позиции **без срока** (dueKey = ∞) по-прежнему образуют отдельный кластер — это не срочно-зависимое поведение, оставлено как есть.

## Проверка
- `node --check` — OK.
- Юнит-логика `hasOverdue`: все сроки в будущем → не дробим; срок == плановой даты → не просрочено; есть прошедший → дробим; бездатные игнорируются — пройдено.
- Прошу проверить на живой форме: позиции одного сырья с разными (но не просроченными) сроками → одна резка/оптимальный раскрой; с просроченной позицией → дробление по сроку сохраняется.