### PR TITLE
fix(atex): пробить VERSION → клиенты получают исправленную очередь резок (#3418)

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 8);
+define("VERSION", 9);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Fixes #3418

## Симптом
После #3415 («ножи по убыванию при равной переналадке») очередь резок на ideav.ru **всё равно идёт по возрастанию**: Станок 3 → `Полосы (6)` → `Полосы (16)` → `Полосы (16)` (скриншот и лог в #3418).

## Диагностика
Алгоритм из #3415 **корректен**. На актуальном коде `orderCuts` для данных со скриншота (MW308: 6 и 16 ножей; MR194: 16 ножей) даёт `16,16,6`:
- репродукция на модуле `production-planning.js` → `orderCuts` = `16,16,6` (cost 45);
- эмуляция старого одиночного старта → `6,16,16` (ровно как на скриншоте);
- тест `experiments/atex-production-planning.test.js` (#3412) проходит, **475 assertions**.

Значит на проде выполнялся **старый** JS. Причина — кэш:
- атекс-шаблоны подключают скрипты как `…/js/production-planning.js?0{_global_.version}`;
- `{_global_.z}` = имя БД, путь постоянный → весь cache-bust держится на `{_global_.version}`;
- `index.php`: `define("VERSION", 8)` — захардкожен и **ни разу не менялся** (с момента добавления), поэтому URL всегда `production-planning.js?08` (виден в логе из #3418);
- #3415 поправил JS, но не сдвинул `VERSION` → браузеры/прокси отдают закэшированный старый файл, генерация идёт старым стартом и сохраняет `6,16,16`.

## Фикс
`VERSION` 8 → 9 — query становится `?09`, клиенты однократно перекачивают js/css и получают исправленный `production-planning.js`.

## Что ещё нужно (действие пользователя)
Очередь рисуется по сохранённой «Очередности» (`sequence`), которую пишет генерация/автопланирование. Для резок, **уже сгенерированных старым кодом**, после обновления нужно **перегенерировать резки** либо нажать **«автопланирование»** — тогда `sequence` перезапишется исправленным `orderCuts` в `16,16,6`.

## Рекомендация (вне scope)
`VERSION` приходится бить вручную при каждой правке js/css — легко забыть (как в #3415). Стоит привязать cache-bust к авто-значению (хэш билда / `filemtime`), чтобы релизы ассетов не зависели от ручного шага.