### PR TITLE
fix(atex): очередь резок — ножи по убыванию при равной переналадке (#3412)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T06:57:48.103Z for PR creation at branch issue-3412-9cd3dd84a2c2 for issue https://github.com/ideav/crm/issues/3412

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T06:57:48.103Z for PR creation at branch issue-3412-9cd3dd84a2c2 for issue https://github.com/ideav/crm/issues/3412

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2625,12 +2625,10 @@
         ];
     }
 
-    // Жадная последовательность: старт — argmin startKey (узкая/много-ножевая); далее argmin changeoverCost, tie-break startKey.
-    function greedySequence(cuts, weights){
-        var pool = (cuts || []).slice();
-        if (!pool.length) return [];
-        pool.sort(function(a, b){ return cmpKey(startKey(a), startKey(b)); });
-        var result = [pool.shift()];
+    // Жадная цепочка от заданного старта: далее argmin changeoverCost, tie-break startKey.
+    function greedyFromStart(start, rest, weights){
+        var pool = (rest || []).slice();
+        var result = [start];
         while (pool.length){
             var cur = result[result.length - 1], bestI = 0, bestCost = Infinity, bestKey = null;
             for (var i = 0; i < pool.length; i++){
@@ -2640,6 +2638,44 @@
             result.push(pool.splice(bestI, 1)[0]);
         }
         return result;
+    }
+    // Суммарная переналадка цепочки (Σ changeoverCost соседей).
+    function chainChangeoverCost(seq, weights){
+        var total = 0;
+        for (var i = 1; i < (seq || []).length; i++) total += changeoverCost(seq[i - 1], seq[i], weights);
+        return round3(total);
+    }
+    // Ряд числа ножей по порядку — критерий «ножи по убыванию» (#3130). Среди равных по
+    // стоимости цепочек предпочитаем ту, чей ряд knifeCount лексикографически больше
+    // (много ножей раньше). Возвращает <0, если ряд a предпочтительнее ряда b.
+    function knifeDescSeq(seq){ return (seq || []).map(function(c){ return Number(c && c.knifeCount) || 0; }); }
+    function cmpKnifeDescSeq(a, b){
+        var n = Math.max(a.length, b.length);
+        for (var i = 0; i < n; i++){ var av = a[i] || 0, bv = b[i] || 0; if (av !== bv) return bv - av; }
+        return 0;
+    }
+    // Лимит полного перебора стартов: при больших очередях остаёмся на одиночном старте
+    // (argmin startKey), чтобы не уходить в O(n³). На станко-день очередь маленькая.
+    var GREEDY_MULTISTART_LIMIT = 60;
+    // Жадная последовательность. Раньше старт жёстко брался argmin startKey (узкий
+    // ролик), из-за чего setup-оптимальная цепочка могла идти по ВОЗРАСТАНИЮ ножей
+    // (6,16,16) вопреки правилу #3130 «много ножей в начале смены» (ideav/crm#3412).
+    // Теперь перебираем все старты, берём минимум суммарной переналадки (#3268), а
+    // среди равных по стоимости — цепочку с ножами по убыванию.
+    function greedySequence(cuts, weights){
+        var pool = (cuts || []).slice();
+        if (pool.length <= 1) return pool;
+        pool.sort(function(a, b){ return cmpKey(startKey(a), startKey(b)); });
+        if (pool.length > GREEDY_MULTISTART_LIMIT) return greedyFromStart(pool[0], pool.slice(1), weights);
+        var best = null, bestCost = Infinity, bestKnife = null;
+        for (var s = 0; s < pool.length; s++){
+            var seq = greedyFromStart(pool[s], pool.slice(0, s).concat(pool.slice(s + 1)), weights);
+            var cost = chainChangeoverCost(seq, weights), knife = knifeDescSeq(seq);
+            if (best === null || cost < bestCost || (cost === bestCost && cmpKnifeDescSeq(knife, bestKnife) < 0)){
+                best = seq; bestCost = cost; bestKnife = knife;
+            }
+        }
+        return best;
     }
     // Внутри последовательности станка число ножей должно убывать к концу дня
     // (ideav/crm#3130): в начале смены ножей много, к вечеру меньше — переналаживать

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -495,6 +495,23 @@ var knifeCuts = [
 assertEqual(planning.orderCuts(knifeCuts).map(function(c){ return c.knifeCount; }), [7, 5, 3], 'orderCuts: ножи убывают к концу дня (7,5,3)');
 assertEqual(planning.byKnifeCountDesc([{ knifeCount: 2, id: 'a' }, { knifeCount: 2, id: 'b' }, { knifeCount: 9, id: 'c' }]).map(function(x){ return x.id; }), ['c', 'a', 'b'], 'byKnifeCountDesc: ↓, равные стабильно');
 
+// #3412: при равной суммарной переналадке очередь должна идти по ножам ↓, а не ↑.
+// Сценарий со скриншота (Станок 3): резки 6, 16, 16 ножей; у малоножевой резки самый
+// узкий ролик → одиночный старт (argmin startKey) выбирал её первой и давал 6,16,16.
+// Цепочка 16,16,6 стоит столько же (мин. переналадка), поэтому ножи должны убывать.
+function w3412(pairs){ var o = []; pairs.forEach(function(pr){ for (var i = 0; i < pr[1]; i++) o.push(pr[0]); }); return o; }
+var cuts3412 = [
+    { id: 'A', materialId: 'MW308', winding: 'OUT', batchId: '', knifeCount: 6,  knifeWidths: w3412([[152, 5], [110, 1]]), rollerWidth: 200 },
+    { id: 'B', materialId: 'MR194', winding: 'OUT', batchId: '', knifeCount: 16, knifeWidths: w3412([[59, 14], [30, 2]]), rollerWidth: 300 },
+    { id: 'C', materialId: 'MW308', winding: 'OUT', batchId: '', knifeCount: 16, knifeWidths: w3412([[59, 14], [30, 2]]), rollerWidth: 300 }
+];
+assertEqual(planning.orderCuts(cuts3412).map(function(c){ return c.knifeCount; }), [16, 16, 6],
+    'orderCuts #3412: при равной переналадке ножи убывают (16,16,6), а не растут (6,16,16)');
+// Минимизация переналадки (#3268) не страдает: цепочка по-прежнему оптимальна по минутам.
+assertEqual(planning.orderedChangeoverCost(cuts3412), planning.orderedChangeoverCost(cuts3412.slice().reverse()),
+    'orderCuts #3412: стоимость переналадки не зависит от исходного порядка (детерминированный минимум)');
+assertEqual(planning.orderedChangeoverCost(cuts3412), 45, 'orderCuts #3412: суммарная переналадка минимальна (45 мин)');
+
 // #3272/#3270: второй вариант планирования учитывает рост усталости к концу очереди.
 assertEqual(planning.fatiguePositionWeight(0, 3, 2), 1, 'fatiguePositionWeight #3272: первая позиция без штрафа');
 assertEqual(planning.fatiguePositionWeight(2, 3, 2), 3, 'fatiguePositionWeight #3272: последняя позиция = 1 + alpha');


### PR DESCRIPTION
## Что не так

На скриншоте из #3412 очередь резок станка идёт по **возрастанию** числа ножей: «Полосы (6)» → «Полосы (16)» → «Полосы (16)». Это противоречит правилу #3130 «много ножей в начале смены, меньше к вечеру» (переналаживать к концу дня тяжелее).

## Причина

`greedySequence` (`download/atex/js/production-planning.js`) строила цепочку от **единственного** старта — `argmin startKey`, где первым критерием идёт ширина ролика. Малоножевая резка с самым узким роликом становилась первой, и хотя итог был оптимален по минутам переналадки (#3268), ножи шли по возрастанию.

При этом **равная по стоимости** цепочка с ножами по убыванию существовала, но не выбиралась: после #3268 знаменитая сортировка `byKnifeCountDesc(greedySequence(...))` была убрана, а ножи остались лишь tie-break внутри `startKey`, который перебивался выбором старта по ролику.

Воспроизведение (сценарий со скриншота, у малоножевой резки самый узкий ролик):

```
До:  orderCuts → A(6), C(16), B(16)   cost 45   (ножи ↑)
```

## Решение

`greedySequence` теперь перебирает **все** старты, берёт минимум суммарной переналадки (#3268), а среди равных по стоимости цепочек — ту, где ряд `knifeCount` лексикографически больше (ножи по убыванию, #3130). При больших очередях (> 60 резок на станко-день) остаётся одиночный старт, чтобы не уходить в O(n³).

```
После: orderCuts → B(16), C(16), A(6)  cost 45   (ножи ↓, та же мин. переналадка)
```

Минимизация переналадки (#3268) не страдает — выбирается тот же минимум минут, просто детерминированно в пользу «ножи ↓».

## Тесты

`experiments/atex-production-planning.test.js`:
- новый кейс #3412: сценарий 6/16/16 → `[16,16,6]` при той же стоимости 45 мин;
- проверка, что суммарная переналадка минимальна и не зависит от исходного порядка;
- все ранее существовавшие проверки (#3130 `[7,5,3]`, #3268 `A-high,A-low,B-mid`, #3272 fatigue) проходят без изменений.

`node experiments/atex-production-planning.test.js` → **464 assertions passed**.

Fixes #3412
