### PR TITLE
fix(atex): title .atex-pp-cut-num — дата от дня планирования, а не сегодня

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5122,9 +5122,10 @@
         });
         var schedById = {};
         var dayWindow = self.workingWindow();
-        // #3280: полночь дня планирования (день 0 расписания) — для title даты+времени старта.
-        var nowD = new Date(controllerNowMs(self));
-        var planBaseMidnightMs = new Date(nowD.getFullYear(), nowD.getMonth(), nowD.getDate(), 0, 0, 0, 0).getTime();
+        // Полночь дня планирования (день 0 расписания) — для title даты+времени старта.
+        // День 0 = дата фильтра (.atex-pp-input), на которую отфильтрована очередь, а не
+        // «сегодня»; иначе title показывал текущую дату вместо плановой (напр. 10.06 вместо 01.06).
+        var planBaseMidnightMs = planBaseMidnightFrom(self.filter && self.filter.date, controllerNowMs(self));
         var schedule = buildSchedule(activeGroup.cuts, {
             windPoints: windPoints,
             times: self.changeTimes,


### PR DESCRIPTION
## Баг
В `.atex-pp-cut-num` title показывает текущую дату (напр. `10.06.2026 08:00`), хотя резки запланированы на выбранную дату (01.06).

## Причина
Текст ячейки — только время (`formatCutStartTime` → ЧЧ:ММ). А **title** = `formatCutStartTitle(sc, planBaseMidnightMs)` = базовая полночь + минута старта. В `renderQueue` базовая полночь бралась от `controllerNowMs` (сегодня) — это display-путь, не охваченный #3311. Поэтому title = сегодняшняя дата + время.

## Фикс
День 0 расписания = дата фильтра `.atex-pp-input` (на неё очередь и отфильтрована). База = `planBaseMidnightFrom(this.filter.date, …)` — тот же хелпер, что в генерации (#3311) и ре-планировании (#3312). Видимые резки по определению на дату фильтра (фильтр по `planDate`-дню), так что база совпадает с плановым днём каждой резки.

## Проверка
`node --check` — OK. Прошу глянуть: при фильтре на 01.06 title резок = 01.06 ЧЧ:ММ.