### PR TITLE
fix(ui): хранить настройки интерфейса в localStorage вместо cookie (HTTP 400 — раздутый Cookie)

### DIFF
--- a/js/dash.js
+++ b/js/dash.js
@@ -3629,22 +3629,44 @@ function dashIsResizableChartViz(vizType) {
     return !!vizType && vizType !== 'table' && vizType !== 'pivot';
 }
 
+// Dashboard view state (tile display mode, chart/table sizes) is kept in
+// localStorage, not cookies, so it is not sent to the server on every request.
+// A legacy cookie of the same name is migrated to localStorage on first read
+// and then deleted. (Function names keep the "Cookie" suffix for call sites.)
 function dashCookieGet(name) {
-    var escaped, match;
-    if (typeof document === 'undefined' || !document.cookie) return '';
-    escaped = String(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
-    return match ? decodeURIComponent(match[1]) : '';
+    if (typeof document === 'undefined') return '';
+    var legacy = null, escaped, match;
+    if (document.cookie) {
+        escaped = String(name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        match = document.cookie.match(new RegExp('(?:^|; )' + escaped + '=([^;]*)'));
+        if (match) legacy = decodeURIComponent(match[1]);
+    }
+    try {
+        if (legacy !== null) {
+            if (localStorage.getItem(name) === null && legacy !== '') localStorage.setItem(name, legacy);
+            document.cookie = String(name) + '=; path=/; max-age=0';
+        }
+        var v = localStorage.getItem(name);
+        return v === null ? '' : v;
+    } catch (e) {
+        return legacy === null ? '' : legacy;
+    }
 }
 
 function dashCookieSet(name, value, maxAge) {
     if (typeof document === 'undefined') return;
-    document.cookie = String(name) + '=' + encodeURIComponent(String(value))
-        + '; path=/; max-age=' + String(maxAge || DASH_CHART_RESIZE_COOKIE_MAX_AGE);
+    try {
+        localStorage.setItem(String(name), String(value));
+        if (document.cookie.indexOf(String(name) + '=') !== -1) document.cookie = String(name) + '=; path=/; max-age=0';
+    } catch (e) {
+        document.cookie = String(name) + '=' + encodeURIComponent(String(value))
+            + '; path=/; max-age=' + String(maxAge || DASH_CHART_RESIZE_COOKIE_MAX_AGE);
+    }
 }
 
 function dashCookieRemove(name) {
     if (typeof document === 'undefined') return;
+    try { localStorage.removeItem(String(name)); } catch (e) { /* ignore */ }
     document.cookie = String(name) + '=; path=/; max-age=0';
 }
 

--- a/js/hints.js
+++ b/js/hints.js
@@ -20,26 +20,35 @@
 (function() {
     'use strict';
 
+    // Hints state (hints_mode, hints_seen_workspaces) is kept in localStorage,
+    // not cookies, so it is not sent to the server on every request. A legacy
+    // cookie of the same name is migrated on first read and then deleted.
     function getCookie(name) {
+        var legacy = null;
         var prefix = name + '=';
-        var parts = document.cookie.split(';');
+        var parts = document.cookie ? document.cookie.split(';') : [];
         for (var i = 0; i < parts.length; i++) {
             var part = parts[i].trim();
-            if (part.indexOf(prefix) === 0) {
-                return decodeURIComponent(part.substring(prefix.length));
-            }
+            if (part.indexOf(prefix) === 0) { legacy = decodeURIComponent(part.substring(prefix.length)); break; }
         }
-        return null;
+        try {
+            if (legacy !== null) {
+                if (localStorage.getItem(name) === null && legacy !== '') localStorage.setItem(name, legacy);
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+            return localStorage.getItem(name);
+        } catch (e) {
+            return legacy;
+        }
     }
 
-    function setCookie(name, value, days) {
-        var expires = '';
-        if (days) {
-            var d = new Date();
-            d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
-            expires = '; expires=' + d.toUTCString();
+    function setCookie(name, value) {
+        try {
+            localStorage.setItem(name, value);
+            if (document.cookie.indexOf(name + '=') !== -1) document.cookie = name + '=; path=/; max-age=0';
+        } catch (e) {
+            document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000';
         }
-        document.cookie = name + '=' + encodeURIComponent(value) + expires + '; path=/';
     }
 
     /**

--- a/js/info.js
+++ b/js/info.js
@@ -14,36 +14,53 @@
 
     // ── Cookie helpers ──────────────────────────────────────────────────────
 
-    function setCookie(name, value, days) {
-        var expires = '';
-        if (days) {
-            var d = new Date();
-            d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
-            expires = '; expires=' + d.toUTCString();
+    // Info-page state (info_active_tab, info_forms_desc_hidden) and hints state
+    // (hints_mode, hints_seen_workspaces) are kept in localStorage, not cookies,
+    // so they are not sent to the server on every request. A legacy cookie of the
+    // same name is migrated on first read and then deleted.
+    function setCookie(name, value) {
+        try {
+            localStorage.setItem(name, value);
+            if (document.cookie.indexOf(name + '=') !== -1) document.cookie = name + '=; path=/; max-age=0';
+        } catch (e) {
+            document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000';
         }
-        document.cookie = name + '=' + encodeURIComponent(value) + expires + '; path=/';
     }
 
     function getCookie(name) {
+        var legacy = null;
         var prefix = name + '=';
-        var parts = document.cookie.split(';');
+        var parts = document.cookie ? document.cookie.split(';') : [];
         for (var i = 0; i < parts.length; i++) {
             var part = parts[i].trim();
-            if (part.indexOf(prefix) === 0) {
-                return decodeURIComponent(part.substring(prefix.length));
-            }
+            if (part.indexOf(prefix) === 0) { legacy = decodeURIComponent(part.substring(prefix.length)); break; }
         }
-        return null;
+        try {
+            if (legacy !== null) {
+                if (localStorage.getItem(name) === null && legacy !== '') localStorage.setItem(name, legacy);
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+            return localStorage.getItem(name);
+        } catch (e) {
+            return legacy;
+        }
     }
 
+    // Clear keys matching prefix…suffix from both localStorage and any legacy cookies.
     function deleteCookiesByMask(prefix, suffix) {
-        var parts = document.cookie.split(';');
+        var parts = document.cookie ? document.cookie.split(';') : [];
         parts.forEach(function(part) {
             var name = part.trim().split('=')[0];
             if (name.indexOf(prefix) === 0 && name.slice(-suffix.length) === suffix) {
                 document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
             }
         });
+        try {
+            for (var i = localStorage.length - 1; i >= 0; i--) {
+                var k = localStorage.key(i);
+                if (k && k.indexOf(prefix) === 0 && k.slice(-suffix.length) === suffix) localStorage.removeItem(k);
+            }
+        } catch (e) { /* ignore */ }
     }
 
     // ── Owner check ──────────────────────────────────────────────────────────

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -9443,11 +9443,11 @@ class IntegramTable{
         }
 
         resetSettings() {
-            // Delete settings cookie
-            document.cookie = `${ this.options.cookiePrefix }-settings=; path=/; max-age=0`;
+            // Clear saved settings
+            itStorageRemove(`${ this.options.cookiePrefix }-settings`);
 
-            // Delete state cookie (column order, visibility, widths)
-            document.cookie = `${ this.options.cookiePrefix }-state=; path=/; max-age=0`;
+            // Clear saved column state (order, visibility, widths)
+            itStorageRemove(`${ this.options.cookiePrefix }-state`);
 
             // Reset to defaults
             this.settings = {
@@ -10674,7 +10674,7 @@ class IntegramTable{
         }
 
         saveColumnState() {
-            // Skip saving to cookies if config was loaded from URL (issue #514)
+            // Skip saving if config was loaded from URL (issue #514)
             // User can still copy current config as a shareable URL
             if (this.configFromUrl) {
                 return;
@@ -10685,16 +10685,14 @@ class IntegramTable{
                 visible: this.visibleColumns,
                 widths: this.columnWidths
             };
-            document.cookie = `${ this.options.cookiePrefix }-state=${ JSON.stringify(state) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-state`, JSON.stringify(state));
         }
 
         loadColumnState() {
-            const cookies = document.cookie.split(';');
-            const stateCookie = cookies.find(c => c.trim().startsWith(`${ this.options.cookiePrefix }-state=`));
-
-            if (stateCookie) {
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-state`);
+            if (raw) {
                 try {
-                    const state = JSON.parse(stateCookie.split('=')[1]);
+                    const state = JSON.parse(raw);
                     this.columnOrder = state.order || [];
                     this.visibleColumns = state.visible || [];
                     this.columnWidths = state.widths || {};
@@ -10714,22 +10712,21 @@ class IntegramTable{
                 hideMenuButtonLabels: this.settings.hideMenuButtonLabels,
                 showReferences: this.settings.showReferences,
             };
-            document.cookie = `${ this.options.cookiePrefix }-settings=${ JSON.stringify(settings) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-settings`, JSON.stringify(settings));
 
             // Save global compact setting if "For All" is checked
             if (this.settings.compactForAll) {
                 const globalSettings = { compact: this.settings.compact };
-                document.cookie = `integram-table-global-settings=${ JSON.stringify(globalSettings) }; path=/; max-age=31536000`;
+                itStorageSet('integram-table-global-settings', JSON.stringify(globalSettings));
             }
         }
 
         loadSettings() {
-            const cookies = document.cookie.split(';');
-            const settingsCookie = cookies.find(c => c.trim().startsWith(`${ this.options.cookiePrefix }-settings=`));
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-settings`);
 
-            if (settingsCookie) {
+            if (raw) {
                 try {
-                    const settings = JSON.parse(settingsCookie.split('=')[1]);
+                    const settings = JSON.parse(raw);
                     this.settings.compact = settings.compact !== undefined ? settings.compact : false;
                     this.settings.compactForAll = settings.compactForAll !== undefined ? settings.compactForAll : true;
                     this.settings.pageSize = settings.pageSize || 20;
@@ -10745,10 +10742,10 @@ class IntegramTable{
                 }
             } else {
                 // No table-specific settings found, try to load global compact setting
-                const globalSettingsCookie = cookies.find(c => c.trim().startsWith('integram-table-global-settings='));
-                if (globalSettingsCookie) {
+                const globalRaw = itStorageGet('integram-table-global-settings');
+                if (globalRaw) {
                     try {
-                        const globalSettings = JSON.parse(globalSettingsCookie.split('=')[1]);
+                        const globalSettings = JSON.parse(globalRaw);
                         if (globalSettings.compact !== undefined) {
                             this.settings.compact = globalSettings.compact;
                         }
@@ -15958,19 +15955,14 @@ class IntegramTable{
         }
 
         saveFormFieldVisibility(typeId, visibility) {
-            const cookieName = `${ this.options.cookiePrefix }-form-fields-${ typeId }`;
-            document.cookie = `${ cookieName }=${ JSON.stringify(visibility) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-form-fields-${ typeId }`, JSON.stringify(visibility));
         }
 
         loadFormFieldVisibility(typeId) {
-            const cookieName = `${ this.options.cookiePrefix }-form-fields-${ typeId }`;
-            const cookies = document.cookie.split(';');
-            const fieldsCookie = cookies.find(c => c.trim().startsWith(`${ cookieName }=`));
-
-            if (fieldsCookie) {
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-form-fields-${ typeId }`);
+            if (raw) {
                 try {
-                    const visibility = JSON.parse(fieldsCookie.split('=')[1]);
-                    return visibility;
+                    return JSON.parse(raw);
                 } catch (error) {
                     console.error('Error parsing form field visibility settings:', error);
                     return {};
@@ -15981,17 +15973,14 @@ class IntegramTable{
         }
 
         saveFormFieldOrder(typeId, order) {
-            const cookieName = `${ this.options.cookiePrefix }-form-order-${ typeId }`;
-            document.cookie = `${ cookieName }=${ JSON.stringify(order) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-form-order-${ typeId }`, JSON.stringify(order));
         }
 
         loadFormFieldOrder(typeId) {
-            const cookieName = `${ this.options.cookiePrefix }-form-order-${ typeId }`;
-            const cookies = document.cookie.split(';');
-            const cookie = cookies.find(c => c.trim().startsWith(`${ cookieName }=`));
-            if (cookie) {
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-form-order-${ typeId }`);
+            if (raw) {
                 try {
-                    return JSON.parse(cookie.split('=')[1]);
+                    return JSON.parse(raw);
                 } catch (e) {
                     return [];
                 }
@@ -16743,16 +16732,13 @@ class IntegramTable{
         }
 
         saveFormShowDelete(typeId, show) {
-            const cookieName = `${ this.options.cookiePrefix }-form-show-delete-${ typeId }`;
-            document.cookie = `${ cookieName }=${ show ? '1' : '0' }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-form-show-delete-${ typeId }`, show ? '1' : '0');
         }
 
         loadFormShowDelete(typeId) {
-            const cookieName = `${ this.options.cookiePrefix }-form-show-delete-${ typeId }`;
-            const cookies = document.cookie.split(';');
-            const cookie = cookies.find(c => c.trim().startsWith(`${ cookieName }=`));
-            if (cookie) {
-                return cookie.split('=')[1].trim() === '1';
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-form-show-delete-${ typeId }`);
+            if (raw !== null) {
+                return raw.trim() === '1';
             }
             return false; // Hidden by default
         }
@@ -18519,6 +18505,99 @@ class IntegramTable{
 if (typeof window !== 'undefined') {
     window._integramTableInstances = window._integramTableInstances || [];
 }
+
+// ── UI-settings persistence ──────────────────────────────────────────────
+// View preferences (column order/visibility/width, table settings, form-field
+// visibility/order, card layout) live in localStorage, not cookies. As cookies
+// they were attached to every request to the whole ideav.ru origin and grew
+// without bound — one entry per table and per database ever opened — until the
+// combined Cookie header passed Apache's LimitRequestFieldSize and the server
+// answered HTTP 400 ("Size of a request header field exceeds server limit") to
+// every page on the domain. localStorage is never sent to the server.
+//
+// On first read of a key, any pre-existing cookie of the same name is copied
+// into localStorage and then deleted, so saved preferences carry over and the
+// bloated cookies clear themselves as the user navigates.
+
+function itStorageGet(name) {
+    let legacy = null;
+    if (typeof document !== 'undefined' && document.cookie) {
+        const parts = document.cookie.split(';');
+        for (let i = 0; i < parts.length; i++) {
+            const p = parts[i].trim();
+            if (p.indexOf(name + '=') === 0) { legacy = p.slice(name.length + 1); break; }
+        }
+    }
+    try {
+        if (legacy !== null) {
+            if (localStorage.getItem(name) === null && legacy !== '') {
+                localStorage.setItem(name, legacy);
+            }
+            // Drop the legacy cookie to free request-header space.
+            document.cookie = name + '=; path=/; max-age=0';
+        }
+        return localStorage.getItem(name);
+    } catch (e) {
+        // localStorage unavailable (private mode/quota) — fall back to the cookie value.
+        return legacy;
+    }
+}
+
+function itStorageSet(name, value) {
+    try {
+        localStorage.setItem(name, value);
+        // Remove any stale cookie of the same name so it stops inflating headers.
+        if (typeof document !== 'undefined' && document.cookie.indexOf(name + '=') !== -1) {
+            document.cookie = name + '=; path=/; max-age=0';
+        }
+    } catch (e) {
+        // localStorage unavailable — last-resort cookie so the setting still persists.
+        try { document.cookie = name + '=' + value + '; path=/; max-age=31536000'; } catch (e2) { /* ignore */ }
+    }
+}
+
+function itStorageRemove(name) {
+    try { localStorage.removeItem(name); } catch (e) { /* ignore */ }
+    try { document.cookie = name + '=; path=/; max-age=0'; } catch (e) { /* ignore */ }
+}
+
+// One-time sweep on script load: move every legacy UI-settings cookie into
+// localStorage and delete it, so the Cookie header shrinks on the next page
+// load even for tables the user does not reopen this session. Only names that
+// match the component's own patterns are touched; integram-table-font-settings
+// is shared with main.html (read there as a cookie) and is left in place.
+function itMigrateLegacyUiCookies() {
+    if (typeof document === 'undefined' || !document.cookie) return;
+    if (typeof window !== 'undefined') {
+        if (window.__itUiCookiesMigrated) return;
+        window.__itUiCookiesMigrated = true;
+    }
+    const isUiKey = function(name) {
+        if (name === 'integram-table-font-settings') return false;
+        return /-state$/.test(name)
+            || /-settings$/.test(name)
+            || /-form-fields-/.test(name)
+            || /-form-order-/.test(name)
+            || /-form-show-delete-/.test(name);
+    };
+    const parts = document.cookie.split(';');
+    for (let i = 0; i < parts.length; i++) {
+        const p = parts[i].trim();
+        const eq = p.indexOf('=');
+        if (eq <= 0) continue;
+        const name = p.slice(0, eq);
+        if (!isUiKey(name)) continue;
+        const value = p.slice(eq + 1);
+        try {
+            if (localStorage.getItem(name) === null && value !== '') {
+                localStorage.setItem(name, value);
+            }
+        } catch (e) { /* ignore */ }
+        document.cookie = name + '=; path=/; max-age=0';
+    }
+}
+
+itMigrateLegacyUiCookies();
 
 function parseIntegramAttrs(attrs) {
     const result = {
@@ -20850,21 +20929,17 @@ class IntegramCreateFormHelper {
      * Save form field visibility settings (issue #837).
      */
     saveFormFieldVisibilityStandalone(typeId, visibility) {
-        const cookieName = `integram-table-form-fields-${typeId}`;
-        document.cookie = `${cookieName}=${JSON.stringify(visibility)}; path=/; max-age=31536000`;
+        itStorageSet(`integram-table-form-fields-${typeId}`, JSON.stringify(visibility));
     }
 
     /**
      * Load form field visibility settings (issue #837).
      */
     loadFormFieldVisibilityStandalone(typeId) {
-        const cookieName = `integram-table-form-fields-${typeId}`;
-        const cookies = document.cookie.split(';');
-        const fieldsCookie = cookies.find(c => c.trim().startsWith(`${cookieName}=`));
-
-        if (fieldsCookie) {
+        const raw = itStorageGet(`integram-table-form-fields-${typeId}`);
+        if (raw) {
             try {
-                return JSON.parse(fieldsCookie.split('=')[1]);
+                return JSON.parse(raw);
             } catch (error) {
                 console.error('Error parsing form field visibility settings:', error);
                 return {};
@@ -20878,20 +20953,17 @@ class IntegramCreateFormHelper {
      * Save form field order settings (issue #837).
      */
     saveFormFieldOrderStandalone(typeId, order) {
-        const cookieName = `integram-table-form-order-${typeId}`;
-        document.cookie = `${cookieName}=${JSON.stringify(order)}; path=/; max-age=31536000`;
+        itStorageSet(`integram-table-form-order-${typeId}`, JSON.stringify(order));
     }
 
     /**
      * Load form field order settings (issue #837).
      */
     loadFormFieldOrderStandalone(typeId) {
-        const cookieName = `integram-table-form-order-${typeId}`;
-        const cookies = document.cookie.split(';');
-        const cookie = cookies.find(c => c.trim().startsWith(`${cookieName}=`));
-        if (cookie) {
+        const raw = itStorageGet(`integram-table-form-order-${typeId}`);
+        if (raw) {
             try {
-                return JSON.parse(cookie.split('=')[1]);
+                return JSON.parse(raw);
             } catch (e) {
                 return [];
             }

--- a/js/integram-table/12-table-settings.js
+++ b/js/integram-table/12-table-settings.js
@@ -192,11 +192,11 @@
         }
 
         resetSettings() {
-            // Delete settings cookie
-            document.cookie = `${ this.options.cookiePrefix }-settings=; path=/; max-age=0`;
+            // Clear saved settings
+            itStorageRemove(`${ this.options.cookiePrefix }-settings`);
 
-            // Delete state cookie (column order, visibility, widths)
-            document.cookie = `${ this.options.cookiePrefix }-state=; path=/; max-age=0`;
+            // Clear saved column state (order, visibility, widths)
+            itStorageRemove(`${ this.options.cookiePrefix }-state`);
 
             // Reset to defaults
             this.settings = {

--- a/js/integram-table/16-state.js
+++ b/js/integram-table/16-state.js
@@ -8,7 +8,7 @@
         }
 
         saveColumnState() {
-            // Skip saving to cookies if config was loaded from URL (issue #514)
+            // Skip saving if config was loaded from URL (issue #514)
             // User can still copy current config as a shareable URL
             if (this.configFromUrl) {
                 return;
@@ -19,16 +19,14 @@
                 visible: this.visibleColumns,
                 widths: this.columnWidths
             };
-            document.cookie = `${ this.options.cookiePrefix }-state=${ JSON.stringify(state) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-state`, JSON.stringify(state));
         }
 
         loadColumnState() {
-            const cookies = document.cookie.split(';');
-            const stateCookie = cookies.find(c => c.trim().startsWith(`${ this.options.cookiePrefix }-state=`));
-
-            if (stateCookie) {
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-state`);
+            if (raw) {
                 try {
-                    const state = JSON.parse(stateCookie.split('=')[1]);
+                    const state = JSON.parse(raw);
                     this.columnOrder = state.order || [];
                     this.visibleColumns = state.visible || [];
                     this.columnWidths = state.widths || {};
@@ -48,22 +46,21 @@
                 hideMenuButtonLabels: this.settings.hideMenuButtonLabels,
                 showReferences: this.settings.showReferences,
             };
-            document.cookie = `${ this.options.cookiePrefix }-settings=${ JSON.stringify(settings) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-settings`, JSON.stringify(settings));
 
             // Save global compact setting if "For All" is checked
             if (this.settings.compactForAll) {
                 const globalSettings = { compact: this.settings.compact };
-                document.cookie = `integram-table-global-settings=${ JSON.stringify(globalSettings) }; path=/; max-age=31536000`;
+                itStorageSet('integram-table-global-settings', JSON.stringify(globalSettings));
             }
         }
 
         loadSettings() {
-            const cookies = document.cookie.split(';');
-            const settingsCookie = cookies.find(c => c.trim().startsWith(`${ this.options.cookiePrefix }-settings=`));
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-settings`);
 
-            if (settingsCookie) {
+            if (raw) {
                 try {
-                    const settings = JSON.parse(settingsCookie.split('=')[1]);
+                    const settings = JSON.parse(raw);
                     this.settings.compact = settings.compact !== undefined ? settings.compact : false;
                     this.settings.compactForAll = settings.compactForAll !== undefined ? settings.compactForAll : true;
                     this.settings.pageSize = settings.pageSize || 20;
@@ -79,10 +76,10 @@
                 }
             } else {
                 // No table-specific settings found, try to load global compact setting
-                const globalSettingsCookie = cookies.find(c => c.trim().startsWith('integram-table-global-settings='));
-                if (globalSettingsCookie) {
+                const globalRaw = itStorageGet('integram-table-global-settings');
+                if (globalRaw) {
                     try {
-                        const globalSettings = JSON.parse(globalSettingsCookie.split('=')[1]);
+                        const globalSettings = JSON.parse(globalRaw);
                         if (globalSettings.compact !== undefined) {
                             this.settings.compact = globalSettings.compact;
                         }

--- a/js/integram-table/21-form-field-settings.js
+++ b/js/integram-table/21-form-field-settings.js
@@ -165,19 +165,14 @@
         }
 
         saveFormFieldVisibility(typeId, visibility) {
-            const cookieName = `${ this.options.cookiePrefix }-form-fields-${ typeId }`;
-            document.cookie = `${ cookieName }=${ JSON.stringify(visibility) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-form-fields-${ typeId }`, JSON.stringify(visibility));
         }
 
         loadFormFieldVisibility(typeId) {
-            const cookieName = `${ this.options.cookiePrefix }-form-fields-${ typeId }`;
-            const cookies = document.cookie.split(';');
-            const fieldsCookie = cookies.find(c => c.trim().startsWith(`${ cookieName }=`));
-
-            if (fieldsCookie) {
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-form-fields-${ typeId }`);
+            if (raw) {
                 try {
-                    const visibility = JSON.parse(fieldsCookie.split('=')[1]);
-                    return visibility;
+                    return JSON.parse(raw);
                 } catch (error) {
                     console.error('Error parsing form field visibility settings:', error);
                     return {};
@@ -188,17 +183,14 @@
         }
 
         saveFormFieldOrder(typeId, order) {
-            const cookieName = `${ this.options.cookiePrefix }-form-order-${ typeId }`;
-            document.cookie = `${ cookieName }=${ JSON.stringify(order) }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-form-order-${ typeId }`, JSON.stringify(order));
         }
 
         loadFormFieldOrder(typeId) {
-            const cookieName = `${ this.options.cookiePrefix }-form-order-${ typeId }`;
-            const cookies = document.cookie.split(';');
-            const cookie = cookies.find(c => c.trim().startsWith(`${ cookieName }=`));
-            if (cookie) {
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-form-order-${ typeId }`);
+            if (raw) {
                 try {
-                    return JSON.parse(cookie.split('=')[1]);
+                    return JSON.parse(raw);
                 } catch (e) {
                     return [];
                 }
@@ -950,16 +942,13 @@
         }
 
         saveFormShowDelete(typeId, show) {
-            const cookieName = `${ this.options.cookiePrefix }-form-show-delete-${ typeId }`;
-            document.cookie = `${ cookieName }=${ show ? '1' : '0' }; path=/; max-age=31536000`;
+            itStorageSet(`${ this.options.cookiePrefix }-form-show-delete-${ typeId }`, show ? '1' : '0');
         }
 
         loadFormShowDelete(typeId) {
-            const cookieName = `${ this.options.cookiePrefix }-form-show-delete-${ typeId }`;
-            const cookies = document.cookie.split(';');
-            const cookie = cookies.find(c => c.trim().startsWith(`${ cookieName }=`));
-            if (cookie) {
-                return cookie.split('=')[1].trim() === '1';
+            const raw = itStorageGet(`${ this.options.cookiePrefix }-form-show-delete-${ typeId }`);
+            if (raw !== null) {
+                return raw.trim() === '1';
             }
             return false; // Hidden by default
         }

--- a/js/integram-table/24-global-functions.js
+++ b/js/integram-table/24-global-functions.js
@@ -4,6 +4,99 @@ if (typeof window !== 'undefined') {
     window._integramTableInstances = window._integramTableInstances || [];
 }
 
+// ── UI-settings persistence ──────────────────────────────────────────────
+// View preferences (column order/visibility/width, table settings, form-field
+// visibility/order, card layout) live in localStorage, not cookies. As cookies
+// they were attached to every request to the whole ideav.ru origin and grew
+// without bound — one entry per table and per database ever opened — until the
+// combined Cookie header passed Apache's LimitRequestFieldSize and the server
+// answered HTTP 400 ("Size of a request header field exceeds server limit") to
+// every page on the domain. localStorage is never sent to the server.
+//
+// On first read of a key, any pre-existing cookie of the same name is copied
+// into localStorage and then deleted, so saved preferences carry over and the
+// bloated cookies clear themselves as the user navigates.
+
+function itStorageGet(name) {
+    let legacy = null;
+    if (typeof document !== 'undefined' && document.cookie) {
+        const parts = document.cookie.split(';');
+        for (let i = 0; i < parts.length; i++) {
+            const p = parts[i].trim();
+            if (p.indexOf(name + '=') === 0) { legacy = p.slice(name.length + 1); break; }
+        }
+    }
+    try {
+        if (legacy !== null) {
+            if (localStorage.getItem(name) === null && legacy !== '') {
+                localStorage.setItem(name, legacy);
+            }
+            // Drop the legacy cookie to free request-header space.
+            document.cookie = name + '=; path=/; max-age=0';
+        }
+        return localStorage.getItem(name);
+    } catch (e) {
+        // localStorage unavailable (private mode/quota) — fall back to the cookie value.
+        return legacy;
+    }
+}
+
+function itStorageSet(name, value) {
+    try {
+        localStorage.setItem(name, value);
+        // Remove any stale cookie of the same name so it stops inflating headers.
+        if (typeof document !== 'undefined' && document.cookie.indexOf(name + '=') !== -1) {
+            document.cookie = name + '=; path=/; max-age=0';
+        }
+    } catch (e) {
+        // localStorage unavailable — last-resort cookie so the setting still persists.
+        try { document.cookie = name + '=' + value + '; path=/; max-age=31536000'; } catch (e2) { /* ignore */ }
+    }
+}
+
+function itStorageRemove(name) {
+    try { localStorage.removeItem(name); } catch (e) { /* ignore */ }
+    try { document.cookie = name + '=; path=/; max-age=0'; } catch (e) { /* ignore */ }
+}
+
+// One-time sweep on script load: move every legacy UI-settings cookie into
+// localStorage and delete it, so the Cookie header shrinks on the next page
+// load even for tables the user does not reopen this session. Only names that
+// match the component's own patterns are touched; integram-table-font-settings
+// is shared with main.html (read there as a cookie) and is left in place.
+function itMigrateLegacyUiCookies() {
+    if (typeof document === 'undefined' || !document.cookie) return;
+    if (typeof window !== 'undefined') {
+        if (window.__itUiCookiesMigrated) return;
+        window.__itUiCookiesMigrated = true;
+    }
+    const isUiKey = function(name) {
+        if (name === 'integram-table-font-settings') return false;
+        return /-state$/.test(name)
+            || /-settings$/.test(name)
+            || /-form-fields-/.test(name)
+            || /-form-order-/.test(name)
+            || /-form-show-delete-/.test(name);
+    };
+    const parts = document.cookie.split(';');
+    for (let i = 0; i < parts.length; i++) {
+        const p = parts[i].trim();
+        const eq = p.indexOf('=');
+        if (eq <= 0) continue;
+        const name = p.slice(0, eq);
+        if (!isUiKey(name)) continue;
+        const value = p.slice(eq + 1);
+        try {
+            if (localStorage.getItem(name) === null && value !== '') {
+                localStorage.setItem(name, value);
+            }
+        } catch (e) { /* ignore */ }
+        document.cookie = name + '=; path=/; max-age=0';
+    }
+}
+
+itMigrateLegacyUiCookies();
+
 function parseIntegramAttrs(attrs) {
     const result = {
         required: false,

--- a/js/integram-table/25-create-form-helper.js
+++ b/js/integram-table/25-create-form-helper.js
@@ -2078,21 +2078,17 @@ class IntegramCreateFormHelper {
      * Save form field visibility settings (issue #837).
      */
     saveFormFieldVisibilityStandalone(typeId, visibility) {
-        const cookieName = `integram-table-form-fields-${typeId}`;
-        document.cookie = `${cookieName}=${JSON.stringify(visibility)}; path=/; max-age=31536000`;
+        itStorageSet(`integram-table-form-fields-${typeId}`, JSON.stringify(visibility));
     }
 
     /**
      * Load form field visibility settings (issue #837).
      */
     loadFormFieldVisibilityStandalone(typeId) {
-        const cookieName = `integram-table-form-fields-${typeId}`;
-        const cookies = document.cookie.split(';');
-        const fieldsCookie = cookies.find(c => c.trim().startsWith(`${cookieName}=`));
-
-        if (fieldsCookie) {
+        const raw = itStorageGet(`integram-table-form-fields-${typeId}`);
+        if (raw) {
             try {
-                return JSON.parse(fieldsCookie.split('=')[1]);
+                return JSON.parse(raw);
             } catch (error) {
                 console.error('Error parsing form field visibility settings:', error);
                 return {};
@@ -2106,20 +2102,17 @@ class IntegramCreateFormHelper {
      * Save form field order settings (issue #837).
      */
     saveFormFieldOrderStandalone(typeId, order) {
-        const cookieName = `integram-table-form-order-${typeId}`;
-        document.cookie = `${cookieName}=${JSON.stringify(order)}; path=/; max-age=31536000`;
+        itStorageSet(`integram-table-form-order-${typeId}`, JSON.stringify(order));
     }
 
     /**
      * Load form field order settings (issue #837).
      */
     loadFormFieldOrderStandalone(typeId) {
-        const cookieName = `integram-table-form-order-${typeId}`;
-        const cookies = document.cookie.split(';');
-        const cookie = cookies.find(c => c.trim().startsWith(`${cookieName}=`));
-        if (cookie) {
+        const raw = itStorageGet(`integram-table-form-order-${typeId}`);
+        if (raw) {
             try {
-                return JSON.parse(cookie.split('=')[1]);
+                return JSON.parse(raw);
             } catch (e) {
                 return [];
             }

--- a/js/main-app.js
+++ b/js/main-app.js
@@ -279,14 +279,31 @@ class MainAppController {
         });
     }
 
+    // Sidebar width and menu-expanded state are kept in localStorage, not cookies,
+    // so they are not sent to the server on every request. A legacy cookie of the
+    // same name is migrated on first read and then deleted.
     getCookie(name) {
+        let legacy = null;
         const match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-        return match ? decodeURIComponent(match[1]) : null;
+        if (match) legacy = decodeURIComponent(match[1]);
+        try {
+            if (legacy !== null) {
+                if (localStorage.getItem(name) === null && legacy !== '') localStorage.setItem(name, legacy);
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+            return localStorage.getItem(name);
+        } catch (e) {
+            return legacy;
+        }
     }
 
-    setCookie(name, value, days) {
-        const expires = new Date(Date.now() + days * 864e5).toUTCString();
-        document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + expires + '; path=/';
+    setCookie(name, value) {
+        try {
+            localStorage.setItem(name, value);
+            if (document.cookie.indexOf(name + '=') !== -1) document.cookie = name + '=; path=/; max-age=0';
+        } catch (e) {
+            document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000';
+        }
     }
 
     getExpandedCookieName() {

--- a/templates/atex/main.html
+++ b/templates/atex/main.html
@@ -169,8 +169,12 @@
             var cookieName = 'sidebarWidth_' + dbName;
             var isCollapsed = localStorage.getItem(storageKey) === 'true';
             var savedWidth = null;
-            var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-            if (match) savedWidth = decodeURIComponent(match[1]);
+            try { savedWidth = localStorage.getItem(cookieName); } catch (e) { /* ignore */ }
+            if (savedWidth === null) {
+                // Fall back to a legacy cookie (pre-localStorage); main-app.js migrates it.
+                var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
+                if (match) savedWidth = decodeURIComponent(match[1]);
+            }
             // Apply sidebar state via CSS before the DOM renders to prevent flash/jump
             var cssRules = '.app-sidebar{transition:none!important;}';
             if (isCollapsed) {

--- a/templates/cards.html
+++ b/templates/cards.html
@@ -662,24 +662,49 @@
         return d.innerHTML;
     }
 
-    function getCookie(name) {
-        var c = document.cookie.split(';');
+    // Card layout settings are kept in localStorage, not cookies. As a cookie the
+    // settings JSON was sent to the server on every request to the whole origin
+    // and accumulated one entry per card table ever opened, helping push the
+    // Cookie header past Apache's LimitRequestFieldSize (HTTP 400 for the domain).
+    // A pre-existing cookie of the same name is migrated to localStorage on first
+    // read and then deleted, so saved layouts carry over and the cookie clears.
+    function getStoredSetting(name) {
+        var legacy = null;
+        var c = document.cookie ? document.cookie.split(';') : [];
         for (var i = 0; i < c.length; i++) {
             var p = c[i].trim();
-            if (p.startsWith(name + '=')) {
-                try { return JSON.parse(p.slice(name.length + 1)); } catch(e) { return p.slice(name.length + 1); }
-            }
+            if (p.indexOf(name + '=') === 0) { legacy = p.slice(name.length + 1); break; }
         }
-        return null;
+        var raw;
+        try {
+            if (legacy !== null) {
+                if (localStorage.getItem(name) === null && legacy !== '') {
+                    localStorage.setItem(name, legacy);
+                }
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+            raw = localStorage.getItem(name);
+        } catch (e) {
+            raw = legacy;
+        }
+        if (raw === null || raw === undefined) return null;
+        try { return JSON.parse(raw); } catch (e) { return raw; }
     }
 
-    function setCookie(name, value, days) {
-        var maxAge = days * 86400;
-        document.cookie = name + '=' + JSON.stringify(value) + '; path=/; max-age=' + maxAge;
+    function setStoredSetting(name, value) {
+        try {
+            localStorage.setItem(name, JSON.stringify(value));
+            if (document.cookie.indexOf(name + '=') !== -1) {
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+        } catch (e) {
+            try { document.cookie = name + '=' + JSON.stringify(value) + '; path=/; max-age=31536000'; } catch (e2) { /* ignore */ }
+        }
     }
 
-    function deleteCookie(name) {
-        document.cookie = name + '=; path=/; max-age=0';
+    function removeStoredSetting(name) {
+        try { localStorage.removeItem(name); } catch (e) { /* ignore */ }
+        try { document.cookie = name + '=; path=/; max-age=0'; } catch (e) { /* ignore */ }
     }
 
     // ─── Type helpers (mirrors integram-table.js logic) ──────────────────────
@@ -1923,7 +1948,7 @@
 
     CardsView.prototype._loadSettings = function() {
         var key = this.options.cookiePrefix + '-settings';
-        var saved = getCookie(key);
+        var saved = getStoredSetting(key);
         if (saved && typeof saved === 'object') {
             this.settings = Object.assign(this.settings, saved);
         }
@@ -1968,7 +1993,7 @@
         // Always save to cookie as local backup
         var toSave = Object.assign({}, this.settings);
         delete toSave._remoteId;
-        setCookie(key, toSave, 365);
+        setStoredSetting(key, toSave);
 
         // Save to table 269 if mode === 'global'
         if (mode === 'global' && srcId) {
@@ -2174,7 +2199,7 @@
         modal.querySelector('#cards-s-reset').addEventListener('click', function() {
             // Reset to defaults
             var key = self.options.cookiePrefix + '-settings';
-            deleteCookie(key);
+            removeStoredSetting(key);
             self.settings = {
                 cardFieldSettings: null,
                 filterFields: null,

--- a/templates/main.html
+++ b/templates/main.html
@@ -168,8 +168,12 @@
             var cookieName = 'sidebarWidth_' + dbName;
             var isCollapsed = localStorage.getItem(storageKey) === 'true';
             var savedWidth = null;
-            var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-            if (match) savedWidth = decodeURIComponent(match[1]);
+            try { savedWidth = localStorage.getItem(cookieName); } catch (e) { /* ignore */ }
+            if (savedWidth === null) {
+                // Fall back to a legacy cookie (pre-localStorage); main-app.js migrates it.
+                var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
+                if (match) savedWidth = decodeURIComponent(match[1]);
+            }
             // Apply sidebar state via CSS before the DOM renders to prevent flash/jump
             var cssRules = '.app-sidebar{transition:none!important;}';
             if (isCollapsed) {

--- a/templates/ru/main.html
+++ b/templates/ru/main.html
@@ -31,8 +31,12 @@
             var cookieName = 'sidebarWidth_' + dbName;
             var isCollapsed = localStorage.getItem(storageKey) === 'true';
             var savedWidth = null;
-            var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-            if (match) savedWidth = decodeURIComponent(match[1]);
+            try { savedWidth = localStorage.getItem(cookieName); } catch (e) { /* ignore */ }
+            if (savedWidth === null) {
+                // Fall back to a legacy cookie (pre-localStorage); main-app.js migrates it.
+                var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
+                if (match) savedWidth = decodeURIComponent(match[1]);
+            }
             // Apply sidebar state via CSS before the DOM renders to prevent flash/jump
             var cssRules = '.app-sidebar{transition:none!important;}';
             if (isCollapsed) {

--- a/templates/sportzania/main.html
+++ b/templates/sportzania/main.html
@@ -171,8 +171,12 @@
             var cookieName = 'sidebarWidth_' + dbName;
             var isCollapsed = localStorage.getItem(storageKey) === 'true';
             var savedWidth = null;
-            var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
-            if (match) savedWidth = decodeURIComponent(match[1]);
+            try { savedWidth = localStorage.getItem(cookieName); } catch (e) { /* ignore */ }
+            if (savedWidth === null) {
+                // Fall back to a legacy cookie (pre-localStorage); main-app.js migrates it.
+                var match = document.cookie.match(new RegExp('(?:^|; )' + cookieName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)'));
+                if (match) savedWidth = decodeURIComponent(match[1]);
+            }
             // Apply sidebar state via CSS before the DOM renders to prevent flash/jump
             var cssRules = '.app-sidebar{transition:none!important;}';
             if (isCollapsed) {

--- a/templates/table.html
+++ b/templates/table.html
@@ -143,21 +143,34 @@
 </div>
 <script>
 (function() {
+    // "Info seen" flags and hints_mode are kept in localStorage, not cookies, so
+    // they are not sent to the server on every request. A legacy cookie of the
+    // same name is migrated on first read and then deleted.
     function getCookie(name) {
+        var legacy = null;
         var prefix = name + '=';
-        var parts = document.cookie.split(';');
+        var parts = document.cookie ? document.cookie.split(';') : [];
         for (var i = 0; i < parts.length; i++) {
             var part = parts[i].trim();
-            if (part.indexOf(prefix) === 0) {
-                return decodeURIComponent(part.substring(prefix.length));
-            }
+            if (part.indexOf(prefix) === 0) { legacy = decodeURIComponent(part.substring(prefix.length)); break; }
         }
-        return null;
+        try {
+            if (legacy !== null) {
+                if (localStorage.getItem(name) === null && legacy !== '') localStorage.setItem(name, legacy);
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+            return localStorage.getItem(name);
+        } catch (e) {
+            return legacy;
+        }
     }
-    function setCookie(name, value, days) {
-        var d = new Date();
-        d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
-        document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + d.toUTCString() + '; path=/';
+    function setCookie(name, value) {
+        try {
+            localStorage.setItem(name, value);
+            if (document.cookie.indexOf(name + '=') !== -1) document.cookie = name + '=; path=/; max-age=0';
+        } catch (e) {
+            document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000';
+        }
     }
     window.tableInfoModalClose = function() {
         var overlay = document.getElementById('table-info-modal-overlay');
@@ -221,21 +234,34 @@
 </div>
 <script>
 (function() {
+    // "Info seen" flags and hints_mode are kept in localStorage, not cookies, so
+    // they are not sent to the server on every request. A legacy cookie of the
+    // same name is migrated on first read and then deleted.
     function getCookie(name) {
+        var legacy = null;
         var prefix = name + '=';
-        var parts = document.cookie.split(';');
+        var parts = document.cookie ? document.cookie.split(';') : [];
         for (var i = 0; i < parts.length; i++) {
             var part = parts[i].trim();
-            if (part.indexOf(prefix) === 0) {
-                return decodeURIComponent(part.substring(prefix.length));
-            }
+            if (part.indexOf(prefix) === 0) { legacy = decodeURIComponent(part.substring(prefix.length)); break; }
         }
-        return null;
+        try {
+            if (legacy !== null) {
+                if (localStorage.getItem(name) === null && legacy !== '') localStorage.setItem(name, legacy);
+                document.cookie = name + '=; path=/; max-age=0';
+            }
+            return localStorage.getItem(name);
+        } catch (e) {
+            return legacy;
+        }
     }
-    function setCookie(name, value, days) {
-        var d = new Date();
-        d.setTime(d.getTime() + days * 24 * 60 * 60 * 1000);
-        document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + d.toUTCString() + '; path=/';
+    function setCookie(name, value) {
+        try {
+            localStorage.setItem(name, value);
+            if (document.cookie.indexOf(name + '=') !== -1) document.cookie = name + '=; path=/; max-age=0';
+        } catch (e) {
+            document.cookie = name + '=' + encodeURIComponent(value) + '; path=/; max-age=31536000';
+        }
     }
     window.tableInfoModal18Close = function() {
         var overlay = document.getElementById('table-info-modal-18-overlay');


### PR DESCRIPTION
## Проблема

На страницах ideav.ru периодически возникает ошибка Apache **HTTP 400 — «Size of a request header field exceeds server limit»**: весь домен перестаёт открываться. Причина — раздувшийся заголовок **Cookie**. Реальный пример с прода — суммарно ~7–8 КБ, что превышает дефолтный Apache `LimitRequestFieldSize` (8190 байт).

Разбор куки показал, что собственно авторизация (`idb_*`) занимает ~200 байт, а ~95% веса — это **клиентские настройки интерфейса**, которые компоненты хранили в cookie и потому без нужды отправляли на сервер при каждом запросе ко всему домену. Каждая таблица/карточка/база, когда-либо открытая пользователем, навсегда добавляла вес.

Главные пожиратели:

| Группа | ~Байт | Где хранилось |
|---|---|---|
| `cards-*-settings` (раскладка карточек) | ~2160 | `templates/cards.html` |
| `tasks-object-form-*`, `…-state`, `…-settings` | ~1770 | `js/integram-table/*` |
| `dash_tile_mode_*`, `menuExpanded_*`, `sidebarWidth_*`, `hints_*`, `info_active_tab`, `table_info_*_seen` | ~700 | dash.js / main-app.js / hints.js / info.js / table.html |

## Решение

Перевести клиентские настройки интерфейса с **Cookie** на **localStorage** (на сервер не отправляется). При первом чтении каждого ключа старая кука переносится в localStorage и удаляется — поэтому сохранённые настройки не теряются, а раздутые куки очищаются сами по мере навигации. В компоненте `integram-table` дополнительно сделан разовый **sweep при загрузке**, который чистит все легаси-куки настроек сразу.

**Переведено на localStorage:**
- `js/integram-table/*` — `{prefix}-state`, `{prefix}-settings`, `integram-table-global-settings`, `…-form-fields/order/show-delete-*`
- `templates/cards.html` — `cards-*-settings`
- `js/dash.js` — `dash_tile_mode_*`, размеры графиков/таблиц
- `js/hints.js`, `js/info.js`, `templates/table.html` — `hints_mode`, `hints_seen_workspaces`, `info_active_tab`, `info_forms_desc_hidden`, `table_info_*_seen`
- `js/main-app.js` + `templates/main.html`, `ru/`, `atex/`, `sportzania/` — `sidebarWidth_*`, `menuExpanded_*`

Для каждого ключа охвачены **все** читатели и писатели — рассинхрона между cookie и localStorage нет.

**Намеренно оставлено в cookie** (читаются сервером или общая инфраструктура):
- `*_locale` / `my_locale` — читает `index.php:95` (выбор языка)
- `default_limit`, `tzone` — читает `index.php`
- `idb_*`, `_xsrf` — авторизация
- `integram-table-font-settings` — читается в `main.html` (глобальный размер шрифта)
- `last_db` — в auth-хелпере `CookieUtil`, мелочь

## Сборка

`js/integram-table.js` пересобран из модулей через `bash build.sh` и закоммичен вместе с модулями.

## Тестирование

Node-тесты на реальном образце куки с прода (мок `document.cookie` + `localStorage`, исполнение настоящего собранного бандла):
- миграция: куки настроек переносятся в localStorage и удаляются; auth/`idb_*`/`*_locale`/`font-settings` не тронуты; на образце Cookie ужался 548 → 139 байт;
- `localStorage` имеет приоритет над устаревшей кукой;
- helpers Set/Get/Remove и маска `table_info_*_seen` — корректны;
- синтаксис всех JS-файлов и script-блоков шаблонов проверен.

Итог: **integram-table 18/18, cards 7/7, dash+hints 10/10, info-mask 4/4 — все зелёные.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
