### PR TITLE
feat(atex): «Календарь занятости станков» — отдельное полноэкранное РМ (#3339)

### DIFF
--- a/docs/atex_menu.json
+++ b/docs/atex_menu.json
@@ -6,6 +6,7 @@
       "menus": [
         { "name": "Приём и ведение заказов", "href": "orders", "icon": "<i class=\"pi pi-shopping-cart\"></i>" },
         { "name": "Планирование производства", "href": "production-planning", "icon": "<i class=\"pi pi-calendar\"></i>" },
+        { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" },
         { "name": "Приёмка сырья", "href": "intake", "icon": "<i class=\"pi pi-inbox\"></i>" },
         { "name": "Пульт слиттера", "href": "slitter", "icon": "<i class=\"pi pi-sliders-h\"></i>" },
         { "name": "Пульт втулкореза", "href": "sleeve-cutter", "icon": "<i class=\"pi pi-cog\"></i>" },
@@ -24,7 +25,8 @@
     {
       "role": "Диспетчер",
       "menus": [
-        { "name": "Планирование производства", "href": "production-planning", "icon": "<i class=\"pi pi-calendar\"></i>" }
+        { "name": "Планирование производства", "href": "production-planning", "icon": "<i class=\"pi pi-calendar\"></i>" },
+        { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" }
       ]
     },
     {
@@ -40,7 +42,8 @@
     {
       "role": "Руководитель",
       "menus": [
-        { "name": "Дашборды и отчёты", "href": "dashboards", "icon": "<i class=\"pi pi-chart-bar\"></i>" }
+        { "name": "Дашборды и отчёты", "href": "dashboards", "icon": "<i class=\"pi pi-chart-bar\"></i>" },
+        { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" }
       ]
     },
     {

--- a/download/atex/css/machine-calendar.css
+++ b/download/atex/css/machine-calendar.css
@@ -1,0 +1,310 @@
+/* Рабочее место atex «Календарь занятости станков» (ideav/crm#3339).
+   Полноэкранный календарь занятости станков (слиттеров). Стили скоупятся под
+   #atex-machine-calendar / .atex-mc, чтобы не пересекаться с другими РМ в main.html.
+   Базовые переменные --pp-* и стили .atex-pp-cal* перенесены из «Планирования
+   производства» (#3334/#3335), где календарь жил до выноса в отдельное РМ. */
+
+.atex-mc {
+    --pp-border: var(--input-border, #d9dee5);
+    --pp-border-soft: var(--border-color, #eef1f5);
+    --pp-bg: var(--input-bg, #ffffff);
+    --pp-surface: var(--bg-secondary, #f8fafc);
+    --pp-muted: var(--text-secondary, #6b7280);
+    --pp-accent: var(--atex-navy, #134174);
+    --pp-warn: var(--color-error, #b91c1c);
+    --pp-cal-track: #f8fafc;
+    --pp-cal-grid: #e5e7eb;
+    --pp-cal-planned: #2563eb;
+    --pp-cal-running: #0891b2;
+    --pp-cal-unfinished: #d97706;
+    --pp-cal-ok: #15803d;
+    --pp-cal-late: #b91c1c;
+    --pp-cal-unknown: #64748b;
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 64px);
+    padding: 16px;
+    gap: 12px;
+    color: var(--text-primary, #1f2933);
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+[data-theme="dark"] .atex-mc {
+    --pp-cal-track: rgba(15, 23, 42, .45);
+    --pp-cal-grid: rgba(148, 163, 184, .28);
+    --pp-cal-planned: #60a5fa;
+    --pp-cal-running: #22d3ee;
+    --pp-cal-unfinished: #f59e0b;
+    --pp-cal-ok: #22c55e;
+    --pp-cal-late: #f87171;
+    --pp-cal-unknown: #94a3b8;
+}
+
+.atex-mc *,
+.atex-mc *::before,
+.atex-mc *::after { box-sizing: border-box; }
+
+.atex-mc.is-busy { opacity: .65; pointer-events: none; }
+
+.atex-mc-loading,
+.atex-mc-fatal { padding: 24px; color: var(--pp-muted); }
+.atex-mc-fatal { color: var(--pp-warn); }
+
+.atex-mc-input,
+.atex-mc-btn {
+    height: 32px;
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    color: inherit;
+    font: inherit;
+}
+.atex-mc-input { padding: 0 8px; }
+.atex-mc-btn { padding: 0 12px; cursor: pointer; white-space: nowrap; }
+.atex-mc-btn:hover { background: var(--pp-border-soft); }
+.atex-mc-slitter { max-width: 200px; }
+
+.atex-mc-toolbar { flex: 0 0 auto; }
+.atex-mc-tools {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: flex-end;
+}
+
+/* Календарь занятости станков (перенос из production-planning.css, #3334). */
+.atex-pp-cal-head {
+    display: grid;
+    grid-template-columns: minmax(170px, 1fr) auto auto minmax(220px, auto);
+    gap: 10px;
+    align-items: center;
+}
+.atex-pp-cal-title {
+    min-width: 0;
+    font-weight: 700;
+    font-size: 18px;
+}
+.atex-pp-cal-period,
+.atex-pp-cal-modes {
+    display: inline-flex;
+    align-items: center;
+}
+.atex-pp-cal-period { gap: 6px; }
+.atex-pp-cal-range {
+    min-width: 184px;
+    text-align: center;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.atex-pp-cal-arrow {
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    color: inherit;
+    cursor: pointer;
+    font: 700 20px/1 inherit;
+}
+.atex-pp-cal-arrow:hover { background: var(--pp-border-soft); }
+.atex-pp-cal-modes {
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--pp-bg);
+}
+.atex-pp-cal-mode {
+    min-width: 58px;
+    height: 32px;
+    padding: 0 10px;
+    border: 0;
+    border-right: 1px solid var(--pp-border);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    white-space: nowrap;
+}
+.atex-pp-cal-mode:last-child { border-right: 0; }
+.atex-pp-cal-mode:hover { background: var(--pp-border-soft); }
+.atex-pp-cal-mode.is-active {
+    background: var(--pp-accent);
+    color: #fff;
+}
+.atex-pp-cal-date {
+    height: 32px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+.atex-pp-cal-legend {
+    flex: 0 0 auto;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    align-items: center;
+    font-size: 12px;
+    color: var(--pp-muted);
+}
+.atex-pp-cal-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    white-space: nowrap;
+}
+.atex-pp-cal-legend-item::before {
+    content: "";
+    width: 10px;
+    height: 10px;
+    border-radius: 3px;
+    background: var(--pp-cal-unknown);
+}
+.atex-pp-cal-legend-item.is-planned::before { background: var(--pp-cal-planned); }
+.atex-pp-cal-legend-item.is-unfinished::before { background: var(--pp-cal-unfinished); }
+.atex-pp-cal-legend-item.is-on-time::before { background: var(--pp-cal-ok); }
+.atex-pp-cal-legend-item.is-late::before { background: var(--pp-cal-late); }
+.atex-pp-cal-scroll {
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1px solid var(--pp-border);
+    border-radius: 8px;
+    background: var(--pp-bg);
+}
+/* Полноэкранно: календарь занимает оставшуюся высоту и скроллит по вертикали. */
+.atex-mc-scroll {
+    flex: 1 1 auto;
+    overflow-y: auto;
+}
+.atex-pp-cal-body {
+    min-width: 420px;
+}
+.atex-pp-cal-body--three,
+.atex-pp-cal-body--week { min-width: 820px; }
+.atex-pp-cal-body--month { min-width: 1040px; }
+.atex-pp-cal-row {
+    display: grid;
+    grid-template-columns: 150px minmax(0, 1fr);
+    border-bottom: 1px solid var(--pp-border-soft);
+}
+.atex-pp-cal-row:last-child { border-bottom: 0; }
+.atex-pp-cal-scale-row {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    min-height: 32px;
+    font-size: 11px;
+    color: var(--pp-muted);
+    background: var(--pp-bg);
+}
+.atex-pp-cal-machine {
+    position: sticky;
+    left: 0;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    padding: 8px 10px;
+    border-right: 1px solid var(--pp-border-soft);
+    background: var(--pp-bg);
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.atex-pp-cal-machine--scale {
+    z-index: 5;
+    color: var(--pp-muted);
+    font-size: 11px;
+}
+.atex-pp-cal-track {
+    position: relative;
+    min-height: 38px;
+    background: var(--pp-cal-track);
+    overflow: hidden;
+}
+.atex-pp-cal-scale { min-height: 32px; }
+.atex-pp-cal-tick {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--pp-cal-grid);
+    pointer-events: none;
+}
+.atex-pp-cal-tick.is-end { transform: translateX(-1px); }
+.atex-pp-cal-tick-label {
+    position: absolute;
+    top: 7px;
+    left: 5px;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+.atex-pp-cal-tick-label.is-minor { display: none; }
+.atex-pp-cal-item {
+    position: absolute;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 12px;
+    height: 24px;
+    padding: 0 7px;
+    border: 1px solid transparent;
+    border-radius: 5px;
+    background: var(--pp-cal-unknown);
+    color: #fff;
+    cursor: pointer;
+    font: 12px/1.2 inherit;
+    text-align: left;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, .16);
+}
+.atex-pp-cal-item:hover,
+.atex-pp-cal-item.is-active {
+    outline: 2px solid rgba(19, 65, 116, .28);
+    outline-offset: 1px;
+}
+.atex-pp-cal-item.is-planned { background: var(--pp-cal-planned); }
+.atex-pp-cal-item.is-running { background: var(--pp-cal-running); }
+.atex-pp-cal-item.is-unfinished { background: var(--pp-cal-unfinished); }
+.atex-pp-cal-item.is-on-time,
+.atex-pp-cal-item.is-done { background: var(--pp-cal-ok); }
+.atex-pp-cal-item.is-late,
+.atex-pp-cal-item.is-late-start { background: var(--pp-cal-late); }
+.atex-pp-cal-item.is-unknown { background: var(--pp-cal-unknown); }
+.atex-pp-cal-item-main,
+.atex-pp-cal-item-status {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.atex-pp-cal-item-main { flex: 1 1 auto; font-weight: 700; }
+.atex-pp-cal-item-status { flex: 0 1 auto; opacity: .9; font-size: 11px; }
+.atex-pp-cal-row-empty {
+    position: absolute;
+    top: 10px;
+    left: 12px;
+    color: var(--pp-muted);
+    font-size: 12px;
+}
+.atex-pp-cal-empty,
+.atex-pp-cal-note {
+    flex: 0 0 auto;
+    padding: 9px 10px 0;
+    color: var(--pp-muted);
+    font-size: 12px;
+}
+
+@media (max-width: 920px) {
+    .atex-pp-cal-head { grid-template-columns: 1fr; }
+    .atex-pp-cal-title { font-size: 16px; }
+    .atex-pp-cal-period,
+    .atex-pp-cal-modes { justify-content: flex-start; }
+    .atex-pp-cal-range { min-width: 0; }
+    .atex-mc-tools { justify-content: flex-start; }
+    .atex-pp-cal-date { max-width: 180px; }
+    .atex-pp-cal-row { grid-template-columns: 110px minmax(0, 1fr); }
+}

--- a/download/atex/js/machine-calendar.js
+++ b/download/atex/js/machine-calendar.js
@@ -1,0 +1,755 @@
+// Рабочее место atex «Календарь занятости станков» (роли Руководитель, Диспетчер).
+//
+// Полноэкранный календарь занятости станков (слиттеров): по каждому станку —
+// дорожка с резками на выбранном интервале (день / 3 дня / неделя / месяц), цвет
+// резки кодирует статус (запланировано / в работе / не завершено / в срок / с
+// опозданием). Только чтение.
+//
+// Решение ideav/crm#3339. Календарь раньше был встроен в «Планирование
+// производства» (#3334/#3335), затем откатан (#3338) и по #3339 вынесен в
+// отдельное полноэкранное рабочее место. Правила РМ — docs/WORKSPACE_DEVELOPMENT_GUIDE.md.
+//
+// Данные — одним отчётом (минимум серверных запросов, docs/integram-reports.md):
+//   • `GET /{db}/report/cut_planning?JSON_KV` — Производственная резка → Обеспечение;
+//     отсюда берутся резки с плановой датой, фактическими стартом/финишем, станком,
+//     статусом и длительностью (для дедлайна).
+//   • `GET /{db}/object/{slitter}/?JSON_OBJ` — справочник станков (чтобы показать и
+//     простаивающие станки без резок). При отсутствии прав станки берутся из резок.
+//
+// Чистое ядро (разбор дат, интервалы, статусы, раскладка резок по дорожкам)
+// вынесено в объект `calendar` и экспортируется через module.exports для модульных
+// тестов (experiments/atex-machine-calendar.test.js).
+
+(function(root, factory) {
+    'use strict';
+    var api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+    if (typeof window !== 'undefined') {
+        window.AtexMachineCalendar = api;
+        if (typeof document !== 'undefined') {
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', api.init);
+            } else {
+                api.init();
+            }
+        }
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+    'use strict';
+
+    // ───────────────────────── Чистое ядро ─────────────────────────
+
+    // Терпимый разбор числа: запятая как десятичный разделитель, пробелы-разделители.
+    function stripNum(value) {
+        if (typeof value === 'number') return isFinite(value) ? value : 0;
+        var text = String(value == null ? '' : value).replace(/\s+/g, '').replace(',', '.');
+        var n = parseFloat(text);
+        return isFinite(n) ? n : 0;
+    }
+
+    function round3(n) { return Math.round(n * 1000) / 1000; }
+
+    // Непустой флаг: «1»/«true»/«да» → true; «0»/«false»/«нет»/'' → false.
+    function truthyFlag(value) {
+        if (value === true) return true;
+        if (value === false || value == null) return false;
+        if (typeof value === 'number') return isFinite(value) && value !== 0;
+        var s = String(value).trim().toLowerCase();
+        if (s === '') return false;
+        if (s === '0' || s === 'false' || s === 'нет' || s === 'no' || s === 'off') return false;
+        return true;
+    }
+
+    function refSearchHelper() {
+        if (typeof window !== 'undefined' && window.AtexRefSearch) return window.AtexRefSearch;
+        if (typeof globalThis !== 'undefined' && globalThis.AtexRefSearch) return globalThis.AtexRefSearch;
+        return null;
+    }
+
+    // Номер резки = плановая дата-штамп (DATETIME). Юникс-штамп → человекочитаемо.
+    function isTimestampCutNumber(value) {
+        var s = String(value == null ? '' : value).trim();
+        if (!/^\d+$/.test(s)) return false;
+        var n = Number(s);
+        if (!isFinite(n) || n < 1000000000) return false;
+        var d = new Date(n * 1000);
+        return !isNaN(d.getTime());
+    }
+
+    function formatCutNumber(value) {
+        if (value == null || value === '') return '';
+        var s = String(value).trim();
+        if (s === '' || !isTimestampCutNumber(s)) return s;
+        var helper = refSearchHelper();
+        if (helper && typeof helper.formatDateTime === 'function') {
+            var formatted = helper.formatDateTime(s);
+            return formatted == null || formatted === '' ? s : String(formatted);
+        }
+        return s;
+    }
+
+    function formatDateTimeMinute(date) {
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(date.getDate()) + '.' + pad(date.getMonth() + 1) + '.' + date.getFullYear() +
+            ' ' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+    }
+
+    var CALENDAR_DAY_MS = 86400000;
+    var CALENDAR_MODES = [
+        { id: 'day', label: 'День', days: 1 },
+        { id: 'three', label: '3 дня', days: 3 },
+        { id: 'week', label: 'Неделя', days: 7 },
+        { id: 'month', label: 'Месяц', days: 0 }
+    ];
+
+    // Колонки отчёта, в которых может прийти длительность резки (минуты).
+    var CUT_DURATION_COLUMNS = ['cut_duration', 'cut_duration_min', 'cut_duration_minutes'];
+
+    function todayISO() {
+        var d = new Date();
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+    }
+
+    function normalizeCalendarMode(mode) {
+        var s = String(mode == null ? '' : mode).trim().toLowerCase();
+        if (s === '3' || s === '3d' || s === '3days' || s === 'three-days') return 'three';
+        for (var i = 0; i < CALENDAR_MODES.length; i++) {
+            if (CALENDAR_MODES[i].id === s) return s;
+        }
+        return 'week';
+    }
+
+    function localDateMs(year, month, day, hour, minute, second) {
+        var d = new Date(Number(year), Number(month) - 1, Number(day),
+            Number(hour) || 0, Number(minute) || 0, Number(second) || 0, 0);
+        if (isNaN(d.getTime())) return null;
+        if (d.getFullYear() !== Number(year) || d.getMonth() !== Number(month) - 1 || d.getDate() !== Number(day)) return null;
+        return d.getTime();
+    }
+
+    function parseCalendarDateTimeMs(value) {
+        var s = String(value == null ? '' : value).trim();
+        if (s === '') return null;
+        if (/^\d{9,13}$/.test(s)) {
+            var num = Number(s);
+            var ms = num >= 1e12 ? num : num * 1000;
+            var stamp = new Date(ms);
+            var year = stamp.getFullYear();
+            if (!isNaN(stamp.getTime()) && year >= 2001 && year <= 2100) return ms;
+        }
+        var iso = s.match(/^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T\s]+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
+        if (iso) return localDateMs(iso[1], iso[2], iso[3], iso[4], iso[5], iso[6]);
+        var dmy = s.match(/^(\d{1,2})[.\/](\d{1,2})[.\/](\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
+        if (dmy) return localDateMs(dmy[3], dmy[2], dmy[1], dmy[4], dmy[5], dmy[6]);
+        var parsed = Date.parse(s);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function localIsoDateFromMs(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+    }
+
+    function startOfLocalDayMs(ms) {
+        var d = new Date(ms);
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0).getTime();
+    }
+
+    // Сдвиг ISO-даты на N календарных дней (через компоненты — корректно через
+    // границы месяцев и переходы летнего времени).
+    function shiftIsoDate(iso, days) {
+        var ms = parseCalendarDateTimeMs(iso);
+        if (ms == null) ms = Date.now();
+        var d = new Date(ms);
+        return localIsoDateFromMs(new Date(d.getFullYear(), d.getMonth(), d.getDate() + Number(days || 0), 0, 0, 0, 0).getTime());
+    }
+
+    function formatCalendarDateShort(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(d.getDate()) + '.' + pad(d.getMonth() + 1);
+    }
+
+    function formatCalendarDateFull(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(d.getDate()) + '.' + pad(d.getMonth() + 1) + '.' + d.getFullYear();
+    }
+
+    function formatCalendarTime(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(d.getHours()) + ':' + pad(d.getMinutes());
+    }
+
+    function calendarRangeLabel(startMs, endMs) {
+        var lastMs = endMs - 1;
+        if (localIsoDateFromMs(startMs) === localIsoDateFromMs(lastMs)) return formatCalendarDateFull(startMs);
+        return formatCalendarDateFull(startMs) + ' - ' + formatCalendarDateFull(lastMs);
+    }
+
+    function calendarRange(anchorIso, mode) {
+        var normalized = normalizeCalendarMode(mode);
+        var anchorMs = parseCalendarDateTimeMs(anchorIso);
+        if (anchorMs == null) anchorMs = startOfLocalDayMs(Date.now());
+        var anchorDay = startOfLocalDayMs(anchorMs);
+        var startMs, endMs;
+        if (normalized === 'week') {
+            var wd = new Date(anchorDay).getDay();
+            var mondayOffset = (wd + 6) % 7;
+            startMs = anchorDay - mondayOffset * CALENDAR_DAY_MS;
+            endMs = startMs + 7 * CALENDAR_DAY_MS;
+        } else if (normalized === 'month') {
+            var m = new Date(anchorDay);
+            startMs = new Date(m.getFullYear(), m.getMonth(), 1, 0, 0, 0, 0).getTime();
+            endMs = new Date(m.getFullYear(), m.getMonth() + 1, 1, 0, 0, 0, 0).getTime();
+        } else {
+            var days = normalized === 'three' ? 3 : 1;
+            startMs = anchorDay;
+            endMs = startMs + days * CALENDAR_DAY_MS;
+        }
+        var outDays = [];
+        for (var t = startMs; t < endMs; t += CALENDAR_DAY_MS) {
+            outDays.push({
+                iso: localIsoDateFromMs(t),
+                label: formatCalendarDateShort(t),
+                leftPct: round3(((t - startMs) / (endMs - startMs)) * 100)
+            });
+        }
+        return {
+            mode: normalized,
+            startMs: startMs,
+            endMs: endMs,
+            startIso: localIsoDateFromMs(startMs),
+            endIso: localIsoDateFromMs(endMs),
+            label: calendarRangeLabel(startMs, endMs),
+            days: outDays
+        };
+    }
+
+    function shiftCalendarAnchor(anchorIso, mode, direction) {
+        var range = calendarRange(anchorIso, mode);
+        var dir = Number(direction) || 0;
+        var normalized = range.mode;
+        if (normalized === 'month') {
+            var d = new Date(range.startMs);
+            return localIsoDateFromMs(new Date(d.getFullYear(), d.getMonth() + dir, 1, 0, 0, 0, 0).getTime());
+        }
+        var step = normalized === 'week' ? 7 : (normalized === 'three' ? 3 : 1);
+        return shiftIsoDate(range.startIso, dir * step);
+    }
+
+    function cutCalendarDeadlineMs(cut) {
+        var planMs = parseCalendarDateTimeMs(cut && cut.planDate);
+        var duration = stripNum(cut && cut.duration);
+        if (planMs == null || !(duration > 0)) return null;
+        return planMs + duration * 60000;
+    }
+
+    function cutCalendarStatus(cut, nowMs) {
+        var now = Number(nowMs);
+        if (!isFinite(now)) now = Date.now();
+        var planMs = parseCalendarDateTimeMs(cut && cut.planDate);
+        var startMs = parseCalendarDateTimeMs(cut && cut.startDate);
+        var endMs = parseCalendarDateTimeMs(cut && cut.endDate);
+        var deadlineMs = cutCalendarDeadlineMs(cut);
+        var unfinished = truthyFlag(cut && cut.status);
+        if (endMs != null) {
+            if (deadlineMs != null && endMs > deadlineMs) return { key: 'late', label: 'С опозданием' };
+            return deadlineMs != null ? { key: 'on-time', label: 'В срок' } : { key: 'done', label: 'Завершено' };
+        }
+        if (deadlineMs != null && now > deadlineMs) return { key: 'late', label: 'С опозданием' };
+        if (unfinished) return { key: 'unfinished', label: 'Не завершено' };
+        if (startMs != null) return { key: 'running', label: 'В работе' };
+        if (planMs != null && now > planMs) return { key: 'late-start', label: 'Старт просрочен' };
+        if (planMs != null) return { key: 'planned', label: 'Запланировано' };
+        return { key: 'unknown', label: 'Без даты' };
+    }
+
+    function cutCalendarTimeRange(cut) {
+        var planMs = parseCalendarDateTimeMs(cut && cut.planDate);
+        var startMs = parseCalendarDateTimeMs(cut && cut.startDate);
+        var endMs = parseCalendarDateTimeMs(cut && cut.endDate);
+        var visualStartMs = startMs != null ? startMs : planMs;
+        if (visualStartMs == null) return null;
+        var deadlineMs = cutCalendarDeadlineMs(cut);
+        var visualEndMs = endMs != null ? endMs : (deadlineMs != null ? deadlineMs : visualStartMs + 30 * 60000);
+        if (!(visualEndMs > visualStartMs)) visualEndMs = visualStartMs + 30 * 60000;
+        return {
+            startMs: visualStartMs,
+            endMs: visualEndMs,
+            planMs: planMs,
+            actualStartMs: startMs,
+            actualEndMs: endMs,
+            deadlineMs: deadlineMs
+        };
+    }
+
+    function cutCalendarItemLabel(cut, range) {
+        var name = formatCutNumber(cut && cut.number) || String((cut && cut.id) || '');
+        var material = String((cut && cut.materialName) || '').trim();
+        var text = formatCalendarTime(range.startMs) + '-' + formatCalendarTime(range.endMs);
+        if (name) text += ' · ' + name;
+        if (material) text += ' · ' + material;
+        return text;
+    }
+
+    function cutCalendarItemTitle(cut, range, status) {
+        var lines = [];
+        lines.push('Резка ' + (formatCutNumber(cut && cut.number) || ('#' + ((cut && cut.id) || ''))));
+        var slitter = cut && cut.slitter && cut.slitter.label;
+        if (slitter) lines.push('Станок: ' + slitter);
+        if (range.planMs != null) lines.push('План: ' + formatDateTimeMinute(new Date(range.planMs)));
+        if (range.actualStartMs != null) lines.push('Старт факт: ' + formatDateTimeMinute(new Date(range.actualStartMs)));
+        if (range.actualEndMs != null) lines.push('Финиш факт: ' + formatDateTimeMinute(new Date(range.actualEndMs)));
+        if (range.deadlineMs != null) lines.push('Дедлайн: ' + formatDateTimeMinute(new Date(range.deadlineMs)));
+        lines.push('Статус: ' + status.label);
+        return lines.join('\n');
+    }
+
+    function cutCalendarItem(cut, range, nowMs) {
+        if (!cut || !range || !(range.endMs > range.startMs)) return null;
+        var timeRange = cutCalendarTimeRange(cut);
+        if (!timeRange) return null;
+        if (timeRange.endMs <= range.startMs || timeRange.startMs >= range.endMs) return null;
+        var clippedStartMs = Math.max(timeRange.startMs, range.startMs);
+        var clippedEndMs = Math.min(timeRange.endMs, range.endMs);
+        var spanMs = range.endMs - range.startMs;
+        var status = cutCalendarStatus(cut, nowMs);
+        return {
+            cut: cut,
+            cutId: String(cut.id == null ? '' : cut.id),
+            startMs: timeRange.startMs,
+            endMs: timeRange.endMs,
+            clippedStartMs: clippedStartMs,
+            clippedEndMs: clippedEndMs,
+            leftPct: round3(((clippedStartMs - range.startMs) / spanMs) * 100),
+            widthPct: round3(Math.max(((clippedEndMs - clippedStartMs) / spanMs) * 100, 0.4)),
+            lane: 0,
+            status: status,
+            label: cutCalendarItemLabel(cut, timeRange),
+            title: cutCalendarItemTitle(cut, timeRange, status)
+        };
+    }
+
+    function assignCalendarLanes(items) {
+        var laneEnds = [];
+        return (items || []).slice().sort(function(a, b) {
+            return (a.startMs - b.startMs) || (a.endMs - b.endMs) || String(a.cutId).localeCompare(String(b.cutId));
+        }).map(function(item) {
+            var lane = 0;
+            while (lane < laneEnds.length && item.startMs < laneEnds[lane]) lane++;
+            laneEnds[lane] = item.endMs;
+            var copy = {};
+            Object.keys(item).forEach(function(k) { copy[k] = item[k]; });
+            copy.lane = lane;
+            return copy;
+        });
+    }
+
+    function calendarItemsForRange(cuts, range, nowMs) {
+        var items = [];
+        (cuts || []).forEach(function(cut) {
+            var item = cutCalendarItem(cut, range, nowMs);
+            if (item) items.push(item);
+        });
+        return assignCalendarLanes(items);
+    }
+
+    function machineCalendarGroups(cuts, slitters, range, nowMs, filters) {
+        var f = filters || {};
+        var status = String(f.status == null ? '' : f.status).trim();
+        var slitterFilter = String(f.slitter == null ? '' : f.slitter).trim();
+        var groups = {};
+        var order = [];
+        function ensure(slitter) {
+            var s = slitter || { id: null, label: '' };
+            var key = s.id == null || String(s.id) === '' ? ' none' : String(s.id);
+            if (!groups[key]) {
+                groups[key] = {
+                    key: key,
+                    slitter: { id: s.id == null || String(s.id) === '' ? null : String(s.id), label: s.label || (s.id == null || String(s.id) === '' ? 'Без станка' : '#' + s.id) },
+                    cuts: [],
+                    items: [],
+                    laneCount: 0
+                };
+                order.push(key);
+            }
+            return groups[key];
+        }
+        (slitters || []).forEach(function(s) {
+            if (slitterFilter && String(s && s.id) !== slitterFilter) return;
+            ensure(s);
+        });
+        (cuts || []).forEach(function(cut) {
+            if (status && String(cut && cut.status || '').trim() !== status) return;
+            var s = cut && cut.slitter || { id: null, label: '' };
+            if (slitterFilter && String(s.id == null ? '' : s.id) !== slitterFilter) return;
+            ensure(s).cuts.push(cut);
+        });
+        order.forEach(function(key) {
+            var group = groups[key];
+            group.items = calendarItemsForRange(group.cuts, range, nowMs);
+            group.laneCount = group.items.reduce(function(max, item) { return Math.max(max, item.lane + 1); }, 0);
+        });
+        return order.map(function(key) { return groups[key]; }).sort(function(a, b) {
+            if (a.slitter.id == null) return 1;
+            if (b.slitter.id == null) return -1;
+            return String(a.slitter.label).localeCompare(String(b.slitter.label), 'ru');
+        });
+    }
+
+    // Строки отчёта cut_planning → резки для календаря (dedup по cut_id; берём только
+    // поля, нужные календарю). Несколько строк на одну резку (join с обеспечением)
+    // схлопываются в одну.
+    function rowsToCuts(rows) {
+        var byId = {};
+        var order = [];
+        function str(v) { return v == null ? '' : String(v); }
+        function durationOf(row) {
+            for (var i = 0; i < CUT_DURATION_COLUMNS.length; i++) {
+                var v = row && row[CUT_DURATION_COLUMNS[i]];
+                if (v != null && v !== '') return stripNum(v);
+            }
+            return 0;
+        }
+        (rows || []).forEach(function(row) {
+            var id = str(row && row.cut_id);
+            if (!id || byId[id]) return;
+            byId[id] = {
+                id: id,
+                number: str(row.cut_plan_date),
+                planDate: str(row.cut_plan_date),
+                status: str(row.cut_status),
+                startDate: str(row.cut_start_date),
+                endDate: str(row.cut_end_date),
+                duration: durationOf(row),
+                materialId: str(row.cut_material_id),
+                materialName: str(row.cut_material),
+                slitter: { id: row.cut_slitter_id ? String(row.cut_slitter_id) : null, label: str(row.cut_slitter) }
+            };
+            order.push(id);
+        });
+        return order.map(function(id) { return byId[id]; });
+    }
+
+    // Уникальные станки, встреченные в резках (резерв, если справочник недоступен).
+    function slittersFromCuts(cuts) {
+        var seen = {};
+        var out = [];
+        (cuts || []).forEach(function(cut) {
+            var s = cut && cut.slitter;
+            if (!s || s.id == null || String(s.id) === '') return;
+            var key = String(s.id);
+            if (seen[key]) return;
+            seen[key] = true;
+            out.push({ id: key, label: s.label || ('#' + key) });
+        });
+        return out;
+    }
+
+    var calendar = {
+        CALENDAR_MODES: CALENDAR_MODES,
+        normalizeCalendarMode: normalizeCalendarMode,
+        parseCalendarDateTimeMs: parseCalendarDateTimeMs,
+        shiftIsoDate: shiftIsoDate,
+        calendarRange: calendarRange,
+        shiftCalendarAnchor: shiftCalendarAnchor,
+        cutCalendarStatus: cutCalendarStatus,
+        cutCalendarTimeRange: cutCalendarTimeRange,
+        cutCalendarItem: cutCalendarItem,
+        calendarItemsForRange: calendarItemsForRange,
+        assignCalendarLanes: assignCalendarLanes,
+        machineCalendarGroups: machineCalendarGroups,
+        rowsToCuts: rowsToCuts,
+        slittersFromCuts: slittersFromCuts,
+        formatCutNumber: formatCutNumber,
+        todayISO: todayISO
+    };
+
+    // ───────────────────────── DOM-хелпер ─────────────────────────
+
+    function el(tag, attrs, children) {
+        var node = document.createElement(tag);
+        if (attrs) Object.keys(attrs).forEach(function(k) {
+            if (k === 'class') node.className = attrs[k];
+            else if (k === 'text') node.textContent = attrs[k];
+            else if (k === 'html') node.innerHTML = attrs[k];
+            else if (k === 'dataset') Object.keys(attrs[k]).forEach(function(d) { node.dataset[d] = attrs[k][d]; });
+            else node.setAttribute(k, attrs[k]);
+        });
+        (children || []).forEach(function(c) {
+            if (c == null) return;
+            node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+        });
+        return node;
+    }
+
+    // ───────────────────────── Контроллер ─────────────────────────
+
+    function AtexMachineCalendar(root) {
+        this.root = root;
+        this.db = (typeof window !== 'undefined' && window.db) || root.getAttribute('data-db') || '';
+        this.slitterTable = root.getAttribute('data-slitter-table') || '1070';
+        this.busy = false;
+        this.cuts = [];
+        this.slitters = [];
+        this.selectedCutId = null;
+        this.state = {
+            mode: 'week',
+            anchor: todayISO(),
+            slitter: '',
+            status: ''
+        };
+    }
+
+    AtexMachineCalendar.prototype.url = function(path) {
+        return '/' + encodeURIComponent(this.db) + '/' + path;
+    };
+
+    AtexMachineCalendar.prototype.getJson = function(path) {
+        return fetch(this.url(path), { credentials: 'same-origin' }).then(function(resp) {
+            return resp.text().then(function(text) {
+                try { return JSON.parse(text); }
+                catch (e) { throw new Error('Некорректный JSON: ' + text.slice(0, 200)); }
+            });
+        });
+    };
+
+    AtexMachineCalendar.prototype.nowMs = function() { return Date.now(); };
+
+    // Справочник станков: object/{slitter}?JSON_OBJ. При ошибке прав — пусто,
+    // станки будут взяты из самих резок (slittersFromCuts).
+    AtexMachineCalendar.prototype.loadSlitters = function() {
+        return this.getJson('object/' + encodeURIComponent(this.slitterTable) + '/?JSON_OBJ&LIMIT=0,1000').then(function(rows) {
+            return (rows || []).map(function(r) {
+                return { id: String(r.i), label: (r.r && r.r[0]) || ('#' + r.i) };
+            });
+        }).catch(function() { return []; });
+    };
+
+    AtexMachineCalendar.prototype.collect = function() {
+        var self = this;
+        return Promise.all([
+            this.getJson('report/cut_planning?JSON_KV&LIMIT=0,5000'),
+            this.loadSlitters()
+        ]).then(function(res) {
+            self.cuts = rowsToCuts(res[0] || []);
+            var refSlitters = res[1] || [];
+            // Объединяем справочник станков и станки из резок (на случай неполного справочника).
+            var merged = {};
+            var ordered = [];
+            refSlitters.concat(slittersFromCuts(self.cuts)).forEach(function(s) {
+                if (!s || s.id == null) return;
+                var key = String(s.id);
+                if (merged[key]) return;
+                merged[key] = { id: key, label: s.label || ('#' + key) };
+                ordered.push(merged[key]);
+            });
+            self.slitters = ordered;
+        });
+    };
+
+    // ── Рендеринг ──
+
+    AtexMachineCalendar.prototype.render = function() {
+        var self = this;
+        var st = this.state;
+        st.mode = normalizeCalendarMode(st.mode);
+        var range = calendarRange(st.anchor || todayISO(), st.mode);
+        if (!st.anchor) st.anchor = range.startIso;
+        var nowMs = this.nowMs();
+
+        this.root.innerHTML = '';
+
+        // ── Тулбар: заголовок · период · режимы · дата · фильтр станка · обновить ──
+        var prevBtn = el('button', { class: 'atex-pp-cal-arrow', type: 'button', text: '‹', title: 'Предыдущий период' });
+        var nextBtn = el('button', { class: 'atex-pp-cal-arrow', type: 'button', text: '›', title: 'Следующий период' });
+        prevBtn.addEventListener('click', function() {
+            st.anchor = shiftCalendarAnchor(st.anchor || range.startIso, st.mode, -1);
+            self.render();
+        });
+        nextBtn.addEventListener('click', function() {
+            st.anchor = shiftCalendarAnchor(st.anchor || range.startIso, st.mode, 1);
+            self.render();
+        });
+
+        var modeWrap = el('div', { class: 'atex-pp-cal-modes', role: 'group', 'aria-label': 'Период календаря' });
+        CALENDAR_MODES.forEach(function(m) {
+            var btn = el('button', {
+                class: 'atex-pp-cal-mode' + (m.id === st.mode ? ' is-active' : ''),
+                type: 'button', text: m.label, title: m.label
+            });
+            btn.addEventListener('click', function() { st.mode = m.id; self.render(); });
+            modeWrap.appendChild(btn);
+        });
+
+        var dateInput = el('input', {
+            class: 'atex-mc-input atex-pp-cal-date', type: 'date',
+            value: st.anchor || range.startIso, title: 'Дата периода'
+        });
+        dateInput.addEventListener('change', function() {
+            if (!dateInput.value) return;
+            st.anchor = dateInput.value;
+            self.render();
+        });
+
+        // Фильтр по станку.
+        var slitterSelect = el('select', { class: 'atex-mc-input atex-mc-slitter', title: 'Станок' });
+        slitterSelect.appendChild(el('option', { value: '', text: 'Все станки' }));
+        this.slitters.forEach(function(s) {
+            var opt = el('option', { value: s.id, text: s.label });
+            if (String(st.slitter) === String(s.id)) opt.setAttribute('selected', 'selected');
+            slitterSelect.appendChild(opt);
+        });
+        slitterSelect.value = st.slitter || '';
+        slitterSelect.addEventListener('change', function() { st.slitter = slitterSelect.value || ''; self.render(); });
+
+        var todayBtn = el('button', { class: 'atex-mc-btn', type: 'button', text: 'Сегодня', title: 'Перейти к текущей дате' });
+        todayBtn.addEventListener('click', function() { st.anchor = todayISO(); self.render(); });
+
+        var refreshBtn = el('button', { class: 'atex-mc-btn', type: 'button', text: 'Обновить', title: 'Перечитать данные' });
+        refreshBtn.addEventListener('click', function() { self.refresh(); });
+
+        var head = el('div', { class: 'atex-mc-toolbar atex-pp-cal-head' }, [
+            el('div', { class: 'atex-pp-cal-title', text: 'Календарь занятости станков' }),
+            el('div', { class: 'atex-pp-cal-period' }, [prevBtn, el('span', { class: 'atex-pp-cal-range', text: range.label }), nextBtn]),
+            modeWrap,
+            el('div', { class: 'atex-mc-tools' }, [dateInput, slitterSelect, todayBtn, refreshBtn])
+        ]);
+        this.root.appendChild(head);
+
+        // ── Легенда ──
+        this.root.appendChild(el('div', { class: 'atex-pp-cal-legend' }, [
+            el('span', { class: 'atex-pp-cal-legend-item is-planned', text: 'Запланировано' }),
+            el('span', { class: 'atex-pp-cal-legend-item is-unfinished', text: 'Не завершено' }),
+            el('span', { class: 'atex-pp-cal-legend-item is-on-time', text: 'В срок' }),
+            el('span', { class: 'atex-pp-cal-legend-item is-late', text: 'С опозданием' })
+        ]));
+
+        // ── Сетка станков ──
+        var groups = machineCalendarGroups(this.cuts, this.slitters, range, nowMs, {
+            status: st.status, slitter: st.slitter
+        });
+        var totalItems = groups.reduce(function(total, group) { return total + group.items.length; }, 0);
+
+        function appendTicks(track, scale) {
+            range.days.forEach(function(day, idx) {
+                var tick = el('span', { class: 'atex-pp-cal-tick' + (scale ? ' is-scale' : '') });
+                tick.style.left = day.leftPct + '%';
+                if (scale) {
+                    var label = el('span', { class: 'atex-pp-cal-tick-label', text: day.label });
+                    if (range.mode === 'month' && idx % 2 !== 0) label.className += ' is-minor';
+                    tick.appendChild(label);
+                }
+                track.appendChild(tick);
+            });
+            var endTick = el('span', { class: 'atex-pp-cal-tick is-end' + (scale ? ' is-scale' : '') });
+            endTick.style.left = '100%';
+            track.appendChild(endTick);
+        }
+
+        var scroll = el('div', { class: 'atex-pp-cal-scroll atex-mc-scroll' });
+        var body = el('div', { class: 'atex-pp-cal-body atex-pp-cal-body--' + range.mode });
+        var scaleRow = el('div', { class: 'atex-pp-cal-row atex-pp-cal-scale-row' });
+        scaleRow.appendChild(el('div', { class: 'atex-pp-cal-machine atex-pp-cal-machine--scale', text: 'Станок' }));
+        var scaleTrack = el('div', { class: 'atex-pp-cal-track atex-pp-cal-scale' });
+        appendTicks(scaleTrack, true);
+        scaleRow.appendChild(scaleTrack);
+        body.appendChild(scaleRow);
+
+        if (!groups.length) {
+            body.appendChild(el('div', { class: 'atex-pp-cal-empty', text: 'Нет станков для календаря' }));
+        } else {
+            groups.forEach(function(group) {
+                var row = el('div', { class: 'atex-pp-cal-row' });
+                row.appendChild(el('div', { class: 'atex-pp-cal-machine', text: group.slitter.label }));
+                var track = el('div', { class: 'atex-pp-cal-track' });
+                var laneCount = Math.max(group.laneCount, group.items.length ? 1 : 0);
+                track.style.minHeight = Math.max(38, laneCount * 30 + 10) + 'px';
+                appendTicks(track, false);
+                if (!group.items.length) {
+                    track.appendChild(el('span', { class: 'atex-pp-cal-row-empty', text: 'Нет резок' }));
+                }
+                group.items.forEach(function(item) {
+                    var active = String(self.selectedCutId) === String(item.cutId);
+                    var statusKey = item.status && item.status.key || 'unknown';
+                    var btn = el('button', {
+                        class: 'atex-pp-cal-item is-' + statusKey + (active ? ' is-active' : ''),
+                        type: 'button', title: item.title, dataset: { cutId: item.cutId }
+                    }, [
+                        el('span', { class: 'atex-pp-cal-item-main', text: item.label }),
+                        el('span', { class: 'atex-pp-cal-item-status', text: item.status.label })
+                    ]);
+                    btn.style.left = item.leftPct + '%';
+                    btn.style.width = item.widthPct + '%';
+                    btn.style.top = (item.lane * 30 + 5) + 'px';
+                    btn.addEventListener('click', function() {
+                        self.selectedCutId = (String(self.selectedCutId) === String(item.cutId)) ? null : item.cutId;
+                        self.render();
+                    });
+                    track.appendChild(btn);
+                });
+                row.appendChild(track);
+                body.appendChild(row);
+            });
+        }
+        scroll.appendChild(body);
+        this.root.appendChild(scroll);
+
+        if (!totalItems) {
+            this.root.appendChild(el('div', { class: 'atex-pp-cal-note', text: 'На выбранном интервале резок нет' }));
+        }
+    };
+
+    AtexMachineCalendar.prototype.setBusy = function(on) {
+        this.busy = on;
+        if (this.root) this.root.classList.toggle('is-busy', !!on);
+    };
+
+    AtexMachineCalendar.prototype.fatal = function(message) {
+        this.root.innerHTML = '';
+        this.root.appendChild(el('div', { class: 'atex-mc-fatal', text: message }));
+    };
+
+    AtexMachineCalendar.prototype.refresh = function() {
+        var self = this;
+        if (this.busy) return Promise.resolve();
+        this.setBusy(true);
+        return this.collect().then(function() {
+            self.render();
+            self.setBusy(false);
+        }).catch(function(err) {
+            self.setBusy(false);
+            self.fatal('Ошибка загрузки данных: ' + err.message);
+        });
+    };
+
+    AtexMachineCalendar.prototype.start = function() {
+        var self = this;
+        this.root.innerHTML = '';
+        this.root.appendChild(el('div', { class: 'atex-mc-loading', text: 'Загрузка календаря занятости станков…' }));
+        return this.refresh()
+            .catch(function(err) { self.fatal('Ошибка инициализации: ' + err.message); });
+    };
+
+    function init() {
+        if (typeof document === 'undefined') return;
+        var root = document.getElementById('atex-machine-calendar');
+        if (!root || root.dataset.initialized === '1') return;
+        root.dataset.initialized = '1';
+        var controller = new AtexMachineCalendar(root);
+        root._atexMachineCalendar = controller;
+        controller.start();
+    }
+
+    return { calendar: calendar, Controller: AtexMachineCalendar, init: init };
+});
+
+//
+//
+// @version 2026-06-11-issue-3339

--- a/experiments/atex-machine-calendar.harness.html
+++ b/experiments/atex-machine-calendar.harness.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<!-- Визуальный harness для «Календаря занятости станков» (#3339).
+     Мокает fetch (report/cut_planning + object/{slitter}) тестовыми данными
+     и монтирует РМ. Запуск: открыть в браузере/Playwright. -->
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>atex · Календарь занятости станков — harness</title>
+<style>
+  :root { --text-primary:#1f2933; --bg-secondary:#f8fafc; --input-bg:#fff;
+          --input-border:#d9dee5; --border-color:#eef1f5; --text-secondary:#6b7280;
+          --atex-navy:#134174; --color-error:#b91c1c; --color-success:#15803d; }
+  body { margin:0; font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+         background:#eef2f7; }
+  .harness-bar { height:64px; display:flex; align-items:center; gap:16px; padding:0 16px;
+                 background:var(--atex-navy); color:#fff; font-weight:600; }
+  .harness-bar button { height:30px; border:0; border-radius:6px; padding:0 12px;
+                        background:#fff; color:var(--atex-navy); cursor:pointer; font:inherit; }
+</style>
+<link rel="stylesheet" href="../download/atex/css/machine-calendar.css">
+</head>
+<body>
+<div class="harness-bar">
+  <span>Harness · /atex/machine-calendar</span>
+  <button id="toggle-theme" type="button">Тема</button>
+</div>
+<div id="atex-machine-calendar" class="atex-mc" data-db="ateh" data-slitter-table="1070">
+  <div class="atex-mc-loading">Загрузка…</div>
+</div>
+
+<script>
+// ── Тестовые данные вокруг «сегодня», чтобы видеть недельный режим по умолчанию ──
+(function () {
+  function pad(n) { return (n < 10 ? '0' : '') + n; }
+  function at(dayOffset, h, m) {
+    var d = new Date();
+    d.setDate(d.getDate() + dayOffset);
+    return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()) +
+      ' ' + pad(h) + ':' + pad(m);
+  }
+  var planning = [
+    // Станок 1 — завершено в срок
+    { cut_id: '1', cut_slitter: 'Станок 1', cut_slitter_id: '101', cut_material: 'MR194',
+      cut_plan_date: at(0, 8, 0), cut_start_date: at(0, 8, 5), cut_end_date: at(0, 9, 0),
+      cut_duration: '60', cut_status: '' },
+    // Станок 1 — с опозданием
+    { cut_id: '2', cut_slitter: 'Станок 1', cut_slitter_id: '101', cut_material: 'BOPP',
+      cut_plan_date: at(0, 10, 0), cut_start_date: at(0, 10, 30), cut_end_date: at(0, 12, 0),
+      cut_duration: '60', cut_status: '' },
+    // Станок 2 — в работе (не завершено)
+    { cut_id: '3', cut_slitter: 'Станок 2', cut_slitter_id: '102', cut_material: 'Фольга 12',
+      cut_plan_date: at(1, 9, 0), cut_start_date: at(1, 9, 10), cut_end_date: '',
+      cut_duration: '90', cut_status: '1' },
+    // Станок 2 — запланировано (будущее)
+    { cut_id: '4', cut_slitter: 'Станок 2', cut_slitter_id: '102', cut_material: 'MR194',
+      cut_plan_date: at(2, 13, 0), cut_start_date: '', cut_end_date: '',
+      cut_duration: '45', cut_status: '' },
+    // Станок 3 — две параллельные резки (проверка дорожек)
+    { cut_id: '5', cut_slitter: 'Станок 3', cut_slitter_id: '103', cut_material: 'PET',
+      cut_plan_date: at(0, 14, 0), cut_start_date: at(0, 14, 0), cut_end_date: at(0, 16, 0),
+      cut_duration: '120', cut_status: '' },
+    { cut_id: '6', cut_slitter: 'Станок 3', cut_slitter_id: '103', cut_material: 'PVC',
+      cut_plan_date: at(0, 15, 0), cut_start_date: at(0, 15, 0), cut_end_date: at(0, 17, 0),
+      cut_duration: '120', cut_status: '' }
+  ];
+  var slitters = [
+    { i: 101, r: ['Станок 1'] },
+    { i: 102, r: ['Станок 2'] },
+    { i: 103, r: ['Станок 3'] },
+    { i: 104, r: ['Станок 4'] } // простаивающий — должен показаться пустой строкой
+  ];
+  window.fetch = function (url) {
+    var body = '[]';
+    if (/report\/cut_planning/.test(url)) body = JSON.stringify(planning);
+    else if (/object\//.test(url)) body = JSON.stringify(slitters);
+    return Promise.resolve({ text: function () { return Promise.resolve(body); } });
+  };
+})();
+document.getElementById('toggle-theme').addEventListener('click', function () {
+  var cur = document.documentElement.getAttribute('data-theme');
+  document.documentElement.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark');
+  document.body.style.background = cur === 'dark' ? '#eef2f7' : '#0f172a';
+});
+</script>
+<script src="../download/atex/js/machine-calendar.js"></script>
+</body>
+</html>

--- a/experiments/atex-machine-calendar.test.js
+++ b/experiments/atex-machine-calendar.test.js
@@ -1,0 +1,121 @@
+// Unit tests for the «Календарь занятости станков» core (ideav/crm#3339).
+// Проверяет чистое ядро автономного рабочего места:
+//   • rowsToCuts          — строки отчёта cut_planning → резки для календаря;
+//   • calendarRange       — интервал по режиму (день/3 дня/неделя/месяц);
+//   • shiftCalendarAnchor — сдвиг периода назад/вперёд;
+//   • cutCalendarStatus   — статус резки (в срок / с опозданием / не завершено …);
+//   • cutCalendarItem     — позиция/ширина плашки на шкале + статус;
+//   • machineCalendarGroups — раскладка резок по станкам и дорожкам.
+//
+// Логика перенесена из «Планирования производства» (#3334/#3335), значения сверены
+// с тем же тестом. Run with: node experiments/atex-machine-calendar.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/machine-calendar.js');
+var calendar = api.calendar;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) {
+        passed++;
+    } else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// ── rowsToCuts: dedup по cut_id, выбор нужных полей, длительность ──
+var cuts = calendar.rowsToCuts([
+    { cut_id: '10', cut_slitter: 'Станок 1', cut_slitter_id: '101',
+      cut_plan_date: '06.05.2026', cut_material: 'MR194', cut_material_id: '5',
+      cut_start_date: '06.05.2026 08:10', cut_end_date: '06.05.2026 09:20',
+      cut_duration: '70', cut_status: 'В работе', supply_id: '900' },
+    // вторая строка той же резки (join с обеспечением) — схлопывается
+    { cut_id: '10', cut_slitter: 'Станок 1', cut_slitter_id: '101',
+      cut_plan_date: '06.05.2026', cut_status: 'В работе', supply_id: '901' },
+    { cut_id: '20', cut_slitter: '', cut_slitter_id: '',
+      cut_plan_date: '27.05.2026', cut_status: 'Ожидает', supply_id: '' }
+]);
+assertEqual(cuts, [
+    { id: '10', number: '06.05.2026', planDate: '06.05.2026', status: 'В работе',
+      startDate: '06.05.2026 08:10', endDate: '06.05.2026 09:20', duration: 70,
+      materialId: '5', materialName: 'MR194', slitter: { id: '101', label: 'Станок 1' } },
+    { id: '20', number: '27.05.2026', planDate: '27.05.2026', status: 'Ожидает',
+      startDate: '', endDate: '', duration: 0,
+      materialId: '', materialName: '', slitter: { id: null, label: '' } }
+], 'rowsToCuts: dedup по cut_id, нужные поля и длительность');
+
+// ── calendarRange: неделя начинается с понедельника и длится 7 дней ──
+var weekRange = calendar.calendarRange('2026-06-11', 'week');
+assertEqual({
+    mode: weekRange.mode,
+    startIso: weekRange.startIso,
+    endIso: weekRange.endIso,
+    days: weekRange.days.map(function(day) { return day.iso; })
+}, {
+    mode: 'week',
+    startIso: '2026-06-08',
+    endIso: '2026-06-15',
+    days: ['2026-06-08', '2026-06-09', '2026-06-10', '2026-06-11', '2026-06-12', '2026-06-13', '2026-06-14']
+}, 'calendarRange: неделя с понедельника, 7 дней');
+
+assertEqual(calendar.shiftCalendarAnchor('2026-06-11', 'three', 1), '2026-06-14',
+    'shiftCalendarAnchor: режим «3 дня» сдвигает на три дня');
+
+// ── cutCalendarStatus ──
+assertEqual(calendar.cutCalendarStatus({
+    planDate: '2026-06-11 08:00', startDate: '2026-06-11 08:05',
+    endDate: '2026-06-11 08:45', duration: 60, status: ''
+}, Date.parse('2026-06-11T08:30:00Z')), { key: 'on-time', label: 'В срок' },
+    'cutCalendarStatus: фактический финиш в пределах план+длительность → в срок');
+
+assertEqual(calendar.cutCalendarStatus({
+    planDate: '2026-06-11 08:00', startDate: '2026-06-11 08:05',
+    endDate: '2026-06-11 09:30', duration: 60, status: ''
+}, Date.parse('2026-06-11T09:40:00Z')), { key: 'late', label: 'С опозданием' },
+    'cutCalendarStatus: финиш позже дедлайна → с опозданием');
+
+assertEqual(calendar.cutCalendarStatus({
+    planDate: '2026-06-11 08:00', startDate: '2026-06-11 08:05',
+    endDate: '', duration: 60, status: '1'
+}, Date.parse('2026-06-11T08:30:00Z')), { key: 'unfinished', label: 'Не завершено' },
+    'cutCalendarStatus: непустой статус резки → не завершено');
+
+// ── cutCalendarItem: плашка по факт. старту/финишу + статус по дедлайну ──
+var dayRange = calendar.calendarRange('2026-06-11', 'day');
+var item = calendar.cutCalendarItem({
+    id: 'calendar-1', number: '2026-06-11 08:00', slitter: { id: '101', label: 'Станок 1' },
+    materialName: 'MR194', planDate: '2026-06-11 08:00',
+    startDate: '2026-06-11 08:05', endDate: '2026-06-11 09:05', duration: 60, status: ''
+}, dayRange, Date.parse('2026-06-11T09:10:00Z'));
+assertEqual({
+    cutId: item.cutId, leftPct: item.leftPct, widthPct: item.widthPct, status: item.status.key
+}, { cutId: 'calendar-1', leftPct: 33.681, widthPct: 4.167, status: 'late' },
+    'cutCalendarItem: плашка по факт. старту/финишу, статус по дедлайну');
+
+// ── machineCalendarGroups: станки в строки, простаивающие тоже видны ──
+var groups = calendar.machineCalendarGroups(
+    [{ id: '10', planDate: '2026-06-11 08:00', startDate: '2026-06-11 08:00',
+       endDate: '2026-06-11 09:00', duration: 60, status: '',
+       slitter: { id: '101', label: 'Станок 1' } }],
+    [{ id: '101', label: 'Станок 1' }, { id: '102', label: 'Станок 2' }],
+    dayRange, Date.parse('2026-06-11T12:00:00Z'), {});
+assertEqual(groups.map(function(g) { return { label: g.slitter.label, cuts: g.items.length }; }),
+    [{ label: 'Станок 1', cuts: 1 }, { label: 'Станок 2', cuts: 0 }],
+    'machineCalendarGroups: простаивающий станок показан пустой строкой');
+
+// ── фильтр по станку ──
+var filtered = calendar.machineCalendarGroups(
+    [{ id: '10', planDate: '2026-06-11 08:00', startDate: '2026-06-11 08:00',
+       endDate: '2026-06-11 09:00', duration: 60, status: '',
+       slitter: { id: '101', label: 'Станок 1' } }],
+    [{ id: '101', label: 'Станок 1' }, { id: '102', label: 'Станок 2' }],
+    dayRange, Date.parse('2026-06-11T12:00:00Z'), { slitter: '101' });
+assertEqual(filtered.map(function(g) { return g.slitter.label; }), ['Станок 1'],
+    'machineCalendarGroups: фильтр по станку оставляет один станок');
+
+console.log('\n' + passed + ' assertions passed');

--- a/templates/atex/machine-calendar.html
+++ b/templates/atex/machine-calendar.html
@@ -1,0 +1,14 @@
+<!-- Рабочее место atex «Календарь занятости станков» (роли Руководитель, Диспетчер). -->
+<!-- Решение ideav/crm#3339. Календарь вынесен из «Планирования производства» -->
+<!-- (#3334/#3335, откат #3338) в отдельное полноэкранное РМ. URL: /atex/machine-calendar -->
+<link rel="stylesheet" href="/download/{_global_.z}/css/atex-brand.css?0{_global_.version}">
+<link rel="stylesheet" href="/download/{_global_.z}/css/machine-calendar.css?0{_global_.version}">
+<div id="atex-machine-calendar"
+     class="atex-mc atex-brand"
+     data-db="{_global_.z}"
+     data-xsrf="{_global_.xsrf}"
+     data-user="{_global_.user}">
+    <div class="atex-mc-loading">Загрузка календаря занятости станков…</div>
+</div>
+<script src="/download/{_global_.z}/js/ref-search.js?0{_global_.version}" defer></script>
+<script src="/download/{_global_.z}/js/machine-calendar.js?0{_global_.version}" defer></script>


### PR DESCRIPTION
Closes #3339

## Контекст
Календарь занятости станков добавляли в «Планирование производства» (#3334/#3335), затем откатили (#3338). По #3339 он вынесен в **отдельное полноэкранное рабочее место** и открывается ролям **Руководитель** и **Диспетчер** с пунктом в меню.

## Что сделано (код)
Новое РМ `/atex/machine-calendar` «Календарь занятости станков»:
- **`templates/atex/machine-calendar.html`** — шаблон, полноэкранный контейнер.
- **`download/atex/js/machine-calendar.js`** — самостоятельный контроллер по образцу `dashboards.js` (только чтение). Данные одним отчётом `report/cut_planning` (резки: план/факт старт-финиш, станок, статус, длительность) + справочник станков `object/{slitter}` (чтобы видеть простаивающие станки; при отсутствии прав станки берутся из самих резок). Чистое ядро (интервалы день/3 дня/неделя/месяц, статусы по факт. финишу и дедлайну, раскладка резок по дорожкам) перенесено из `production-planning` и экспортируется для тестов.
- **`download/atex/css/machine-calendar.css`** — полноэкранная вёрстка + перенос стилей календаря (`.atex-pp-cal*`) и переменных, тёмная тема, sticky-шкала.
- **`docs/atex_menu.json`** — пункт «Календарь занятости станков» ролям Администратор, Диспетчер, Руководитель (`href: machine-calendar`).

Удобство: фильтр по станку, кнопки «Сегодня»/«Обновить», параллельные резки раскладываются по дорожкам, простаивающие станки — пустыми строками.

Маппинги в `update.conf` — wildcard (`templates/atex/*`, `download/atex/{js,css}/*`), новые файлы деплоятся автоматически.

## Проверка
- `node experiments/atex-machine-calendar.test.js` — **9 assertions passed**
- `node --check download/atex/js/machine-calendar.js`
- Playwright (`experiments/atex-machine-calendar.harness.html`): режимы день/неделя, цвета статусов, дорожки, простаивающий станок, тёмная тема.

## Отдельно (по API на боевой ateh, вне этого PR)
- Записи меню (таблица 151) ролям Руководитель (1615) и Диспетчер (1619): `name=Календарь занятости станков`, `href=machine-calendar`.
- Гранты READ на цепочку `cut_planning` для Руководителя (у Диспетчера уже есть).
- Деплой через `update.php`.