### PR TITLE
fix(upload): не сдвигать importMap при autoParent — терялась крайняя колонка (#3356)

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -880,11 +880,13 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                     }
                     j=0;
                     for(i in m){
+                        // Заполняем пропуски колонок заглушками так, чтобы визуальная позиция
+                        // каждого поля совпадала с его входной колонкой (importMap=индекс).
+                        // Колонку-родителя отдельной «дыркой» не выкусываем: она читается из
+                        // data[autoParent-1] и в выход идёт первой — здесь это обычный пропуск
+                        // (issue #3356, согласовано с importMap в gatherSet).
                         while(j<i)
-                            if(uploadSets[chosenSet].autoParent&&uploadSets[chosenSet].autoParent==j)
-                                j++;
-                            else
-                                m[j++]=addSortable('','','---','---');
+                            m[j++]=addSortable('','','---','---');
                         j++;
                     }
                     h=m.join('');
@@ -1075,7 +1077,12 @@ function gatherSet(){
                             ,link:$('#l'+this.id).hasClass('is-link')?($('#l'+this.id).hasClass('multiselect')?2:1):0};
             else
                 sourceMap[i]={id:this.id,base:$('#t'+this.id).val(),name:$('#n'+this.id).val(),skip:0};
-            importMap[this.id]=autoParent<=i+1?i+1:i;
+            // importMap — это ВХОДНАЯ колонка данных, на которую пользователь выровнял
+            // поле перетаскиванием; она не зависит от autoParent. Родитель читается
+            // отдельно из data[autoParent-1], а в выходной файл уходит первой колонкой
+            // (jMap=origMap+1). Прежний сдвиг +1 здесь дублировал учёт родителя и при
+            // включении autoParent уводил крайнее поле за пределы данных (issue #3356).
+            importMap[this.id]=i;
         }
         i++;
     });


### PR DESCRIPTION
Fixes #3356

## Симптом

При импорте через `templates/upload.html`: после установки номера родителя (`autoParent`) поле «Заказанное количество» переезжает из колонки 8 в колонку 9. В синтетической строке-линейке `1 2 … 13` колонка 9 есть, а в реальных данных (8 колонок) — нет, поэтому в предпросмотре последняя колонка пустая (а строки могут схлопываться).

## Причина

`importMap[id]` задаёт **входную** колонку данных, из которой поле читает значение, и выравнивается перетаскиванием. Формула в `gatherSet`:

```js
importMap[this.id] = autoParent<=i+1 ? i+1 : i;
```

завязывала входную колонку на `autoParent` и добавляла `+1` «на пропуск» родителя. Но родитель и так:
- читается отдельно из `data[autoParent-1]` (строка 1185),
- и уходит в выходной файл **первой** колонкой (`jMap=origMap+1`, строки 1190-1191).

То есть `+1` дублировал учёт родителя: при включении `autoParent` каждое поле сдвигалось на одну входную колонку вправо, и крайнее поле уезжало за пределы данных → `undefined` → пустая ячейка в предпросмотре.

Парсер (PapaParse) здесь ни при чём — он отдаёт все 8 колонок включая «504»; колонка терялась именно на шаге `importMap`.

## Исправление (2 согласованные правки)

1. **`gatherSet`** — `importMap[id] = i` (визуальный индекс), без `autoParent`-сдвига.
2. **Реконструкция загрузки набора** — колонку-родителя не выкусываем «дыркой», ставим обычный плейсхолдер, чтобы визуальная позиция = входная колонка.

Выходная ветка (родитель первой колонкой, `jMap=origMap+1`) и чтение родителя (`data[autoParent-1]`) **не менялись**.

## Совместимость

- Наборы с родителем в **1-й колонке** грузятся без изменений — round-trip `importMap` сохраняется (проверено на наборе из тикета).
- Наборы с родителем **в середине** меняют поведение: там старый код сам был непоследователен (`save≠load`, тот же сдвиг) — теперь выпрямлено.

## Тестирование

Node-харнесс (порт логики `gatherSet` + реконструкции + сборки `toImport` + проверка PapaParse 5.3.1 на точных данных тикета). Покрыто:

- с родителем и без;
- родитель в начале / в середине; поля **до** и **после** родителя;
- тоггл `autoParent` off→on на одном визуале → **сдвига нет**;
- ручные заглушки `--` пропускают входную колонку;
- drag поля до/после позиции родителя;
- round-trip набора тикета: `importMap` воспроизводится 1:1;
- сквозь: поле «Заказанное количество» читает «504», родитель `2830` идёт первым.

Все сценарии зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
