### PR TITLE
templates/main.html: скрыть старый ИИ-чат, добавить упрощённый ИИ-агент с проверкой оплаты (#3392)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T18:04:22.720Z for PR creation at branch issue-3392-8dfe510e111d for issue https://github.com/ideav/crm/issues/3392

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T18:04:22.720Z for PR creation at branch issue-3392-8dfe510e111d for issue https://github.com/ideav/crm/issues/3392

--- a/css/ai-chat.css
+++ b/css/ai-chat.css
@@ -325,6 +325,92 @@
     flex-shrink: 0;
 }
 
+/* Issue #3392: упрощённый ИИ-агент — компоновщик с иконками */
+.ai-chat-composer {
+    flex-direction: column;
+    align-items: stretch;
+}
+
+.ai-agent-composer-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.ai-agent-composer-row textarea {
+    flex: 1;
+    min-height: 42px;
+    max-height: 160px;
+    resize: vertical;
+    font-family: inherit;
+}
+
+.ai-chat-icon-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.ai-agent-send {
+    color: var(--button-primary);
+}
+
+.ai-agent-attachments {
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 0.6rem;
+    padding: 0;
+}
+
+.ai-agent-attachments:empty {
+    display: none;
+}
+
+.ai-agent-attachment {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    max-width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: 0.78rem;
+}
+
+.ai-agent-attachment-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 220px;
+}
+
+.ai-agent-attachment-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.85rem;
+}
+
+.ai-agent-attachment-remove:hover {
+    color: var(--button-primary);
+}
+
+.ai-chat-message-pay {
+    display: inline-block;
+    margin-top: 0.4rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--button-primary);
+}
+
 @media (max-width: 600px) {
     .ai-chat-panel {
         width: 100vw;

--- a/index.php
+++ b/index.php
@@ -8611,6 +8611,7 @@ function aiChatError($message, $code=400){
 function aiChatHttpStatusText($code){
     $statuses = array(
         400 => "Bad Request",
+        402 => "Payment Required",
         403 => "Forbidden",
         404 => "Not Found",
         405 => "Method Not Allowed",
@@ -8633,6 +8634,214 @@ function getAiAccessibleDbs(){
     if(!in_array("my", $dbs, true))
         $dbs[] = "my";
     return array_values(array_unique($dbs));
+}
+# ============================================================
+# Issue #3392: упрощённый ИИ-агент (/{db}/ai/agent)
+#
+# Новый чат обращается только к нашему фиксированному агенту. Доступ разрешён
+# только пользователю, имя которого совпадает с именем базы. Условие доработки —
+# действующая оплата клиента, которая проверяется запросом к отчёту 237290 и
+# кешируется. Все действия агента ограничены текущей базой данных
+# (см. docs/integram-app-workflow.md).
+# ============================================================
+function handleAiAgentRequest($com){
+    global $z;
+    if($_SERVER["REQUEST_METHOD"] !== "POST")
+        aiAgentError(t9n("[RU]ИИ-агент принимает только POST[EN]The AI agent accepts POST only"), 405);
+    check(); # XSRF
+
+    # Доступ только владельцу базы — пользователю, имя которого совпадает с именем базы.
+    $user = isset($GLOBALS["GLOBAL_VARS"]["user"]) ? strtolower((string)$GLOBALS["GLOBAL_VARS"]["user"]) : "";
+    if($user === "" || $user !== strtolower((string)$z))
+        aiAgentError(t9n("[RU]ИИ-агент доступен только владельцу базы — пользователю, имя которого совпадает с именем базы данных.[EN]The AI agent is available only to the database owner — the user whose name matches the database name."), 403);
+
+    # Проверка оплаты (закеширована). При отсутствии/истечении оплаты — ссылка на оплату.
+    $payment = checkAiAgentPayment($z);
+    if(empty($payment["ok"]))
+        aiAgentError($payment["message"], 402, array("paymentStatus" => $payment["status"], "payUrl" => $payment["payUrl"]));
+
+    $message = isset($_POST["message"]) ? trim((string)$_POST["message"]) : "";
+    $attachments = collectAiAgentAttachments();
+    if($message === "" && !count($attachments))
+        aiAgentError(t9n("[RU]Сообщение для ИИ-агента не передано[EN]No message provided for the AI agent"), 400);
+
+    try {
+        $response = callIntegramAgent($z, $message, $attachments, $payment);
+        api_dump(json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+    } catch(Exception $e) {
+        $code = (int)$e->getCode();
+        if($code < 400 || $code > 599)
+            $code = 502;
+        aiAgentError($e->getMessage(), $code);
+    }
+}
+function aiAgentError($message, $code=400, $extra=array()){
+    header("HTTP/1.0 ".$code." ".aiChatHttpStatusText($code));
+    $payload = array_merge(array("error" => $message), is_array($extra) ? $extra : array());
+    api_dump(json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+}
+function collectAiAgentAttachments(){
+    $attachments = array();
+    if(empty($_FILES) || !isset($_FILES["files"]))
+        return $attachments;
+    $files = $_FILES["files"];
+    $maxBytes = 10 * 1024 * 1024; # 10 МБ на файл
+    $names = is_array($files["name"]) ? $files["name"] : array($files["name"]);
+    $tmp = is_array($files["tmp_name"]) ? $files["tmp_name"] : array($files["tmp_name"]);
+    $types = is_array($files["type"]) ? $files["type"] : array($files["type"]);
+    $sizes = is_array($files["size"]) ? $files["size"] : array($files["size"]);
+    $errors = is_array($files["error"]) ? $files["error"] : array($files["error"]);
+    foreach($names as $i => $name){
+        if(!isset($errors[$i]) || $errors[$i] !== UPLOAD_ERR_OK)
+            continue;
+        if(!isset($tmp[$i]) || !is_uploaded_file($tmp[$i]))
+            continue;
+        if((int)$sizes[$i] > $maxBytes)
+            continue;
+        $content = @file_get_contents($tmp[$i]);
+        if($content === false)
+            continue;
+        $attachments[] = array(
+            "name" => (string)$name,
+            "type" => (string)$types[$i],
+            "size" => (int)$sizes[$i],
+            "content" => base64_encode($content)
+        );
+    }
+    return $attachments;
+}
+function checkAiAgentPayment($db){
+    $ttl = (int)aiConfigValue(array("AI_AGENT_PAYMENT_CACHE_TTL"));
+    if($ttl <= 0)
+        $ttl = 3600; # кеш на 1 час
+    $safeDb = preg_replace('/[^a-z0-9_]/i', '', (string)$db);
+    $cacheFile = sys_get_temp_dir()."/ai_agent_pay_".$safeDb.".json";
+    $raw = false;
+    if($safeDb !== "" && is_readable($cacheFile) && (time() - filemtime($cacheFile) < $ttl)){
+        $cached = @file_get_contents($cacheFile);
+        if($cached !== false && trim((string)$cached) !== "")
+            $raw = $cached;
+    }
+    if($raw === false){
+        $fetched = fetchAiAgentPaymentReport($safeDb);
+        if($fetched !== false){
+            $raw = $fetched;
+            if($safeDb !== "")
+                @file_put_contents($cacheFile, $raw);
+        }
+    }
+    return evaluateAiAgentPayment($raw, $safeDb);
+}
+function fetchAiAgentPaymentReport($db){
+    # GET https://ideav.ru/my/report/237290?JSON_KV&FR_DB={db} — срок действия оплаты.
+    $base = aiConfigValue(array("AI_AGENT_PAYMENT_REPORT_URL"));
+    if($base === "")
+        $base = "https://ideav.ru/my/report/237290?JSON_KV&FR_DB=";
+    $url = $base.rawurlencode((string)$db);
+    if(!function_exists("curl_init")){
+        $ctx = stream_context_create(array("http" => array("method" => "GET", "timeout" => 8)));
+        $raw = @file_get_contents($url, false, $ctx);
+        return $raw === false ? false : $raw;
+    }
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, false);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 8);
+    $raw = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if($raw === false || $httpCode < 200 || $httpCode >= 300)
+        return false;
+    return $raw;
+}
+function evaluateAiAgentPayment($raw, $db){
+    $payUrl = aiConfigValue(array("AI_AGENT_PAY_URL"));
+    if($payUrl === "")
+        $payUrl = "https://ideav.ru/my/";
+    $result = array(
+        "ok" => false,
+        "status" => "unknown",
+        "message" => "",
+        "payUrl" => $payUrl,
+        "amount" => 0,
+        "paidAt" => 0,
+        "paidUntil" => 0
+    );
+    $notPaidMessage = t9n("[RU]Доступ к ИИ-агенту не оплачен. Оплатите доступ, чтобы продолжить.[EN]Access to the AI agent is not paid. Please pay to continue.")." ".$payUrl;
+    $data = is_string($raw) && trim($raw) !== "" ? json_decode($raw, true) : null;
+    $row = (is_array($data) && isset($data[0]) && is_array($data[0])) ? $data[0] : null;
+    if(!$row || !isset($row["Paid"]) || trim((string)$row["Paid"]) === ""){
+        $result["status"] = "not_paid";
+        $result["message"] = $notPaidMessage;
+        return $result;
+    }
+    $paidAt = (int)$row["Paid"];
+    $amount = isset($row["Payment"]) ? (float)$row["Payment"] : 0;
+    $result["paidAt"] = $paidAt;
+    $result["amount"] = $amount;
+    # Сумма должна быть 5950 или 12500.
+    $validAmount = (abs($amount - 5950) < 0.01 || abs($amount - 12500) < 0.01);
+    if(!$validAmount){
+        $result["status"] = "not_paid";
+        $result["message"] = $notPaidMessage;
+        return $result;
+    }
+    # Дата не старше месяца.
+    $monthAgo = time() - 31 * 24 * 3600;
+    if($paidAt < $monthAgo){
+        $result["status"] = "expired";
+        $result["message"] = t9n("[RU]Оплаченный период использования ИИ-агента истёк. Продлите оплату, чтобы продолжить.[EN]Your paid AI agent period has expired. Please renew the payment to continue.")." ".$payUrl;
+        return $result;
+    }
+    $result["ok"] = true;
+    $result["status"] = "active";
+    $result["paidUntil"] = $paidAt + 31 * 24 * 3600;
+    return $result;
+}
+function callIntegramAgent($db, $message, $attachments, $payment){
+    # Отправка данных фиксированному ИИ-агенту. Описание API будет предоставлено в
+    # следующем тикете (issue #3392), поэтому endpoint берётся из конфигурации,
+    # а при его отсутствии возвращается подтверждение готовности без вызова.
+    $endpoint = aiConfigValue(array("INTEGRAM_AGENT_ENDPOINT", "AI_AGENT_ENDPOINT"));
+    $paymentInfo = array("status" => $payment["status"], "paidUntil" => $payment["paidUntil"]);
+    if($endpoint === ""){
+        $names = array();
+        foreach($attachments as $a)
+            $names[] = $a["name"];
+        $note = count($names)
+            ? " ".t9n("[RU]Получены вложения[EN]Attachments received").": ".implode(", ", $names)."."
+            : "";
+        return array(
+            "assistant" => array(
+                "content" => t9n("[RU]ИИ-агент готов к работе, оплата подтверждена. Подключение к API ИИ-агента будет добавлено в следующем тикете.[EN]The AI agent is ready and the payment is confirmed. The AI agent API connection will be added in the next ticket.").$note
+            ),
+            "status" => "pending_api",
+            "payment" => $paymentInfo
+        );
+    }
+    validateAiProviderEndpoint($endpoint);
+    $request = array(
+        "db" => $db,
+        "user" => isset($GLOBALS["GLOBAL_VARS"]["user"]) ? $GLOBALS["GLOBAL_VARS"]["user"] : "",
+        "message" => $message,
+        "attachments" => $attachments
+    );
+    $headers = array("Content-Type: application/json; charset=UTF-8", "Accept: application/json", "User-Agent: Integram AI Agent");
+    $token = aiConfigValue(array("INTEGRAM_AGENT_TOKEN", "AI_AGENT_TOKEN"));
+    if($token !== "")
+        $headers[] = "Authorization: Bearer ".$token;
+    $raw = aiChatPostJson($endpoint, $request, $headers);
+    $decoded = json_decode($raw, true);
+    $content = extractAiProviderContent($decoded, $raw);
+    if(trim($content) === "")
+        throw new Exception(t9n("[RU]ИИ-агент вернул пустой ответ[EN]The AI agent returned an empty response"), 502);
+    return array(
+        "assistant" => array("content" => $content),
+        "status" => "ok",
+        "payment" => $paymentInfo
+    );
 }
 function getAiChatSettings($settings=array()){
     if(is_string($settings)){
@@ -9749,7 +9958,13 @@ if(Validate_Token())
 	switch ($a)
 	{
         case "ai":
-            handleAiChatRequest($com);
+            # Issue #3392: /{db}/ai/agent — упрощённый чат с фиксированным ИИ-агентом
+            # (доступ только владельцу базы + проверка оплаты). Старый /{db}/ai/chat
+            # сохранён как backend, но скрыт из интерфейса.
+            if(isset($com[3]) && $com[3] === "agent")
+                handleAiAgentRequest($com);
+            else
+                handleAiChatRequest($com);
             break;
 
 		# Issue #3308: серверный прокси для загрузки файла по ссылке в рабочем месте

--- a/js/ai-agent-chat.js
+++ b/js/ai-agent-chat.js
@@ -1,0 +1,281 @@
+/*
+ * Issue #3392: упрощённый ИИ-чат.
+ *
+ * Новый чат связан только с нашим фиксированным ИИ-агентом текущей базы данных.
+ * Доступ к агенту разрешён сервером (index.php, ветка /{db}/ai/agent) только
+ * пользователю, имя которого совпадает с именем базы, и только при действующей
+ * оплате. Все действия агента ограничены текущей базой данных.
+ *
+ * Старый расширенный ИИ-чат (js/ai-chat.js) скрыт из интерфейса, но оставлен в
+ * репозитории как backend-история.
+ */
+(function () {
+    'use strict';
+
+    var IntegramAiAgentChat = {
+        attachments: [],
+        sending: false,
+
+        init: function () {
+            this.toggle = document.getElementById('ai-chat-toggle');
+            this.panel = document.getElementById('ai-agent-panel');
+            this.backdrop = document.getElementById('ai-agent-backdrop');
+            this.closeBtn = document.getElementById('ai-agent-close');
+            this.input = document.getElementById('ai-agent-input');
+            this.sendBtn = document.getElementById('ai-agent-send');
+            this.attachBtn = document.getElementById('ai-agent-attach');
+            this.fileInput = document.getElementById('ai-agent-files');
+            this.messages = document.getElementById('ai-agent-messages');
+            this.attachmentsList = document.getElementById('ai-agent-attachments');
+            this.statusEl = document.getElementById('ai-agent-status');
+
+            // Без панели и кнопки вызова работать нечему — тихо выходим.
+            if (!this.toggle || !this.panel) return false;
+
+            var self = this;
+
+            this.toggle.addEventListener('click', function () { self.togglePanel(); });
+            if (this.closeBtn) this.closeBtn.addEventListener('click', function () { self.closePanel(); });
+            if (this.backdrop) this.backdrop.addEventListener('click', function () { self.closePanel(); });
+
+            document.addEventListener('keydown', function (e) {
+                if (e.key === 'Escape' && self.isOpen()) self.closePanel();
+            });
+
+            if (this.sendBtn) this.sendBtn.addEventListener('click', function () { self.send(); });
+
+            if (this.input) {
+                this.input.addEventListener('keydown', function (e) {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        self.send();
+                    }
+                });
+            }
+
+            if (this.attachBtn && this.fileInput) {
+                this.attachBtn.addEventListener('click', function () { self.fileInput.click(); });
+                this.fileInput.addEventListener('change', function () {
+                    self.addFiles(self.fileInput.files);
+                    self.fileInput.value = '';
+                });
+            }
+
+            return true;
+        },
+
+        isOpen: function () {
+            return this.panel && this.panel.classList.contains('open');
+        },
+
+        togglePanel: function () {
+            if (this.isOpen()) this.closePanel(); else this.openPanel();
+        },
+
+        openPanel: function () {
+            if (!this.panel) return;
+            this.panel.classList.add('open');
+            this.panel.setAttribute('aria-hidden', 'false');
+            this.panel.removeAttribute('inert');
+            if (this.backdrop) this.backdrop.hidden = false;
+            if (this.toggle) this.toggle.setAttribute('aria-expanded', 'true');
+            if (this.input) this.input.focus();
+            this.scrollToBottom();
+        },
+
+        closePanel: function () {
+            if (!this.panel) return;
+            this.panel.classList.remove('open');
+            this.panel.setAttribute('aria-hidden', 'true');
+            this.panel.setAttribute('inert', '');
+            if (this.backdrop) this.backdrop.hidden = true;
+            if (this.toggle) this.toggle.setAttribute('aria-expanded', 'false');
+        },
+
+        getCurrentDbName: function () {
+            if (typeof db !== 'undefined' && db) return String(db);
+            if (typeof window !== 'undefined' && window.db) return String(window.db);
+            var parts = window.location.pathname.split('/').filter(Boolean);
+            return parts.length > 0 ? parts[0] : '';
+        },
+
+        getXsrfToken: function () {
+            if (typeof xsrf !== 'undefined' && xsrf) return String(xsrf);
+            if (typeof window !== 'undefined' && window.xsrf) return String(window.xsrf);
+            var meta = document.querySelector ? document.querySelector('meta[name="_xsrf"]') : null;
+            return meta ? meta.getAttribute('content') : '';
+        },
+
+        getAgentUrl: function () {
+            var dbName = this.getCurrentDbName() || 'my';
+            return '/' + encodeURIComponent(dbName) + '/ai/agent?JSON=1';
+        },
+
+        addFiles: function (fileList) {
+            if (!fileList || !fileList.length) return;
+            for (var i = 0; i < fileList.length; i++) {
+                this.attachments.push(fileList[i]);
+            }
+            this.renderAttachments();
+        },
+
+        removeAttachment: function (index) {
+            this.attachments.splice(index, 1);
+            this.renderAttachments();
+        },
+
+        renderAttachments: function () {
+            if (!this.attachmentsList) return;
+            var self = this;
+            this.attachmentsList.innerHTML = '';
+            this.attachments.forEach(function (file, index) {
+                var li = document.createElement('li');
+                li.className = 'ai-agent-attachment';
+
+                var icon = document.createElement('i');
+                icon.className = 'pi pi-file';
+                li.appendChild(icon);
+
+                var name = document.createElement('span');
+                name.className = 'ai-agent-attachment-name';
+                name.textContent = file.name;
+                li.appendChild(name);
+
+                var remove = document.createElement('button');
+                remove.type = 'button';
+                remove.className = 'ai-agent-attachment-remove';
+                remove.title = 'Убрать файл';
+                remove.setAttribute('aria-label', 'Убрать файл');
+                remove.innerHTML = '<i class="pi pi-times"></i>';
+                remove.addEventListener('click', function () { self.removeAttachment(index); });
+                li.appendChild(remove);
+
+                self.attachmentsList.appendChild(li);
+            });
+        },
+
+        setStatus: function (text) {
+            if (this.statusEl) this.statusEl.textContent = text;
+        },
+
+        setSending: function (sending) {
+            this.sending = sending;
+            if (this.sendBtn) this.sendBtn.disabled = sending;
+            if (this.attachBtn) this.attachBtn.disabled = sending;
+            this.setStatus(sending ? 'ИИ-агент печатает…' : 'Готов к работе');
+        },
+
+        send: function () {
+            if (this.sending) return;
+            var text = this.input ? this.input.value.trim() : '';
+            if (!text && !this.attachments.length) return;
+
+            this.addMessage('user', text || '(вложения)');
+
+            var form = new FormData();
+            form.append('_xsrf', this.getXsrfToken());
+            form.append('message', text);
+            this.attachments.forEach(function (file) {
+                form.append('files[]', file, file.name);
+            });
+
+            if (this.input) this.input.value = '';
+            this.attachments = [];
+            this.renderAttachments();
+            this.setSending(true);
+
+            var self = this;
+            fetch(this.getAgentUrl(), {
+                method: 'POST',
+                body: form,
+                credentials: 'same-origin',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            }).then(function (response) {
+                return response.json().catch(function () { return null; }).then(function (data) {
+                    return { status: response.status, ok: response.ok, data: data };
+                });
+            }).then(function (result) {
+                self.setSending(false);
+                self.handleResponse(result);
+            }).catch(function () {
+                self.setSending(false);
+                self.addMessage('assistant', 'Не удалось связаться с ИИ-агентом. Повторите попытку позже.');
+            });
+        },
+
+        handleResponse: function (result) {
+            var data = result.data;
+
+            // Оплата не подтверждена / истекла — index.php возвращает 402 + ссылку.
+            if (result.status === 402 && data) {
+                this.addMessage('assistant', this.getErrorText(data) || 'Доступ к ИИ-агенту не оплачен.', data.payUrl);
+                return;
+            }
+
+            if (!result.ok || !data) {
+                this.addMessage('assistant', this.getErrorText(data) || 'ИИ-агент недоступен. Повторите попытку позже.');
+                return;
+            }
+
+            var content = this.getAssistantContent(data);
+            this.addMessage('assistant', content || 'ИИ-агент не вернул ответ.');
+        },
+
+        getAssistantContent: function (data) {
+            if (!data) return '';
+            if (data.assistant && typeof data.assistant.content === 'string') return data.assistant.content;
+            if (typeof data.content === 'string') return data.content;
+            if (typeof data.message === 'string') return data.message;
+            return '';
+        },
+
+        getErrorText: function (data) {
+            if (!data) return '';
+            if (typeof data.error === 'string') return data.error;
+            if (data.error && data.error.message) return data.error.message;
+            return '';
+        },
+
+        addMessage: function (role, text, payUrl) {
+            if (!this.messages) return;
+            var wrap = document.createElement('div');
+            wrap.className = 'ai-chat-message ' + (role === 'user' ? 'ai-chat-message-user' : 'ai-chat-message-assistant');
+
+            var author = document.createElement('div');
+            author.className = 'ai-chat-message-author';
+            author.textContent = role === 'user' ? 'Вы' : 'ИИ-агент';
+            wrap.appendChild(author);
+
+            var body = document.createElement('div');
+            body.className = 'ai-chat-message-text';
+            body.textContent = text;
+            wrap.appendChild(body);
+
+            if (payUrl) {
+                var link = document.createElement('a');
+                link.className = 'ai-chat-message-pay';
+                link.href = payUrl;
+                link.target = '_blank';
+                link.rel = 'noopener';
+                link.textContent = 'Перейти к оплате';
+                wrap.appendChild(link);
+            }
+
+            this.messages.appendChild(wrap);
+            this.scrollToBottom();
+        },
+
+        scrollToBottom: function () {
+            var body = this.messages ? this.messages.parentNode : null;
+            if (body && typeof body.scrollTop === 'number') body.scrollTop = body.scrollHeight;
+        }
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function () { IntegramAiAgentChat.init(); });
+    } else {
+        IntegramAiAgentChat.init();
+    }
+
+    if (typeof window !== 'undefined') window.IntegramAiAgentChat = IntegramAiAgentChat;
+})();

--- a/templates/main.html
+++ b/templates/main.html
@@ -202,7 +202,7 @@
             <div class="navbar-workspace">{_global_.action}</div>
         </div>
         <div class="navbar-right">
-            <button id="ai-chat-toggle" class="ai-chat-toggle" type="button" title="ИИ-чат" aria-label="Открыть ИИ-чат" aria-controls="ai-chat-panel" aria-expanded="false">
+            <button id="ai-chat-toggle" class="ai-chat-toggle" type="button" title="ИИ-агент" aria-label="Открыть ИИ-агент" aria-controls="ai-agent-panel" aria-expanded="false">
                 <i class="pi pi-comments"></i>
             </button>
             <div class="user-menu-wrapper">
@@ -272,113 +272,41 @@
         </div>
     </nav>
 
-    <div id="ai-chat-backdrop" class="ai-chat-backdrop" hidden></div>
-    <aside id="ai-chat-panel" class="ai-chat-panel" aria-hidden="true" aria-labelledby="ai-chat-title" inert>
+    <!-- Issue #3392: упрощённый ИИ-агент. Старый ИИ-чат (#ai-chat-panel + js/ai-chat.js)
+         скрыт; новый чат связан только с фиксированным агентом текущей базы. -->
+    <div id="ai-agent-backdrop" class="ai-chat-backdrop" hidden></div>
+    <aside id="ai-agent-panel" class="ai-chat-panel" aria-hidden="true" aria-labelledby="ai-agent-title" inert>
         <div class="ai-chat-header">
             <div>
-                <h2 id="ai-chat-title">ИИ-чат</h2>
-                <span id="ai-chat-status" class="ai-chat-status">Не подключен</span>
+                <h2 id="ai-agent-title">ИИ-агент</h2>
+                <span id="ai-agent-status" class="ai-chat-status">Готов к работе</span>
             </div>
-            <button id="ai-chat-close" class="ai-chat-icon-btn" type="button" title="Закрыть" aria-label="Закрыть ИИ-чат">
+            <button id="ai-agent-close" class="ai-chat-icon-btn" type="button" title="Закрыть" aria-label="Закрыть ИИ-агент">
                 <i class="pi pi-times"></i>
             </button>
         </div>
 
         <div class="ai-chat-body">
-            <section class="ai-chat-config" aria-label="Настройки ИИ-сервиса">
-                <div class="ai-chat-config-grid">
-                    <div class="database-field-group">
-                        <label for="ai-service-provider" class="database-field-label">Сервис</label>
-                        <select id="ai-service-provider" class="database-field-input">
-                            <option value="gemini">Google Gemini</option>
-                            <option value="integram">Интеграм AI</option>
-                            <option value="openai">ChatGPT / OpenAI</option>
-                            <option value="gigachat">ГигаЧат</option>
-                            <option value="deepseek">DeepSeek</option>
-                            <option value="groq">Groq</option>
-                            <option value="mistral">Mistral AI</option>
-                            <option value="custom">Другой API</option>
-                        </select>
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-token-mode" class="database-field-label">Токен</label>
-                        <select id="ai-token-mode" class="database-field-input">
-                            <option value="adc">Application Default Credentials</option>
-                            <option value="rotating">Токены Интеграма</option>
-                            <option value="own">Мой токен</option>
-                        </select>
-                    </div>
-                    <div class="database-field-group ai-chat-config-wide">
-                        <label for="ai-service-endpoint" class="database-field-label">API endpoint</label>
-                        <input id="ai-service-endpoint" class="database-field-input" type="text" autocomplete="off">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-service-model" class="database-field-label">Модель</label>
-                        <input id="ai-service-model" class="database-field-input" type="text" autocomplete="off">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-service-token" class="database-field-label">API token</label>
-                        <!-- Токен AI-сервиса — секрет, но не пароль входа. type="text" + маска
-                             text-security вместо type="password": иначе менеджер паролей браузера
-                             принимает пару «Модель + Токен» за логин и предлагает «Сохранить пароль»
-                             при любом submit-подобном событии (например, применении фильтра) — #3118. -->
-                        <input id="ai-service-token" class="database-field-input" type="text" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other" spellcheck="false" style="-webkit-text-security:disc; text-security:disc;">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-target-db" class="database-field-label">База данных</label>
-                        <select id="ai-target-db" class="database-field-input"></select>
-                    </div>
-                    <label class="ai-chat-checkbox-label">
-                        <input id="ai-charge-balance" type="checkbox">
-                        <span>Оплата с баланса ЛК</span>
-                    </label>
-                </div>
-                <div class="ai-chat-config-actions">
-                    <button id="ai-save-settings-btn" type="button" class="btn-secondary btn-small">
-                        <i class="pi pi-save"></i>
-                        <span>Сохранить</span>
-                    </button>
-                    <button id="ai-connect-service-btn" type="button" class="btn-primary btn-small">
-                        <i class="pi pi-link"></i>
-                        <span>Подключить</span>
-                    </button>
-                </div>
-                <span id="ai-settings-state" class="field-hint"></span>
-            </section>
-
-            <section class="ai-chat-presets" aria-label="Типовые команды">
-                <button type="button" class="ai-preset-btn" data-ai-command="create_table">
-                    <i class="pi pi-table"></i>
-                    <span>Создай таблицу</span>
-                </button>
-                <button type="button" class="ai-preset-btn" data-ai-command="create_structure">
-                    <i class="pi pi-sitemap"></i>
-                    <span>Создай структуру</span>
-                </button>
-                <button type="button" class="ai-preset-btn" data-ai-command="create_workspace">
-                    <i class="pi pi-desktop"></i>
-                    <span>Создай рабочее место</span>
-                </button>
-            </section>
-
-            <div id="ai-chat-messages" class="ai-chat-messages" role="log" aria-live="polite">
+            <div id="ai-agent-messages" class="ai-chat-messages" role="log" aria-live="polite">
                 <div class="ai-chat-message ai-chat-message-assistant">
-                    <div class="ai-chat-message-author">Интеграм AI</div>
-                    <div class="ai-chat-message-text">Готов принять задачу для выбранной базы данных.</div>
+                    <div class="ai-chat-message-author">ИИ-агент</div>
+                    <div class="ai-chat-message-text">Здравствуйте! Опишите задачу — я помогу в рамках вашей базы данных.</div>
                 </div>
             </div>
-
-            <section id="ai-command-queue" class="ai-command-queue" aria-label="Команды ИИ">
-                <div class="ai-command-empty">Команд пока нет</div>
-            </section>
         </div>
 
         <div class="ai-chat-composer">
-            <textarea id="ai-chat-input" class="database-field-input" rows="3" placeholder="Опишите задачу"></textarea>
-            <button id="ai-chat-send" type="button" class="btn-primary" title="Отправить">
-                <i class="pi pi-send"></i>
-                <span>Отправить</span>
-            </button>
+            <ul id="ai-agent-attachments" class="ai-agent-attachments" aria-label="Вложения"></ul>
+            <div class="ai-agent-composer-row">
+                <input id="ai-agent-files" type="file" multiple hidden>
+                <button id="ai-agent-attach" type="button" class="ai-chat-icon-btn" title="Прикрепить файл" aria-label="Прикрепить файл">
+                    <i class="pi pi-paperclip"></i>
+                </button>
+                <textarea id="ai-agent-input" class="database-field-input" rows="2" placeholder="Сообщение для ИИ-агента"></textarea>
+                <button id="ai-agent-send" type="button" class="ai-chat-icon-btn ai-agent-send" title="Отправить" aria-label="Отправить">
+                    <i class="pi pi-send"></i>
+                </button>
+            </div>
         </div>
     </aside>
 
@@ -419,7 +347,7 @@
         ];
     </script>
     <script src="/js/app.js"></script>
-    <script src="/js/ai-chat.js"></script>
+    <script src="/js/ai-agent-chat.js"></script>
     <script src="/js/main-app.js"></script>
     <script src="/js/form-submit.js" defer></script>
     <script>


### PR DESCRIPTION
## Что сделано

Скрыт старый расширенный ИИ-чат и создан новый **упрощённый ИИ-чат**, связанный только с нашим фиксированным агентом текущей базы данных. Реализованы все 5 пунктов из issue #3392.

Fixes #3392

### 1. Кнопка вызова чата — прежняя
Кнопка `#ai-chat-toggle` в навбаре оставлена без изменений (поменялись только подписи на «ИИ-агент» и `aria-controls`).

### 2. Окно чата
Новая упрощённая панель `#ai-agent-panel` в `templates/main.html`:
- поле ввода текста (`textarea`);
- иконка отправки (`pi-send`);
- иконка прикрепления файла (`pi-paperclip`) + список вложений с возможностью удалить;
- лента сообщений с приветствием.

Старый блок `#ai-chat-panel` (настройки сервиса, пресеты, очередь команд) и подключение `js/ai-chat.js` удалены из `templates/main.html`. Сами файлы `js/ai-chat.js` и `css/ai-chat.css` оставлены в репозитории — старый чат скрыт из интерфейса, а его темы переиспользованы для новой панели.

### 3. Проверка оплаты в index.php
Создана **отдельная ветка маршрута** `/{db}/ai/agent` (рядом с существующей `/{db}/ai/chat`). Перед работой агента:
- доступ разрешён **только владельцу базы** — пользователю, имя которого совпадает с именем базы (иначе `403`);
- проверяется действующая оплата запросом `GET https://ideav.ru/my/report/237290?JSON_KV&FR_DB={db}`, результат **кешируется** в `sys_get_temp_dir` (TTL по умолчанию 1 час, настраивается через `AI_AGENT_PAYMENT_CACHE_TTL`);
- сумма должна быть **5950 или 12500**, а дата платежа — **не старше месяца** (Unix-штамп). Иначе возвращается `402` с сообщением и ссылкой на оплату;
- если период истёк — пользователю показывается, что оплаченный период закончился, и даётся ссылка на оплату.

### 4. Отправка данных ИИ-агенту
Отправка вынесена в `callIntegramAgent()`. Endpoint берётся из конфигурации (`INTEGRAM_AGENT_ENDPOINT`/`AI_AGENT_ENDPOINT`) с SSRF-защитой `validateAiProviderEndpoint`. **Описание API будет предоставлено в следующем тикете**, поэтому пока endpoint не задан — агент подтверждает готовность (оплата проверена), не делая внешнего вызова. Все данные ограничены текущей базой (см. `docs/integram-app-workflow.md`).

### 5. Получение и отображение ответа
Новый контроллер `js/ai-agent-chat.js` отправляет сообщение и файлы (`FormData` + XSRF) на `/{db}/ai/agent`, показывает ответ агента, а при `402` — сообщение об истёкшей/отсутствующей оплате со ссылкой «Перейти к оплате».

## Безопасность
- Доступ к агенту — только пользователю, чьё имя совпадает с именем базы.
- Все действия ограничены текущей базой; никакого межбазового доступа и агрегации секретов (`docs/integram-app-workflow.md`).
- XSRF-проверка (`check()`), серверная валидация оплаты, SSRF-защита эндпоинта агента.

## Как воспроизвести / проверить
- **Логика оплаты:** `php experiments/test_ai_agent_payment.php` — проверяет правила суммы (5950/12500) и срока (не старше месяца), статусы `active`/`expired`/`not_paid` (все тесты проходят).
- **Синтаксис:** `php -l index.php`, `node --check js/ai-agent-chat.js` — без ошибок.
- **UI:** открыть чат кнопкой в навбаре → ввести сообщение, при необходимости прикрепить файл → отправить. При истёкшей оплате показывается уведомление со ссылкой на оплату.

## Конфигурация (env/константы)
| Имя | Назначение | По умолчанию |
| --- | --- | --- |
| `AI_AGENT_PAYMENT_CACHE_TTL` | TTL кеша оплаты, сек | `3600` |
| `AI_AGENT_PAYMENT_REPORT_URL` | URL отчёта оплаты (префикс до `FR_DB`) | отчёт `237290` |
| `AI_AGENT_PAY_URL` | Ссылка на оплату | `https://ideav.ru/my/` |
| `INTEGRAM_AGENT_ENDPOINT` / `AI_AGENT_ENDPOINT` | Endpoint ИИ-агента | пусто (ждёт следующий тикет) |
| `INTEGRAM_AGENT_TOKEN` / `AI_AGENT_TOKEN` | Токен агента | пусто |

## Примечание
Issue явно про `templates/main.html`. Брендированные шаблоны `templates/ru/main.html` и `templates/atex/main.html` пока используют прежний чат — их можно мигрировать отдельно при необходимости.
