### PR TITLE
feat(ai-agent): серверная проводка async-агента через callback (B1)

### DIFF
--- a/experiments/test-ai-agent-callback.php
+++ b/experiments/test-ai-agent-callback.php
@@ -1,0 +1,171 @@
+<?php
+# Regression test: async ИИ-агент через callback (вариант B1).
+# Контекст — продолжение #3410 (см. docs/ai-agent-endpoint.md).
+#
+# Проверяем серверную проводку B1 целиком, с реальными callIntegramAgent /
+# aiAgentSubmitRequest / handleAiAgentCallback и стабом только сетевого слоя:
+#   1) в запрос к агенту попадают job_id / callback_url / callback_secret;
+#   2) async-ack агента (202 {status:queued}) -> задача остаётся processing;
+#   3) callback с верным секретом -> задача done с content; идемпотентность;
+#   4) callback status=error -> задача error;
+#   5) защита: неверный секрет 403, неизвестная задача 404, нет job_id/пустой
+#      content 400;
+#   6) синхронный ответ агента ({content}) по-прежнему даёт сразу done.
+
+$failures = 0;
+function expect($cond, $name){
+    global $failures;
+    if($cond){ echo "PASS: $name\n"; } else { echo "FAIL: $name\n"; $failures++; }
+}
+
+define("AI_AGENT_JOBS_MAX", 20);
+define("AI_AGENT_JOBS_TTL", 24 * 3600);
+
+class ApiDone extends Exception { public $json; function __construct($json){ $this->json=$json; parent::__construct("done"); } }
+class ApiErr extends Exception { public $payload; function __construct($code,$payload){ $this->payload=$payload; parent::__construct("err",$code); } }
+
+function api_dump($json, $name="api.json"){ throw new ApiDone($json); }
+function aiAgentError($message, $code=400, $extra=array()){
+    throw new ApiErr($code, array_merge(array("error"=>$message), is_array($extra)?$extra:array()));
+}
+function t9n($v){ return preg_match('/^\[RU\](.*?)\[EN\]/s',$v,$m) ? $m[1] : $v; }
+function check(){}
+function checkAiAgentPayment($db){ return array("ok"=>true,"status"=>"active","paidUntil"=>time()+1000,"payUrl"=>"https://pay"); }
+function validateAiProviderEndpoint($e){}
+
+# Конфиг: endpoint задан => callIntegramAgent идёт по HTTP-пути; callback-URL из base.
+$GLOBALS["__cfg"] = array(
+    "INTEGRAM_AGENT_ENDPOINT" => "https://agent.example/agent",
+    "AI_AGENT_CALLBACK_BASE_URL" => "https://crm.example"
+);
+function aiConfigValue($names){
+    foreach($names as $n)
+        if(isset($GLOBALS["__cfg"][$n]) && trim((string)$GLOBALS["__cfg"][$n]) !== "")
+            return trim((string)$GLOBALS["__cfg"][$n]);
+    return "";
+}
+# Стаб сетевого вызова: запоминаем запрос, возвращаем заданное тело.
+function aiChatPostJson($endpoint, $request, $headers, $timeout=60){
+    $GLOBALS["__capture"] = $request;
+    return $GLOBALS["__ret"];
+}
+# Стаб тела callback-запроса.
+function aiAgentRawInput(){ return isset($GLOBALS["__body"]) ? $GLOBALS["__body"] : ""; }
+
+function extract_function_source($source, $name){
+    $needle = "function ".$name."(";
+    $start = strpos($source, $needle);
+    if($start === false) throw new Exception("not found: ".$name);
+    $brace = strpos($source, "{", $start);
+    $depth=0; $len=strlen($source);
+    for($i=$brace;$i<$len;$i++){
+        if($source[$i]==="{") $depth++;
+        elseif($source[$i]==="}"){ $depth--; if($depth===0) return substr($source,$start,$i-$start+1); }
+    }
+    throw new Exception("not closed: ".$name);
+}
+
+$source = file_get_contents(__DIR__."/../index.php");
+$fns = array(
+    "callIntegramAgent","extractAiProviderContent",
+    "handleAiAgentRequest","aiAgentRequireOwner","aiAgentSubmitRequest","aiAgentStatusRequest",
+    "handleAiAgentCallback","aiAgentCallbackUrl","collectAiAgentAttachments",
+    "aiAgentJobsFile","aiAgentJobId","aiAgentJobNew","aiAgentJobsAppend","aiAgentJobsFind",
+    "aiAgentJobsLatest","aiAgentJobsPrune","aiAgentJobsApplyChanges","aiAgentJobsReplace",
+    "aiAgentJobPublic","aiAgentJobsEncode","aiAgentJobsDecode","aiAgentJobsLoadRaw",
+    "aiAgentJobsMutate","aiAgentJobCreate","aiAgentJobUpdate","aiAgentJobGet","aiAgentJobLatest"
+);
+foreach($fns as $fn) eval(extract_function_source($source, $fn));
+
+$db = "cb".getmypid();
+$GLOBALS["z"] = $db;
+$GLOBALS["GLOBAL_VARS"] = array("user"=>$db);
+@unlink(aiAgentJobsFile($db));
+
+function submit($message){
+    $_SERVER["REQUEST_METHOD"]="POST"; $_GET=array(); $_POST=array("message"=>$message); $_FILES=array();
+    try { handleAiAgentRequest(array()); }
+    catch(ApiDone $d){ return array("ok"=>true,"data"=>json_decode($d->json,true)); }
+    catch(ApiErr $e){ return array("ok"=>false,"code"=>$e->getCode(),"data"=>$e->payload); }
+}
+function status($jobId){
+    $_SERVER["REQUEST_METHOD"]="GET"; $_GET=array("job"=>$jobId); $_POST=array();
+    try { handleAiAgentRequest(array()); }
+    catch(ApiDone $d){ return array("ok"=>true,"data"=>json_decode($d->json,true)); }
+    catch(ApiErr $e){ return array("ok"=>false,"code"=>$e->getCode(),"data"=>$e->payload); }
+}
+function callback($body, $secret){
+    global $db;
+    $_SERVER["REQUEST_METHOD"]="POST";
+    $_SERVER["HTTP_X_AGENT_SECRET"]= $secret;
+    $GLOBALS["__body"] = is_string($body) ? $body : json_encode($body);
+    try { handleAiAgentCallback($db); }
+    catch(ApiDone $d){ return array("ok"=>true,"data"=>json_decode($d->json,true)); }
+    catch(ApiErr $e){ return array("ok"=>false,"code"=>$e->getCode(),"data"=>$e->payload); }
+}
+
+# 1) Async submit: агент отвечает 202 {status:queued}.
+$GLOBALS["__ret"] = json_encode(array("job_id"=>"agent-1","status"=>"queued"));
+$r = submit("долгий запрос");
+expect($r["ok"] && isset($r["data"]["job"]), "async submit returns a job");
+$job = $r["data"]["job"];
+$jobId = $job["id"];
+expect($job["status"] === "processing", "async job stays in processing (ждём callback)");
+expect(!isset($job["result"]) || $job["result"]===null, "no result yet on processing job");
+
+# Запрос к агенту содержит callback-поля.
+$cap = $GLOBALS["__capture"];
+expect($cap["job_id"] === $jobId, "agent request carries our job_id");
+expect($cap["callback_url"] === "https://crm.example/".$db."/ai/agent/callback", "agent request carries callback_url");
+expect(isset($cap["callback_secret"]) && strlen($cap["callback_secret"]) >= 16, "agent request carries callback_secret");
+
+# agentJobId сохранён во внутренней задаче, в публичном виде не светится.
+$internal = aiAgentJobGet($db, $jobId);
+expect($internal["agentJobId"] === "agent-1", "agent job_id stored internally");
+$secret = $internal["callbackSecret"];
+expect(!isset($job["callbackSecret"]), "callbackSecret NOT exposed in public job");
+
+# 2) Защита callback.
+$r = callback(array("job_id"=>$jobId,"status"=>"done","content"=>"x"), "wrong-secret");
+expect(!$r["ok"] && $r["code"]===403, "callback with wrong secret -> 403");
+$r = callback(array("job_id"=>"deadbeef","status"=>"done","content"=>"x"), $secret);
+expect(!$r["ok"] && $r["code"]===404, "callback for unknown job -> 404");
+$r = callback(array("status"=>"done","content"=>"x"), $secret);
+expect(!$r["ok"] && $r["code"]===400, "callback without job_id -> 400");
+$r = callback(array("job_id"=>$jobId,"status"=>"done","content"=>"   "), $secret);
+expect(!$r["ok"] && $r["code"]===400, "callback with empty content -> 400");
+
+# 3) Успешный callback -> задача done с content.
+$r = callback(array("job_id"=>$jobId,"status"=>"done","content"=>"итоговый ответ"), $secret);
+expect($r["ok"] && $r["data"]["status"]==="done", "valid callback acknowledged");
+$r = status($jobId);
+expect($r["ok"] && $r["data"]["job"]["status"]==="done", "job is done after callback");
+expect($r["data"]["job"]["result"]["assistant"]["content"]==="итоговый ответ", "callback content delivered to client");
+
+# Идемпотентность: повторный callback не ломает завершённую задачу.
+$r = callback(array("job_id"=>$jobId,"status"=>"done","content"=>"другое"), $secret);
+expect($r["ok"], "duplicate callback acknowledged (idempotent)");
+$r = status($jobId);
+expect($r["data"]["job"]["result"]["assistant"]["content"]==="итоговый ответ", "duplicate callback does not overwrite result");
+
+# 4) Callback с ошибкой.
+$GLOBALS["__ret"] = json_encode(array("job_id"=>"agent-2","status"=>"queued"));
+$r = submit("второй");
+$jobId2 = $r["data"]["job"]["id"];
+$secret2 = aiAgentJobGet($db, $jobId2)["callbackSecret"];
+$r = callback(array("job_id"=>$jobId2,"status"=>"error","error"=>"агент не смог"), $secret2);
+expect($r["ok"] && $r["data"]["status"]==="error", "error callback acknowledged");
+$r = status($jobId2);
+expect($r["data"]["job"]["status"]==="error", "job marked error after error callback");
+
+# 5) Синхронный ответ агента ({content}) -> сразу done, без callback.
+$GLOBALS["__ret"] = json_encode(array("content"=>"быстрый ответ"));
+$r = submit("быстрый");
+expect($r["ok"] && $r["data"]["job"]["status"]==="done", "sync agent answer -> job done immediately");
+expect($r["data"]["job"]["result"]["assistant"]["content"]==="быстрый ответ", "sync content delivered");
+
+@unlink(aiAgentJobsFile($db));
+
+echo "\n";
+if($failures){ echo "FAILED: $failures check(s) failed\n"; exit(1); }
+echo "ALL TESTS PASSED\n";

--- a/experiments/test-issue-3410-ai-agent-flow.php
+++ b/experiments/test-issue-3410-ai-agent-flow.php
@@ -28,6 +28,8 @@ function aiAgentError($message, $code=400, $extra=array()){
 }
 function t9n($v){ return preg_match('/^\[RU\](.*?)\[EN\]/s',$v,$m) ? $m[1] : $v; }
 function check(){ /* XSRF — noop в тесте */ }
+# aiConfigValue нужен aiAgentCallbackUrl(): в этом тесте callback не задействован.
+function aiConfigValue($names){ return ""; }
 
 # Управляемые из тестов заглушки оплаты и вызова агента.
 $GLOBALS["__pay_ok"] = true;
@@ -59,7 +61,7 @@ function extract_function_source($source, $name){
 $source = file_get_contents(__DIR__."/../index.php");
 $fns = array(
     "handleAiAgentRequest","aiAgentRequireOwner","aiAgentSubmitRequest","aiAgentStatusRequest",
-    "collectAiAgentAttachments",
+    "aiAgentCallbackUrl","collectAiAgentAttachments",
     "aiAgentJobsFile","aiAgentJobId","aiAgentJobNew","aiAgentJobsAppend","aiAgentJobsFind",
     "aiAgentJobsLatest","aiAgentJobsPrune","aiAgentJobsApplyChanges","aiAgentJobsReplace",
     "aiAgentJobPublic","aiAgentJobsEncode","aiAgentJobsDecode","aiAgentJobsLoadRaw",

--- a/index.php
+++ b/index.php
@@ -92,6 +92,16 @@ elseif($z==="auth.asp" && !empty($_GET['error'])){
 elseif(!preg_match(DB_MASK, $z))
     die("Invalid database");
 
+# Callback асинхронного ИИ-агента (server-to-server, без сессии). Принимаем результат
+# здесь — до подключения к БД и до Validate_Token(); аутентификация — секрет per-job
+# в заголовке X-Agent-Secret (см. handleAiAgentCallback / docs/ai-agent-endpoint.md).
+# Хранилище задач файловое, поэтому соединение с БД не требуется.
+if((isset($com[2]) ? $com[2] : "") === "ai"
+    && (isset($com[3]) ? $com[3] : "") === "agent"
+    && (isset($com[4]) ? $com[4] : "") === "callback"){
+    handleAiAgentCallback($z);
+}
+
 $locale = isset($_COOKIE[$z."_locale"]) ? $_COOKIE[$z."_locale"] : (isset($_COOKIE["my_locale"]) ? $_COOKIE["my_locale"] : "RU");
 include "include/connection.php";
 # Check the DB existence
@@ -8688,14 +8698,27 @@ function aiAgentSubmitRequest($com){
     $job = aiAgentJobCreate($z, $message, $attachmentNames);
     $jobId = $job["id"];
 
+    # Для асинхронного агента готовим callback (см. docs/ai-agent-endpoint.md):
+    # секрет per-job и URL вида https://host/{db}/ai/agent/callback. Секрет хранится
+    # в задаче (в публичное представление не попадает) и сверяется при приёме
+    # результата в handleAiAgentCallback().
+    $callbackSecret = aiAgentJobId();
+    $callbackUrl = aiAgentCallbackUrl($z);
+
     try {
-        aiAgentJobUpdate($z, $jobId, array("status" => "processing"));
-        # callIntegramAgent сейчас отвечает сразу (реальный API агента — в его
-        # тикете). Когда вызов станет асинхронным, здесь задача останется в статусе
-        # processing, а результат запишет отдельный обработчик — клиентский опрос
-        # уже это поддерживает.
-        $response = callIntegramAgent($z, $message, $attachments, $payment);
-        $updated = aiAgentJobUpdate($z, $jobId, array("status" => "done", "result" => $response, "error" => null));
+        aiAgentJobUpdate($z, $jobId, array("status" => "processing", "callbackSecret" => $callbackSecret));
+        # Синхронный агент (вариант A) отвечает сразу content -> задача done.
+        # Асинхронный (вариант B1) отвечает 202 {status:queued} -> задача остаётся
+        # processing, результат придёт в callback; клиентский опрос это поддерживает.
+        $response = callIntegramAgent($z, $message, $attachments, $payment, $jobId, $callbackUrl, $callbackSecret);
+        if(!empty($response["pending"])){
+            $changes = array("status" => "processing");
+            if(!empty($response["agentJobId"]))
+                $changes["agentJobId"] = (string)$response["agentJobId"];
+            $updated = aiAgentJobUpdate($z, $jobId, $changes);
+        } else {
+            $updated = aiAgentJobUpdate($z, $jobId, array("status" => "done", "result" => $response, "error" => null));
+        }
         $job = $updated ? $updated : aiAgentJobGet($z, $jobId);
     } catch(Exception $e) {
         $code = (int)$e->getCode();
@@ -8728,6 +8751,84 @@ function aiAgentStatusRequest($com){
 
     $job = aiAgentJobLatest($z);
     api_dump(json_encode(array("job" => $job ? aiAgentJobPublic($job) : null), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+}
+# POST /{db}/ai/agent/callback — приём результата от асинхронного ИИ-агента
+# (вариант B1, см. docs/ai-agent-endpoint.md). Вызов server-to-server, без сессии
+# пользователя, поэтому маршрут обрабатывается ДО Validate_Token() (см. диспетчер в
+# начале файла). Аутентификация — секрет per-job (заголовок X-Agent-Secret),
+# сверяемый с секретом, сохранённым в задаче при постановке. БД не требуется:
+# хранилище задач файловое.
+function handleAiAgentCallback($db){
+    if((isset($_SERVER["REQUEST_METHOD"]) ? strtoupper((string)$_SERVER["REQUEST_METHOD"]) : "") !== "POST")
+        aiAgentError(t9n("[RU]Callback ИИ-агента принимает только POST[EN]The AI agent callback accepts POST only"), 405);
+
+    $raw = aiAgentRawInput();
+    $data = (is_string($raw) && trim($raw) !== "") ? json_decode($raw, true) : null;
+    if(!is_array($data))
+        aiAgentError(t9n("[RU]Некорректное тело callback[EN]Invalid callback body"), 400);
+
+    $jobId = isset($data["job_id"]) ? preg_replace('/[^a-f0-9]/i', '', (string)$data["job_id"]) : "";
+    if($jobId === "")
+        aiAgentError(t9n("[RU]В callback не передан job_id[EN]Callback is missing job_id"), 400);
+
+    $job = aiAgentJobGet($db, $jobId);
+    # Принимаем callback только для задачи, которую сами поставили на async (есть
+    # сохранённый секрет). Иначе — 404, чтобы не раскрывать существование задач.
+    if(!$job || empty($job["callbackSecret"]))
+        aiAgentError(t9n("[RU]Задача ИИ-агента не найдена[EN]AI agent job not found"), 404);
+
+    # Сверка секрета (constant-time): секрет задачи либо общий секрет из конфига.
+    $provided = isset($_SERVER["HTTP_X_AGENT_SECRET"]) ? (string)$_SERVER["HTTP_X_AGENT_SECRET"] : "";
+    $globalSecret = aiConfigValue(array("AI_AGENT_CALLBACK_SECRET", "INTEGRAM_AGENT_CALLBACK_SECRET"));
+    $okSecret = ($provided !== "" && hash_equals((string)$job["callbackSecret"], $provided))
+             || ($globalSecret !== "" && $provided !== "" && hash_equals($globalSecret, $provided));
+    if(!$okSecret)
+        aiAgentError(t9n("[RU]Неверный секрет callback[EN]Invalid callback secret"), 403);
+
+    # Идемпотентность: повторный callback по уже завершённой задаче — без изменений.
+    $current = isset($job["status"]) ? (string)$job["status"] : "";
+    if($current === "done" || $current === "error"){
+        api_dump(json_encode(array("ok" => true, "status" => $current), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+        return;
+    }
+
+    $status = isset($data["status"]) ? strtolower(trim((string)$data["status"])) : "done";
+    if($status === "error"){
+        $error = (isset($data["error"]) && trim((string)$data["error"]) !== "")
+            ? (string)$data["error"]
+            : t9n("[RU]ИИ-агент завершил работу с ошибкой[EN]The AI agent finished with an error");
+        aiAgentJobUpdate($db, $jobId, array("status" => "error", "error" => $error));
+        api_dump(json_encode(array("ok" => true, "status" => "error"), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+        return;
+    }
+
+    $content = isset($data["content"]) ? (string)$data["content"] : "";
+    if(trim($content) === "")
+        aiAgentError(t9n("[RU]В callback пустой content[EN]Callback content is empty"), 400);
+    aiAgentJobUpdate($db, $jobId, array(
+        "status" => "done",
+        "result" => array("assistant" => array("content" => $content), "status" => "ok"),
+        "error" => null
+    ));
+    api_dump(json_encode(array("ok" => true, "status" => "done"), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), "ai-agent.json");
+}
+# Абсолютный HTTPS-URL callback для текущей базы. По умолчанию строится из Host
+# запроса; можно переопределить за прокси через AI_AGENT_CALLBACK_BASE_URL.
+# Сырое тело запроса (вынесено отдельно, чтобы callback можно было тестировать без
+# реального php://input).
+function aiAgentRawInput(){
+    return file_get_contents("php://input");
+}
+function aiAgentCallbackUrl($db){
+    $base = aiConfigValue(array("AI_AGENT_CALLBACK_BASE_URL", "INTEGRAM_AGENT_CALLBACK_BASE_URL"));
+    if($base === ""){
+        $host = isset($_SERVER["HTTP_HOST"]) ? preg_replace('/[^a-z0-9.\-:]/i', '', (string)$_SERVER["HTTP_HOST"]) : "";
+        if($host === "")
+            return "";
+        $base = "https://".$host;
+    }
+    $base = rtrim($base, "/");
+    return $base."/".rawurlencode((string)$db)."/ai/agent/callback";
 }
 function aiAgentError($message, $code=400, $extra=array()){
     header("HTTP/1.0 ".$code." ".aiChatHttpStatusText($code));
@@ -8900,10 +9001,12 @@ function evaluateAiAgentPayment($raw, $db){
     $result["paidUntil"] = $paidAt + 31 * 24 * 3600;
     return $result;
 }
-function callIntegramAgent($db, $message, $attachments, $payment){
-    # Отправка данных фиксированному ИИ-агенту. Описание API будет предоставлено в
-    # следующем тикете (issue #3392), поэтому endpoint берётся из конфигурации,
-    # а при его отсутствии возвращается подтверждение готовности без вызова.
+function callIntegramAgent($db, $message, $attachments, $payment, $jobId="", $callbackUrl="", $callbackSecret=""){
+    # Отправка данных фиксированному ИИ-агенту (см. docs/ai-agent-endpoint.md).
+    # Endpoint берётся из конфигурации; при его отсутствии возвращается подтверждение
+    # готовности без вызова. $jobId/$callbackUrl/$callbackSecret включают async-режим
+    # (вариант B1): агент может ответить 202 {status:queued} и прислать результат в
+    # callback вместо синхронного content.
     $endpoint = aiConfigValue(array("INTEGRAM_AGENT_ENDPOINT", "AI_AGENT_ENDPOINT"));
     $paymentInfo = array("status" => $payment["status"], "paidUntil" => $payment["paidUntil"]);
     if($endpoint === ""){
@@ -8928,6 +9031,13 @@ function callIntegramAgent($db, $message, $attachments, $payment){
         "message" => $message,
         "attachments" => $attachments
     );
+    # Async-режим (вариант B1): сообщаем агенту, куда вернуть результат. Для
+    # синхронного агента поля безвредны — он их игнорирует и отвечает content сразу.
+    if($jobId !== "" && $callbackUrl !== ""){
+        $request["job_id"] = $jobId;
+        $request["callback_url"] = $callbackUrl;
+        $request["callback_secret"] = $callbackSecret;
+    }
     $headers = array("Content-Type: application/json; charset=UTF-8", "Accept: application/json", "User-Agent: Integram AI Agent");
     $token = aiConfigValue(array("INTEGRAM_AGENT_TOKEN", "AI_AGENT_TOKEN"));
     if($token !== "")
@@ -8943,6 +9053,18 @@ function callIntegramAgent($db, $message, $attachments, $payment){
         $agentTimeout = 600;
     $raw = aiChatPostJson($endpoint, $request, $headers, $agentTimeout);
     $decoded = json_decode($raw, true);
+    # Async-ack (вариант B1): агент принял задачу в очередь и вернёт результат в
+    # callback. Тело не трактуем как ответ — задача остаётся processing до callback.
+    $ackStatus = (is_array($decoded) && isset($decoded["status"])) ? strtolower(trim((string)$decoded["status"])) : "";
+    if(in_array($ackStatus, array("queued", "processing", "accepted", "pending"), true)){
+        return array(
+            "pending" => true,
+            "status" => $ackStatus,
+            "agentJobId" => (is_array($decoded) && isset($decoded["job_id"])) ? (string)$decoded["job_id"] : "",
+            "payment" => $paymentInfo
+        );
+    }
+    # Синхронный ответ (вариант A) — извлекаем content.
     $content = extractAiProviderContent($decoded, $raw);
     if(trim($content) === "")
         throw new Exception(t9n("[RU]ИИ-агент вернул пустой ответ[EN]The AI agent returned an empty response"), 502);


### PR DESCRIPTION
## Что сделано

Серверная проводка асинхронного ИИ-агента (вариант **B1 — callback**) поверх слоя #3410. Нужна для агента, который ставит запрос в очередь и присылает ответ позже. Контракт — `docs/ai-agent-endpoint.md` (PR #3416).

### Запрос к агенту
В тело `POST <INTEGRAM_AGENT_ENDPOINT>` добавлены поля:
- `job_id` — генерирует CRM (= id задачи job-store #3410), агент возвращает его эхом;
- `callback_url` — `https://<host>/{db}/ai/agent/callback`;
- `callback_secret` — случайный **per-job**, хранится в задаче, в публичное представление задачи не попадает.

### Авто-определение sync/async по ответу
- `{status: queued|processing|accepted|pending}` → задача остаётся `processing`, ждём callback (тело **не** трактуется как ответ);
- ответ с `content` (или OpenAI/Gemini-форма) → сразу `done` — синхронный вариант A работает как прежде.

### Новый маршрут `POST /{db}/ai/agent/callback`
- Обрабатывается **до `Validate_Token()` и до подключения к БД** — агент ходит server-to-server без сессии, хранилище задач файловое.
- Аутентификация — заголовок `X-Agent-Secret`, сверяется `hash_equals` с секретом задачи (или общим `AI_AGENT_CALLBACK_SECRET`).
- `{status:done, content}` → задача `done`; `{status:error, error}` → задача `error`.
- **Идемпотентен**: повторный callback по завершённой задаче не перезаписывает результат.
- Защита: неверный секрет → **403**, неизвестная задача → **404**, нет `job_id` / пустой `content` → **400**.

### Клиент не меняется
`js/ai-agent-chat.js` уже опрашивает `processing`-задачи и подхватывает результат (#3410). Async-submit возвращает задачу со статусом `processing` → клиент поллит → видит `done` после callback.

## Конфиг (через `define()` или env)
| Имя | Назначение | По умолчанию |
| --- | --- | --- |
| `AI_AGENT_CALLBACK_BASE_URL` | хост для `callback_url` (за прокси) | из `Host` запроса |
| `AI_AGENT_CALLBACK_SECRET` | опциональный общий секрет callback | — (используется per-job) |

## Проверка (PHP 7.4 и 8.2)
- `experiments/test-ai-agent-callback.php` — реальные `callIntegramAgent` + submit + callback, стаб только сетевого слоя: async→processing, доставка callback, идемпотентность, error, 403/404/400, sync-путь (21 проверка).
- Обновлён `experiments/test-issue-3410-ai-agent-flow.php` под новую сигнатуру.
- Регрессия `#3410`/`#3404` и `php -l index.php` — зелёные.

Контекст: продолжение #3410; реализует контракт из #3416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)