### PR TITLE
fix(atex): учитывать лидер BETWEEN_CUTS на каждую резку цуга (#3401)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T19:27:35.268Z for PR creation at branch issue-3401-1bf8c31d5ce7 for issue https://github.com/ideav/crm/issues/3401

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T19:27:35.268Z for PR creation at branch issue-3401-1bf8c31d5ce7 for issue https://github.com/ideav/crm/issues/3401

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1063,12 +1063,23 @@
         return round3(changeoverParts(prev, next, times).reduce(function(sum, p){ return sum + (Number(p.minutes) || 0); }, 0));
     }
 
-    // Полный setup перед резкой (#3240): лидер между резками (BETWEEN_CUTS, база) +
-    // переналадка с предыдущей (changeoverParts). prev=null (первая резка очереди/дня) →
-    // только лидер. Σ minutes == setupMin расписания buildSchedule. → [{ code, label, minutes }].
+    // #3401: число резок в цуге (в терминологии заказчика общая «резка» состоит из
+    // множества резок — бывших «проходов», см. «Кол-во резок план»). Лидер BETWEEN_CUTS
+    // («лидер между резками») заправляется ПЕРЕД КАЖДОЙ резкой, поэтому его множим на это
+    // число. Нет «Кол-во план»/0 → 1 (как раньше — один лидер на резку без проходов).
+    function cutLeaderRuns(cut){
+        var r = stripNum(cut && cut.plannedRuns);
+        return r > 0 ? Math.round(r) : 1;
+    }
+
+    // Полный setup перед резкой (#3240): лидер между резками (BETWEEN_CUTS, база × число
+    // резок цуга, #3401) + переналадка с предыдущей (changeoverParts). prev=null (первая
+    // резка очереди/дня) → только лидер. Σ minutes == setupMin расписания buildSchedule.
+    // → [{ code, label, minutes }].
     function setupBreakdown(prev, next, times){
         var t = times || DEFAULT_OP_TIMES;
-        var leader = Number(t.BETWEEN_CUTS != null ? t.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS) || 0;
+        // #3401: лидер на каждую резку цуга, а не один раз на весь цуг.
+        var leader = (Number(t.BETWEEN_CUTS != null ? t.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS) || 0) * cutLeaderRuns(next);
         var parts = [];
         if (leader > 0) parts.push({ code: 'BETWEEN_CUTS', label: 'лидер между резками', minutes: round3(leader) });
         Array.prototype.push.apply(parts, changeoverParts(prev, next, times));
@@ -1822,7 +1833,7 @@
 
     // Расписание очереди (по порядку): для каждой резки — старт/финиш в минутах от
     // полуночи дня 0 (через сутки — следующий рабочий день). setup перед резкой = лидер
-    // (BETWEEN_CUTS) + переналадка с предыдущей (changeoverCost, мин); длительность =
+    // (BETWEEN_CUTS × число резок цуга, #3401) + переналадка с предыдущей (changeoverCost, мин); длительность =
     // намотка прогона × «Кол-во план» либо сохранённая «Длительность, минут» как
     // fallback. Рабочее окно дня — [shiftStartMin, shiftEndMin] (08:00–16:30);
     // резка, не влезающая до конца окна, переносится на 08:00 следующего дня.
@@ -1844,7 +1855,8 @@
         var t = shiftStart;   // день 0, начало смены
         var out = [];
         (cuts || []).forEach(function(c, i){
-            var setup = leader + (i > 0 ? changeoverCost(cuts[i-1], c, times) : 0);
+            // #3401: лидер заправляют перед каждой резкой цуга → лидер × «Кол-во план».
+            var setup = leader * cutLeaderRuns(c) + (i > 0 ? changeoverCost(cuts[i-1], c, times) : 0);
             var dur = scheduleDurationMinutes(c, Number(runLen[String(c.id)]) || 0, wind);
             var start = t + setup;
             var day = Math.floor(start / 1440);
@@ -1908,6 +1920,9 @@
     // резку, упирающуюся в конец рабочего окна, обрезаем по числу влезающих проходов;
     // остаток проходов — продолжение с 08:00 следующего дня ТОЙ ЖЕ резки без переналадки
     // (ножи остаются на станке → setup продолжения = 0).
+    // #3401: лидер (BETWEEN_CUTS) заправляют ПЕРЕД КАЖДОЙ резкой цуга — он входит в стоимость
+    // одного прохода (perPass + leader), а не в одноразовый setup. Так лидеры раскладываются
+    // по дням вместе с проходами (а не упираются все в первый день/переполняют окно).
     //   orderedCuts — уже упорядоченная очередь станка (как из orderCuts).
     //   opts: { dayStartMin, dayEndMin, leader, times, perPassByCut:{cutId:мин/проход},
     //           runsByCut:{cutId:проходов} } (perPass/runs можно не задавать — берём из резки).
@@ -1961,17 +1976,20 @@
                 prevPhysical = c;
                 return;
             }
+            // #3401: каждая резка цуга включает свой лидер — добавляем его к стоимости прохода.
+            var perPassEff = perPass + leader;
             while (remaining > 0) {
-                var setup = isCont ? 0 : (leader + (prevPhysical ? changeoverCost(prevPhysical, c, times) : 0));
+                // #3401: setup сегмента — только переналадка с предыдущей резкой; лидер уже в perPassEff.
+                var setup = isCont ? 0 : (prevPhysical ? changeoverCost(prevPhysical, c, times) : 0);
                 var avail = effCapacity(day) - clock;
-                var maxPasses = Math.floor((avail - setup) / perPass);
+                var maxPasses = Math.floor((avail - setup) / perPassEff);
                 if (maxPasses < 1) {
                     if (clock > 0) { day += 1; clock = 0; continue; }   // переносим на чистый след. день
                     maxPasses = 1;   // целый день не вмещает даже setup+1 проход — кладём 1 (переполнение)
                 }
                 var passesNow = Math.min(remaining, maxPasses);
                 var windowStart = day * 1440 + dayStart + clock;
-                var segDur = passesNow * perPass;
+                var segDur = passesNow * perPassEff;
                 segments.push({ cutId: String(cid), dayOffset: day, runs: passesNow,
                     windowStartMin: round3(windowStart), startMin: round3(windowStart + setup),
                     setupMin: round3(setup), durationMin: round3(segDur),

--- a/experiments/atex-production-planning-3401.demo.js
+++ b/experiments/atex-production-planning-3401.demo.js
@@ -1,0 +1,33 @@
+// #3401 demo — лидер (BETWEEN_CUTS) учитывается перед КАЖДОЙ резкой цуга, а не один раз.
+// Раньше «резка» состояла из проходов; в терминологии заказчика цуг состоит из множества
+// резок (бывших проходов), и каждая включает этап BETWEEN_CUTS — его множим на их число.
+//
+// Run with: node experiments/atex-production-planning-3401.demo.js
+process.env.TZ = 'UTC';
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+var pts = [{ m: 600, min: 4 }];            // норма намотки: 600 м → 4 мин/проход
+var times = { BETWEEN_CUTS: 2 };           // лидер 2 мин на резку
+
+// Цуг из 5 резок (проходов) по 600 м.
+var cut = { id: 'C', plannedRuns: 5 };
+var sched = planning.buildSchedule([cut], { windPoints: pts, times: times, runLengthByCut: { C: 600 }, shiftStartMin: 480 });
+
+console.log('=== #3401: лидер на каждую резку цуга ===');
+console.log('Цуг: 5 резок × (намотка 4 мин + лидер 2 мин)');
+console.log('Расписание buildSchedule:', JSON.stringify(sched[0]));
+console.log('  setupMin =', sched[0].setupMin, '(лидер 2 × 5 резок = 10; было бы 2 при разовом лидере)');
+console.log('  durationMin =', sched[0].durationMin, '(намотка 4 × 5 = 20)');
+
+var breakdown = planning.setupBreakdown(null, cut, times);
+console.log('Разбивка setup (модалка тайминга):', JSON.stringify(breakdown));
+
+// Раскладка по дням: каждый проход стоит perPass + leader.
+var segs = planning.splitMachineQueue([{ id: 'C' }], {
+    dayStartMin: 480, dayEndMin: 510, times: times, perPassByCut: { C: 4 }, runsByCut: { C: 5 }
+});
+console.log('\nРаскладка по дням splitMachineQueue (окно всего 30 мин):');
+segs.forEach(function (s) {
+    console.log('  день', s.dayOffset, '— резок:', s.runs, ', длительность:', s.durationMin, 'мин');
+});
+console.log('  (проход = 4 + 2 = 6 мин → в 30 мин влезает 5 резок ровно)');

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1081,13 +1081,50 @@ assertEqual(sched[1], { cutId:'B', startMin:485.2, finishMin:489.2, setupMin:2, 
 var schedPlannedRuns = planning.buildSchedule([
   { id:'C', plannedRuns:3 }
 ], { windPoints: pts, runLengthByCut: { C:600 }, shiftStartMin: 480 });
-assertEqual(schedPlannedRuns[0], { cutId:'C', startMin:482, finishMin:494, setupMin:2, durationMin:12 },
-    'buildSchedule #3229: длительность очереди учитывает Кол-во план');
+// #3401: лидер 2 заправляется перед КАЖДОЙ из 3 резок → setup = 2 × 3 = 6 (было 2).
+assertEqual(schedPlannedRuns[0], { cutId:'C', startMin:486, finishMin:498, setupMin:6, durationMin:12 },
+    'buildSchedule #3401: лидер учитывается на каждую резку (setup = лидер × Кол-во план)');
 var schedStoredDuration = planning.buildSchedule([
   { id:'D', duration:12.5 }
 ], { windPoints: pts, runLengthByCut: {}, shiftStartMin: 480 });
 assertEqual(schedStoredDuration[0], { cutId:'D', startMin:482, finishMin:494.5, setupMin:2, durationMin:12.5 },
     'buildSchedule #3229: cut_duration используется как fallback, если метраж отчёта отсутствует');
+
+// ── #3401: лидер (BETWEEN_CUTS) учитывается перед КАЖДОЙ резкой цуга ──
+// setupBreakdown множит лидер на «Кол-во план» (число резок цуга); переналадка — один раз.
+assertEqual(planning.setupBreakdown(null, { plannedRuns:3 }, null),
+    [{code:'BETWEEN_CUTS', label:'лидер между резками', minutes:6}],
+    'setupBreakdown #3401: первая резка цуга из 3 → лидер 2 × 3 = 6');
+assertEqual(planning.setupBreakdown(toBase, toClone({materialId:'2', plannedRuns:4}), null),
+    [{code:'BETWEEN_CUTS', label:'лидер между резками', minutes:8}, {code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}],
+    'setupBreakdown #3401: лидер 2 × 4 = 8 + одна переналадка сырья 15');
+// Без «Кол-во план» (0/пусто) лидер остаётся одинарным (поведение до #3401).
+assertEqual(planning.setupBreakdown(null, {}, null),
+    [{code:'BETWEEN_CUTS', label:'лидер между резками', minutes:2}],
+    'setupBreakdown #3401: без Кол-во план → один лидер (fallback)');
+// buildSchedule: окно резки растёт на лидер × (Кол-во план − 1) относительно прежнего одинарного лидера.
+var sched3401 = planning.buildSchedule([
+  { id:'A', materialId:'1', winding:'IN', batchId:'b', knifeCount:4, knifeWidths:[60], rollerWidth:60, plannedRuns:2 },
+  { id:'B', materialId:'2', winding:'IN', batchId:'b', knifeCount:4, knifeWidths:[60], rollerWidth:60, plannedRuns:3 }
+], { windPoints: pts, runLengthByCut: { A:600, B:600 }, shiftStartMin: 480 });
+// A: setup = лидер 2 × 2 = 4; намотка 4 × 2 = 8 → 484–492.
+assertEqual(sched3401[0], { cutId:'A', startMin:484, finishMin:492, setupMin:4, durationMin:8 },
+    'buildSchedule #3401: A (2 резки) — лидер 2 × 2 = 4');
+// B: setup = лидер 2 × 3 = 6 + смена сырья 15 = 21; намотка 4 × 3 = 12 → старт 492+21=513.
+assertEqual(sched3401[1], { cutId:'B', startMin:513, finishMin:525, setupMin:21, durationMin:12 },
+    'buildSchedule #3401: B (3 резки) — лидер 2 × 3 = 6 + переналадка 15');
+// splitMachineQueue: лидер входит в стоимость прохода (perPass + leader), раскладывается по дням.
+var seg3401 = planning.splitMachineQueue([{ id:'A' }],
+    { dayStartMin:0, dayEndMin:1000, times:{ BETWEEN_CUTS:3 }, perPassByCut:{ A:10 }, runsByCut:{ A:4 } });
+assertEqual(seg3401.map(function(s){ return { c:s.cutId, runs:s.runs, dur:s.durationMin, setup:s.setupMin }; }),
+    [{ c:'A', runs:4, dur:52, setup:0 }],
+    'splitMachineQueue #3401: 4 прохода × (10 намотка + 3 лидер) = 52 мин');
+// Разбиение по дням: каждый проход стоит perPass+leader, поэтому в день влезает меньше проходов.
+var segDays3401 = planning.splitMachineQueue([{ id:'A' }],
+    { dayStartMin:0, dayEndMin:30, times:{ BETWEEN_CUTS:5 }, perPassByCut:{ A:5 }, runsByCut:{ A:5 } });
+assertEqual(segDays3401.map(function(s){ return { day:s.dayOffset, runs:s.runs }; }),
+    [{ day:0, runs:3 }, { day:1, runs:2 }],
+    'splitMachineQueue #3401: проход = 5+5=10 мин → в окно 30 мин влезает 3 прохода, остаток на след. день');
 // #3262: строка показывает ВСЁ окно (setup+резка): старт = startMin−setupMin (08:00),
 // длительность = setup(2)+12.5 = 14.5 (диапазон совпадает с числом минут).
 assertEqual(planning.formatScheduleLine(schedStoredDuration[0], 0, true),
@@ -1886,18 +1923,20 @@ assertEqual(
     ],
     'splitMachineQueue: перелив дня → продолжение на след. день, setup=0 (ножи остаются)'
 );
-// 3) Лидер съедает часть окна; хвост растягивается на 3 дня.
+// 3) #3401: лидер заправляют перед КАЖДОЙ резкой → каждый проход стоит perPass+leader
+// (10+5=15). В окно 100 мин влезает 6 проходов (90 мин); хвост 20 проходов — на 4 дня.
 assertEqual(
     planning.splitMachineQueue(
         [{ id: 'c1', plannedRuns: 20 }],
         { dayStartMin: 0, dayEndMin: 100, leader: 5, times: splitTimes, perPassByCut: { c1: 10 } }
     ),
     [
-        { cutId: 'c1', dayOffset: 0, runs: 9, windowStartMin: 0, startMin: 5, setupMin: 5, durationMin: 90, isContinuation: false, parentCutId: null },
-        { cutId: 'c1', dayOffset: 1, runs: 10, windowStartMin: 1440, startMin: 1440, setupMin: 0, durationMin: 100, isContinuation: true, parentCutId: 'c1' },
-        { cutId: 'c1', dayOffset: 2, runs: 1, windowStartMin: 2880, startMin: 2880, setupMin: 0, durationMin: 10, isContinuation: true, parentCutId: 'c1' }
+        { cutId: 'c1', dayOffset: 0, runs: 6, windowStartMin: 0, startMin: 0, setupMin: 0, durationMin: 90, isContinuation: false, parentCutId: null },
+        { cutId: 'c1', dayOffset: 1, runs: 6, windowStartMin: 1440, startMin: 1440, setupMin: 0, durationMin: 90, isContinuation: true, parentCutId: 'c1' },
+        { cutId: 'c1', dayOffset: 2, runs: 6, windowStartMin: 2880, startMin: 2880, setupMin: 0, durationMin: 90, isContinuation: true, parentCutId: 'c1' },
+        { cutId: 'c1', dayOffset: 3, runs: 2, windowStartMin: 4320, startMin: 4320, setupMin: 0, durationMin: 30, isContinuation: true, parentCutId: 'c1' }
     ],
-    'splitMachineQueue: лидер + многодневный хвост; продолжения без setup'
+    'splitMachineQueue #3401: лидер на каждый проход (perPass+leader); хвост по дням, продолжения без setup'
 );
 // 4) Две одинаковые резки: первая заполняет день, вторая (НЕ продолжение) уходит на день 1.
 var splitTwo = planning.splitMachineQueue(


### PR DESCRIPTION
## Проблема (#3401)

В терминологии заказчика общее понятие «резка» (цуг) состоит из множества **резок** (раньше называвшихся «проходами», см. поле «Кол-во резок план» = `plannedRuns`). Каждая такая резка включает этап **BETWEEN_CUTS** («лидер между резками»): лидер заправляют **перед каждой** резкой цуга.

Раньше `production-planning.js` учитывал лидер **один раз** на весь цуг. Из‑за этого расчёт длительности/расписания недооценивал время на лидеры, когда в цуге несколько резок.

## Решение

Лидер `BETWEEN_CUTS` умножается на число резок цуга (`plannedRuns`). Если «Кол-во план» не задано/0 — остаётся одинарный лидер (поведение до #3401).

Изменения в `download/atex/js/production-planning.js`:

- **`cutLeaderRuns(cut)`** — новый помощник: число резок цуга (`stripNum(plannedRuns)`, 0/пусто → 1).
- **`setupBreakdown(prev, next, times)`** (модалка тайминга, #3240) — лидер = база × `cutLeaderRuns(next)`.
- **`buildSchedule(...)`** (очередь/расписание) — `setup = лидер × Кол‑во план + переналадка`.
- **`splitMachineQueue(...)`** (раскладка по дням, #3280) — лидер входит в **стоимость одного прохода** (`perPassEff = perPass + leader`), а не в одноразовый setup. Так лидеры раскладываются по дням вместе с проходами, а не упираются все в первый день и не переполняют рабочее окно. Итог по цугу совпадает с `buildSchedule`.

Вырожденная ветка `splitMachineQueue` (нет проходов / нет окна) оставлена как есть. Сохранённая «Длительность, минут» (намотка) лидер не включала и не включает — изменений не требует.

## Проверка / воспроизведение

Демо `experiments/atex-production-planning-3401.demo.js` (цуг из 5 резок, намотка 4 мин, лидер 2 мин):

```
Расписание buildSchedule: {"cutId":"C","startMin":490,"finishMin":510,"setupMin":10,"durationMin":20}
  setupMin = 10 (лидер 2 × 5 резок = 10; было бы 2 при разовом лидере)
Разбивка setup: [{"code":"BETWEEN_CUTS","label":"лидер между резками","minutes":10}]
Раскладка по дням: день 0 — резок: 5, длительность: 30 мин (проход = 4 + 2 = 6 → 5 резок в 30 мин)
```

Тесты (`node experiments/atex-production-planning.test.js`) — **449 assertions passed**:
- новый блок `#3401` для `setupBreakdown` / `buildSchedule` / `splitMachineQueue`;
- обновлён существующий тест дневной раскладки на новое поведение «лидер на каждый проход».

`node experiments/atex-production-planning-3391.test.js` — 32 assertions passed.

Closes #3401
