### PR TITLE
fix(atex): кнопка «Автопланирование» — пересборка очереди существующих резок (#3418)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -6381,10 +6381,21 @@
         genBtn.addEventListener('click', function() { self.generateCuts(queueActions); });
         this.genBtn = genBtn;
         this.genSpinner = genSpinner;
+        // «Сгенерировать резки» создаёт резки только под НЕобеспеченные позиции и не трогает
+        // уже сохранённую «Очередность». Чтобы пересобрать порядок СУЩЕСТВУЮЩИХ резок по
+        // актуальному правилу (минимум переналадок, #3268; много ножей в начале смены, #3130)
+        // нужен явный триггер — иначе очередь, сохранённая старой генерацией, остаётся как была
+        // (#3418: правка алгоритма #3412/#3415 не доходит до уже созданных резок). runPlanning
+        // перезапускает orderCuts по станкам и сохраняет изменившуюся «Очередность».
+        var planBtn = el('button', { class: 'atex-pp-btn atex-pp-plan-btn', type: 'button', text: 'Автопланирование',
+            title: 'Пересобрать очередь существующих резок: минимум переналадок, много ножей в начале смены' });
+        planBtn.addEventListener('click', function() { self.runPlanning(queueActions); });
+        this.planBtn = planBtn;
         var addBtn = el('button', { class: 'atex-pp-btn atex-pp-btn-primary atex-pp-add', type: 'button', text: '+ Новая резка' });
         addBtn.addEventListener('click', function() { self.openForm(); });
         queueActions.appendChild(genSpinner);
         queueActions.appendChild(genBtn);
+        queueActions.appendChild(planBtn);
         queueActions.appendChild(addBtn);
         var queueHead = el('div', { class: 'atex-pp-panel-head' }, [
             el('h2', { class: 'atex-pp-form-title', text: 'Очередь резок по станкам' }),

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -2117,6 +2117,30 @@ assertEqual(ops.updates, [{ cutId: 'c1', sequence: 1, planStartTs: 1780963200, p
 assertEqual(ops.creates, [{ parentCutId: 'c1', sequence: 2, planStartTs: 1781049600, plannedRuns: 5 }], 'planCutOperations: остаток → create продолжения на след. день (5 проходов)');
 assertEqual(ops.deletes, [], 'planCutOperations: нет прежних продолжений → нет удалений');
 
+// ── #3418: автопланирование пересобирает СОХРАНЁННУЮ очередь существующих резок ──
+// Сценарий со скриншота: три резки одного станко-дня, сохранённые старой генерацией
+// по ВОЗРАСТАНИЮ ножей (6,16,16). Правка алгоритма (#3412/#3415) меняет только новую
+// генерацию — уже созданные резки остаются как были, пока их не пересоберёт явный
+// триггер «Автопланирование» (runPlanning → planCutOperations → orderCuts по станкам).
+// Ожидаем порядок «Очередности»: ножи убывают (16,16,6).
+function cut3418(id, knifeWidths, runs) {
+    return { id: id, slitter: { id: 'm3' }, materialId: id === 'B' ? 'MR194' : 'MW308',
+        winding: 'OUT', knifeWidths: knifeWidths, knifeCount: knifeWidths.length,
+        plannedRuns: runs, planDate: '1780963200' };
+}
+function w3418(pairs) { var o = []; pairs.forEach(function(pr) { for (var i = 0; i < pr[1]; i++) o.push(pr[0]); }); return o; }
+var ops3418 = planning.planCutOperations(
+    [ cut3418('A', w3418([[152, 5], [110, 1]]), 1),   // 6 ножей, MW308
+      cut3418('C', w3418([[59, 14], [30, 2]]), 1),    // 16 ножей, MW308
+      cut3418('B', w3418([[59, 14], [30, 2]]), 1) ],  // 16 ножей, MR194
+    { perPassByCut: { A: 10, B: 10, C: 10 }, dayStartMin: 0, dayEndMin: 10000,
+      times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000 }
+);
+assertEqual(ops3418.updates.slice().sort(function(a, b) { return a.sequence - b.sequence; }).map(function(u) { return u.cutId; }),
+    ['B', 'C', 'A'], 'planCutOperations #3418: автопланирование переставляет 6,16,16 → 16,16,6 (ножи убывают)');
+assertEqual(ops3418.creates, [], 'planCutOperations #3418: один день, без переноса');
+assertEqual(ops3418.deletes, [], 'planCutOperations #3418: без удалений');
+
 // ── #3280: splitSupplyShares — деление Обеспечения по проходам (рулоны целые) ──
 assertEqual(planning.splitSupplyShares(15, 1500, [10, 5]), [{ rolls: 10, footage: 1000 }, { rolls: 5, footage: 500 }], 'splitSupplyShares: 15 рулонов / 1500 м по 10:5 → 10/1000 и 5/500');
 assertEqual(planning.splitSupplyShares(10, 90, [1, 1, 1]), [{ rolls: 4, footage: 30 }, { rolls: 3, footage: 30 }, { rolls: 3, footage: 30 }], 'splitSupplyShares: остаток рулона по наибольшей дробной части; сумма = 10');

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 9);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 10);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Refs #3418

## Симптом
После #3415 (алгоритм «ножи по убыванию при равной переналадке») и #3419 (пробитый VERSION) очередь резок на ideav.ru всё равно идёт по возрастанию: **Станок 3 → Полосы (6) → Полосы (16) → Полосы (16)**.

## Диагностика
Алгоритм **корректен**. Репродукция `orderCuts` на данных со скриншота (`positions_list.json` из #3418, `rollerWidth=0` — как их строит генерация) даёт `16,16,6` при любом входном порядке; цепочки `[6,16,16]` и `[16,16,6]` равны по переналадке (45 мин), tie-break ставит ножи по убыванию. Проблема не в сортировке:

1. Очередь рисуется по **сохранённой** «Очередности» (`groupBySlitter` сортирует по `sequence`; «ножи по убыванию» — лишь fallback для ещё не пронумерованных резок). Резки, созданные старой генерацией, хранят `sequence` 1,2,3 = 6,16,16.
2. «Сгенерировать резки» создаёт резки только под **необеспеченные** позиции. В логе #3418 после генерации `необеспеченных: 0`, поэтому повторное нажатие новых резок не создаёт и старую `sequence` не трогает.
3. Единственный триггер пересборки существующей очереди — `runPlanning`. Кнопку «Запланировать», вызывавшую его (#3075), убрали из формы в #3289, а метод остался **без единого вызова в UI**. Совет из #3419 «нажать автопланирование» ссылался на кнопку, которой нет.

## Фикс
- **`download/atex/js/production-planning.js`** — вернул явный триггер в шапку очереди: кнопка **«Автопланирование»** → `runPlanning` → `planCutOperations` → `orderCuts` по станкам → сохранение изменившейся «Очередности». Выбор стратегии (#3272: «мин. переналадок» / «сложные раньше») рисуется инлайн через `confirmAction`. Для резок со скриншота это переставляет `6,16,16 → 16,16,6` (B@1, C@2, A@3) без создания/удаления записей.
- **`index.php`** — `VERSION` 9 → 10 (клиенты однократно перекачивают исправленный js).

## Тесты
`experiments/atex-production-planning.test.js`: новый кейс #3418 — `planCutOperations` на трёх существующих резках станко-дня (сохранённый порядок 6,16,16) возвращает `updates` в порядке **16,16,6**, без creates/deletes.

`node experiments/atex-production-planning.test.js` → **478 assertions passed**.

## Действие пользователя после деплоя
Один раз нажать **«Автопланирование»** — существующая очередь пересоберётся по актуальному правилу (перегенерация резок не нужна).

🤖 Generated with [Claude Code](https://claude.com/claude-code)