### PR TITLE
fix(ai-agent): проверять оплату SQL-запросом к $connection вместо HTTP-отчёта (#3404)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T20:23:20.887Z for PR creation at branch issue-3404-52a2a9163c6d for issue https://github.com/ideav/crm/issues/3404

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T20:23:20.887Z for PR creation at branch issue-3404-52a2a9163c6d for issue https://github.com/ideav/crm/issues/3404

--- a/experiments/test-issue-3404-ai-agent-payment-sql.php
+++ b/experiments/test-issue-3404-ai-agent-payment-sql.php
@@ -1,0 +1,123 @@
+<?php
+# Regression test for issue #3404
+# https://github.com/ideav/crm/issues/3404
+#
+# Запрос для проверки оплаты ИИ-агента должен выполняться напрямую к $connection
+# (SQL-запрос к таблице `my`), а вместо плейсхолдера {имя БД} должно
+# подставляться имя текущей базы данных (с экранированием).
+#
+# Тест извлекает чистые функции buildAiAgentPaymentSql(), fetchAiAgentPaymentReport()
+# и evaluateAiAgentPayment() из index.php и проверяет:
+#  1) SQL строится по образцу из тикета, плейсхолдер {имя БД} заменён;
+#  2) имя базы экранируется (нет SQL-инъекции через одинарную кавычку);
+#  3) диспетчер по умолчанию идёт в SQL, а при заданном URL — в HTTP;
+#  4) evaluateAiAgentPayment() корректно трактует строку SQL-результата.
+
+$failures = 0;
+
+function check($cond, $name){
+    global $failures;
+    if($cond){
+        echo "PASS: $name\n";
+    } else {
+        echo "FAIL: $name\n";
+        $failures++;
+    }
+}
+
+# t9n() и aiConfigValue() — заглушки для изоляции тестируемых функций.
+function t9n($value){
+    # Возвращаем RU-вариант, чтобы сравнения по сообщению были детерминированы.
+    if(preg_match('/^\[RU\](.*?)\[EN\]/s', $value, $m))
+        return $m[1];
+    return $value;
+}
+$GLOBALS["__config"] = array();
+function aiConfigValue($names){
+    foreach($names as $name)
+        if(isset($GLOBALS["__config"][$name]) && trim((string)$GLOBALS["__config"][$name]) !== "")
+            return trim((string)$GLOBALS["__config"][$name]);
+    return "";
+}
+
+function extract_function_source($source, $name){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false)
+        throw new Exception("Function not found: ".$name);
+    $brace = strpos($source, "{", $start);
+    if($brace === false)
+        throw new Exception("Function body not found: ".$name);
+    $depth = 0;
+    $length = strlen($source);
+    for($i = $brace; $i < $length; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+    throw new Exception("Function body is not closed: ".$name);
+}
+
+$source = file_get_contents(__DIR__."/../index.php");
+foreach(array("buildAiAgentPaymentSql", "fetchAiAgentPaymentReportSql", "fetchAiAgentPaymentReportHttp", "fetchAiAgentPaymentReport", "evaluateAiAgentPayment") as $fn)
+    eval(extract_function_source($source, $fn));
+
+# 1) SQL строится по образцу и подставляет имя базы вместо {имя БД}.
+$sql = buildAiAgentPaymentSql("acme");
+check(strpos($sql, "{имя БД}") === false, "placeholder {имя БД} is replaced");
+check(strpos($sql, "a271_val ='acme'") !== false, "database name substituted into a271_val filter");
+check(strpos($sql, "a1085.val ='c2ai'") !== false, "fixed c2ai product filter preserved");
+check(strpos($sql, "a967.val as 'Paid'") !== false, "Paid column kept (matches report format)");
+check(strpos($sql, "a957.val as 'Payment'") !== false, "Payment column kept (matches report format)");
+check(strpos($sql, "FROM my a957") !== false, "query runs against the `my` table");
+check(strtoupper(substr(ltrim($sql), 0, 6)) === "SELECT", "query is a read-only SELECT");
+
+# 2) Имя базы экранируется — одинарная кавычка не разрывает строковый литерал.
+$evil = buildAiAgentPaymentSql("x' OR '1'='1");
+check(strpos($evil, "a271_val ='x\\' OR \\'1\\'=\\'1'") !== false, "single quotes in db name are escaped (no injection)");
+
+# 3) Диспетчер fetchAiAgentPaymentReport(): без URL — SQL-путь (нет $connection ->
+#    false), с URL — HTTP-путь (несуществующий хост -> false, но без падения).
+$GLOBALS["__config"] = array();
+unset($GLOBALS["connection"]);
+$sqlResult = fetchAiAgentPaymentReport("acme");
+check($sqlResult === false, "SQL path returns false when no DB connection is available");
+
+$GLOBALS["__config"] = array("AI_AGENT_PAYMENT_REPORT_URL" => "http://127.0.0.1:9/none?FR_DB=");
+$httpResult = fetchAiAgentPaymentReport("acme");
+check($httpResult === false, "HTTP path used when AI_AGENT_PAYMENT_REPORT_URL is configured");
+
+# 4) evaluateAiAgentPayment() трактует SQL-результат (JSON-массив строк) так же,
+#    как прежний отчёт. Сумма 5950/12500 и дата не старше месяца -> active.
+$GLOBALS["__config"] = array();
+$paidAt = time() - 3 * 24 * 3600;
+$active = json_encode(array(array("Paid" => (string)$paidAt, "Payment" => "5950")));
+$res = evaluateAiAgentPayment($active, "acme");
+check(!empty($res["ok"]) && $res["status"] === "active", "valid recent 5950 payment -> active");
+
+$expiredAt = time() - 60 * 24 * 3600;
+$expired = json_encode(array(array("Paid" => (string)$expiredAt, "Payment" => "12500")));
+$res = evaluateAiAgentPayment($expired, "acme");
+check(empty($res["ok"]) && $res["status"] === "expired", "old payment -> expired");
+
+$wrongAmount = json_encode(array(array("Paid" => (string)$paidAt, "Payment" => "100")));
+$res = evaluateAiAgentPayment($wrongAmount, "acme");
+check(empty($res["ok"]) && $res["status"] === "not_paid", "wrong amount -> not_paid");
+
+# Пустой SQL-результат (нет строк оплаты) -> not_paid.
+$res = evaluateAiAgentPayment("[]", "acme");
+check(empty($res["ok"]) && $res["status"] === "not_paid", "empty SQL result -> not_paid");
+
+$res = evaluateAiAgentPayment(false, "acme");
+check(empty($res["ok"]) && $res["status"] === "not_paid", "fetch failure (false) -> not_paid");
+
+echo "\n";
+if($failures){
+    echo "FAILED: $failures check(s) failed\n";
+    exit(1);
+}
+echo "ALL TESTS PASSED\n";

--- a/index.php
+++ b/index.php
@@ -8640,9 +8640,9 @@ function getAiAccessibleDbs(){
 #
 # Новый чат обращается только к нашему фиксированному агенту. Доступ разрешён
 # только пользователю, имя которого совпадает с именем базы. Условие доработки —
-# действующая оплата клиента, которая проверяется запросом к отчёту 237290 и
-# кешируется. Все действия агента ограничены текущей базой данных
-# (см. docs/integram-app-workflow.md).
+# действующая оплата клиента, которая проверяется SQL-запросом напрямую к
+# $connection (issue #3404) и кешируется. Все действия агента ограничены текущей
+# базой данных (см. docs/integram-app-workflow.md).
 # ============================================================
 function handleAiAgentRequest($com){
     global $z;
@@ -8733,10 +8733,56 @@ function checkAiAgentPayment($db){
     return evaluateAiAgentPayment($raw, $safeDb);
 }
 function fetchAiAgentPaymentReport($db){
-    # GET https://ideav.ru/my/report/237290?JSON_KV&FR_DB={db} — срок действия оплаты.
+    # Issue #3404: срок действия оплаты берётся напрямую из базы ($connection)
+    # SQL-запросом, а не из HTTP-отчёта 237290. HTTP-путь сохранён как опция
+    # обратной совместимости — он используется только если задан
+    # AI_AGENT_PAYMENT_REPORT_URL.
     $base = aiConfigValue(array("AI_AGENT_PAYMENT_REPORT_URL"));
-    if($base === "")
-        $base = "https://ideav.ru/my/report/237290?JSON_KV&FR_DB=";
+    if($base !== "")
+        return fetchAiAgentPaymentReportHttp($base, $db);
+    return fetchAiAgentPaymentReportSql($db);
+}
+# Строит SQL-запрос проверки оплаты, подставляя имя базы вместо плейсхолдера
+# {имя БД}. Имя экранируется ($connection при наличии, иначе addslashes), что
+# делает функцию тестируемой без подключения к БД.
+function buildAiAgentPaymentSql($db, $connection=null){
+    $name = ($connection !== null && $connection !== false)
+        ? mysqli_real_escape_string($connection, (string)$db)
+        : addslashes((string)$db);
+    return "SELECT  a967.val as 'Paid',a957.val as 'Payment'\n"
+        ."FROM my a957\n"
+        ."   LEFT JOIN my a967 ON a967.up=a957.id AND a967.t=967\n"
+        ."   LEFT JOIN my a1085 ON a1085.up=a957.id AND a1085.t=1085\n"
+        ."  LEFT JOIN (SELECT a18.id,a18.id a18_id\n"
+        ."  FROM my a18\n"
+        ."    WHERE a18.t=18\n"
+        ."    ) a18 ON a957.up=a18.id\n"
+        ."  LEFT JOIN (SELECT a271.up,a271.val a271_val\n"
+        ."  FROM my a271\n"
+        ."    WHERE a271.t=271\n"
+        ."    ) a271 ON a271.up=a18_id\n"
+        ."WHERE a957.up!=0 AND a957.t!=a957.up AND length(a957.val)!=0 AND a957.t=957  AND a271_val ='".$name."'    AND a1085.val ='c2ai'     \n"
+        ."ORDER BY a967.val DESC LIMIT 1";
+}
+# Выполняет SQL-проверку оплаты к $connection. Возвращает JSON-строку в том же
+# формате, что и прежний отчёт (массив строк с ключами Paid/Payment), чтобы
+# evaluateAiAgentPayment() и кеширование работали без изменений. При ошибке
+# подключения/запроса — false (не кешируется), при отсутствии оплаты — "[]".
+function fetchAiAgentPaymentReportSql($db){
+    global $connection;
+    if(empty($connection))
+        return false;
+    $sql = buildAiAgentPaymentSql($db, $connection);
+    $result = @mysqli_query($connection, $sql);
+    if(!$result)
+        return false;
+    $row = mysqli_fetch_assoc($result);
+    if(is_object($result) && function_exists("mysqli_free_result"))
+        @mysqli_free_result($result);
+    return json_encode(is_array($row) ? array($row) : array(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+}
+function fetchAiAgentPaymentReportHttp($base, $db){
+    # GET https://ideav.ru/my/report/237290?JSON_KV&FR_DB={db} — срок действия оплаты.
     $url = $base.rawurlencode((string)$db);
     if(!function_exists("curl_init")){
         $ctx = stream_context_create(array("http" => array("method" => "GET", "timeout" => 8)));


### PR DESCRIPTION
## Что сделано

Запрос проверки оплаты ИИ-агента теперь выполняется **напрямую к `$connection`** (SQL-запрос к таблице `my`), а не через HTTP-отчёт `237290`. Вместо плейсхолдера `{имя БД}` в условие `a271_val = '…'` подставляется имя текущей базы данных с экранированием.

Fixes #3404

### Изменения в `index.php`
- `fetchAiAgentPaymentReport()` стал диспетчером: по умолчанию идёт в новый SQL-путь, а HTTP-отчёт используется только если задан `AI_AGENT_PAYMENT_REPORT_URL` (обратная совместимость).
- Добавлена `buildAiAgentPaymentSql($db, $connection)` — строит запрос из тикета, подставляя имя базы вместо `{имя БД}`. Имя экранируется (`mysqli_real_escape_string`, иначе `addslashes`), что исключает SQL-инъекцию и делает функцию тестируемой без подключения к БД.
- Добавлена `fetchAiAgentPaymentReportSql($db)` — выполняет запрос к `$connection` и возвращает JSON в том же формате (`[{"Paid":…,"Payment":…}]`), что и прежний отчёт, поэтому `evaluateAiAgentPayment()` и кеширование работают без изменений. Ошибка подключения/запроса → `false` (не кешируется), отсутствие оплаты → `"[]"`.
- HTTP-логика вынесена в `fetchAiAgentPaymentReportHttp($base, $db)`.

### Используемый запрос (из тикета, с подстановкой имени базы)
```sql
SELECT  a967.val as 'Paid',a957.val as 'Payment'
FROM my a957
   LEFT JOIN my a967 ON a967.up=a957.id AND a967.t=967
   LEFT JOIN my a1085 ON a1085.up=a957.id AND a1085.t=1085
  LEFT JOIN (SELECT a18.id,a18.id a18_id FROM my a18 WHERE a18.t=18) a18 ON a957.up=a18.id
  LEFT JOIN (SELECT a271.up,a271.val a271_val FROM my a271 WHERE a271.t=271) a271 ON a271.up=a18_id
WHERE a957.up!=0 AND a957.t!=a957.up AND length(a957.val)!=0 AND a957.t=957  AND a271_val ='<имя базы>'    AND a1085.val ='c2ai'
ORDER BY a967.val DESC LIMIT 1
```

## Тестирование
`experiments/test-issue-3404-ai-agent-payment-sql.php` — извлекает функции из `index.php` и проверяет:
- плейсхолдер `{имя БД}` заменён, имя базы попало в фильтр `a271_val`;
- одинарные кавычки в имени экранируются (нет инъекции);
- диспетчер по умолчанию идёт в SQL, а при заданном URL — в HTTP;
- `evaluateAiAgentPayment()` корректно трактует результат SQL (active / expired / not_paid / пустой результат / ошибка).

```
$ php experiments/test-issue-3404-ai-agent-payment-sql.php
... ALL TESTS PASSED
```

`php -l index.php` → `No syntax errors detected`.
