### PR TITLE
fix(atex): slitter planDate fallback to row[0] (#3352)

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -729,7 +729,10 @@
                     slitter: slitterRef.label,
                     batchId: batchRef.id,
                     batch: batchRef.label,
-                    planDate: planDateIdx >= 0 ? (row[planDateIdx] || '') : '',
+                    // #3352: главное значение резки (row[0]) = «Дата план»;
+                    // если colIndex не нашёл реквизит — берём row[0], иначе
+                    // prepareCutQueue отфильтрует все резки по пустой дате.
+                    planDate: (planDateIdx >= 0 ? row[planDateIdx] : null) || row[0] || '',
                     sequence: sequenceIdx >= 0 ? row[sequenceIdx] : '',
                     plannedRuns: plannedRunsIdx >= 0 ? row[plannedRunsIdx] : '',
                     runLength: runLengthIdx >= 0 ? row[runLengthIdx] : '',


### PR DESCRIPTION
## Summary

Fixes [#3352](https://github.com/ideav/crm/issues/3352) — «Пульт слиттера: резок нет после открытия смены».

### Root cause

`loadCuts` в `slitter.js` вычисляет индекс колонки «Дата план» через `colIndex(meta, 'Дата план')`. Когда «Дата план» является **главным значением** таблицы, а не обычным реквизитом, это поле отсутствует в `meta.reqs`, и `colIndex` возвращает `-1`. В итоге:

```js
planDate: planDateIdx >= 0 ? (row[planDateIdx] || '') : ''
//                                            ^^^^ всегда '', planDateIdx === -1
```

`prepareCutQueue` затем сравнивает `dateKey('') === Infinity` с выбранной датой — несовпадение, и все резки отфильтровываются. Именно поэтому после фикса детекции открытой смены (#3351 / #3348) пользователь видит «Резок пока нет».

### Fix

В `loadCuts` добавлен fallback на `row[0]` (главное значение JSON_OBJ = Unix-штамп плановой даты):

```js
planDate: (planDateIdx >= 0 ? row[planDateIdx] : null) || row[0] || '',
```

Когда реквизит найден и значение непустое — используется он. Иначе берётся `row[0]`, которое всегда содержит правильный штамп.

## Test plan

- [ ] Открыть «Пульт слиттера», выбрать станок и дату → резки для выбранного дня отображаются в списке
- [ ] Выбрать другую дату → список меняется / пуст для дней без плана
- [ ] Открыть смену → переход к списку резок работает

🤖 Generated with [Claude Code](https://claude.com/claude-code)