### PR TITLE
feat(ai-agent): асинхронная работа — индикатор «думает», поллинг и сохранение результата (#3410)

### DIFF
--- a/css/ai-chat.css
+++ b/css/ai-chat.css
@@ -437,3 +437,52 @@
         justify-content: center;
     }
 }
+
+/* Issue #3410: индикатор «ИИ-агент думает» и статус ожидания. */
+.ai-chat-status.is-waiting {
+    color: var(--accent-color, var(--text-secondary));
+}
+
+.ai-chat-message-thinking .ai-chat-message-text {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-secondary);
+}
+
+.ai-agent-typing {
+    display: inline-flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 0.9em;
+    flex: 0 0 auto;
+}
+
+.ai-agent-typing i {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0.5;
+    animation: aiAgentTyping 1.2s infinite ease-in-out both;
+}
+
+.ai-agent-typing i:nth-child(2) { animation-delay: 0.15s; }
+.ai-agent-typing i:nth-child(3) { animation-delay: 0.3s; }
+
+.ai-agent-thinking-label {
+    font-size: 0.85rem;
+    line-height: 1.35;
+}
+
+@keyframes aiAgentTyping {
+    0%, 80%, 100% { transform: translateY(0); opacity: 0.35; }
+    40% { transform: translateY(-3px); opacity: 0.9; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ai-agent-typing i {
+        animation: none;
+        opacity: 0.6;
+    }
+}

--- a/experiments/test-issue-3410-ai-agent-async.js
+++ b/experiments/test-issue-3410-ai-agent-async.js
@@ -1,0 +1,67 @@
+/*
+ * Regression test for issue #3410
+ * https://github.com/ideav/crm/issues/3410
+ *
+ * Клиент ИИ-агента (js/ai-agent-chat.js) во время ожидания показывает, что агент
+ * думает, а при долгом ожидании — что нужно ещё время / задача в очереди.
+ * Проверяем чистые функции выбора текста и извлечения ответа/ошибки без браузера
+ * (модуль экспортируется через module.exports, авто-init не запускается без DOM).
+ */
+'use strict';
+
+var assert = require('assert');
+var agent = require('../js/ai-agent-chat.js');
+
+var failures = 0;
+function check(cond, name) {
+    if (cond) {
+        console.log('PASS: ' + name);
+    } else {
+        console.log('FAIL: ' + name);
+        failures++;
+    }
+}
+
+// Модуль загрузился без DOM и отдал объект агента.
+check(agent && typeof agent.waitMessage === 'function', 'module exports the agent without needing a DOM');
+
+// waitMessage: эскалация по времени ожидания.
+check(agent.waitMessage(0).indexOf('Думаю') === 0, 'waitMessage: instant -> "Думаю над ответом…"');
+check(agent.waitMessage(5000).indexOf('Думаю') === 0, 'waitMessage: <12s -> still "Думаю…"');
+check(agent.waitMessage(20000).indexOf('до минуты') !== -1, 'waitMessage: 12..45s -> "может занять до минуты"');
+check(agent.waitMessage(60000).indexOf('очередь') !== -1, 'waitMessage: >45s -> "поставлена в очередь"');
+check(agent.waitMessage(60000).indexOf('другого браузера') !== -1, 'waitMessage: long wait mentions cross-browser recovery');
+
+// statusMessage: короткий текст в шапке.
+check(agent.statusMessage(0) === 'ИИ-агент думает…', 'statusMessage: instant -> "ИИ-агент думает…"');
+check(agent.statusMessage(20000).indexOf('ещё немного времени') !== -1, 'statusMessage: 12..45s -> "нужно ещё немного времени"');
+check(agent.statusMessage(60000).indexOf('очереди') !== -1, 'statusMessage: >45s -> "Задача в очереди"');
+
+// Пороги монотонны (текст меняется ровно дважды).
+check(agent.waitMessage(11999) !== agent.waitMessage(12000), 'waitMessage threshold at 12s');
+check(agent.waitMessage(44999) !== agent.waitMessage(45000), 'waitMessage threshold at 45s');
+
+// getAssistantContent: достаёт ответ из разных форм результата задачи.
+check(agent.getAssistantContent({ assistant: { content: 'привет' } }) === 'привет', 'getAssistantContent: assistant.content');
+check(agent.getAssistantContent({ content: 'x' }) === 'x', 'getAssistantContent: top-level content');
+check(agent.getAssistantContent({ message: 'm' }) === 'm', 'getAssistantContent: message fallback');
+check(agent.getAssistantContent(null) === '', 'getAssistantContent: null -> empty');
+check(agent.getAssistantContent({}) === '', 'getAssistantContent: unknown shape -> empty');
+
+// getErrorText: достаёт текст ошибки.
+check(agent.getErrorText({ error: 'нет оплаты' }) === 'нет оплаты', 'getErrorText: string error');
+check(agent.getErrorText({ error: { message: 'oops' } }) === 'oops', 'getErrorText: object error.message');
+check(agent.getErrorText(null) === '', 'getErrorText: null -> empty');
+
+// getStatusUrl: формирует адрес опроса статуса по id и последней задачи.
+agent.getCurrentDbName = function () { return 'acme'; };
+check(agent.getStatusUrl('abc') === '/acme/ai/agent?JSON=1&job=abc', 'getStatusUrl: by job id');
+check(agent.getStatusUrl(null) === '/acme/ai/agent?JSON=1&latest=1', 'getStatusUrl: latest');
+
+assert.ok(true);
+console.log('');
+if (failures) {
+    console.log('FAILED: ' + failures + ' check(s) failed');
+    process.exit(1);
+}
+console.log('ALL TESTS PASSED');

--- a/experiments/test-issue-3410-ai-agent-dom.js
+++ b/experiments/test-issue-3410-ai-agent-dom.js
@@ -1,0 +1,202 @@
+/*
+ * Regression test for issue #3410 (клиентская проводка js/ai-agent-chat.js).
+ * https://github.com/ideav/crm/issues/3410
+ *
+ * Лёгкий харнесс без jsdom: подменяем document/window/fetch/setInterval и
+ * проверяем поведение целиком:
+ *   A) отправка -> «думает» -> готовый ответ в ленте;
+ *   B) восстановление последней задачи при загрузке (заход с другого браузера);
+ *   C) долгая задача -> поллинг статуса -> готовый ответ, таймеры остановлены.
+ */
+'use strict';
+
+var realSetTimeout = global.setTimeout;
+var path = require.resolve('../js/ai-agent-chat.js');
+
+var failures = 0;
+function expect(cond, name){
+    if(cond){ console.log('PASS: ' + name); } else { console.log('FAIL: ' + name); failures++; }
+}
+function flush(){ return new Promise(function(res){ realSetTimeout(res, 0); }); }
+function settle(){ return flush().then(flush).then(flush); }
+
+// --- Минимальный фейковый DOM ---
+function FE(tag){
+    this.tag = tag; this.children = []; this.attrs = {}; this._classes = {};
+    this._text = ''; this.style = {}; this.parentNode = null;
+    this.scrollTop = 0; this.scrollHeight = 100; this.disabled = false;
+    this.hidden = false; this.value = ''; this.listeners = {};
+    var self = this;
+    this.classList = {
+        add: function(c){ self._classes[c] = true; },
+        remove: function(c){ delete self._classes[c]; },
+        contains: function(c){ return !!self._classes[c]; },
+        toggle: function(c){ self._classes[c] = !self._classes[c]; }
+    };
+}
+FE.prototype.appendChild = function(c){ c.parentNode = this; this.children.push(c); return c; };
+FE.prototype.setAttribute = function(k, v){ this.attrs[k] = v; };
+FE.prototype.removeAttribute = function(k){ delete this.attrs[k]; };
+FE.prototype.getAttribute = function(k){ return this.attrs.hasOwnProperty(k) ? this.attrs[k] : null; };
+FE.prototype.addEventListener = function(ev, fn){ this.listeners[ev] = fn; };
+FE.prototype.focus = function(){};
+FE.prototype.click = function(){};
+FE.prototype.querySelector = function(sel){
+    var cls = sel.charAt(0) === '.' ? sel.slice(1) : sel;
+    return findByClass(this, cls);
+};
+Object.defineProperty(FE.prototype, 'textContent', {
+    get: function(){ return this._text; },
+    set: function(v){ this._text = (v === undefined || v === null) ? '' : String(v); this.children = []; }
+});
+Object.defineProperty(FE.prototype, 'innerHTML', {
+    get: function(){ return this._html || ''; },
+    set: function(v){ this._html = String(v); if(v === '') this.children = []; }
+});
+Object.defineProperty(FE.prototype, 'className', {
+    get: function(){ return Object.keys(this._classes).join(' '); },
+    set: function(v){ this._classes = {}; var self = this; String(v).split(/\s+/).forEach(function(c){ if(c) self._classes[c] = true; }); }
+});
+function findByClass(node, cls){
+    for(var i = 0; i < node.children.length; i++){
+        var ch = node.children[i];
+        if(ch._classes && ch._classes[cls]) return ch;
+        var deep = findByClass(ch, cls);
+        if(deep) return deep;
+    }
+    return null;
+}
+
+var IDS = ['ai-chat-toggle','ai-agent-panel','ai-agent-backdrop','ai-agent-close','ai-agent-input',
+    'ai-agent-send','ai-agent-attach','ai-agent-files','ai-agent-messages','ai-agent-attachments','ai-agent-status'];
+
+function makeEnv(fetchHandler){
+    var els = {};
+    IDS.forEach(function(id){ els[id] = new FE('div'); });
+    // messages нужен родитель со scroll-метриками.
+    var body = new FE('div');
+    body.appendChild(els['ai-agent-messages']);
+
+    global.document = {
+        readyState: 'complete',
+        getElementById: function(id){ return els[id] || null; },
+        createElement: function(tag){ return new FE(tag); },
+        addEventListener: function(){},
+        querySelector: function(){ return null; }
+    };
+    global.window = { db: 'acme', location: { pathname: '/acme/main' } };
+    global.__intervals = [];
+    global.setInterval = function(fn, ms){ var h = { fn: fn, ms: ms, cleared: false }; global.__intervals.push(h); return h; };
+    global.clearInterval = function(h){ if(h) h.cleared = true; };
+    global.fetch = function(url, opts){
+        var res = fetchHandler(url, opts || {});
+        return Promise.resolve({
+            ok: res.ok !== false,
+            status: res.status || 200,
+            json: function(){ return Promise.resolve(res.data); }
+        });
+    };
+    return els;
+}
+
+function freshAgent(fetchHandler){
+    var els = makeEnv(fetchHandler);
+    delete require.cache[path];
+    var agent = require(path);  // авто-init выполнится сразу (document готов)
+    return { agent: agent, els: els };
+}
+
+function messagesText(els, role){
+    var msgs = els['ai-agent-messages'].children;
+    var out = [];
+    msgs.forEach(function(m){
+        var isUser = m._classes['ai-chat-message-user'];
+        var isAsst = m._classes['ai-chat-message-assistant'];
+        if(role === 'user' && !isUser) return;
+        if(role === 'assistant' && !isAsst) return;
+        var t = m.querySelector('.ai-chat-message-text');
+        out.push(t ? t.textContent : '');
+    });
+    return out;
+}
+function activeTimers(){ return global.__intervals.filter(function(h){ return !h.cleared; }).length; }
+
+// ===================== A) Отправка -> ответ =====================
+function scenarioA(){
+    var ctx = freshAgent(function(url, opts){
+        if((opts.method || 'GET') === 'POST')
+            return { data: { job: { id: 'jA', status: 'done', message: 'привет', result: { assistant: { content: 'Ответ 42' } } } } };
+        return { data: { job: null } }; // resume latest -> пусто
+    });
+    var a = ctx.agent, els = ctx.els;
+    els['ai-agent-input'].value = 'привет';
+    a.send();
+    return settle().then(function(){
+        expect(messagesText(els, 'user').indexOf('привет') !== -1, 'A: user message shown');
+        expect(messagesText(els, 'assistant').indexOf('Ответ 42') !== -1, 'A: agent answer rendered');
+        expect(a.sending === false, 'A: sending released after answer');
+        expect(activeTimers() === 0, 'A: no timers left running after done');
+        expect(els['ai-agent-status'].textContent === 'Готов к работе', 'A: status reset to ready');
+    });
+}
+
+// ============ B) Восстановление при заходе (другой браузер) ============
+function scenarioB(){
+    var ctx = freshAgent(function(url, opts){
+        // Любой GET latest отдаёт прошлую завершённую задачу.
+        return { data: { job: { id: 'jB', status: 'done', message: 'прошлый вопрос', result: { assistant: { content: 'старый ответ' } } } } };
+    });
+    var els = ctx.els;
+    return settle().then(function(){
+        expect(messagesText(els, 'user').indexOf('прошлый вопрос') !== -1, 'B: restored user message from server');
+        expect(messagesText(els, 'assistant').indexOf('старый ответ') !== -1, 'B: restored agent answer (survives reload / other browser)');
+    });
+}
+
+// ============ C) Долгая задача -> поллинг -> готово ============
+function scenarioC(){
+    var phase = { done: false };
+    var ctx = freshAgent(function(url, opts){
+        if((opts.method || 'GET') === 'POST')
+            return { data: { job: { id: 'jC', status: 'processing', message: 'долгий запрос' } } };
+        // GET: сначала resume (latest) -> пусто до отправки; после отправки опрос
+        // статуса jC возвращает processing, затем done.
+        if(url.indexOf('job=jC') !== -1)
+            return { data: { job: { id: 'jC', status: phase.done ? 'done' : 'processing', message: 'долгий запрос', result: phase.done ? { assistant: { content: 'итоговый ответ' } } : null } } };
+        return { data: { job: null } };
+    });
+    var a = ctx.agent, els = ctx.els;
+    return settle().then(function(){
+        els['ai-agent-input'].value = 'долгий запрос';
+        a.send();
+        return settle();
+    }).then(function(){
+        expect(a.sending === true, 'C: still waiting while processing');
+        var poll = global.__intervals.filter(function(h){ return !h.cleared && h.ms === a.pollIntervalMs; });
+        expect(poll.length === 1, 'C: a status poll timer is running');
+        expect(els['ai-agent-messages'].querySelector('.ai-chat-message-thinking') !== null, 'C: thinking bubble visible while processing');
+        // Имитируем срабатывание опроса — задача всё ещё processing.
+        poll[0].fn();
+        return settle();
+    }).then(function(){
+        expect(a.sending === true, 'C: keeps waiting while still processing');
+        // Теперь агент завершил — следующий опрос вернёт done.
+        phase.done = true;
+        var poll = global.__intervals.filter(function(h){ return !h.cleared && h.ms === a.pollIntervalMs; });
+        poll[0].fn();
+        return settle();
+    }).then(function(){
+        expect(messagesText(els, 'assistant').indexOf('итоговый ответ') !== -1, 'C: final answer rendered after polling');
+        expect(a.sending === false, 'C: sending released after completion');
+        expect(activeTimers() === 0, 'C: all timers cleared after completion');
+    });
+}
+
+scenarioA().then(scenarioB).then(scenarioC).then(function(){
+    console.log('');
+    if(failures){ console.log('FAILED: ' + failures + ' check(s) failed'); process.exit(1); }
+    console.log('ALL TESTS PASSED');
+}).catch(function(e){
+    console.log('ERROR: ' + (e && e.stack ? e.stack : e));
+    process.exit(1);
+});

--- a/experiments/test-issue-3410-ai-agent-flow.php
+++ b/experiments/test-issue-3410-ai-agent-flow.php
@@ -1,0 +1,140 @@
+<?php
+# Regression test for issue #3410 (HTTP-контракт маршрута /{db}/ai/agent)
+# https://github.com/ideav/crm/issues/3410
+#
+# Проверяем проводку диспетчера и job-модель целиком, со стаб-заглушками внешних
+# зависимостей (XSRF, оплата, вызов агента):
+#   • POST владельцем -> создаётся job, ответ {job:{status:done,result:...}};
+#   • GET ?job=ID и GET ?latest возвращают ту же задачу;
+#   • не-владелец -> 403; нет оплаты -> 402; пустой запрос -> 400;
+#   • сбой агента -> 502, а задача сохраняется со статусом error.
+
+$failures = 0;
+function expect($cond, $name){
+    global $failures;
+    if($cond){ echo "PASS: $name\n"; } else { echo "FAIL: $name\n"; $failures++; }
+}
+
+define("AI_AGENT_JOBS_MAX", 20);
+define("AI_AGENT_JOBS_TTL", 24 * 3600);
+
+# --- Заглушки внешних зависимостей index.php ---
+class ApiDone extends Exception { public $json; function __construct($json){ $this->json=$json; parent::__construct("done"); } }
+class ApiErr extends Exception { public $payload; function __construct($code,$payload){ $this->payload=$payload; parent::__construct("err",$code); } }
+
+function api_dump($json, $name="api.json"){ throw new ApiDone($json); }
+function aiAgentError($message, $code=400, $extra=array()){
+    throw new ApiErr($code, array_merge(array("error"=>$message), is_array($extra)?$extra:array()));
+}
+function t9n($v){ return preg_match('/^\[RU\](.*?)\[EN\]/s',$v,$m) ? $m[1] : $v; }
+function check(){ /* XSRF — noop в тесте */ }
+
+# Управляемые из тестов заглушки оплаты и вызова агента.
+$GLOBALS["__pay_ok"] = true;
+$GLOBALS["__agent_throw"] = false;
+function checkAiAgentPayment($db){
+    if(empty($GLOBALS["__pay_ok"]))
+        return array("ok"=>false,"status"=>"not_paid","message"=>"нужна оплата","payUrl"=>"https://pay");
+    return array("ok"=>true,"status"=>"active","paidUntil"=>time()+1000,"payUrl"=>"https://pay");
+}
+function callIntegramAgent($db,$message,$attachments,$payment){
+    if(!empty($GLOBALS["__agent_throw"]))
+        throw new Exception("агент упал", 502);
+    return array("assistant"=>array("content"=>"ОТВЕТ"),"status"=>"pending_api","payment"=>array("status"=>$payment["status"]));
+}
+
+function extract_function_source($source, $name){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false) throw new Exception("Function not found: ".$name);
+    $brace = strpos($source, "{", $start);
+    $depth=0; $len=strlen($source);
+    for($i=$brace;$i<$len;$i++){
+        if($source[$i]==="{") $depth++;
+        elseif($source[$i]==="}"){ $depth--; if($depth===0) return substr($source,$start,$i-$start+1); }
+    }
+    throw new Exception("not closed: ".$name);
+}
+
+$source = file_get_contents(__DIR__."/../index.php");
+$fns = array(
+    "handleAiAgentRequest","aiAgentRequireOwner","aiAgentSubmitRequest","aiAgentStatusRequest",
+    "collectAiAgentAttachments",
+    "aiAgentJobsFile","aiAgentJobId","aiAgentJobNew","aiAgentJobsAppend","aiAgentJobsFind",
+    "aiAgentJobsLatest","aiAgentJobsPrune","aiAgentJobsApplyChanges","aiAgentJobsReplace",
+    "aiAgentJobPublic","aiAgentJobsEncode","aiAgentJobsDecode","aiAgentJobsLoadRaw",
+    "aiAgentJobsMutate","aiAgentJobCreate","aiAgentJobUpdate","aiAgentJobGet","aiAgentJobLatest"
+);
+foreach($fns as $fn) eval(extract_function_source($source, $fn));
+
+# Окружение «владельца базы».
+$db = "flow3410_".getmypid();
+$GLOBALS["z"] = $db;
+$GLOBALS["GLOBAL_VARS"] = array("user"=>$db);
+@unlink(aiAgentJobsFile($db));
+
+function run($method, $get=array(), $post=array()){
+    $_SERVER["REQUEST_METHOD"] = $method;
+    $_GET = $get; $_POST = $post; $_FILES = array();
+    try { handleAiAgentRequest(array()); }
+    catch(ApiDone $d){ return array("ok"=>true, "data"=>json_decode($d->json,true)); }
+    catch(ApiErr $e){ return array("ok"=>false, "code"=>$e->getCode(), "data"=>$e->payload); }
+    return array("ok"=>false, "code"=>0, "data"=>null);
+}
+
+# 1) POST владельцем -> job done с результатом.
+$r = run("POST", array(), array("message"=>"посчитай заказы"));
+expect($r["ok"] && isset($r["data"]["job"]), "POST owner returns a job");
+$job = $r["data"]["job"];
+expect($job["status"] === "done", "submitted job resolves to done (instant stub)");
+expect($job["result"]["assistant"]["content"] === "ОТВЕТ", "job result carries the agent answer");
+expect($job["message"] === "посчитай заказы", "job keeps the user message");
+$jobId = $job["id"];
+
+# 2) GET ?job=ID -> та же задача.
+$r = run("GET", array("job"=>$jobId));
+expect($r["ok"] && $r["data"]["job"]["id"] === $jobId, "GET ?job returns the same job by id");
+expect($r["data"]["job"]["status"] === "done", "GET ?job shows done status");
+
+# 3) GET latest -> последняя задача.
+$r = run("GET", array());
+expect($r["ok"] && $r["data"]["job"]["id"] === $jobId, "GET latest returns the most recent job");
+
+# 4) Не-владелец -> 403.
+$GLOBALS["GLOBAL_VARS"]["user"] = "someoneelse";
+$r = run("POST", array(), array("message"=>"hi"));
+expect(!$r["ok"] && $r["code"] === 403, "non-owner POST is rejected with 403");
+$r = run("GET", array());
+expect(!$r["ok"] && $r["code"] === 403, "non-owner GET is rejected with 403");
+$GLOBALS["GLOBAL_VARS"]["user"] = $db;
+
+# 5) Нет оплаты -> 402 + payUrl.
+$GLOBALS["__pay_ok"] = false;
+$r = run("POST", array(), array("message"=>"hi"));
+expect(!$r["ok"] && $r["code"] === 402, "unpaid POST is rejected with 402");
+expect(isset($r["data"]["payUrl"]) && $r["data"]["payUrl"] === "https://pay", "402 includes a payment link");
+$GLOBALS["__pay_ok"] = true;
+
+# 6) Пустой запрос -> 400.
+$r = run("POST", array(), array("message"=>"   "));
+expect(!$r["ok"] && $r["code"] === 400, "empty message is rejected with 400");
+
+# 7) Сбой агента -> 502, задача сохранена как error.
+$GLOBALS["__agent_throw"] = true;
+$r = run("POST", array(), array("message"=>"ломай"));
+expect(!$r["ok"] && $r["code"] === 502, "agent failure surfaces as 502");
+expect(isset($r["data"]["jobId"]), "502 response carries the jobId for polling");
+$failedId = isset($r["data"]["jobId"]) ? $r["data"]["jobId"] : "";
+$GLOBALS["__agent_throw"] = false;
+$r = run("GET", array("job"=>$failedId));
+expect($r["ok"] && $r["data"]["job"]["status"] === "error", "failed job is stored with status error");
+
+# 8) GET несуществующей задачи -> 404.
+$r = run("GET", array("job"=>"deadbeef"));
+expect(!$r["ok"] && $r["code"] === 404, "GET of unknown job id -> 404");
+
+@unlink(aiAgentJobsFile($db));
+
+echo "\n";
+if($failures){ echo "FAILED: $failures check(s) failed\n"; exit(1); }
+echo "ALL TESTS PASSED\n";

--- a/experiments/test-issue-3410-ai-agent-jobs.php
+++ b/experiments/test-issue-3410-ai-agent-jobs.php
@@ -1,0 +1,149 @@
+<?php
+# Regression test for issue #3410
+# https://github.com/ideav/crm/issues/3410
+#
+# Асинхронная работа ИИ-агента: запрос сохраняется как задача (job) в серверном
+# хранилище (JSON-файл во временной директории, ключ — имя базы). Это нужно, чтобы
+# показывать «агент думает», переживать таймаут сервера и не терять результат при
+# повторном открытии панели (в т.ч. из другого браузера).
+#
+# Тест извлекает чистые функции работы с задачами из index.php и проверяет:
+#   1) создание задачи (статус queued, нормализация полей);
+#   2) операции над списком (append с ограничением, find, latest, prune, replace);
+#   3) публичное представление (результат только у завершённой задачи);
+#   4) файловый round-trip create → update → get → latest с реальным хранилищем.
+
+$failures = 0;
+
+function check($cond, $name){
+    global $failures;
+    if($cond){
+        echo "PASS: $name\n";
+    } else {
+        echo "FAIL: $name\n";
+        $failures++;
+    }
+}
+
+# Хранилище ограничено этими лимитами (как в index.php).
+define("AI_AGENT_JOBS_MAX", 20);
+define("AI_AGENT_JOBS_TTL", 24 * 3600);
+
+function extract_function_source($source, $name){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false)
+        throw new Exception("Function not found: ".$name);
+    $brace = strpos($source, "{", $start);
+    if($brace === false)
+        throw new Exception("Function body not found: ".$name);
+    $depth = 0;
+    $length = strlen($source);
+    for($i = $brace; $i < $length; $i++){
+        if($source[$i] === "{")
+            $depth++;
+        elseif($source[$i] === "}"){
+            $depth--;
+            if($depth === 0)
+                return substr($source, $start, $i - $start + 1);
+        }
+    }
+    throw new Exception("Function body is not closed: ".$name);
+}
+
+$source = file_get_contents(__DIR__."/../index.php");
+$fns = array(
+    "aiAgentJobsFile", "aiAgentJobId", "aiAgentJobNew",
+    "aiAgentJobsAppend", "aiAgentJobsFind", "aiAgentJobsLatest", "aiAgentJobsPrune",
+    "aiAgentJobsApplyChanges", "aiAgentJobsReplace", "aiAgentJobPublic",
+    "aiAgentJobsEncode", "aiAgentJobsDecode", "aiAgentJobsLoadRaw", "aiAgentJobsMutate",
+    "aiAgentJobCreate", "aiAgentJobUpdate", "aiAgentJobGet", "aiAgentJobLatest"
+);
+foreach($fns as $fn)
+    eval(extract_function_source($source, $fn));
+
+# 1) Создание задачи.
+$now = 1000000;
+$job = aiAgentJobNew("привет", array("a.txt", 42), $now);
+check($job["status"] === "queued", "new job starts in 'queued' status");
+check($job["message"] === "привет", "new job keeps the message");
+check($job["createdAt"] === $now && $job["updatedAt"] === $now, "new job stamps createdAt/updatedAt");
+check($job["result"] === null && $job["error"] === null, "new job has no result/error yet");
+check($job["attachments"] === array("a.txt", "42"), "attachment names normalized to strings");
+check(is_string($job["id"]) && strlen($job["id"]) >= 16, "new job gets a non-trivial id");
+check($job["id"] !== aiAgentJobNew("x", array(), $now)["id"], "job ids are unique");
+
+# 2) Операции над списком.
+$jobs = array();
+for($i = 0; $i < 25; $i++)
+    $jobs = aiAgentJobsAppend($jobs, array("id" => "j$i", "createdAt" => $now + $i), AI_AGENT_JOBS_MAX);
+check(count($jobs) === AI_AGENT_JOBS_MAX, "append caps the list at AI_AGENT_JOBS_MAX");
+check($jobs[0]["id"] === "j5" && $jobs[19]["id"] === "j24", "append keeps the most recent jobs");
+
+check(aiAgentJobsFind($jobs, "j10")["id"] === "j10", "find returns the matching job");
+check(aiAgentJobsFind($jobs, "nope") === null, "find returns null for unknown id");
+check(aiAgentJobsLatest($jobs)["id"] === "j24", "latest returns the newest by createdAt");
+check(aiAgentJobsLatest(array()) === null, "latest of empty list is null");
+
+$mixed = array(
+    array("id" => "old", "createdAt" => $now - 2 * AI_AGENT_JOBS_TTL),
+    array("id" => "fresh", "createdAt" => $now)
+);
+$pruned = aiAgentJobsPrune($mixed, $now, AI_AGENT_JOBS_TTL);
+check(count($pruned) === 1 && $pruned[0]["id"] === "fresh", "prune drops jobs older than TTL");
+
+$applied = aiAgentJobsApplyChanges(array("id" => "j", "status" => "queued", "createdAt" => $now), array("status" => "done", "result" => array("x" => 1)), $now + 5);
+check($applied["status"] === "done" && $applied["result"] === array("x" => 1), "applyChanges merges changes");
+check($applied["updatedAt"] === $now + 5, "applyChanges bumps updatedAt");
+
+$replaced = aiAgentJobsReplace($jobs, "j10", array("id" => "j10", "status" => "done"));
+check(aiAgentJobsFind($replaced, "j10")["status"] === "done", "replace swaps the job by id");
+check(count($replaced) === count($jobs), "replace keeps the list length");
+
+# 3) Публичное представление.
+$queued = aiAgentJobNew("q", array(), $now);
+$pubQueued = aiAgentJobPublic($queued);
+check($pubQueued["result"] === null, "public hides result while not done");
+check(!array_key_exists("result", $pubQueued) || $pubQueued["result"] === null, "public result null for queued");
+
+$doneJob = aiAgentJobsApplyChanges($queued, array("status" => "done", "result" => array("assistant" => array("content" => "ответ"))), $now + 1);
+$pubDone = aiAgentJobPublic($doneJob);
+check(isset($pubDone["result"]["assistant"]["content"]) && $pubDone["result"]["assistant"]["content"] === "ответ", "public exposes result for done job");
+check($pubDone["status"] === "done" && $pubDone["message"] === "q", "public keeps status and message");
+
+# 4) Файловый round-trip с реальным хранилищем.
+$db = "t3410test" . getmypid();
+$path = aiAgentJobsFile($db);
+check($path !== "" && strpos($path, "ai_agent_jobs_") !== false, "store path is derived from db name");
+check(aiAgentJobsFile("bad/name'; --") === sys_get_temp_dir()."/ai_agent_jobs_badname.json", "db name sanitized in store path");
+@unlink($path);
+
+$created = aiAgentJobCreate($db, "запрос", array("file.csv"));
+check(is_file($path), "create writes the store file");
+$fetched = aiAgentJobGet($db, $created["id"]);
+check($fetched && $fetched["status"] === "queued", "get returns the created job (queued)");
+
+aiAgentJobUpdate($db, $created["id"], array("status" => "processing"));
+check(aiAgentJobGet($db, $created["id"])["status"] === "processing", "update moves job to processing");
+
+$result = array("assistant" => array("content" => "готово"), "status" => "ok");
+$updated = aiAgentJobUpdate($db, $created["id"], array("status" => "done", "result" => $result));
+check($updated["status"] === "done", "update returns the updated job");
+$pub = aiAgentJobPublic(aiAgentJobGet($db, $created["id"]));
+check($pub["result"]["assistant"]["content"] === "готово", "stored done job exposes the result");
+
+$second = aiAgentJobCreate($db, "второй", array());
+check(aiAgentJobLatest($db)["id"] === $second["id"], "latest returns the most recent stored job");
+
+check(aiAgentJobUpdate($db, "doesnotexist", array("status" => "done")) === null, "update of unknown id returns null");
+check(aiAgentJobGet($db, "doesnotexist") === null, "get of unknown id returns null");
+
+@unlink($path);
+check(aiAgentJobLatest($db) === null, "latest is null when store is empty/cleared");
+
+echo "\n";
+if($failures){
+    echo "FAILED: $failures check(s) failed\n";
+    exit(1);
+}
+echo "ALL TESTS PASSED\n";

--- a/index.php
+++ b/index.php
@@ -8645,15 +8645,29 @@ function getAiAccessibleDbs(){
 # базой данных (см. docs/integram-app-workflow.md).
 # ============================================================
 function handleAiAgentRequest($com){
-    global $z;
-    if($_SERVER["REQUEST_METHOD"] !== "POST")
-        aiAgentError(t9n("[RU]ИИ-агент принимает только POST[EN]The AI agent accepts POST only"), 405);
-    check(); # XSRF
-
-    # Доступ только владельцу базы — пользователю, имя которого совпадает с именем базы.
+    # Issue #3410: POST — поставить запрос ИИ-агенту (создаётся job), GET — узнать
+    # статус/результат ранее поставленной задачи (для индикатора «агент думает» и
+    # восстановления результата при повторном открытии панели, в т.ч. с другого
+    # браузера). Сам ответ агента сохраняется на сервере и переживает таймаут.
+    $method = isset($_SERVER["REQUEST_METHOD"]) ? strtoupper((string)$_SERVER["REQUEST_METHOD"]) : "GET";
+    if($method === "GET")
+        return aiAgentStatusRequest($com);
+    if($method !== "POST")
+        aiAgentError(t9n("[RU]ИИ-агент принимает GET (статус) или POST (запрос)[EN]The AI agent accepts GET (status) or POST (request)"), 405);
+    return aiAgentSubmitRequest($com);
+}
+# Доступ к ИИ-агенту — только владельцу базы (имя пользователя совпадает с именем
+# базы). При нарушении завершает запрос ответом 403.
+function aiAgentRequireOwner($db){
     $user = isset($GLOBALS["GLOBAL_VARS"]["user"]) ? strtolower((string)$GLOBALS["GLOBAL_VARS"]["user"]) : "";
-    if($user === "" || $user !== strtolower((string)$z))
+    if($user === "" || $user !== strtolower((string)$db))
         aiAgentError(t9n("[RU]ИИ-агент доступен только владельцу базы — пользователю, имя которого совпадает с именем базы данных.[EN]The AI agent is available only to the database owner — the user whose name matches the database name."), 403);
+}
+# POST /{db}/ai/agent — поставить новый запрос ИИ-агенту.
+function aiAgentSubmitRequest($com){
+    global $z;
+    check(); # XSRF
+    aiAgentRequireOwner($z);
 
     # Проверка оплаты (закеширована). При отсутствии/истечении оплаты — ссылка на оплату.
     $payment = checkAiAgentPayment($z);
@@ -8665,15 +8679,55 @@ function handleAiAgentRequest($com){
     if($message === "" && !count($attachments))
         aiAgentError(t9n("[RU]Сообщение для ИИ-агента не передано[EN]No message provided for the AI agent"), 400);
 
+    # Сначала сохраняем задачу как job (статус queued), и только потом обрабатываем.
+    # Если соединение оборвётся по таймауту сервера (30–60 c), клиент подхватит
+    # результат опросом GET /{db}/ai/agent?job=ID (см. js/ai-agent-chat.js).
+    $attachmentNames = array();
+    foreach($attachments as $a)
+        $attachmentNames[] = isset($a["name"]) ? (string)$a["name"] : "";
+    $job = aiAgentJobCreate($z, $message, $attachmentNames);
+    $jobId = $job["id"];
+
     try {
+        aiAgentJobUpdate($z, $jobId, array("status" => "processing"));
+        # callIntegramAgent сейчас отвечает сразу (реальный API агента — в его
+        # тикете). Когда вызов станет асинхронным, здесь задача останется в статусе
+        # processing, а результат запишет отдельный обработчик — клиентский опрос
+        # уже это поддерживает.
         $response = callIntegramAgent($z, $message, $attachments, $payment);
-        api_dump(json_encode($response, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+        $updated = aiAgentJobUpdate($z, $jobId, array("status" => "done", "result" => $response, "error" => null));
+        $job = $updated ? $updated : aiAgentJobGet($z, $jobId);
     } catch(Exception $e) {
         $code = (int)$e->getCode();
         if($code < 400 || $code > 599)
             $code = 502;
-        aiAgentError($e->getMessage(), $code);
+        aiAgentJobUpdate($z, $jobId, array("status" => "error", "error" => $e->getMessage()));
+        aiAgentError($e->getMessage(), $code, array("jobId" => $jobId));
     }
+
+    if(!$job)
+        $job = aiAgentJobGet($z, $jobId);
+    api_dump(json_encode(array("job" => aiAgentJobPublic($job)), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+}
+# GET /{db}/ai/agent?job=ID  — статус/результат конкретной задачи.
+# GET /{db}/ai/agent          — последняя задача (для восстановления при открытии
+# панели). Оплата здесь не проверяется: уже готовый результат можно прочитать,
+# даже если оплаченный период истёк.
+function aiAgentStatusRequest($com){
+    global $z;
+    aiAgentRequireOwner($z);
+
+    $jobId = isset($_GET["job"]) ? preg_replace('/[^a-f0-9]/i', '', (string)$_GET["job"]) : "";
+    if($jobId !== ""){
+        $job = aiAgentJobGet($z, $jobId);
+        if(!$job)
+            aiAgentError(t9n("[RU]Задача ИИ-агента не найдена[EN]AI agent job not found"), 404);
+        api_dump(json_encode(array("job" => aiAgentJobPublic($job)), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+        return;
+    }
+
+    $job = aiAgentJobLatest($z);
+    api_dump(json_encode(array("job" => $job ? aiAgentJobPublic($job) : null), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
 }
 function aiAgentError($message, $code=400, $extra=array()){
     header("HTTP/1.0 ".$code." ".aiChatHttpStatusText($code));
@@ -8897,6 +8951,196 @@ function callIntegramAgent($db, $message, $attachments, $payment){
         "status" => "ok",
         "payment" => $paymentInfo
     );
+}
+# ============================================================
+# Issue #3410: серверное хранилище задач ИИ-агента.
+#
+# Задача (job) запоминается в JSON-файле во временной директории сервера, ключ —
+# имя базы (как и кеш оплаты из #3404). Это даёт:
+#   • индикатор «агент думает», пока задача в работе;
+#   • сохранность результата, если пользователь закрыл вкладку — он подхватывается
+#     при повторном открытии панели, в т.ч. из ДРУГОГО браузера (состояние лежит
+#     на сервере, а не в localStorage);
+#   • устойчивость к таймауту сервера (30–60 c): запрос сохраняется до обработки.
+# Хранилище ограничено владельцем базы (aiAgentRequireOwner) и текущей базой.
+# Пер-база храним последние AI_AGENT_JOBS_MAX задач не старше AI_AGENT_JOBS_TTL.
+# ============================================================
+if(!defined("AI_AGENT_JOBS_MAX")) define("AI_AGENT_JOBS_MAX", 20);
+if(!defined("AI_AGENT_JOBS_TTL")) define("AI_AGENT_JOBS_TTL", 24 * 3600);
+
+function aiAgentJobsFile($db){
+    $safeDb = preg_replace('/[^a-z0-9_]/i', '', (string)$db);
+    if($safeDb === "")
+        return "";
+    return sys_get_temp_dir()."/ai_agent_jobs_".$safeDb.".json";
+}
+function aiAgentJobId(){
+    if(function_exists("random_bytes")){
+        try { return bin2hex(random_bytes(16)); } catch(Exception $e) {}
+    }
+    return md5(uniqid((string)mt_rand(), true));
+}
+function aiAgentJobNew($message, $attachmentNames, $now){
+    $names = is_array($attachmentNames) ? array_values(array_map("strval", $attachmentNames)) : array();
+    return array(
+        "id" => aiAgentJobId(),
+        "createdAt" => (int)$now,
+        "updatedAt" => (int)$now,
+        "status" => "queued",
+        "message" => (string)$message,
+        "attachments" => $names,
+        "result" => null,
+        "error" => null
+    );
+}
+# --- Чистые операции над списком задач (тестируются без файловой системы) ---
+function aiAgentJobsAppend($jobs, $job, $max){
+    $jobs = is_array($jobs) ? array_values($jobs) : array();
+    $jobs[] = $job;
+    $max = (int)$max > 0 ? (int)$max : 1;
+    if(count($jobs) > $max)
+        $jobs = array_slice($jobs, count($jobs) - $max);
+    return array_values($jobs);
+}
+function aiAgentJobsFind($jobs, $id){
+    if(!is_array($jobs) || (string)$id === "")
+        return null;
+    foreach($jobs as $job)
+        if(is_array($job) && isset($job["id"]) && $job["id"] === $id)
+            return $job;
+    return null;
+}
+function aiAgentJobsLatest($jobs){
+    if(!is_array($jobs))
+        return null;
+    $latest = null;
+    foreach($jobs as $job){
+        if(!is_array($job) || !isset($job["createdAt"]))
+            continue;
+        if($latest === null || (int)$job["createdAt"] >= (int)$latest["createdAt"])
+            $latest = $job;
+    }
+    return $latest;
+}
+function aiAgentJobsPrune($jobs, $now, $ttl){
+    if(!is_array($jobs))
+        return array();
+    $ttl = (int)$ttl;
+    $kept = array();
+    foreach($jobs as $job){
+        if(!is_array($job) || !isset($job["createdAt"]))
+            continue;
+        if($ttl > 0 && ((int)$now - (int)$job["createdAt"]) > $ttl)
+            continue;
+        $kept[] = $job;
+    }
+    return array_values($kept);
+}
+function aiAgentJobsApplyChanges($job, $changes, $now){
+    if(!is_array($job))
+        return $job;
+    if(is_array($changes))
+        foreach($changes as $k => $v)
+            $job[$k] = $v;
+    $job["updatedAt"] = (int)$now;
+    return $job;
+}
+function aiAgentJobsReplace($jobs, $id, $newJob){
+    $out = array();
+    foreach($jobs as $job){
+        if(is_array($job) && isset($job["id"]) && $job["id"] === $id)
+            $out[] = $newJob;
+        else
+            $out[] = $job;
+    }
+    return array_values($out);
+}
+# Публичное представление задачи для клиента — без внутренних полей. Результат
+# отдаётся только для завершённой задачи.
+function aiAgentJobPublic($job){
+    if(!is_array($job))
+        return null;
+    $status = isset($job["status"]) ? (string)$job["status"] : "unknown";
+    $result = ($status === "done" && isset($job["result"])) ? $job["result"] : null;
+    return array(
+        "id" => isset($job["id"]) ? (string)$job["id"] : "",
+        "status" => $status,
+        "createdAt" => isset($job["createdAt"]) ? (int)$job["createdAt"] : 0,
+        "updatedAt" => isset($job["updatedAt"]) ? (int)$job["updatedAt"] : 0,
+        "message" => isset($job["message"]) ? (string)$job["message"] : "",
+        "attachments" => (isset($job["attachments"]) && is_array($job["attachments"])) ? array_values($job["attachments"]) : array(),
+        "result" => $result,
+        "error" => isset($job["error"]) ? $job["error"] : null
+    );
+}
+function aiAgentJobsEncode($jobs){
+    return json_encode(array("jobs" => array_values($jobs)), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+}
+function aiAgentJobsDecode($raw){
+    $data = (is_string($raw) && trim($raw) !== "") ? json_decode($raw, true) : null;
+    if(is_array($data) && isset($data["jobs"]) && is_array($data["jobs"]))
+        return array_values($data["jobs"]);
+    return array();
+}
+# --- Файловые обёртки (эксклюзивная блокировка на чтение-модификацию-запись) ---
+function aiAgentJobsLoadRaw($db){
+    $path = aiAgentJobsFile($db);
+    if($path === "" || !is_readable($path))
+        return array();
+    $raw = @file_get_contents($path);
+    return aiAgentJobsDecode($raw === false ? "" : $raw);
+}
+# $mutator(array $jobs): array — должен вернуть array($newJobs, $return).
+function aiAgentJobsMutate($db, $mutator){
+    $path = aiAgentJobsFile($db);
+    if($path === "")
+        return null;
+    $fp = @fopen($path, "c+");
+    if(!$fp){
+        $jobs = aiAgentJobsLoadRaw($db);
+        list($jobs, $ret) = $mutator($jobs);
+        @file_put_contents($path, aiAgentJobsEncode($jobs));
+        return $ret;
+    }
+    @flock($fp, LOCK_EX);
+    $raw = stream_get_contents($fp);
+    $jobs = aiAgentJobsDecode($raw === false ? "" : $raw);
+    list($jobs, $ret) = $mutator($jobs);
+    @ftruncate($fp, 0);
+    @rewind($fp);
+    @fwrite($fp, aiAgentJobsEncode($jobs));
+    @fflush($fp);
+    @flock($fp, LOCK_UN);
+    @fclose($fp);
+    return $ret;
+}
+function aiAgentJobCreate($db, $message, $attachmentNames){
+    $now = time();
+    $job = aiAgentJobNew($message, $attachmentNames, $now);
+    aiAgentJobsMutate($db, function($jobs) use ($job, $now){
+        $jobs = aiAgentJobsPrune($jobs, $now, AI_AGENT_JOBS_TTL);
+        $jobs = aiAgentJobsAppend($jobs, $job, AI_AGENT_JOBS_MAX);
+        return array($jobs, null);
+    });
+    return $job;
+}
+function aiAgentJobUpdate($db, $id, $changes){
+    $now = time();
+    return aiAgentJobsMutate($db, function($jobs) use ($id, $changes, $now){
+        $job = aiAgentJobsFind($jobs, $id);
+        if(!$job)
+            return array($jobs, null);
+        $job = aiAgentJobsApplyChanges($job, $changes, $now);
+        $jobs = aiAgentJobsReplace($jobs, $id, $job);
+        return array($jobs, $job);
+    });
+}
+function aiAgentJobGet($db, $id){
+    return aiAgentJobsFind(aiAgentJobsLoadRaw($db), $id);
+}
+function aiAgentJobLatest($db){
+    $jobs = aiAgentJobsPrune(aiAgentJobsLoadRaw($db), time(), AI_AGENT_JOBS_TTL);
+    return aiAgentJobsLatest($jobs);
 }
 function getAiChatSettings($settings=array()){
     if(is_string($settings)){

--- a/js/ai-agent-chat.js
+++ b/js/ai-agent-chat.js
@@ -1,10 +1,20 @@
 /*
- * Issue #3392: упрощённый ИИ-чат.
+ * Issue #3392: упрощённый ИИ-чат. Issue #3410: асинхронная работа агента.
  *
  * Новый чат связан только с нашим фиксированным ИИ-агентом текущей базы данных.
  * Доступ к агенту разрешён сервером (index.php, ветка /{db}/ai/agent) только
  * пользователю, имя которого совпадает с именем базы, и только при действующей
  * оплате. Все действия агента ограничены текущей базой данных.
+ *
+ * Issue #3410: задача агента может выполняться долго (до минуты и дольше) и
+ * ставиться в очередь. Поэтому:
+ *   • POST /{db}/ai/agent создаёт задачу (job) и возвращает её статус;
+ *   • пока задача в работе — показываем «ИИ-агент думает», а при долгом ожидании
+ *     сообщаем, что нужно ещё немного времени;
+ *   • статус/результат опрашиваются GET /{db}/ai/agent?job=ID;
+ *   • при открытии панели подхватываем последнюю задачу (GET ?latest), поэтому
+ *     результат не теряется, если пользователь закрыл вкладку и вернулся — даже
+ *     из другого браузера (состояние хранится на сервере, не в localStorage).
  *
  * Старый расширенный ИИ-чат (js/ai-chat.js) скрыт из интерфейса, но оставлен в
  * репозитории как backend-история.
@@ -16,7 +26,20 @@
         attachments: [],
         sending: false,
 
+        // Issue #3410: состояние ожидания/опроса.
+        pollIntervalMs: 2500,   // как часто опрашивать статус задачи
+        thinkStart: 0,          // когда начали ждать ответ (мс)
+        activeJobId: null,      // id задачи, которую ждём
+        pollJobId: null,        // id задачи, по которой идёт опрос
+        pollTimer: null,        // setInterval опроса статуса
+        tickTimer: null,        // setInterval обновления текста ожидания
+        currentBubble: null,    // «пузырь» агента с индикатором «думает»
+        rendered: {},           // id задач, уже показанных в ленте
+        localActivity: false,   // были ли отправки в этой сессии вкладки
+        resumeChecked: false,   // восстановление выполняем один раз за загрузку
+
         init: function () {
+            this.rendered = {};
             this.toggle = document.getElementById('ai-chat-toggle');
             this.panel = document.getElementById('ai-agent-panel');
             this.backdrop = document.getElementById('ai-agent-backdrop');
@@ -61,6 +84,10 @@
                 });
             }
 
+            // Issue #3410: подхватываем незавершённую/последнюю задачу с сервера —
+            // результат не теряется при перезагрузке или заходе с другого браузера.
+            this.resume();
+
             return true;
         },
 
@@ -80,6 +107,7 @@
             if (this.backdrop) this.backdrop.hidden = false;
             if (this.toggle) this.toggle.setAttribute('aria-expanded', 'true');
             if (this.input) this.input.focus();
+            this.resume();
             this.scrollToBottom();
         },
 
@@ -109,6 +137,14 @@
         getAgentUrl: function () {
             var dbName = this.getCurrentDbName() || 'my';
             return '/' + encodeURIComponent(dbName) + '/ai/agent?JSON=1';
+        },
+
+        // GET-адрес статуса: по id задачи либо последней задачи (?latest).
+        getStatusUrl: function (jobId) {
+            var base = this.getAgentUrl();
+            return jobId
+                ? base + '&job=' + encodeURIComponent(jobId)
+                : base + '&latest=1';
         },
 
         addFiles: function (fileList) {
@@ -158,11 +194,27 @@
             if (this.statusEl) this.statusEl.textContent = text;
         },
 
-        setSending: function (sending) {
-            this.sending = sending;
-            if (this.sendBtn) this.sendBtn.disabled = sending;
-            if (this.attachBtn) this.attachBtn.disabled = sending;
-            this.setStatus(sending ? 'ИИ-агент печатает…' : 'Готов к работе');
+        // --- Issue #3410: тексты ожидания (чистые функции, тестируются в node) ---
+
+        // Сообщение в «пузыре» агента в зависимости от того, сколько уже ждём.
+        waitMessage: function (elapsedMs) {
+            elapsedMs = elapsedMs || 0;
+            if (elapsedMs < 12000)
+                return 'Думаю над ответом…';
+            if (elapsedMs < 45000)
+                return 'Думаю над ответом. Это может занять до минуты — подождите, пожалуйста…';
+            return 'Задача поставлена в очередь, ответ придёт чуть позже. Можно закрыть окно — '
+                + 'результат сохранится и откроется, когда вы вернётесь, даже из другого браузера.';
+        },
+
+        // Короткий текст в шапке панели.
+        statusMessage: function (elapsedMs) {
+            elapsedMs = elapsedMs || 0;
+            if (elapsedMs < 12000)
+                return 'ИИ-агент думает…';
+            if (elapsedMs < 45000)
+                return 'ИИ-агент думает, нужно ещё немного времени…';
+            return 'Задача в очереди, ответ скоро будет…';
         },
 
         send: function () {
@@ -170,6 +222,7 @@
             var text = this.input ? this.input.value.trim() : '';
             if (!text && !this.attachments.length) return;
 
+            this.localActivity = true;
             this.addMessage('user', text || '(вложения)');
 
             var form = new FormData();
@@ -182,7 +235,9 @@
             if (this.input) this.input.value = '';
             this.attachments = [];
             this.renderAttachments();
-            this.setSending(true);
+
+            // Показываем «думает» сразу — ещё до того, как сервер вернул job.
+            this.beginWaiting(null);
 
             var self = this;
             fetch(this.getAgentUrl(), {
@@ -195,31 +250,209 @@
                     return { status: response.status, ok: response.ok, data: data };
                 });
             }).then(function (result) {
-                self.setSending(false);
-                self.handleResponse(result);
+                self.handleSubmitResponse(result);
             }).catch(function () {
-                self.setSending(false);
-                self.addMessage('assistant', 'Не удалось связаться с ИИ-агентом. Повторите попытку позже.');
+                // Соединение оборвалось (например, таймаут сервера). Задача уже
+                // создана на сервере — пробуем подхватить её опросом.
+                self.recoverAfterSubmitFailure();
             });
         },
 
-        handleResponse: function (result) {
+        handleSubmitResponse: function (result) {
             var data = result.data;
 
             // Оплата не подтверждена / истекла — index.php возвращает 402 + ссылку.
             if (result.status === 402 && data) {
-                this.addMessage('assistant', this.getErrorText(data) || 'Доступ к ИИ-агенту не оплачен.', data.payUrl);
+                this.replaceThinking(this.getErrorText(data) || 'Доступ к ИИ-агенту не оплачен.', data.payUrl);
+                this.endWaiting();
                 return;
             }
 
-            if (!result.ok || !data) {
-                this.addMessage('assistant', this.getErrorText(data) || 'ИИ-агент недоступен. Повторите попытку позже.');
+            if (!result.ok && (!data || !data.job)) {
+                this.replaceThinking(this.getErrorText(data) || 'ИИ-агент недоступен. Повторите попытку позже.');
+                this.endWaiting();
                 return;
             }
 
-            var content = this.getAssistantContent(data);
-            this.addMessage('assistant', content || 'ИИ-агент не вернул ответ.');
+            this.routeJob(data && data.job ? data.job : null, false);
         },
+
+        // Подхват задачи, если submit-запрос не дождался ответа (обрыв/таймаут).
+        recoverAfterSubmitFailure: function () {
+            var self = this;
+            fetch(this.getStatusUrl(null), {
+                credentials: 'same-origin',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            }).then(function (response) {
+                return response.json().catch(function () { return null; });
+            }).then(function (data) {
+                var job = data && data.job ? data.job : null;
+                if (job) {
+                    self.routeJob(job, false);
+                } else {
+                    self.replaceThinking('Не удалось связаться с ИИ-агентом. Повторите попытку позже.');
+                    self.endWaiting();
+                }
+            }).catch(function () {
+                self.replaceThinking('Не удалось связаться с ИИ-агентом. Повторите попытку позже.');
+                self.endWaiting();
+            });
+        },
+
+        // Маршрутизация задачи по статусу. fromPoll=true — вызвано опросом (тогда
+        // временные сбои не считаем фатальными).
+        routeJob: function (job, fromPoll) {
+            if (!job) {
+                if (!fromPoll) {
+                    this.replaceThinking('ИИ-агент недоступен. Повторите попытку позже.');
+                    this.endWaiting();
+                }
+                return;
+            }
+            this.activeJobId = job.id;
+
+            if (job.status === 'done') {
+                this.finalizeAnswer(job);
+                this.endWaiting();
+                return;
+            }
+            if (job.status === 'error') {
+                this.replaceThinking(this.getErrorText(job.result) || job.error || 'ИИ-агент завершил работу с ошибкой.');
+                this.endWaiting();
+                return;
+            }
+            // queued / processing — ждём дальше и опрашиваем статус.
+            if (!this.currentBubble) this.currentBubble = this.addThinkingBubble();
+            if (!this.sending) this.beginWaiting(job.id);
+            this.ensurePolling(job.id);
+        },
+
+        finalizeAnswer: function (job) {
+            var content = this.getAssistantContent(job.result) || 'ИИ-агент не вернул ответ.';
+            this.replaceThinking(content);
+            if (job.id) this.rendered[job.id] = true;
+        },
+
+        // --- ожидание и индикатор «думает» ---
+
+        beginWaiting: function (jobId) {
+            this.sending = true;
+            if (this.sendBtn) this.sendBtn.disabled = true;
+            if (this.attachBtn) this.attachBtn.disabled = true;
+            this.thinkStart = this.now();
+            if (!this.currentBubble) this.currentBubble = this.addThinkingBubble();
+            this.activeJobId = jobId || this.activeJobId;
+            this.updateWaiting();
+            this.startTick();
+        },
+
+        endWaiting: function () {
+            this.sending = false;
+            if (this.sendBtn) this.sendBtn.disabled = false;
+            if (this.attachBtn) this.attachBtn.disabled = false;
+            this.stopTick();
+            this.stopPolling();
+            this.activeJobId = null;
+            this.currentBubble = null;
+            if (this.statusEl) this.statusEl.classList.remove('is-waiting');
+            this.setStatus('Готов к работе');
+        },
+
+        startTick: function () {
+            this.stopTick();
+            var self = this;
+            if (typeof setInterval === 'undefined') return;
+            this.tickTimer = setInterval(function () { self.updateWaiting(); }, 1000);
+        },
+
+        stopTick: function () {
+            if (this.tickTimer && typeof clearInterval !== 'undefined') clearInterval(this.tickTimer);
+            this.tickTimer = null;
+        },
+
+        updateWaiting: function () {
+            var elapsed = this.now() - this.thinkStart;
+            if (this.statusEl) this.statusEl.classList.add('is-waiting');
+            this.setStatus(this.statusMessage(elapsed));
+            if (this.currentBubble && this.currentBubble.label)
+                this.currentBubble.label.textContent = this.waitMessage(elapsed);
+        },
+
+        ensurePolling: function (jobId) {
+            if (!jobId) return;
+            this.activeJobId = jobId;
+            if (this.pollTimer && this.pollJobId === jobId) return;
+            this.stopPolling();
+            this.pollJobId = jobId;
+            var self = this;
+            if (typeof setInterval === 'undefined') return;
+            this.pollTimer = setInterval(function () { self.pollOnce(); }, this.pollIntervalMs);
+        },
+
+        stopPolling: function () {
+            if (this.pollTimer && typeof clearInterval !== 'undefined') clearInterval(this.pollTimer);
+            this.pollTimer = null;
+            this.pollJobId = null;
+        },
+
+        pollOnce: function () {
+            var jobId = this.pollJobId;
+            if (!jobId) return;
+            var self = this;
+            fetch(this.getStatusUrl(jobId), {
+                credentials: 'same-origin',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            }).then(function (response) {
+                return response.json().catch(function () { return null; });
+            }).then(function (data) {
+                // Нет данных — временный сбой/таймаут опроса, продолжаем ждать.
+                if (!data || !data.job) return;
+                self.routeJob(data.job, true);
+            }).catch(function () {
+                // Сетевой сбой опроса не фатален: задача жива на сервере.
+            });
+        },
+
+        // --- восстановление при открытии (в т.ч. из другого браузера) ---
+
+        resume: function () {
+            if (this.resumeChecked) return;
+            this.resumeChecked = true;
+            if (this.localActivity) return;
+            if (typeof fetch === 'undefined') return;
+            var self = this;
+            fetch(this.getStatusUrl(null), {
+                credentials: 'same-origin',
+                headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            }).then(function (response) {
+                return response.json().catch(function () { return null; });
+            }).then(function (data) {
+                var job = data && data.job ? data.job : null;
+                if (!job || self.localActivity) return;
+                self.restoreJob(job);
+            }).catch(function () {});
+        },
+
+        restoreJob: function (job) {
+            if (!job || !job.id || this.rendered[job.id]) return;
+            this.addMessage('user', job.message || '(вложения)');
+            this.rendered[job.id] = true;
+
+            if (job.status === 'done') {
+                this.addMessage('assistant', this.getAssistantContent(job.result) || 'ИИ-агент не вернул ответ.');
+                return;
+            }
+            if (job.status === 'error') {
+                this.addMessage('assistant', this.getErrorText(job.result) || job.error || 'ИИ-агент завершил работу с ошибкой.');
+                return;
+            }
+            // Задача ещё выполняется — показываем «думает» и продолжаем опрос.
+            this.currentBubble = this.addThinkingBubble();
+            this.beginWaiting(job.id);
+            this.ensurePolling(job.id);
+        },
+
+        // --- сообщения ленты ---
 
         getAssistantContent: function (data) {
             if (!data) return '';
@@ -237,7 +470,7 @@
         },
 
         addMessage: function (role, text, payUrl) {
-            if (!this.messages) return;
+            if (!this.messages) return null;
             var wrap = document.createElement('div');
             wrap.className = 'ai-chat-message ' + (role === 'user' ? 'ai-chat-message-user' : 'ai-chat-message-assistant');
 
@@ -251,31 +484,90 @@
             body.textContent = text;
             wrap.appendChild(body);
 
-            if (payUrl) {
-                var link = document.createElement('a');
-                link.className = 'ai-chat-message-pay';
-                link.href = payUrl;
-                link.target = '_blank';
-                link.rel = 'noopener';
-                link.textContent = 'Перейти к оплате';
-                wrap.appendChild(link);
-            }
+            if (payUrl) this.appendPayLink(wrap, payUrl);
 
             this.messages.appendChild(wrap);
             this.scrollToBottom();
+            return wrap;
+        },
+
+        appendPayLink: function (wrap, payUrl) {
+            var link = document.createElement('a');
+            link.className = 'ai-chat-message-pay';
+            link.href = payUrl;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            link.textContent = 'Перейти к оплате';
+            wrap.appendChild(link);
+        },
+
+        // «Пузырь» агента с анимированным индикатором набора и подписью ожидания.
+        addThinkingBubble: function () {
+            if (!this.messages) return null;
+            var wrap = document.createElement('div');
+            wrap.className = 'ai-chat-message ai-chat-message-assistant ai-chat-message-thinking';
+
+            var author = document.createElement('div');
+            author.className = 'ai-chat-message-author';
+            author.textContent = 'ИИ-агент';
+            wrap.appendChild(author);
+
+            var body = document.createElement('div');
+            body.className = 'ai-chat-message-text';
+
+            var dots = document.createElement('span');
+            dots.className = 'ai-agent-typing';
+            dots.setAttribute('aria-hidden', 'true');
+            dots.innerHTML = '<i></i><i></i><i></i>';
+            body.appendChild(dots);
+
+            var label = document.createElement('span');
+            label.className = 'ai-agent-thinking-label';
+            label.textContent = this.waitMessage(0);
+            body.appendChild(label);
+
+            wrap.appendChild(body);
+            this.messages.appendChild(wrap);
+            this.scrollToBottom();
+            return { el: wrap, label: label };
+        },
+
+        // Заменяет «думает»-пузырь готовым ответом (или создаёт новое сообщение).
+        replaceThinking: function (text, payUrl) {
+            var bubble = this.currentBubble;
+            if (bubble && bubble.el) {
+                bubble.el.className = 'ai-chat-message ai-chat-message-assistant';
+                var body = bubble.el.querySelector('.ai-chat-message-text');
+                if (body) {
+                    body.innerHTML = '';
+                    body.textContent = text;
+                }
+                if (payUrl) this.appendPayLink(bubble.el, payUrl);
+                this.scrollToBottom();
+            } else {
+                this.addMessage('assistant', text, payUrl);
+            }
+            this.currentBubble = null;
         },
 
         scrollToBottom: function () {
             var body = this.messages ? this.messages.parentNode : null;
             if (body && typeof body.scrollTop === 'number') body.scrollTop = body.scrollHeight;
+        },
+
+        now: function () {
+            return (typeof Date !== 'undefined' && Date.now) ? Date.now() : 0;
         }
     };
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function () { IntegramAiAgentChat.init(); });
-    } else {
-        IntegramAiAgentChat.init();
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', function () { IntegramAiAgentChat.init(); });
+        } else {
+            IntegramAiAgentChat.init();
+        }
     }
 
     if (typeof window !== 'undefined') window.IntegramAiAgentChat = IntegramAiAgentChat;
+    if (typeof module !== 'undefined' && module.exports) module.exports = IntegramAiAgentChat;
 })();


### PR DESCRIPTION
## Что сделано

Доработка упрощённого ИИ-агента (#3396) под асинхронную работу из issue #3410: задача может выполняться долго (до минуты и дольше) и ставиться в очередь, а результат не должен теряться при таймауте сервера или закрытии вкладки — в том числе при заходе **с другого браузера**.

Fixes #3410

### 1. Агент думает / нужно ещё время
Пока задача выполняется, в ленте показывается анимированный индикатор «ИИ-агент думает…». При долгом ожидании текст эскалируется: «нужно ещё немного времени» (>12 c) → «задача поставлена в очередь, результат сохранится» (>45 c). Короткий статус дублируется в шапке панели.

### 2. Результат не теряется (в т.ч. с другого браузера)
Запрос сохраняется на сервере как задача (`job`) **до** обработки. Состояние лежит в JSON-файле во временной директории сервера, ключ — имя базы (тот же подход, что у кеша оплаты из #3404), а не в `localStorage`. Поэтому при повторном открытии панели (GET `/{db}/ai/agent` без параметров) последняя/незавершённая задача подхватывается и показывается даже в другом браузере.

### 3. Устойчивость к таймауту сервера (30–60 c)
POST `/{db}/ai/agent` создаёт задачу и сразу её обрабатывает, возвращая `{job:{status,result,…}}`. Если соединение оборвётся по таймауту — задача уже сохранена, и клиент подхватывает её опросом GET `/{db}/ai/agent?job=ID`. Поллинг переживает временные сетевые сбои (задача жива на сервере).

### Маршрут `/{db}/ai/agent`
- **POST** — поставить запрос (создать job, обработать, вернуть статус/результат).
- **GET `?job=ID`** — статус/результат задачи (для поллинга).
- **GET** (без `job`) — последняя задача (для восстановления при открытии панели).
- Доступ — только владельцу базы. Оплата проверяется на POST; готовый результат по GET доступен и при истёкшей оплате.
- Хранилище: `flock`, последние **20** задач на базу, TTL **24 ч**.

### Подключение реального API агента
`callIntegramAgent()` пока отвечает сразу (реальный API агента — в его тикете). Когда вызов станет асинхронным, задача останется в статусе `processing`, а результат запишет отдельный обработчик — клиентский поллинг это **уже** поддерживает, серверный контракт менять не придётся.

## Безопасность
- Доступ к агенту и его задачам — только пользователю, чьё имя совпадает с именем базы (`aiAgentRequireOwner`).
- Все данные ограничены текущей базой; имя базы санируется при построении пути хранилища.
- XSRF-проверка на POST сохранена.

## Как проверить
Прогон на PHP 7.4 и 8.2 + Node:
- `php experiments/test-issue-3410-ai-agent-jobs.php` — хранилище задач (unit + файловый round-trip).
- `php experiments/test-issue-3410-ai-agent-flow.php` — HTTP-контракт маршрута (submit/status, 403/402/400/502, error-задача).
- `node experiments/test-issue-3410-ai-agent-async.js` — тексты ожидания и разбор ответа.
- `node experiments/test-issue-3410-ai-agent-dom.js` — проводка клиента (отправка→ответ, восстановление, поллинг до готовности).
- Регрессия: `php experiments/test-issue-3404-ai-agent-payment-sql.php` и `php -l index.php` — без изменений.

## Изменённые файлы
| Файл | Что |
| --- | --- |
| `index.php` | маршрут GET/POST, серверное хранилище задач (job-store) |
| `js/ai-agent-chat.js` | индикатор «думает», поллинг, восстановление задачи |
| `css/ai-chat.css` | анимация индикатора + статус ожидания (учтён `prefers-reduced-motion`) |
| `experiments/test-issue-3410-*` | тесты (PHP + Node) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)