### PR TITLE
feat(atex,ru): мигрировать брендированные шаблоны на упрощённый ИИ-агент (#3392)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T18:53:23.147Z for PR creation at branch issue-3397-267300d20acd for issue https://github.com/ideav/crm/issues/3397

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T18:53:23.147Z for PR creation at branch issue-3397-267300d20acd for issue https://github.com/ideav/crm/issues/3397

--- a/templates/atex/main.html
+++ b/templates/atex/main.html
@@ -203,7 +203,7 @@
             <div class="navbar-workspace">{_global_.action}</div>
         </div>
         <div class="navbar-right">
-            <button id="ai-chat-toggle" class="ai-chat-toggle" type="button" title="ИИ-чат" aria-label="Открыть ИИ-чат" aria-controls="ai-chat-panel" aria-expanded="false">
+            <button id="ai-chat-toggle" class="ai-chat-toggle" type="button" title="ИИ-агент" aria-label="Открыть ИИ-агент" aria-controls="ai-agent-panel" aria-expanded="false">
                 <i class="pi pi-comments"></i>
             </button>
             <div class="user-menu-wrapper">
@@ -273,113 +273,41 @@
         </div>
     </nav>
 
-    <div id="ai-chat-backdrop" class="ai-chat-backdrop" hidden></div>
-    <aside id="ai-chat-panel" class="ai-chat-panel" aria-hidden="true" aria-labelledby="ai-chat-title" inert>
+    <!-- Issue #3392: упрощённый ИИ-агент. Старый ИИ-чат (#ai-chat-panel + js/ai-chat.js)
+         скрыт; новый чат связан только с фиксированным агентом текущей базы. -->
+    <div id="ai-agent-backdrop" class="ai-chat-backdrop" hidden></div>
+    <aside id="ai-agent-panel" class="ai-chat-panel" aria-hidden="true" aria-labelledby="ai-agent-title" inert>
         <div class="ai-chat-header">
             <div>
-                <h2 id="ai-chat-title">ИИ-чат</h2>
-                <span id="ai-chat-status" class="ai-chat-status">Не подключен</span>
+                <h2 id="ai-agent-title">ИИ-агент</h2>
+                <span id="ai-agent-status" class="ai-chat-status">Готов к работе</span>
             </div>
-            <button id="ai-chat-close" class="ai-chat-icon-btn" type="button" title="Закрыть" aria-label="Закрыть ИИ-чат">
+            <button id="ai-agent-close" class="ai-chat-icon-btn" type="button" title="Закрыть" aria-label="Закрыть ИИ-агент">
                 <i class="pi pi-times"></i>
             </button>
         </div>
 
         <div class="ai-chat-body">
-            <section class="ai-chat-config" aria-label="Настройки ИИ-сервиса">
-                <div class="ai-chat-config-grid">
-                    <div class="database-field-group">
-                        <label for="ai-service-provider" class="database-field-label">Сервис</label>
-                        <select id="ai-service-provider" class="database-field-input">
-                            <option value="gemini">Google Gemini</option>
-                            <option value="integram">Интеграм AI</option>
-                            <option value="openai">ChatGPT / OpenAI</option>
-                            <option value="gigachat">ГигаЧат</option>
-                            <option value="deepseek">DeepSeek</option>
-                            <option value="groq">Groq</option>
-                            <option value="mistral">Mistral AI</option>
-                            <option value="custom">Другой API</option>
-                        </select>
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-token-mode" class="database-field-label">Токен</label>
-                        <select id="ai-token-mode" class="database-field-input">
-                            <option value="adc">Application Default Credentials</option>
-                            <option value="rotating">Токены Интеграма</option>
-                            <option value="own">Мой токен</option>
-                        </select>
-                    </div>
-                    <div class="database-field-group ai-chat-config-wide">
-                        <label for="ai-service-endpoint" class="database-field-label">API endpoint</label>
-                        <input id="ai-service-endpoint" class="database-field-input" type="text" autocomplete="off">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-service-model" class="database-field-label">Модель</label>
-                        <input id="ai-service-model" class="database-field-input" type="text" autocomplete="off">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-service-token" class="database-field-label">API token</label>
-                        <!-- Токен AI-сервиса — секрет, но не пароль входа. type="text" + маска
-                             text-security вместо type="password": иначе менеджер паролей браузера
-                             принимает пару «Модель + Токен» за логин и предлагает «Сохранить пароль»
-                             при любом submit-подобном событии (например, применении фильтра) — #3118. -->
-                        <input id="ai-service-token" class="database-field-input" type="text" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other" spellcheck="false" style="-webkit-text-security:disc; text-security:disc;">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-target-db" class="database-field-label">База данных</label>
-                        <select id="ai-target-db" class="database-field-input"></select>
-                    </div>
-                    <label class="ai-chat-checkbox-label">
-                        <input id="ai-charge-balance" type="checkbox">
-                        <span>Оплата с баланса ЛК</span>
-                    </label>
-                </div>
-                <div class="ai-chat-config-actions">
-                    <button id="ai-save-settings-btn" type="button" class="btn-secondary btn-small">
-                        <i class="pi pi-save"></i>
-                        <span>Сохранить</span>
-                    </button>
-                    <button id="ai-connect-service-btn" type="button" class="btn-primary btn-small">
-                        <i class="pi pi-link"></i>
-                        <span>Подключить</span>
-                    </button>
-                </div>
-                <span id="ai-settings-state" class="field-hint"></span>
-            </section>
-
-            <section class="ai-chat-presets" aria-label="Типовые команды">
-                <button type="button" class="ai-preset-btn" data-ai-command="create_table">
-                    <i class="pi pi-table"></i>
-                    <span>Создай таблицу</span>
-                </button>
-                <button type="button" class="ai-preset-btn" data-ai-command="create_structure">
-                    <i class="pi pi-sitemap"></i>
-                    <span>Создай структуру</span>
-                </button>
-                <button type="button" class="ai-preset-btn" data-ai-command="create_workspace">
-                    <i class="pi pi-desktop"></i>
-                    <span>Создай рабочее место</span>
-                </button>
-            </section>
-
-            <div id="ai-chat-messages" class="ai-chat-messages" role="log" aria-live="polite">
+            <div id="ai-agent-messages" class="ai-chat-messages" role="log" aria-live="polite">
                 <div class="ai-chat-message ai-chat-message-assistant">
-                    <div class="ai-chat-message-author">Интеграм AI</div>
-                    <div class="ai-chat-message-text">Готов принять задачу для выбранной базы данных.</div>
+                    <div class="ai-chat-message-author">ИИ-агент</div>
+                    <div class="ai-chat-message-text">Здравствуйте! Опишите задачу — я помогу в рамках вашей базы данных.</div>
                 </div>
             </div>
-
-            <section id="ai-command-queue" class="ai-command-queue" aria-label="Команды ИИ">
-                <div class="ai-command-empty">Команд пока нет</div>
-            </section>
         </div>
 
         <div class="ai-chat-composer">
-            <textarea id="ai-chat-input" class="database-field-input" rows="3" placeholder="Опишите задачу"></textarea>
-            <button id="ai-chat-send" type="button" class="btn-primary" title="Отправить">
-                <i class="pi pi-send"></i>
-                <span>Отправить</span>
-            </button>
+            <ul id="ai-agent-attachments" class="ai-agent-attachments" aria-label="Вложения"></ul>
+            <div class="ai-agent-composer-row">
+                <input id="ai-agent-files" type="file" multiple hidden>
+                <button id="ai-agent-attach" type="button" class="ai-chat-icon-btn" title="Прикрепить файл" aria-label="Прикрепить файл">
+                    <i class="pi pi-paperclip"></i>
+                </button>
+                <textarea id="ai-agent-input" class="database-field-input" rows="2" placeholder="Сообщение для ИИ-агента"></textarea>
+                <button id="ai-agent-send" type="button" class="ai-chat-icon-btn ai-agent-send" title="Отправить" aria-label="Отправить">
+                    <i class="pi pi-send"></i>
+                </button>
+            </div>
         </div>
     </aside>
 
@@ -420,7 +348,7 @@
         ];
     </script>
     <script src="/js/app.js"></script>
-    <script src="/js/ai-chat.js"></script>
+    <script src="/js/ai-agent-chat.js"></script>
     <script src="/js/main-app.js"></script>
     <script src="/js/form-submit.js" defer></script>
     <script>

--- a/templates/ru/main.html
+++ b/templates/ru/main.html
@@ -65,7 +65,7 @@
             <div class="navbar-workspace">{_global_.action}</div>
         </div>
         <div class="navbar-right">
-            <button id="ai-chat-toggle" class="ai-chat-toggle" type="button" title="ИИ-чат" aria-label="Открыть ИИ-чат" aria-controls="ai-chat-panel" aria-expanded="false">
+            <button id="ai-chat-toggle" class="ai-chat-toggle" type="button" title="ИИ-агент" aria-label="Открыть ИИ-агент" aria-controls="ai-agent-panel" aria-expanded="false">
                 <i class="pi pi-comments"></i>
             </button>
             <div class="user-menu-wrapper">
@@ -106,113 +106,41 @@
         </div>
     </nav>
 
-    <div id="ai-chat-backdrop" class="ai-chat-backdrop" hidden></div>
-    <aside id="ai-chat-panel" class="ai-chat-panel" aria-hidden="true" aria-labelledby="ai-chat-title" inert>
+    <!-- Issue #3392: упрощённый ИИ-агент. Старый ИИ-чат (#ai-chat-panel + js/ai-chat.js)
+         скрыт; новый чат связан только с фиксированным агентом текущей базы. -->
+    <div id="ai-agent-backdrop" class="ai-chat-backdrop" hidden></div>
+    <aside id="ai-agent-panel" class="ai-chat-panel" aria-hidden="true" aria-labelledby="ai-agent-title" inert>
         <div class="ai-chat-header">
             <div>
-                <h2 id="ai-chat-title">ИИ-чат</h2>
-                <span id="ai-chat-status" class="ai-chat-status">Не подключен</span>
+                <h2 id="ai-agent-title">ИИ-агент</h2>
+                <span id="ai-agent-status" class="ai-chat-status">Готов к работе</span>
             </div>
-            <button id="ai-chat-close" class="ai-chat-icon-btn" type="button" title="Закрыть" aria-label="Закрыть ИИ-чат">
+            <button id="ai-agent-close" class="ai-chat-icon-btn" type="button" title="Закрыть" aria-label="Закрыть ИИ-агент">
                 <i class="pi pi-times"></i>
             </button>
         </div>
 
         <div class="ai-chat-body">
-            <section class="ai-chat-config" aria-label="Настройки ИИ-сервиса">
-                <div class="ai-chat-config-grid">
-                    <div class="database-field-group">
-                        <label for="ai-service-provider" class="database-field-label">Сервис</label>
-                        <select id="ai-service-provider" class="database-field-input">
-                            <option value="gemini">Google Gemini</option>
-                            <option value="integram">Интеграм AI</option>
-                            <option value="openai">ChatGPT / OpenAI</option>
-                            <option value="gigachat">ГигаЧат</option>
-                            <option value="deepseek">DeepSeek</option>
-                            <option value="groq">Groq</option>
-                            <option value="mistral">Mistral AI</option>
-                            <option value="custom">Другой API</option>
-                        </select>
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-token-mode" class="database-field-label">Токен</label>
-                        <select id="ai-token-mode" class="database-field-input">
-                            <option value="adc">Application Default Credentials</option>
-                            <option value="rotating">Токены Интеграма</option>
-                            <option value="own">Мой токен</option>
-                        </select>
-                    </div>
-                    <div class="database-field-group ai-chat-config-wide">
-                        <label for="ai-service-endpoint" class="database-field-label">API endpoint</label>
-                        <input id="ai-service-endpoint" class="database-field-input" type="text" autocomplete="off">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-service-model" class="database-field-label">Модель</label>
-                        <input id="ai-service-model" class="database-field-input" type="text" autocomplete="off">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-service-token" class="database-field-label">API token</label>
-                        <!-- Токен AI-сервиса — секрет, но не пароль входа. type="text" + маска
-                             text-security вместо type="password": иначе менеджер паролей браузера
-                             принимает пару «Модель + Токен» за логин и предлагает «Сохранить пароль»
-                             при любом submit-подобном событии (например, применении фильтра) — #3118. -->
-                        <input id="ai-service-token" class="database-field-input" type="text" autocomplete="off" data-lpignore="true" data-1p-ignore data-form-type="other" spellcheck="false" style="-webkit-text-security:disc; text-security:disc;">
-                    </div>
-                    <div class="database-field-group">
-                        <label for="ai-target-db" class="database-field-label">База данных</label>
-                        <select id="ai-target-db" class="database-field-input"></select>
-                    </div>
-                    <label class="ai-chat-checkbox-label">
-                        <input id="ai-charge-balance" type="checkbox">
-                        <span>Оплата с баланса ЛК</span>
-                    </label>
-                </div>
-                <div class="ai-chat-config-actions">
-                    <button id="ai-save-settings-btn" type="button" class="btn-secondary btn-small">
-                        <i class="pi pi-save"></i>
-                        <span>Сохранить</span>
-                    </button>
-                    <button id="ai-connect-service-btn" type="button" class="btn-primary btn-small">
-                        <i class="pi pi-link"></i>
-                        <span>Подключить</span>
-                    </button>
-                </div>
-                <span id="ai-settings-state" class="field-hint"></span>
-            </section>
-
-            <section class="ai-chat-presets" aria-label="Типовые команды">
-                <button type="button" class="ai-preset-btn" data-ai-command="create_table">
-                    <i class="pi pi-table"></i>
-                    <span>Создай таблицу</span>
-                </button>
-                <button type="button" class="ai-preset-btn" data-ai-command="create_structure">
-                    <i class="pi pi-sitemap"></i>
-                    <span>Создай структуру</span>
-                </button>
-                <button type="button" class="ai-preset-btn" data-ai-command="create_workspace">
-                    <i class="pi pi-desktop"></i>
-                    <span>Создай рабочее место</span>
-                </button>
-            </section>
-
-            <div id="ai-chat-messages" class="ai-chat-messages" role="log" aria-live="polite">
+            <div id="ai-agent-messages" class="ai-chat-messages" role="log" aria-live="polite">
                 <div class="ai-chat-message ai-chat-message-assistant">
-                    <div class="ai-chat-message-author">Интеграм AI</div>
-                    <div class="ai-chat-message-text">Готов принять задачу для выбранной базы данных.</div>
+                    <div class="ai-chat-message-author">ИИ-агент</div>
+                    <div class="ai-chat-message-text">Здравствуйте! Опишите задачу — я помогу в рамках вашей базы данных.</div>
                 </div>
             </div>
-
-            <section id="ai-command-queue" class="ai-command-queue" aria-label="Команды ИИ">
-                <div class="ai-command-empty">Команд пока нет</div>
-            </section>
         </div>
 
         <div class="ai-chat-composer">
-            <textarea id="ai-chat-input" class="database-field-input" rows="3" placeholder="Опишите задачу"></textarea>
-            <button id="ai-chat-send" type="button" class="btn-primary" title="Отправить">
-                <i class="pi pi-send"></i>
-                <span>Отправить</span>
-            </button>
+            <ul id="ai-agent-attachments" class="ai-agent-attachments" aria-label="Вложения"></ul>
+            <div class="ai-agent-composer-row">
+                <input id="ai-agent-files" type="file" multiple hidden>
+                <button id="ai-agent-attach" type="button" class="ai-chat-icon-btn" title="Прикрепить файл" aria-label="Прикрепить файл">
+                    <i class="pi pi-paperclip"></i>
+                </button>
+                <textarea id="ai-agent-input" class="database-field-input" rows="2" placeholder="Сообщение для ИИ-агента"></textarea>
+                <button id="ai-agent-send" type="button" class="ai-chat-icon-btn ai-agent-send" title="Отправить" aria-label="Отправить">
+                    <i class="pi pi-send"></i>
+                </button>
+            </div>
         </div>
     </aside>
 
@@ -252,7 +180,7 @@
         ];
     </script>
     <script src="/js/app.js"></script>
-    <script src="/js/ai-chat.js"></script>
+    <script src="/js/ai-agent-chat.js"></script>
     <script src="/js/main-app.js"></script>
     <script src="/js/form-submit.js" defer></script>
     <script>


### PR DESCRIPTION
## Что сделано

Применены те же изменения, что PR #3396 сделал для `templates/main.html`, к двум брендированным шаблонам, которые PR #3396 не затронул (см. примечание в его описании).

Fixes #3397

### Изменённые файлы

- `templates/atex/main.html`
- `templates/ru/main.html`

### Суть изменений (в обоих файлах одинаковые)

1. **Кнопка в навбаре** — обновлены `title`, `aria-label` и `aria-controls`:
   - было: `title="ИИ-чат"`, `aria-controls="ai-chat-panel"`
   - стало: `title="ИИ-агент"`, `aria-controls="ai-agent-panel"`

2. **Панель** — старый расширенный `#ai-chat-panel` (настройки сервиса, пресеты, очередь команд) заменён на упрощённый `#ai-agent-panel` с лентой сообщений, textarea и кнопками «прикрепить файл» / «отправить» — идентично `templates/main.html`.

3. **Скрипт** — `js/ai-chat.js` → `js/ai-agent-chat.js`.

## Как проверить

Открыть любую из баз, использующих `atex` или `ru` шаблон, нажать кнопку ИИ-агента в навбаре — должна открываться упрощённая панель вместо старой с конфигурацией.

---
*This PR was created automatically by the AI issue solver*