### PR TITLE
fix(upload): орфанное поле сохранённого набора не дублировать как главное значение (#3358)

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -875,8 +875,15 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                     for(i in uploadSets[chosenSet].importMap){
                         if(json.req_type[i])
                             m[uploadSets[chosenSet].importMap[i]]=addSortable(i,json.req_type[i],json.req_base[i],json.req_base_id[i]);
-                        else
+                        else if(i==json.type.id)
                             m[uploadSets[chosenSet].importMap[i]]=addSortable(json.type.id,json.type.val,json.type.base,json.base.id);
+                        else
+                            // Поле из сохранённого набора больше не реквизит типа (колонку
+                            // удалили/изменили) и не является главным значением — ставим
+                            // пропуск-заглушку, а не дубль главного значения. Иначе «Заказанное
+                            // количество» появлялось дважды, а в gatherSet importMap[type.id]
+                            // затирался индексом орфана (issue #3358).
+                            m[uploadSets[chosenSet].importMap[i]]=addSortable('','','---','---');
                     }
                     j=0;
                     for(i in m){


### PR DESCRIPTION
Fixes #3358

## Симптом

У таблицы, в которую **добавили/изменили колонку**, при загрузке сохранённой настройки импорта главное значение типа («Заказанное количество») появляется в списке колонок **дважды** — на своём месте (col 7) и в конце (col 13).

## Причина

При реконструкции набора (`case 'type'`, загрузка сохранённого `importMap`) код для каждого поля делал:

```js
if(json.req_type[i])
    m[...] = addSortable(i, ...);              // реквизит
else
    m[...] = addSortable(json.type.id, ...);   // ← считает ЛЮБОЕ не-реквизитное поле главным значением
```

Но «не реквизит» бывает в **двух** случаях:
1. настоящее главное значение типа (`i == json.type.id`);
2. **орфан** — поле, которое было реквизитом на момент сохранения набора, но перестало им быть после изменения схемы (его id больше нет в `req_order`/`req_type`).

Орфан ошибочно подставлялся как **ещё одно главное значение** → визуальный дубль. Хуже: затем `gatherSet` делает `importMap[id]=индекс` для **обоих** вхождений `json.type.id`, и второе (орфан, col 13) **затирает** первое (col 7) — главное значение начинает читать чужую колонку.

Подтверждено на реальных метаданных типа `1076` (live): `req_order` не содержит `35560`, а сохранённый набор мапит `35560→col13` → «Заказанное количество» дублируется на 13-й колонке, `importMap[1076]` затёрт в `13`.

## Исправление

Различаем три случая: реквизит / настоящее главное значение (`i==json.type.id`) / **орфан → пропуск-заглушка** (`addSortable('','','---','---')`). Колонки прочих полей сохраняются; при пересохранении набора орфанное поле естественно выпадает из `importMap`.

## Не связано с #3356

Там правились только заполнение пропусков и `gatherSet` (строки 882-890, 1078). Дубль рождается выше — в строках 876-879, которые #3356 не трогал. Это отдельный, ранее существовавший баг (проявляется при изменении схемы таблицы).

## Тестирование

Node-харнесс на **реальных метаданных типа 1076** (`req_order` с live) + сохранённый набор из тикета:
- текущий код: «Заказанное количество» 2×, `importMap[1076]=13` (читает чужую колонку);
- с фиксом: 1×, `importMap[1076]=7`, орфан `35560` стал пропуском, поля `1077→8`, `1080→12` и прочие на местах.

Все проверки зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
