### PR TITLE
feat(#3372): фактическая ширина резки в планировании производства

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1250,6 +1250,76 @@
         return String(round3(Number(width) || 0));
     }
 
+    // ── #3372: фактическая ширина резки ──────────────────────────────────────
+    // Справочник «Фактическая ширина резки» (table 66190) задаёт пары
+    // номинал («Ширина в заказе») → факт (главное значение записи) с условием в
+    // поле «Код»: '' (пусто) — безусловно; 'j=910'/'j>1000' — по ширине джамбо
+    // вида сырья; 's=0.5'/'s=1' — по диаметру втулки в дюймах (8188 «Дюймы»).
+    // Поддержаны операторы = > < >= <=. ⚠️ Жёсткий фильтр (#3372): факт. ширина
+    // применяется ТОЛЬКО при выполнении условия, иначе берётся номинал заказа.
+    function parseActualWidthCode(code) {
+        var c = String(code == null ? '' : code).trim().toLowerCase().replace(/\s+/g, '');
+        if (!c) return { key: '', op: '', val: 0 };           // безусловно
+        var m = c.match(/^([js])(>=|<=|=|>|<)(\d+(?:\.\d+)?)$/);
+        if (!m) return { key: '?', op: '', val: 0 };          // нераспознан → не применяем
+        return { key: m[1], op: m[2], val: Number(m[3]) };
+    }
+
+    // ctx: { jumbo, inches } (любое поле может быть null/undefined). key 'j' →
+    // сверяем с jumbo (ширина джамбо), 's' → с inches (дюймы втулки).
+    // '' → всегда true; '?' → всегда false (жёсткий фильтр).
+    function actualWidthCodeMatches(parsed, ctx) {
+        if (!parsed || parsed.key === '') return true;
+        if (parsed.key === '?') return false;
+        var v = parsed.key === 'j' ? (ctx && ctx.jumbo) : (ctx && ctx.inches);
+        if (v == null || v === '' || !isFinite(Number(v))) return false;
+        v = Number(v);
+        switch (parsed.op) {
+            case '=':  return Math.abs(v - parsed.val) < 1e-6;
+            case '>':  return v > parsed.val + 1e-9;
+            case '<':  return v < parsed.val - 1e-9;
+            case '>=': return v >= parsed.val - 1e-9;
+            case '<=': return v <= parsed.val + 1e-9;
+        }
+        return false;
+    }
+
+    // rows: [{ actual, order, code }] из справочника → индекс
+    // { stripWidthKey(order): [{ actual, parsed }] }. Условные строки идут раньше
+    // безусловных — приоритет более специфичного правила при совпадении номинала.
+    function buildActualWidthIndex(rows) {
+        var index = {};
+        (rows || []).forEach(function(row) {
+            var order = Number(row && row.order);
+            var actual = Number(row && row.actual);
+            if (!isFinite(order) || order <= 0 || !isFinite(actual) || actual <= 0) return;
+            var key = stripWidthKey(order);
+            (index[key] || (index[key] = [])).push({ actual: actual, parsed: parseActualWidthCode(row.code) });
+        });
+        Object.keys(index).forEach(function(key) {
+            index[key].sort(function(a, b) {
+                return (b.parsed.key !== '' ? 1 : 0) - (a.parsed.key !== '' ? 1 : 0);
+            });
+        });
+        return index;
+    }
+
+    // Фактическая ширина резки для номинальной ширины заказа с учётом контекста
+    // позиции (ширина джамбо вида сырья, диаметр втулки в дюймах). Нет правила или
+    // ни одно условие не выполнено → возвращаем номинал как есть (жёсткий фильтр).
+    function resolveCutWidth(nominalWidth, ctx, index) {
+        var n = Number(nominalWidth);
+        if (!isFinite(n) || n <= 0) return nominalWidth;
+        var rows = (index && index[stripWidthKey(n)]) || [];
+        for (var i = 0; i < rows.length; i++) {
+            if (actualWidthCodeMatches(rows[i].parsed, ctx)) {
+                var w = Number(rows[i].actual);
+                return isFinite(w) && w > 0 ? w : n;
+            }
+        }
+        return n;
+    }
+
     function nonStockStripQtyForWidth(layout, width) {
         var key = stripWidthKey(width);
         return (layout && layout.strips || []).reduce(function(sum, s) {
@@ -2532,6 +2602,10 @@
         tableByName: tableByName,
         reqIdByName: reqIdByName,
         columnIndex: columnIndex,
+        parseActualWidthCode: parseActualWidthCode,      // #3372
+        actualWidthCodeMatches: actualWidthCodeMatches,  // #3372
+        buildActualWidthIndex: buildActualWidthIndex,    // #3372
+        resolveCutWidth: resolveCutWidth,                // #3372
         mapCutRecord: mapCutRecord,
         groupBySlitter: groupBySlitter,
         filterCuts: filterCuts,
@@ -3089,6 +3163,70 @@
             self.jumboWidthByMaterial = map;
             self.toleranceByMaterial = tol;
             self.materialNameById = names;
+        });
+    };
+
+    // #3372: справочник «Фактическая ширина резки» → this.actualWidthIndex.
+    // Таблица/колонки резолвятся по имени из _metaAll (схемоустойчиво при пересборке
+    // БД). Главное значение записи (r[0]) — фактическая ширина; «Ширина в заказе» —
+    // номинал; «Код» — условие применения. Нет таблицы/доступа → пустой индекс
+    // (фича тихо деградирует к номиналу).
+    AtexProductionPlanning.prototype.loadActualWidths = function() {
+        var self = this;
+        this.actualWidthIndex = {};
+        var meta = tableByName(this._metaAll || [], 'Фактическая ширина резки');
+        if (!meta) return Promise.resolve();
+        var orderIdx = columnIndex(meta, 'Ширина в заказе');
+        var codeIdx = columnIndex(meta, 'Код');
+        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,5000').then(function(rows) {
+            var list = (rows || []).map(function(rec) {
+                var r = rec.r || [];
+                return {
+                    actual: r[0],
+                    order: orderIdx >= 0 ? r[orderIdx] : null,
+                    code: codeIdx >= 0 ? r[codeIdx] : ''
+                };
+            });
+            self.actualWidthIndex = buildActualWidthIndex(list);
+        }).catch(function() { self.actualWidthIndex = {}; });
+    };
+
+    // #3372: диаметр втулки в дюймах по id записи «Диаметр втулки» (8188 «Дюймы»)
+    // → this.sleeveInchesById = { sleeveId: дюймы }. Контекст для условия 's=…'
+    // фактической ширины. Нет колонки/доступа → пустая карта.
+    AtexProductionPlanning.prototype.loadSleeveInches = function() {
+        var self = this;
+        this.sleeveInchesById = {};
+        var meta = tableByName(this._metaAll || [], 'Диаметр втулки');
+        if (!meta) return Promise.resolve();
+        var inchIdx = columnIndex(meta, 'Дюймы');
+        if (inchIdx < 0) return Promise.resolve();
+        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,2000').then(function(rows) {
+            var map = {};
+            (rows || []).forEach(function(rec) {
+                var raw = (rec.r || [])[inchIdx];
+                if (raw == null || String(raw).trim() === '') return;
+                var n = Number(raw);
+                if (isFinite(n)) map[String(rec.i)] = n;
+            });
+            self.sleeveInchesById = map;
+        }).catch(function() { self.sleeveInchesById = {}; });
+    };
+
+    // #3372: проставить позициям фактическую ширину резки. Номинал заказа
+    // сохраняется в orderWidth (для отображения), а width становится фактической —
+    // её используют раскладка, полосы, Партии ГП и обеспечение (вся геометрия
+    // раскроя). Идемпотентно: резолв всегда от orderWidth. Вызывается после загрузки
+    // позиций, ширин джамбо и справочников 66190/8188.
+    AtexProductionPlanning.prototype.annotatePositionsCutWidth = function() {
+        var self = this;
+        (this.genPositions || []).forEach(function(p) {
+            if (p.orderWidth == null) p.orderWidth = p.width;   // номинал из заказа
+            var ctx = {
+                jumbo: self.jumboWidthByMaterial ? self.jumboWidthByMaterial[String(p.materialId)] : null,
+                inches: self.sleeveInchesById ? self.sleeveInchesById[String(p.sleeveId)] : null
+            };
+            p.width = resolveCutWidth(p.orderWidth, ctx, self.actualWidthIndex);
         });
     };
 
@@ -3700,7 +3838,7 @@
             return {
                 id: String(p.id), position: p, remaining: remaining,
                 rolls: stripSupplyRolls(stripRolls, remaining),
-                label: posLabelById[String(p.id)] || ('Сырьё#' + (p.materialId || '?') + ' · ' + (p.width || '?') + ' мм')
+                label: posLabelById[String(p.id)] || ('Сырьё#' + (p.materialId || '?') + ' · ' + ((p.orderWidth != null ? p.orderWidth : p.width) || '?') + ' мм')
             };
         }).filter(function(c) { return c.remaining > 0 && c.rolls > 0; });
         candidates.sort(function(a, b) { return a.label < b.label ? -1 : a.label > b.label ? 1 : 0; });
@@ -4758,7 +4896,7 @@
             var p = posById[String(s.positionId)] || {};
             return {
                 id: s.positionId == null ? '' : s.positionId,
-                width: p.width || '',
+                width: (p.orderWidth != null ? p.orderWidth : p.width) || '',  // #3372: заказанная ширина (не фактическая)
                 qty: p.qty || '',
                 length: p.length || '',
                 reason: (s && s.reason) || 'без причины'
@@ -5256,8 +5394,8 @@
         var unsup = uncoveredPositions(this.genPositions, this.supplies).filter(function(p) { return p.approved; });
         var options = unsup.map(function(p) {
             var remaining = remainingRollsForPosition(p, self.supplies);
-            var base = posLabelById[String(p.id)] || ('Сырьё#' + (p.materialId || '?') + ' · ' + (p.width || '?') + ' мм');
-            return { id: String(p.id), remaining: remaining, width: p.width,
+            var base = posLabelById[String(p.id)] || ('Сырьё#' + (p.materialId || '?') + ' · ' + ((p.orderWidth != null ? p.orderWidth : p.width) || '?') + ' мм');
+            return { id: String(p.id), remaining: remaining, width: (p.orderWidth != null ? p.orderWidth : p.width),  // #3372: заказанная ширина
                 label: base + ' · ост. ' + round3(remaining) + ' рул.' };
         }).filter(function(o) { return o.remaining > 0; });
 
@@ -5836,11 +5974,14 @@
                     self.loadSupplyFootage(),  // метраж обеспечений (длительность/расписание)
                     self.loadConsumption(),    // расход сырья (FIFO-резерв, Фаза 1b)
                     self.loadSleeveBatches(),  // #3340: партии втулок «в работе» (FIFO) + втулкорез TC-20
+                    self.loadActualWidths(),   // #3372: справочник фактической ширины резки (66190)
+                    self.loadSleeveInches(),   // #3372: дюймы втулки по записи 8188 (контекст условия)
                     // Полосы перед очередью: knifeCount/knifeWidths вливаются в резки в loadPlanning.
                     self.loadCutStrips().then(function() { return self.loadPlanning(); })
                 ]);
             })
-            .then(function() { self.resolveCutMaterials(); self.render(); })
+            // #3372: фактическая ширина резки — после загрузки позиций/ширин джамбо/справочников.
+            .then(function() { self.annotatePositionsCutWidth(); self.resolveCutMaterials(); self.render(); })
             .catch(function(err) { self.fatal('Ошибка инициализации: ' + err.message); });
     };
 

--- a/experiments/test-issue-3372-actual-cut-width.js
+++ b/experiments/test-issue-3372-actual-cut-width.js
@@ -1,0 +1,115 @@
+// Unit-тесты фактической ширины резки (ideav/crm#3372).
+// Справочник «Фактическая ширина резки» (table 66190) задаёт пары
+// номинал → факт с условием в поле «Код». Жёсткий фильтр: факт. ширина
+// применяется ТОЛЬКО при выполнении условия, иначе берётся номинал.
+//
+// Проверяем чистые помощники:
+//   • parseActualWidthCode   — разбор кода условия (j/s, операторы = > < >= <=);
+//   • actualWidthCodeMatches — проверка условия по контексту {jumbo, inches};
+//   • buildActualWidthIndex  — индекс по номиналу (условные строки раньше);
+//   • resolveCutWidth        — номинал + контекст → фактическая ширина.
+//
+// Run with: node experiments/test-issue-3372-actual-cut-width.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) {
+        passed++;
+    } else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// ── Реальный датасет справочника 66190 (с проставленными кодами, бой) ──
+var ROWS = [
+    { actual: 32.5,  order: 33,  code: 'j=910' },
+    { actual: 33,    order: 33,  code: 'j>1000' },
+    { actual: 44,    order: 45,  code: '' },
+    { actual: 49,    order: 50,  code: '' },
+    { actual: 55,    order: 57,  code: 's=0.5' },
+    { actual: 59,    order: 60,  code: '' },
+    { actual: 63.5,  order: 64,  code: 's=1' },
+    { actual: 63.5,  order: 65,  code: 's=1' },
+    { actual: 74,    order: 75,  code: '' },
+    { actual: 89,    order: 90,  code: '' },
+    { actual: 99,    order: 100, code: '' },
+    { actual: 103.5, order: 104, code: '' }
+];
+var INDEX = planning.buildActualWidthIndex(ROWS);
+
+// ── parseActualWidthCode ──
+assertEqual(planning.parseActualWidthCode(''),        { key: '', op: '', val: 0 },          'parseCode: пусто → безусловно');
+assertEqual(planning.parseActualWidthCode(null),      { key: '', op: '', val: 0 },          'parseCode: null → безусловно');
+assertEqual(planning.parseActualWidthCode('j=910'),   { key: 'j', op: '=', val: 910 },       'parseCode: j=910');
+assertEqual(planning.parseActualWidthCode('j>1000'),  { key: 'j', op: '>', val: 1000 },      'parseCode: j>1000');
+assertEqual(planning.parseActualWidthCode('s=0.5'),   { key: 's', op: '=', val: 0.5 },       'parseCode: s=0.5');
+assertEqual(planning.parseActualWidthCode(' S = 1 '), { key: 's', op: '=', val: 1 },         'parseCode: пробелы/регистр нормализуются');
+assertEqual(planning.parseActualWidthCode('j>=900'),  { key: 'j', op: '>=', val: 900 },      'parseCode: оператор >=');
+assertEqual(planning.parseActualWidthCode('бред'),    { key: '?', op: '', val: 0 },          'parseCode: нераспознан → ?');
+
+// ── actualWidthCodeMatches ──
+var P = planning.parseActualWidthCode;
+assertEqual(planning.actualWidthCodeMatches(P(''),      { jumbo: 999 }),        true,  'match: безусловно → true');
+assertEqual(planning.actualWidthCodeMatches(P('бред'),  { jumbo: 910 }),        false, 'match: нераспознан → false');
+assertEqual(planning.actualWidthCodeMatches(P('j=910'), { jumbo: 910 }),        true,  'match: j=910 при jumbo 910');
+assertEqual(planning.actualWidthCodeMatches(P('j=910'), { jumbo: 1000 }),       false, 'match: j=910 при jumbo 1000 → false');
+assertEqual(planning.actualWidthCodeMatches(P('j>1000'),{ jumbo: 1050 }),       true,  'match: j>1000 при jumbo 1050');
+assertEqual(planning.actualWidthCodeMatches(P('j>1000'),{ jumbo: 1000 }),       false, 'match: j>1000 при ровно 1000 → false');
+assertEqual(planning.actualWidthCodeMatches(P('s=1'),   { inches: 1.0 }),       true,  'match: s=1 при втулке 1.0');
+assertEqual(planning.actualWidthCodeMatches(P('s=0.5'), { inches: 0.5 }),       true,  'match: s=0.5 при втулке 0.5');
+assertEqual(planning.actualWidthCodeMatches(P('s=1'),   { inches: 0.5 }),       false, 'match: s=1 при втулке 0.5 → false');
+assertEqual(planning.actualWidthCodeMatches(P('j=910'), {}),                    false, 'match: нет jumbo в контексте → false');
+assertEqual(planning.actualWidthCodeMatches(P('s=1'),   { inches: '' }),        false, 'match: пустые дюймы → false');
+
+// ── buildActualWidthIndex: условные строки идут раньше безусловных ──
+assertEqual(INDEX['33'].map(function(r){ return r.parsed.op + r.parsed.val; }), ['=910', '>1000'], 'index[33]: две условные строки');
+assertEqual(INDEX['45'].length, 1, 'index[45]: одна безусловная строка');
+assertEqual(INDEX['45'][0].actual, 44, 'index[45]: факт 44');
+
+// ── resolveCutWidth (главный сценарий) ──
+function R(nominal, ctx) { return planning.resolveCutWidth(nominal, ctx, INDEX); }
+
+// Номинал 33 различается по ширине джамбо
+assertEqual(R(33, { jumbo: 910 }),            32.5, '33 + джамбо 910 → 32.5');
+assertEqual(R(33, { jumbo: 1050 }),           33,   '33 + джамбо 1050 → 33');
+assertEqual(R(33, { jumbo: 950 }),            33,   '33 + джамбо 950 (между) → номинал 33 (жёсткий фильтр)');
+assertEqual(R(33, { jumbo: 800 }),            33,   '33 + джамбо 800 (<910) → номинал 33');
+assertEqual(R(33, {}),                        33,   '33 без ширины джамбо → номинал 33');
+
+// Номинал по втулке (жёсткий фильтр: нет втулки → номинал)
+assertEqual(R(57, { inches: 0.5 }),           55,   '57 + втулка 0.5" → 55');
+assertEqual(R(57, { inches: 1.0 }),           57,   '57 + втулка 1" → номинал 57 (условие не выполнено)');
+assertEqual(R(57, {}),                        57,   '57 без втулки → номинал 57');
+assertEqual(R(64, { inches: 1.0 }),           63.5, '64 + втулка 1" → 63.5');
+assertEqual(R(64, { inches: 0.5 }),           64,   '64 + втулка 0.5" → номинал 64');
+assertEqual(R(65, { inches: 1.0 }),           63.5, '65 + втулка 1" → 63.5');
+assertEqual(R(65, {}),                        65,   '65 без втулки → номинал 65');
+
+// Безусловные строки применяются всегда
+assertEqual(R(45, {}),                        44,   '45 → 44 (безусловно)');
+assertEqual(R(50, { jumbo: 910, inches: 1 }), 49,   '50 → 49 (безусловно, контекст игнорируется)');
+assertEqual(R(60, {}),                        59,   '60 → 59');
+assertEqual(R(75, {}),                        74,   '75 → 74');
+assertEqual(R(90, {}),                        89,   '90 → 89');
+assertEqual(R(100, {}),                       99,   '100 → 99');
+assertEqual(R(104, {}),                       103.5, '104 → 103.5');
+
+// Нет правила → номинал как есть
+assertEqual(R(999, { jumbo: 910 }),           999,  'нет правила → номинал 999');
+assertEqual(R(0, {}),                         0,    'вырожденная ширина 0 → 0');
+
+console.log('\n' + passed + ' проверок прошло.');
+if (process.exitCode === 1) {
+    console.log('ЕСТЬ ПАДЕНИЯ — см. выше.');
+} else {
+    console.log('Все проверки #3372 зелёные.');
+}


### PR DESCRIPTION
Closes #3372

## Что
Полосы в планировании производства считаются по **фактической** ширине резки (она меньше номинала из заказа), а не по номиналу.

Маппинг номинал → факт берётся из справочника **«Фактическая ширина резки»** (`table/66190`). Какую строку применить, определяет поле **«Код»** (жёсткий фильтр):
- пусто — безусловно;
- `j=910` / `j>1000` — по ширине джамбо «Вида сырья»;
- `s=0.5` / `s=1` — по диаметру втулки в дюймах (`8188` «Дюймы»).

Поддержаны операторы `= > < >= <=`. **Жёсткий фильтр:** факт. ширина применяется только при выполнении условия, иначе берётся номинал.

## Изменения в БД (уже на боевой ateh, аддитивно)
- В `66190` добавлено поле «Код» (req `66236`), проставлены условия: `66195=j=910`, `66196=j>1000`, `66199=s=0.5`, `66201/66202=s=1`; остальные строки пустые.
- READ-грант на `66190` ролям 1619/1621/1617 (зеркало 8188).

## Код (`download/atex/js/production-planning.js`)
Подход «флип»: позиция получает `orderWidth` (номинал, для подписей), а `width` становится **фактической** — её использует вся геометрия раскроя (раскладка `cut-layout`, полосы, Партии ГП, обеспечение, `posWidthKey`) автоматически, без правок геометрических узлов. 4 места отображения переведены на `orderWidth`.

Новое: чистые `parseActualWidthCode`/`actualWidthCodeMatches`/`buildActualWidthIndex`/`resolveCutWidth` (экспортированы в `planning`); загрузчики `loadActualWidths` (66190) и `loadSleeveInches` (8188) — резолв таблиц/колонок **по имени** (переживает пересборку БД); аннотация `annotatePositionsCutWidth` в `start()`.

## Тесты
- `experiments/test-issue-3372-actual-cut-width.js` — **43 PASS** (все сценарии из issue).
- Регресс `experiments/atex-production-planning.test.js` — **426 PASS**.
- Интерактив раскроя проверяется в браузере.

## ⚠️ К сведению по данным
Ширина джамбо у «Вида сырья» почти везде ровно **910** (→ `j=910` ловит). MWR112=1010 (→ `j>1000`). **MWR410L=1000 ровно** — `j>1000` не ловит (это «более 1000» строго), для номинала 33 останется 33. Если нужно включить ровно-1000 — поменять «Код» строки 66196 на `j>=1000` (правка данных, без кода).
