### PR TITLE
fix(atex): клик по пустым зонам панели карточки резки тоже показывает «Связанные позиции» (#3323)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
+# Updated: 2026-06-11T10:07:32.942Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-08T05:51:11.657Z for PR creation at branch issue-3229-4948d30e1075 for issue https://github.com/ideav/crm/issues/3229
 # Updated: 2026-06-08T06:10:50.080Z
 # Updated: 2026-06-08T06:59:45.729Z
-# Updated: 2026-06-11T10:07:32.942Z

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2450,7 +2450,19 @@
         return p;
     }
 
+    // #3323: клик по любому месту карточки резки .atex-pp-cut выбирает её (→ боковая
+    // панель «Связанные позиции»). Исключение — клики по самим кнопкам ↑/↓/Полосы и
+    // по панели полос: их перерисовка очереди закрыла бы только что открытую панель
+    // полос. Пустые зоны .atex-pp-cut-controls (отступы и промежутки между кнопками)
+    // теперь тоже считаются кликом по карточке. Чистая (принимает цель клика с
+    // .closest) → проверяется модульным тестом без DOM-движка.
+    function cutClickSelectsCut(target) {
+        if (!target || typeof target.closest !== 'function') return true;
+        return !(target.closest('button') || target.closest('.atex-pp-strip-panel'));
+    }
+
     var planning = {
+        cutClickSelectsCut: cutClickSelectsCut,
         parseRef: parseRef,
         parseMultiRefIds: parseMultiRefIds,
         isMaterialBlocked: isMaterialBlocked,
@@ -5380,12 +5392,11 @@
                 el('span', { class: 'atex-pp-cut-supplies', text: supplies ? ('связей: ' + supplies) : 'нет связей' })
             ]);
             cardPanel.appendChild(info);
-            // Выбор резки кликом по всей карточке (#3149), а не только по .atex-pp-cut-info.
-            // Клики по контролам (↑/↓/Полосы) и панели полос не считаем выбором: их
-            // перерисовка очереди закрыла бы только что открытую панель полос.
+            // Выбор резки кликом по всей карточке (#3149, #3323), а не только по
+            // .atex-pp-cut-info. Логика «считать ли клик выбором» вынесена в чистую
+            // cutClickSelectsCut (см. её комментарий и модульный тест #3323).
             cardPanel.addEventListener('click', function(e) {
-                if (e.target.closest('.atex-pp-cut-controls') ||
-                    e.target.closest('.atex-pp-strip-panel')) return;
+                if (!cutClickSelectsCut(e.target)) return;
                 self.selectedCutId = c.id;
                 self.render();
             });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1192,6 +1192,61 @@ assertEqual(planning.progressPercent(20, 10), 100, 'progressPercent: done>total 
 assertEqual(planning.progressPercent(-3, 10), 0, 'progressPercent: done<0 → клампится до 0');
 assertEqual(planning.progressPercent('абв', 10), 0, 'progressPercent: нечисло → 0');
 
+// ── cutClickSelectsCut (#3323) ──
+// Клик в любом месте карточки .atex-pp-cut должен выбирать резку (→ «Связанные
+// позиции»), КРОМЕ кликов по самим кнопкам ↑/↓/Полосы и по панели полос. Раньше
+// возврат был по всему контейнеру .atex-pp-cut-controls, поэтому клик по его пустым
+// зонам (отступы/промежутки между кнопками) резку не выбирал. Строим минимальное
+// дерево карточки с .closest, как у реального renderQueue, и проверяем решение.
+(function() {
+    function dom(tag, className) {
+        return {
+            tag: String(tag).toUpperCase(),
+            className: className || '',
+            parent: null,
+            child: function(tagName, cls) {
+                var c = dom(tagName, cls);
+                c.parent = this;
+                return c;
+            },
+            matches: function(sel) {
+                if (sel === 'button') return this.tag === 'BUTTON';
+                if (sel.charAt(0) === '.') {
+                    return (' ' + this.className + ' ').indexOf(' ' + sel.slice(1) + ' ') >= 0;
+                }
+                return false;
+            },
+            closest: function(sel) {
+                var n = this;
+                while (n) { if (n.matches(sel)) return n; n = n.parent; }
+                return null;
+            }
+        };
+    }
+    // Структура карточки как в renderQueue: card > info(spans), time(div role=button),
+    // controls(div > buttons ↑/↓/Полосы), strip-panel(div > input/button).
+    var card = dom('div', 'atex-pp-cut is-active');
+    var info = card.child('div', 'atex-pp-cut-info');
+    var numSpan = info.child('span', 'atex-pp-cut-num');
+    var timeEl = card.child('div', 'atex-pp-cut-time'); // role=button, но это div
+    var controls = card.child('div', 'atex-pp-cut-controls');
+    var upBtn = controls.child('button', 'atex-pp-move');
+    var stripsBtn = controls.child('button', 'atex-pp-strips');
+    var stripPanel = card.child('div', 'atex-pp-strip-panel');
+    var stripInput = stripPanel.child('input', 'atex-pp-strip-width');
+
+    assertEqual(planning.cutClickSelectsCut(card), true, 'cutClickSelectsCut: клик по телу карточки выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(info), true, 'cutClickSelectsCut: клик по .atex-pp-cut-info выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(numSpan), true, 'cutClickSelectsCut: клик по span внутри info выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(timeEl), true, 'cutClickSelectsCut: клик по строке времени выбирает резку (#3309)');
+    assertEqual(planning.cutClickSelectsCut(controls), true, 'cutClickSelectsCut: клик по пустой зоне .atex-pp-cut-controls выбирает резку (#3323)');
+    assertEqual(planning.cutClickSelectsCut(upBtn), false, 'cutClickSelectsCut: клик по кнопке ↑ НЕ выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(stripsBtn), false, 'cutClickSelectsCut: клик по кнопке «Полосы» НЕ выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(stripPanel), false, 'cutClickSelectsCut: клик по панели полос НЕ выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(stripInput), false, 'cutClickSelectsCut: клик по полю внутри панели полос НЕ выбирает резку');
+    assertEqual(planning.cutClickSelectsCut(null), true, 'cutClickSelectsCut: пустая цель → по умолчанию выбирает');
+})();
+
 function req(id, val, extra) {
     var r = { id: id, val: val };
     Object.keys(extra || {}).forEach(function(k) { r[k] = extra[k]; });


### PR DESCRIPTION
## Задача
Клик в **любом месте** карточки резки `.atex-pp-cut` должен показывать её «Связанные позиции» (#3309). Сейчас клик по `.atex-pp-cut-controls` этого не делает — нужно проверить и остальные элементы панели.

Fixes #3323

## Что было
Обработчик клика по карточке (`renderQueue`) выбирал резку (`selectedCutId` → `renderLink` показывает «Связанные позиции»), но делал ранний возврат для **всего контейнера** `.atex-pp-cut-controls`:

```js
if (e.target.closest('.atex-pp-cut-controls') ||
    e.target.closest('.atex-pp-strip-panel')) return;
```

Из-за этого клик по **пустым зонам** панели контролов (отступ сверху `margin-top: 8px`, промежутки `gap: 6px` между кнопками ↑/↓/Полосы) попадал в `.atex-pp-cut-controls`, но не на сами кнопки — и резку не выбирал.

## Что стало
Исключаем из выбора только **сами интерактивные кнопки** (`button`: ↑/↓/Полосы) и панель полос `.atex-pp-strip-panel` — их перерисовка очереди закрыла бы только что открытую панель полос. Пустые зоны `.atex-pp-cut-controls` теперь считаются кликом по карточке → резка выбирается.

Логика «считать ли клик выбором» вынесена в чистую функцию `planning.cutClickSelectsCut(target)`, чтобы её можно было покрыть модульным тестом без DOM-движка.

### Проверка остальных элементов панели карточки
- Тело карточки, `.atex-pp-cut-info` и span'ы внутри → **выбирают** резку ✅
- Строка времени `.atex-pp-cut-time` (div, `role="button"`) → **выбирает** резку и открывает тайминг (поведение #3309 сохранено) ✅
- Пустые зоны `.atex-pp-cut-controls` → теперь **выбирают** резку ✅ (исправление)
- Кнопки ↑/↓/Полосы → выполняют своё действие, резку **не** выбирают (намеренно) ✅
- Панель полос `.atex-pp-strip-panel` и поля внутри → резку **не** выбирают (намеренно) ✅

## Тесты
- `node --check download/atex/js/production-planning.js` — OK.
- `node experiments/atex-production-planning.test.js` — **414 assertions passed** (добавлено 10 проверок для `cutClickSelectsCut`, воспроизводящих баг: клик по пустой зоне `.atex-pp-cut-controls` раньше давал `false`, теперь `true`).

Прошу также проверить на живой форме: клик по отступам/промежуткам блока ↑/↓/Полосы выбирает резку и показывает её «Связанные позиции»; клики по самим кнопкам и панели полос — как прежде.
