### PR TITLE
feat(upload): авто-применять диапазон Excel и сворачивать панель при сохранённой настройке (#3386)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T07:37:32.420Z for PR creation at branch issue-3386-5b60dd15fcb1 for issue https://github.com/ideav/crm/issues/3386

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T07:37:32.420Z for PR creation at branch issue-3386-5b60dd15fcb1 for issue https://github.com/ideav/crm/issues/3386

--- a/experiments/test-issue-3386-xlsx-auto-apply-collapse.js
+++ b/experiments/test-issue-3386-xlsx-auto-apply-collapse.js
@@ -1,0 +1,126 @@
+// Regression test for issue #3386.
+//
+// "https://github.com/ideav/crm/pull/3385 При выборе сохранённой настройки и
+//  загрузке excel файла автоматически применять сохранённый диапазон и
+//  сворачивать панель #xlsx-area"
+//
+// Building on #3384/#3385 (which persist the Excel sheet/range inside an upload
+// set and restore them on the next .xlsx load), this change makes the restore
+// fully hands-off: when a saved set carries an Excel block and the matching
+// sheet loads, handleExcelFile() must
+//   1. restore the sheet + range (renderXlsxSheet(saved.sheet,saved)) — as before,
+//   2. immediately apply the range (applyXlsxRange()) so #input is populated
+//      without the user pressing «Применить диапазон», and
+//   3. collapse the #xlsx-area panel (xlsxSetAreaCollapsed(true)) — but only when
+//      the apply actually produced data (applyXlsxRange() returns true).
+// When no saved block is present the panel is expanded for manual selection.
+//
+// This test extracts the REAL handleExcelFile / xlsxSetAreaCollapsed /
+// xlsxToggleArea / applyXlsxRange sources from the template, runs static wiring
+// checks, and drives the collapse logic against a tiny DOM shim to assert the
+// round-trip set/toggle behaviour and the "only collapse on success" contract.
+
+var fs = require('fs');
+var path = require('path');
+
+var passed = 0, failed = 0;
+function check(name, ok){
+  console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+  if (ok) passed++; else { failed++; process.exitCode = 1; }
+}
+
+var template = fs.readFileSync(path.join(__dirname, '..', 'templates', 'upload.html'), 'utf8');
+function extractFn(name){
+  var start = template.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error(name + '() not found in template');
+  var depth = 0, end = -1;
+  for (var i = template.indexOf('{', start); i < template.length; i++) {
+    if (template[i] === '{') depth++;
+    else if (template[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+  }
+  return template.slice(start, end);
+}
+
+// ── Static wiring checks on handleExcelFile ──────────────────────────────────
+var handleSrc = extractFn('handleExcelFile');
+check('handleExcelFile still restores the saved sheet/range first',
+  /renderXlsxSheet\(saved\.sheet,saved\)/.test(handleSrc));
+check('handleExcelFile auto-applies the range and collapses on success (issue #3386)',
+  /xlsxSetAreaCollapsed\(applyXlsxRange\(\)\)/.test(handleSrc));
+check('handleExcelFile keeps the panel expanded when there is no saved block',
+  /renderXlsxSheet\(xlsxWorkbook\.SheetNames\[0\]\)[\s\S]*xlsxSetAreaCollapsed\(false\)/.test(handleSrc));
+
+// applyXlsxRange must report success/failure so the collapse can be conditional.
+var applySrc = extractFn('applyXlsxRange');
+check('applyXlsxRange returns false on empty sheet / empty range',
+  /xlsxShowError\('Лист пуст'\);\s*return false/.test(applySrc) &&
+  /xlsxShowError\('В выбранном диапазоне нет данных'\);\s*return false/.test(applySrc));
+check('applyXlsxRange returns true after populating #input',
+  /importParse\(\);\s*return true/.test(applySrc));
+
+// ── Behavioural harness for xlsxSetAreaCollapsed()/xlsxToggleArea() ──────────
+// Minimal classList + element shim so the real DOM-touching code runs in Node.
+function makeArea(){
+  var classes = {};
+  var btn = { innerHTML: '' };
+  var area = {
+    classList: {
+      toggle: function(name, force){
+        var has = !!classes[name];
+        var next = (arguments.length > 1) ? !!force : !has;
+        if (next) classes[name] = true; else delete classes[name];
+        return next;
+      },
+      contains: function(name){ return !!classes[name]; }
+    },
+    querySelector: function(sel){ return sel === '.xlsx-area-toggle' ? btn : null; }
+  };
+  return { area: area, btn: btn, isCollapsed: function(){ return area.classList.contains('xlsx-collapsed'); } };
+}
+
+function buildCollapseApi(dom){
+  var setSrc = extractFn('xlsxSetAreaCollapsed');
+  var toggleSrc = extractFn('xlsxToggleArea');
+  var factory = new Function('document',
+    setSrc + '\n' + toggleSrc + '\n' +
+    'return { set: xlsxSetAreaCollapsed, toggle: xlsxToggleArea };');
+  return factory({ getElementById: function(id){ return id === 'xlsx-area' ? dom.area : null; } });
+}
+
+(function(){
+  var dom = makeArea();
+  var api = buildCollapseApi(dom);
+
+  api.set(true);
+  check('setAreaCollapsed(true) collapses and shows the ▼ (expand) arrow',
+    dom.isCollapsed() && dom.btn.innerHTML === '&#9660;');
+
+  api.set(false);
+  check('setAreaCollapsed(false) expands and shows the ▲ (collapse) arrow',
+    !dom.isCollapsed() && dom.btn.innerHTML === '&#9650;');
+
+  api.set(true); api.set(true);
+  check('setAreaCollapsed is idempotent (true twice stays collapsed)', dom.isCollapsed());
+
+  api.toggle();
+  check('toggle flips collapsed → expanded', !dom.isCollapsed() && dom.btn.innerHTML === '&#9650;');
+  api.toggle();
+  check('toggle flips expanded → collapsed', dom.isCollapsed() && dom.btn.innerHTML === '&#9660;');
+})();
+
+// ── "Only collapse on success" contract, mirrored against the real logic ─────
+// Reproduce the exact handleExcelFile branch — xlsxSetAreaCollapsed(applyXlsxRange())
+// — to prove a failed apply leaves the panel open and a successful one collapses it.
+(function(){
+  var dom = makeArea();
+  var api = buildCollapseApi(dom);
+
+  api.set(false);
+  api.set(/*failed apply*/ false === true ? true : false);   // simulate applyXlsxRange()===false
+  check('failed apply (returns false) leaves the panel expanded', !dom.isCollapsed());
+
+  api.set(/*succeeded apply*/ true);                          // simulate applyXlsxRange()===true
+  check('successful apply (returns true) collapses the panel', dom.isCollapsed());
+})();
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1469,9 +1469,18 @@ function handleExcelFile(file){
             if(saved&&saved.sheet&&xlsxWorkbook.SheetNames.indexOf(saved.sheet)!==-1){
                 $('#xlsx-sheet').val(saved.sheet);
                 renderXlsxSheet(saved.sheet,saved);
+                // issue #3386: восстановили лист/диапазон из сохранённой настройки —
+                // сразу применяем его и сворачиваем панель, чтобы пользователю не
+                // приходилось вручную жать «Применить диапазон». Панель остаётся
+                // доступной (можно развернуть кнопкой ▼) для ручной правки. Если
+                // применять нечего (пустой диапазон), панель не сворачиваем.
+                xlsxSetAreaCollapsed(applyXlsxRange());
             }
-            else
+            else{
                 renderXlsxSheet(xlsxWorkbook.SheetNames[0]);
+                // без сохранённого выбора панель всегда раскрыта — нужен ручной выбор диапазона.
+                xlsxSetAreaCollapsed(false);
+            }
         };
         fr.onerror=function(){ $('#xlsx-area').hide(); xlsxShowError('Ошибка чтения файла'); };
         fr.readAsArrayBuffer(file);
@@ -1546,22 +1555,34 @@ function drawXlsxGrid(){
 
 function xlsxClearLimits(){ xlsxSel.r1=null; xlsxSel.c1=null; drawXlsxGrid(); }
 
-function xlsxToggleArea(){
+// Явно задаёт состояние свёрнутости панели #xlsx-area и синхронизирует стрелку
+// кнопки. Используется и кнопкой переключения, и авто-сворачиванием (issue #3386).
+function xlsxSetAreaCollapsed(collapsed){
     var area = document.getElementById('xlsx-area');
-    var collapsed = area.classList.toggle('xlsx-collapsed');
+    if(!area) return;
+    area.classList.toggle('xlsx-collapsed', !!collapsed);
     var btn = area.querySelector('.xlsx-area-toggle');
     if(btn) btn.innerHTML = collapsed ? '&#9660;' : '&#9650;';
 }
 
+function xlsxToggleArea(){
+    var area = document.getElementById('xlsx-area');
+    if(!area) return;
+    xlsxSetAreaCollapsed(!area.classList.contains('xlsx-collapsed'));
+}
+
+// Возвращает true, если диапазон применён (данные нашлись и попали в #input),
+// иначе false — авто-сворачивание панели (issue #3386) опирается на этот признак,
+// чтобы не прятать панель, когда применять нечего.
 function applyXlsxRange(){
-    if(!xlsxRows.length){ xlsxShowError('Лист пуст'); return; }
+    if(!xlsxRows.length){ xlsxShowError('Лист пуст'); return false; }
     var eR=xlsxEndR(), eC=xlsxEndC(), out=[];
     for(var r=xlsxSel.r0;r<=eR;r++){
         var row=[];
         for(var c=xlsxSel.c0;c<=eC;c++) row.push(xlsxRows[r]&&xlsxRows[r][c]!==undefined?xlsxRows[r][c]:'');
         if(row.some(function(v){ return String(v).trim()!==''; })) out.push(row);
     }
-    if(!out.length){ xlsxShowError('В выбранном диапазоне нет данных'); return; }
+    if(!out.length){ xlsxShowError('В выбранном диапазоне нет данных'); return false; }
     // issue #3374: распознанные строки кладём в #input как текст (CSV), чтобы их
     // можно было отредактировать перед загрузкой; дальше идёт обычный текстовый путь
     // (Papa.parse → importDoParse). Так Excel и текстовый импорт ведут себя одинаково:
@@ -1571,6 +1592,7 @@ function applyXlsxRange(){
         return row.map(function(v){ return serializeUploadCellValue(v); });
     }),{delimiter:$('#delim').val()||','}));
     importParse();
+    return true;
 }
 
 $(document).on('click','#xlsx-grid td[data-r]',function(e){


### PR DESCRIPTION
## Что делает

Issue #3386 — продолжение #3384/#3385. Когда выбрана **сохранённая настройка импорта** с записанным Excel-блоком (лист + диапазон) и затем загружается тот же `.xlsx`, теперь происходит автоматически:

1. **Восстановление** листа и диапазона из настройки (как раньше, из #3385).
2. **Применение диапазона** — `applyXlsxRange()` вызывается сам, поле `#input` сразу заполняется CSV-срезом. Пользователю **не нужно** вручную жать «Применить диапазон».
3. **Сворачивание панели** `#xlsx-area` — место освобождается, но панель остаётся доступной (кнопка **▼** разворачивает её для ручной правки).

Если применять нечего (восстановленный диапазон оказался пустым после клиппинга по факт. границам), панель **не** сворачивается, чтобы пользователь мог поправить выбор.

Без сохранённой настройки поведение не меняется: панель раскрыта, диапазон выбирается вручную.

## Как воспроизвести (до фикса)

1. Универсальная загрузка → выбрать `.xlsx`, выбрать лист, стартовую ячейку, при желании Shift+клик — границы.
2. «Применить диапазон» → «Настроить» → **Сохранить настройку**.
3. Заново выбрать эту настройку и загрузить тот же файл.
4. **Было:** лист/диапазон восстанавливались, но приходилось вручную жать «Применить диапазон»; панель Excel оставалась раскрытой.
   **Стало:** диапазон применяется автоматически, панель сворачивается.

## Реализация (`templates/upload.html`)

- **`handleExcelFile`**: в ветке восстановления из сохранённой настройки после `renderXlsxSheet(saved.sheet,saved)` вызывается `xlsxSetAreaCollapsed(applyXlsxRange())` — применить и свернуть только при успехе. В ветке без настройки — `xlsxSetAreaCollapsed(false)` (панель раскрыта).
- **`applyXlsxRange`**: теперь возвращает `true`/`false` (применён ли диапазон) — ранние выходы при пустом листе/диапазоне возвращают `false`.
- **`xlsxSetAreaCollapsed(collapsed)`**: новая функция, явно задаёт состояние свёрнутости и синхронизирует стрелку кнопки; `xlsxToggleArea()` теперь обёртка над ней (поведение кнопки прежнее).

## Тест

`experiments/test-issue-3386-xlsx-auto-apply-collapse.js` — извлекает реальные `handleExcelFile`/`applyXlsxRange`/`xlsxSetAreaCollapsed`/`xlsxToggleArea` из шаблона, проверяет проводку авто-применения и сворачивания, контракт «сворачиваем только при успехе», идемпотентность сеттера и переключение кнопкой. **12 passed, 0 failed.** Регрессионный тест #3384 — по-прежнему **14 passed, 0 failed.**

Fixes #3386
