### PR TITLE
fix(upload): пропускать строку по главному значению, а не по первой колонке (#3389)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T18:03:33.993Z for PR creation at branch issue-3389-569f1189a2c6 for issue https://github.com/ideav/crm/issues/3389

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T18:03:33.993Z for PR creation at branch issue-3389-569f1189a2c6 for issue https://github.com/ideav/crm/issues/3389

--- a/experiments/issue-3389-upload-skip-empty.test.js
+++ b/experiments/issue-3389-upload-skip-empty.test.js
@@ -1,0 +1,144 @@
+// Regression test for issue #3389.
+//
+// templates/upload.html — importDoParse() decides whether to drop a data row as
+// "empty". The original check looked at the FIRST INPUT column (`j==='0'`): if it
+// was empty, the whole row was skipped. But with a saved import set the user may
+// not use the first input column at all (e.g. a CSV with a leading comma:
+// `,3580,Образец…`). Those rows were silently dropped even though the field the
+// user actually imports (the chosen type's value, which lands first in the OUTPUT
+// after the importMap layout) is present.
+//
+// The fix: skip a row only when the MAIN value — the chosen type's field — is
+// empty, not the first input column. This test extracts the real importDoParse()
+// source from the template and runs it under tiny shims.
+
+var fs = require('fs');
+var path = require('path');
+
+var passed = 0, failed = 0;
+function check(name, ok){
+  console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+  if (ok) passed++; else { failed++; process.exitCode = 1; }
+}
+
+// ── Extract the real importDoParse() source from the template ────────────────
+var template = fs.readFileSync(path.join(__dirname, '..', 'templates', 'upload.html'), 'utf8');
+var start = template.indexOf('function importDoParse(input){');
+if (start < 0) throw new Error('importDoParse() not found in template');
+var depth = 0, end = -1;
+for (var i = template.indexOf('{', start); i < template.length; i++) {
+  if (template[i] === '{') depth++;
+  else if (template[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+}
+var importDoParseSrc = template.slice(start, end);
+
+// The fix must no longer key the skip on the first input column.
+check('importDoParse no longer skips rows by the first input column (j===\'0\')',
+  !/j===['"]0['"]&&val===['"]['"]/.test(importDoParseSrc) &&
+  /sourceMap\[k\]\.id===chosenType/.test(importDoParseSrc));
+
+// ── Faithful, tiny reimplementation of serializeUploadCellValue ──────────────
+function serializeUploadCellValue(v){
+  if (v === undefined || v === null) return '';
+  if (typeof v === 'object') { try { return JSON.stringify(v); } catch(e) { return String(v); } }
+  return v.toString();
+}
+
+// ── jQuery shim: captures .html() into a store, answers .prop('checked') ──────
+function makeShim(opts, store){
+  return function(sel){
+    var id = sel.charAt(0) === '#' ? sel.slice(1) : sel;
+    return {
+      html: function(v){ if (arguments.length) { store[id] = v; return this; } return store[id] || ''; },
+      hide: function(){ return this; },
+      show: function(){ return this; },
+      prop: function(){ if (id === 'trim') return !!opts.trim; if (id === 'header') return !!opts.header; return false; }
+    };
+  };
+}
+
+function runImportDoParse(scenario){
+  var store = {};
+  var $ = makeShim(scenario, store);
+  var noop = function(){};
+  var factory = new Function(
+    '$', 'escape', 'serializeUploadCellValue', 'parseType', 'procStats', 'drawPage',
+    'previewCopyActionHtml', 'setPreviewCopyStatus',
+    'chosenType', 'sourceMap', 'importMap', 'origMap', 'formulas', 'autoParent', 'chunkSize',
+    'var toImport, statArr, evalExpr={}, evalErrs={};\n' +
+    importDoParseSrc +
+    '\nreturn { run: importDoParse, toImport: function(){ return toImport; } };'
+  );
+  var api = factory(
+    $, function(s){ return s; }, serializeUploadCellValue, noop, noop, noop,
+    function(){ return ''; }, noop,
+    scenario.chosenType, scenario.sourceMap, scenario.importMap, scenario.origMap,
+    scenario.formulas || {}, scenario.autoParent, 1000
+  );
+  api.run({ data: scenario.data });
+  var rows = api.toImport().filter(function(r){ return r !== undefined; });
+  // "всего строк: <b>N</b>" from the #resume summary.
+  var m = /всего строк[\s\S]*?<b>(\d+)<\/b>/.exec(store.resume || '');
+  return { rows: rows, total: m ? parseInt(m[1], 10) : null };
+}
+
+// ── Scenario from the issue: type 1076, first input column unused & empty ─────
+// Saved set importMap maps 66405→col0 (empty leading comma), 1076 (chosen type,
+// "Заказанное количество")→col7, autoParent=2 → parent read from col1.
+var issueScenario = {
+  chosenType: '1076',
+  autoParent: 2,
+  trim: 1,
+  header: 0,
+  sourceMap: [
+    { id: '66405', base: '1',  name: 'Неиспользуемая колонка', skip: 0 },
+    { id: '1138',  base: '1',  name: 'Артикул',                skip: 0 },
+    { id: '1076',  base: '13', name: 'Заказанное количество',  skip: 0 }
+  ],
+  importMap: { '66405': 0, '1138': 2, '1076': 7 },
+  origMap:   { '1076': 0, '1138': 3, '66405': 4 },
+  data: [
+    ['', '3580', 'Образец MW208 (110*200) OUT с прозрачным лидером', '75мм х 5', '16.06.2026', '', '', '3'],
+    ['', '3580', 'Образец MW208 (75*200) OUT с прозрачным лидером',  '75мм х 5', '16.06.2026', '', '', '5'],
+    ['', '3580', 'Образец MW208 (30*200) OUT с прозрачным лидером',  '75мм х 5', '16.06.2026', '', '', '6']
+  ]
+};
+
+var res = runImportDoParse(issueScenario);
+check('all 3 rows are imported even though the first input column is empty',
+  res.total === 3 && res.rows.length === 3);
+
+// ── Row whose MAIN value (chosen type, col7) is empty must still be skipped ───
+var emptyMainScenario = JSON.parse(JSON.stringify(issueScenario));
+emptyMainScenario.data = [
+  ['', '3580', 'Образец A', '75мм', '16.06.2026', '', '', '3'],
+  ['', '3580', 'Образец B', '75мм', '16.06.2026', '', '', ''],   // main qty empty → skip
+  ['', '3580', 'Образец C', '75мм', '16.06.2026', '', '', '6']
+];
+var res2 = runImportDoParse(emptyMainScenario);
+check('a row with an empty MAIN value (chosen type) is skipped',
+  res2.total === 2 && res2.rows.length === 2);
+
+// ── chosenType===undefined keeps the original "first column" semantics ────────
+var newTypeScenario = {
+  chosenType: undefined,
+  autoParent: undefined,
+  trim: 1,
+  header: 0,
+  sourceMap: [
+    { id: 0, base: '1', name: 'Колонка A', skip: 0 },
+    { id: 1, base: '1', name: 'Колонка B', skip: 0 }
+  ],
+  importMap: {},
+  origMap: {},
+  data: [
+    ['x', 'a'],
+    ['',  'b'],   // first column empty → skipped when creating a new type
+    ['y', 'c']
+  ]
+};
+var res3 = runImportDoParse(newTypeScenario);
+check('creating a new type still skips rows with an empty first column',
+  res3.total === 2 && res3.rows.length === 2);
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1236,8 +1236,31 @@ function importDoParse(input){
         else
             reverseMap[sourceMap[j].name]=importMap[sourceMap[j].id];
     }
+    // issue #3389: считаем строку пустой и пропускаем её, только если пусто ГЛАВНОЕ
+    // значение — поле выбранного типа, которое после раскладки по importMap встаёт
+    // первым в выходе. Раньше проверялась первая ВХОДНАЯ колонка (j==='0'), но она
+    // может быть пустой по задумке и вообще не участвовать в загрузке (например,
+    // ведущая запятая в CSV: ,3580,Образец…). Такие строки терять нельзя.
+    function rowCellTrimmed(row,j){
+        var v=chosenType===undefined?input.data[row][sourceMap[j].id]:input.data[row][importMap[sourceMap[j].id]];
+        if(v!==undefined||$('#trim').prop('checked'))
+            v=serializeUploadCellValue(v);
+        if($('#trim').prop('checked')&&v!==' ')
+            v=v.trim();
+        return v;
+    }
+    function isPrimaryEmpty(row){
+        for(var k in sourceMap)
+            if(sourceMap[k].skip===0&&(chosenType===undefined?k==='0':sourceMap[k].id===chosenType))
+                return rowCellTrimmed(row,k)==='';
+        return false;
+    }
     mainloop:for(i in input.data)
         if(!$('#header').prop('checked')||i!=0){
+            if(isPrimaryEmpty(i)){
+                skippedInvalid++;
+                continue mainloop;
+            }
             l++;
             if(autoParent)
                 toImport[l]=Array(serializeUploadCellValue(input.data[i][autoParent-1]));
@@ -1260,12 +1283,6 @@ function importDoParse(input){
                     if($('#trim').prop('checked'))
                         if(val!==' ')
                             val=val.trim();
-                    if(j==='0'&&val===''){
-                        skippedInvalid++;
-                        l--;
-                        toImport.pop();
-                        continue mainloop;
-                    }
                     if(formulas[sourceMap[j].id]){
                         expr=formulas[sourceMap[j].id].replace(/\[(.+?)\]/mug,function($1,$2){
                                 if(reverseMap[$2]!==undefined)


### PR DESCRIPTION
## Что чинит

Fixes #3389

В `templates/upload.html` функция `importDoParse()` отбрасывала строку как «пустую», если была пуста **первая входная колонка** (`j==='0'`). При сохранённой настройке импорта эта колонка может вообще не использоваться при загрузке — например, в CSV с ведущей запятой:

```
,3580,Образец MW208 (110*200) OUT с прозрачным лидером,…,16.06.2026,,,3
,3580,Образец MW208 (75*200) OUT с прозрачным лидером,…,16.06.2026,,,5
,3580,Образец MW208 (30*200) OUT с прозрачным лидером,…,16.06.2026,,,6
```

Здесь колонка 0 пустая по задумке (поле `66405` в `importMap` указывает на неё), а реально загружаемое значение — поле выбранного типа `1076` «Заказанное количество» (колонка 7). Все три валидные строки молча терялись.

## Решение

Строка пропускается только если пусто **главное значение** — поле выбранного типа (`sourceMap[k].id===chosenType`), которое после раскладки по `importMap` встаёт первым в выходе. Это и есть «та колонка, которая стала первой после вычислений» из формулировки issue.

- При выбранном типе проверяется значение поля типа, а не первая входная колонка.
- Для создания нового типа (`chosenType===undefined`) поведение прежнее — проверяется первая колонка.
- Проверка вынесена до инкремента счётчика строк, поэтому статистика по пропущенным строкам больше не искажается.

## Как воспроизвести

1. Сохранить настройку импорта с `importMap`, где первая входная колонка не используется как главное значение (как в issue).
2. Загрузить CSV/Excel, где первая колонка пустая, а главное значение заполнено.
3. До фикса: строки пропускались («пропущено пустых»). После фикса: импортируются все строки.

## Тест

Добавлен регрессионный тест `experiments/issue-3389-upload-skip-empty.test.js`, который извлекает реальный код `importDoParse()` из шаблона и проверяет:

- все 3 строки из примера issue импортируются, несмотря на пустую первую колонку;
- строка с пустым **главным** значением по-прежнему пропускается;
- при создании нового типа сохраняется прежняя логика «первой колонки».

```
$ node experiments/issue-3389-upload-skip-empty.test.js
PASS — importDoParse no longer skips rows by the first input column (j==='0')
PASS — all 3 rows are imported even though the first input column is empty
PASS — a row with an empty MAIN value (chosen type) is skipped
PASS — creating a new type still skips rows with an empty first column

4 passed, 0 failed
```
