### PR TITLE
fix(atex): панель полос — не закрывать при удалении, защитить полосы «в заказ» (#3318)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -334,6 +334,8 @@
 .atex-pp-strip-purpose--order { color: var(--pp-ok); }
 .atex-pp-strip-purpose--stock { color: var(--pp-muted); }
 .atex-pp-strip-del { padding: 6px 0; text-align: center; }
+/* #3318: полоса «в заказ» — кнопка удаления неактивна (но кликабельна для tooltip-подсказки). */
+.atex-pp-strip-del.is-disabled { opacity: .4; cursor: not-allowed; }
 .atex-pp-strip-add { margin-bottom: 12px; }
 
 .atex-pp-strip-summary {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3512,11 +3512,26 @@
                 self.setBusy(false);
                 self.notify('Связь с позицией удалена', 'info');
                 self.render();
+                // #3318 п.2: если открыт редактор полос — переоткрыть, чтобы «Назначение»
+                // полосы обновилось (Заказ→Склад) и удаление снова стало доступным.
+                self.reopenStripsIfOpen();
             });
         }).catch(function(err) {
             self.setBusy(false);
             self.notify('Ошибка удаления связи: ' + err.message, 'error');
         });
+    };
+
+    // #3318: после изменения связей переоткрыть панель полос (если была открыта) для
+    // той же резки — render() пересобирает очередь и панель теряется; открываем заново
+    // с обновлёнными данными (orderedBatchIds → «Назначение» полосы и доступность удаления).
+    AtexProductionPlanning.prototype.reopenStripsIfOpen = function() {
+        var editId = this.stripEditCutId;
+        if (editId == null) return;
+        var cut = (this.cuts || []).filter(function(c) { return String(c.id) === String(editId); })[0];
+        var cardPanel = this.queueEl && this.queueEl.querySelector('.atex-pp-cut[data-cut-id="' + editId + '"]');
+        this.stripEditCutId = null;   // сбросить, чтобы openStrips открыл, а не закрыл (toggle)
+        if (cut && cardPanel) this.openStrips(cut, cardPanel);
     };
 
     AtexProductionPlanning.prototype.reload = function() {
@@ -3698,9 +3713,23 @@
                     text: purpose
                 }));
 
-                var del = el('button', { class: 'atex-pp-btn atex-pp-strip-del', type: 'button', title: 'Удалить полосу', text: '×' });
-                del.addEventListener('click', function() {
-                    if (self.busy) return;
+                var isOrdered = purpose === 'Заказ';
+                var del = el('button', {
+                    class: 'atex-pp-btn atex-pp-strip-del' + (isOrdered ? ' is-disabled' : ''),
+                    type: 'button',
+                    title: isOrdered
+                        ? 'Полоса зарезервирована в заказ. Чтобы удалить, отвяжите позиции на форме «Связанные позиции» справа — тогда полоса станет складской и её можно будет удалить.'
+                        : 'Удалить полосу',
+                    text: '×'
+                });
+                del.addEventListener('click', function(e) {
+                    // #3318 п.1: не всплывать к обработчику карточки — иначе renderRows()
+                    // отцепляет кнопку, closest('.atex-pp-strip-panel') возвращает null и
+                    // self.render() закрывает панель полос.
+                    e.stopPropagation();
+                    // #3318 п.2: полосу «в заказ» (есть связи-обеспечения) удалить нельзя —
+                    // кнопка неактивна; удаление — через отвязку позиций справа.
+                    if (self.busy || isOrdered) return;
                     var removed = strips.splice(idx, 1)[0];
                     renderRows();
                     recalc();


### PR DESCRIPTION
Closes #3318

## 1. Панель полос не должна закрываться при удалении полосы
`renderRows()` синхронно перестраивает тело панели и **отцепляет нажатую кнопку** `.atex-pp-strip-del`. Дальше клик всплывает к обработчику карточки, где `e.target.closest('.atex-pp-strip-panel')` на уже отцепленном узле возвращает `null` → не срабатывает исключение → `self.render()` пересобирает очередь и **закрывает панель**.
**Фикс:** `e.stopPropagation()` в обработчике удаления — клик не доходит до карточки.

## 2. Полосы «в заказ» нельзя удалить — кнопку неактивной + title
Полоса со ссылкой из Обеспечения (`orderedBatchIds[s.id]`, «Назначение: Заказ») не удаляется `_m_del` из-за связей. Теперь её кнопка удаления — **неактивна** (класс `is-disabled`, клик no-op) с **title**: «зарезервирована в заказ, удалять отвязав позиции на форме „Связанные позиции“ справа».

Кнопка сделана визуально-неактивной (класс), а не `disabled`-атрибутом, чтобы tooltip-подсказка надёжно показывалась (Chrome не показывает title на `disabled`-кнопках).

## …и обновление полосы при отвязке
`deleteSupply` после отвязки и `render()` вызывает `reopenStripsIfOpen()` — переоткрывает панель полос той же резки с обновлёнными данными: «Назначение» меняется Заказ→Склад, удаление снова доступно.

## Проверка
`node --check` — OK. Прошу проверить на форме: удаление складской полосы не закрывает панель; у полосы «в заказ» крестик неактивен с подсказкой; после отвязки позиции справа полоса становится «Склад» и удаляется.