### PR TITLE
fix(atex): linked positions clear, shift open detection, compact week-grid calendar (#3347 #3348 #3349)

### DIFF
--- a/download/atex/css/machine-calendar.css
+++ b/download/atex/css/machine-calendar.css
@@ -298,6 +298,91 @@
     font-size: 12px;
 }
 
+/* #3347: Компактная сетка недель (week / month режимы). */
+.atex-mc-grid {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    width: 100%;
+    gap: 3px;
+    padding: 4px;
+    box-sizing: border-box;
+}
+
+.atex-mc-week-labels {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 3px;
+}
+.atex-mc-day-label {
+    padding: 4px 2px;
+    text-align: center;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--pp-muted);
+}
+
+.atex-mc-week {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: 3px;
+    flex: 1 1 0;
+    min-height: 64px;
+}
+
+.atex-mc-day {
+    display: flex;
+    flex-direction: column;
+    min-height: 64px;
+    padding: 5px 6px 4px;
+    border: 1px solid var(--pp-border-soft);
+    border-radius: 5px;
+    background: var(--pp-bg);
+    cursor: pointer;
+    transition: background .12s;
+    overflow: hidden;
+}
+.atex-mc-day:hover { background: var(--pp-surface); }
+.atex-mc-day.is-today { border-color: var(--pp-accent); }
+.atex-mc-day.has-cuts { background: color-mix(in srgb, var(--pp-cal-planned) 5%, var(--pp-bg)); }
+.atex-mc-day--empty { cursor: default; background: transparent; border-color: transparent; }
+.atex-mc-day--empty:hover { background: transparent; }
+
+.atex-mc-day-num {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--pp-muted);
+    line-height: 1;
+    margin-bottom: 5px;
+    flex: 0 0 auto;
+}
+.atex-mc-day.is-today .atex-mc-day-num { color: var(--pp-accent); }
+
+.atex-mc-day-cuts {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    align-content: flex-start;
+    flex: 1 1 auto;
+}
+
+.atex-mc-cut-block {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: var(--pp-cal-unknown);
+    flex: 0 0 auto;
+    cursor: pointer;
+}
+.atex-mc-cut-block.is-planned { background: var(--pp-cal-planned); }
+.atex-mc-cut-block.is-running { background: var(--pp-cal-running); }
+.atex-mc-cut-block.is-unfinished { background: var(--pp-cal-unfinished); }
+.atex-mc-cut-block.is-on-time,
+.atex-mc-cut-block.is-done { background: var(--pp-cal-ok); }
+.atex-mc-cut-block.is-late,
+.atex-mc-cut-block.is-late-start { background: var(--pp-cal-late); }
+
 @media (max-width: 920px) {
     .atex-pp-cal-head { grid-template-columns: 1fr; }
     .atex-pp-cal-title { font-size: 16px; }

--- a/download/atex/js/machine-calendar.js
+++ b/download/atex/js/machine-calendar.js
@@ -631,7 +631,22 @@
             el('span', { class: 'atex-pp-cal-legend-item is-late', text: 'С опозданием' })
         ]));
 
-        // ── Сетка станков ──
+        // ── Тело: компактная сетка недель (day/three → тайминг; week/month → сетка) ──
+        // #3347: режимы week и month показывают компактную сетку дней по неделям;
+        // режим day — подробный тайминг. Клик по ячейке дня переключает в day-режим.
+        var scroll = el('div', { class: 'atex-pp-cal-scroll atex-mc-scroll' });
+        if (st.mode === 'day' || st.mode === 'three') {
+            scroll.appendChild(this._buildTimelineBody(range, nowMs));
+        } else {
+            scroll.appendChild(this._buildWeekGrid(range, nowMs));
+        }
+        this.root.appendChild(scroll);
+    };
+
+    // Горизонтальный тайминг (day / three): станки строками, время по горизонтали.
+    AtexMachineCalendar.prototype._buildTimelineBody = function(range, nowMs) {
+        var self = this;
+        var st = this.state;
         var groups = machineCalendarGroups(this.cuts, this.slitters, range, nowMs, {
             status: st.status, slitter: st.slitter
         });
@@ -653,7 +668,6 @@
             track.appendChild(endTick);
         }
 
-        var scroll = el('div', { class: 'atex-pp-cal-scroll atex-mc-scroll' });
         var body = el('div', { class: 'atex-pp-cal-body atex-pp-cal-body--' + range.mode });
         var scaleRow = el('div', { class: 'atex-pp-cal-row atex-pp-cal-scale-row' });
         scaleRow.appendChild(el('div', { class: 'atex-pp-cal-machine atex-pp-cal-machine--scale', text: 'Станок' }));
@@ -698,12 +712,92 @@
                 body.appendChild(row);
             });
         }
-        scroll.appendChild(body);
-        this.root.appendChild(scroll);
 
         if (!totalItems) {
-            this.root.appendChild(el('div', { class: 'atex-pp-cal-note', text: 'На выбранном интервале резок нет' }));
+            body.appendChild(el('div', { class: 'atex-pp-cal-note', text: 'На выбранном интервале резок нет' }));
         }
+        return body;
+    };
+
+    // #3347: Компактная сетка недель: строки = недели, ячейки = дни.
+    // Все станки в одной ячейке; резки — цветные блоки без подписей (подпись в title).
+    // Клик по дню → переключение в day-режим с тайм-линией для этого дня.
+    AtexMachineCalendar.prototype._buildWeekGrid = function(range, nowMs) {
+        var self = this;
+        var st = this.state;
+        var todayIso = todayISO();
+
+        // Все группы без фильтра статуса, с фильтром станка если выбран.
+        var groups = machineCalendarGroups(this.cuts, this.slitters, range, nowMs, { slitter: st.slitter });
+
+        // Карта: isoDay → [{cut, slitter}] — все резки, захватывающие данный день.
+        var dayCutsMap = {};
+        groups.forEach(function(group) {
+            group.cuts.forEach(function(cut) {
+                var tr = cutCalendarTimeRange(cut);
+                if (!tr) return;
+                range.days.forEach(function(day) {
+                    var dayMs = parseCalendarDateTimeMs(day.iso);
+                    if (dayMs == null) return;
+                    if (tr.endMs > dayMs && tr.startMs < dayMs + CALENDAR_DAY_MS) {
+                        if (!dayCutsMap[day.iso]) dayCutsMap[day.iso] = [];
+                        dayCutsMap[day.iso].push({ cut: cut, slitter: group.slitter });
+                    }
+                });
+            });
+        });
+
+        // Разбить дни на недели ≤7.
+        var days = range.days;
+        var weeks = [];
+        for (var i = 0; i < days.length; i += 7) {
+            weeks.push(days.slice(i, Math.min(i + 7, days.length)));
+        }
+
+        var grid = el('div', { class: 'atex-mc-grid' });
+
+        // Заголовок дней недели — только если показываем полные недели.
+        if (range.mode === 'week' || range.mode === 'month') {
+            var DOW = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Вс'];
+            var labelsRow = el('div', { class: 'atex-mc-week-labels' });
+            DOW.forEach(function(d) { labelsRow.appendChild(el('div', { class: 'atex-mc-day-label', text: d })); });
+            grid.appendChild(labelsRow);
+        }
+
+        weeks.forEach(function(week) {
+            var weekEl = el('div', { class: 'atex-mc-week' });
+            week.forEach(function(day) {
+                var entries = dayCutsMap[day.iso] || [];
+                var cls = 'atex-mc-day';
+                if (day.iso === todayIso) cls += ' is-today';
+                if (entries.length) cls += ' has-cuts';
+                var dayEl = el('div', { class: cls });
+                dayEl.appendChild(el('div', { class: 'atex-mc-day-num', text: day.label }));
+                if (entries.length) {
+                    var cutsEl = el('div', { class: 'atex-mc-day-cuts' });
+                    entries.forEach(function(entry) {
+                        var tr = cutCalendarTimeRange(entry.cut);
+                        var status = cutCalendarStatus(entry.cut, nowMs);
+                        var titleText = entry.slitter.label + '\n' + cutCalendarItemTitle(entry.cut, tr || {}, status);
+                        cutsEl.appendChild(el('span', { class: 'atex-mc-cut-block is-' + status.key, title: titleText }));
+                    });
+                    dayEl.appendChild(cutsEl);
+                }
+                dayEl.addEventListener('click', function() {
+                    self.state.anchor = day.iso;
+                    self.state.mode = 'day';
+                    self.render();
+                });
+                weekEl.appendChild(dayEl);
+            });
+            // Добиваем неполные недели до 7 пустыми ячейками.
+            for (var p = week.length; p < 7; p++) {
+                weekEl.appendChild(el('div', { class: 'atex-mc-day atex-mc-day--empty' }));
+            }
+            grid.appendChild(weekEl);
+        });
+
+        return grid;
     };
 
     AtexMachineCalendar.prototype.setBusy = function(on) {
@@ -752,4 +846,4 @@
 
 //
 //
-// @version 2026-06-11-issue-3339
+// @version 2026-06-12-issue-3347

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5393,7 +5393,9 @@
         var dateFilter = el('input', { class: 'atex-pp-input', type: 'date', value: this.filter.date || '' });
         dateFilter.addEventListener('change', function() {
             self.filter.date = dateFilter.value;
+            self.selectedCutId = null;   // #3349: очищать панель «Связанные позиции»
             self.renderQueue();
+            self.renderLink();
         });
         filters.appendChild(field('Дата плана', dateFilter));
         filters.appendChild(field('Статус', statusFilter));

--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -825,7 +825,7 @@
             return {
                 id: String(rec.i),
                 when: r[0] || '',
-                type: typeIdx >= 0 ? (r[typeIdx] || '') : '',
+                type: typeIdx >= 0 ? (parseRef(r[typeIdx]).label || '') : '',  // #3348: тип — ссылка «id:Начало смены»
                 cutId: cutId || null,
                 userId: userRef.id,
                 user: userRef.label,


### PR DESCRIPTION
## Summary

Fixes three open issues in one PR.

### #3349 — `production-planning.html`: очищать «Связанные позиции» при смене «Дата плана»
`renderQueue` при изменении фильтра даты теперь сбрасывает `selectedCutId` и перерисовывает панель `renderLink()`. Раньше после смены даты в панели справа оставались позиции резки, которая уже не видна в очереди.

### #3348 — `slitter.html`: не вижу открытой смены
В `parseEventRows` поле `type` читалось как raw-строка `"54237:Начало смены"`, которую `isShiftStartType` не распознавал (сравнивает с `"начало смены"`). Теперь применяется `parseRef(r[typeIdx]).label`, так же как для других ref-полей в том же методе.

### #3347 — Изменения структуры календаря
`machine-calendar.js` + `machine-calendar.css`:
- Для режимов `week` / `month` — новый компактный вид **_buildWeekGrid**: строки = недели (≤7 дней), ячейки = дни, все станки в одной ячейке, резки — цветные блоки без подписей (подпись в `title`).
- Для режимов `day` / `three` — прежний горизонтальный тайминг (**_buildTimelineBody**, код вынесен из `render`).
- Клик по ячейке дня переключает в `day`-режим с таймлайном конкретного дня.
- Сетка занимает всю доступную ширину и высоту (`flex: 1 1 auto`).

## Test plan

- [ ] **#3348**: открыть «Пульт слиттера», выбрать станок, нажать «Открыть смену» → смена отображается как открытая, кнопка «Открыть» пропадает
- [ ] **#3349**: в «Планировании производства» выбрать резку → в правой панели появятся «Связанные позиции»; сменить «Дата плана» → панель очищается
- [ ] **#3347**: зайти в «Календарь занятости станков» → в режиме «Неделя» отображается сетка 7 дней с цветными блоками; клик по дню → переход в детальный таймлайн дня

🤖 Generated with [Claude Code](https://claude.com/claude-code)