### PR TITLE
feat(upload): добавить кнопку сворачивания/разворачивания панели xlsx-area (#3382)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T06:06:21.167Z for PR creation at branch issue-3382-f009e65c93f1 for issue https://github.com/ideav/crm/issues/3382

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T06:06:21.167Z for PR creation at branch issue-3382-f009e65c93f1 for issue https://github.com/ideav/crm/issues/3382

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -142,6 +142,13 @@ table.xlsx-grid td.xr { background: rgba(13, 110, 253, .14); }
 table.xlsx-grid td.xs { outline: 2px solid var(--color-primary, #0d6efd); outline-offset: -2px; font-weight: 600; }
 table.xlsx-grid td.xe { box-shadow: inset 0 0 0 2px var(--color-success, #28a745); }
 table.xlsx-grid td:hover { background: rgba(13, 110, 253, .22); }
+/* Excel-панель: заголовок со значком сворачивания (issue #3382) */
+.xlsx-area-header { display: flex; align-items: center; justify-content: space-between; gap: .5rem; }
+.xlsx-area-header-title { flex: 1; }
+.xlsx-area-toggle { background: none; border: none; padding: 2px 6px; cursor: pointer; color: var(--text-secondary, #6c757d); font-size: .85rem; line-height: 1; border-radius: 3px; }
+.xlsx-area-toggle:hover { background: var(--bg-secondary, #f1f5f9); color: var(--text-primary, #212529); }
+#xlsx-area.xlsx-collapsed #xlsx-area-body { display: none; }
+#xlsx-area.xlsx-collapsed .xlsx-area-header { margin-bottom: 0 !important; }
 </style>
 <script src="/js/jquery3.1.1.min.js"></script>
 <script src="/js/jquery-ui1.12.1.min.js"></script>
@@ -226,14 +233,19 @@ table.xlsx-grid td:hover { background: rgba(13, 110, 253, .22); }
     </div>
     <div id="log" class="upload-log-bg overflow-auto small shadow-sm p-2 mb-2" style="max-height: 100px; display:none"></div>
     <div id="xlsx-area" class="mb-4 p-2 p-sm-3 shadow" style="display:none">
-        <div class="mb-2"><b>Excel-файл.</b> Выберите лист и кликните <b>стартовую ячейку</b> — будут взяты данные правее и ниже неё. <b>Shift+клик</b> по другой ячейке — задать правую/нижнюю границу.</div>
-        <div class="mb-2 d-flex align-items-center" style="gap:.75rem;flex-wrap:wrap">
-            <label class="mb-0">Лист:&nbsp;<select id="xlsx-sheet" class="form-control d-inline-block" style="width:auto;min-width:140px"></select></label>
-            <span id="xlsx-info" class="small" style="color:var(--text-secondary)"></span>
-            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="xlsxClearLimits()">Сбросить границы</button>
+        <div class="xlsx-area-header mb-2">
+            <span class="xlsx-area-header-title"><b>Excel-файл.</b> Выберите лист и кликните <b>стартовую ячейку</b> — будут взяты данные правее и ниже неё. <b>Shift+клик</b> по другой ячейке — задать правую/нижнюю границу.</span>
+            <button type="button" class="xlsx-area-toggle" onclick="xlsxToggleArea()" title="Свернуть / развернуть панель">&#9650;</button>
         </div>
-        <div id="xlsx-grid" class="xlsx-grid-wrap"></div>
-        <div class="mt-2"><button type="button" class="btn btn-primary" onclick="applyXlsxRange()">Применить диапазон</button></div>
+        <div id="xlsx-area-body">
+            <div class="mb-2 d-flex align-items-center" style="gap:.75rem;flex-wrap:wrap">
+                <label class="mb-0">Лист:&nbsp;<select id="xlsx-sheet" class="form-control d-inline-block" style="width:auto;min-width:140px"></select></label>
+                <span id="xlsx-info" class="small" style="color:var(--text-secondary)"></span>
+                <button type="button" class="btn btn-sm btn-outline-secondary" onclick="xlsxClearLimits()">Сбросить границы</button>
+            </div>
+            <div id="xlsx-grid" class="xlsx-grid-wrap"></div>
+            <div class="mt-2"><button type="button" class="btn btn-primary" onclick="applyXlsxRange()">Применить диапазон</button></div>
+        </div>
     </div>
     <div id="progress" class="upload-progress-bg shadow p-2" style="display:none"></div>
     <div id="errors" class="upload-errors-bg p-2 mt-1" style="display:none"></div>
@@ -1491,6 +1503,13 @@ function drawXlsxGrid(){
 }
 
 function xlsxClearLimits(){ xlsxSel.r1=null; xlsxSel.c1=null; drawXlsxGrid(); }
+
+function xlsxToggleArea(){
+    var area = document.getElementById('xlsx-area');
+    var collapsed = area.classList.toggle('xlsx-collapsed');
+    var btn = area.querySelector('.xlsx-area-toggle');
+    if(btn) btn.innerHTML = collapsed ? '&#9660;' : '&#9650;';
+}
 
 function applyXlsxRange(){
     if(!xlsxRows.length){ xlsxShowError('Лист пуст'); return; }


### PR DESCRIPTION
## Что делает

Закрывает #3382.

Добавляет кнопку **▲ / ▼** в правый верхний угол панели Excel-файла (`#xlsx-area`), чтобы пользователь мог свернуть её, когда уже применил диапазон и работает с данными в поле ввода `#input`.

## Детали реализации

- В `#xlsx-area` добавлен заголовочный ряд `.xlsx-area-header` с flex-выравниванием: слева — текст-подсказка, справа — кнопка-треугольник.
- Содержимое панели (выбор листа, сетка, кнопка «Применить диапазон») обёрнуто в `#xlsx-area-body`.
- CSS: при классе `xlsx-collapsed` на `#xlsx-area` тело скрывается через `display:none`, отступ заголовка убирается.
- JS-функция `xlsxToggleArea()` переключает класс и меняет иконку (`▲` → `▼` и обратно).

## Как воспроизвести

1. Импорт → выбрать `.xlsx/.xls` файл.
2. Дождаться появления панели Excel.
3. Нажать кнопку **▲** в правом верхнем углу панели — панель свернётся.
4. Нажать **▼** — панель развернётся обратно.


Fixes #3382