### PR TITLE
fix(atex): повторная генерация резок идемпотентна — не пересоздавать продолжения (#3427)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2224,15 +2224,24 @@
     // #3280: план операций физического разбиения резок по дням. Сливает цепочки-продолжения
     // (mergeContinuationChains), упорядочивает очередь каждого станка (orderCuts) и
     // раскладывает по дням на уровне проходов (splitMachineQueue). →
-    //   { updates:[{cutId, sequence, planStartTs, plannedRuns}],            // первый сегмент → существующая запись
-    //     creates:[{parentCutId, sequence, planStartTs, plannedRuns}],       // продолжения → новые записи
-    //     deletes:[cutId…] }                                                 // записи-продолжения прежних цепочек
-    // Деление Обеспечения и копию Полос на продолжения выполняет аппликатор (нужны id новых
-    // записей и метаданные ссылок) — здесь только очередь/время/проходы. Вход не мутирует.
+    //   { updates:[{cutId, sequence, planStartTs, plannedRuns}],            // сегменты, легшие на существующие записи цепочки
+    //     creates:[{parentCutId, sequence, planStartTs, plannedRuns}],       // сегменты сверх имеющихся записей → новые
+    //     deletes:[cutId…] }                                                 // лишние записи цепочки (сегментов стало меньше)
+    // #3427: ИДЕМПОТЕНТНОСТЬ. Сегменты-продолжения переиспользуют УЖЕ существующие записи
+    // цепочки (chainByLogical: голова + продолжения по дням), а не пересоздаются каждый раз.
+    // Поэтому повторный прогон при неизменной раскладке даёт те же записи с теми же
+    // очередностью/временем/проходами → autoSequenceQueue отфильтрует их как «без изменений»
+    // и не сделает ни одной записи. Прежняя версия всегда удаляла продолжения и создавала их
+    // заново, а аппликатор при этом повторно делил уже делённое Обеспечение головы (метраж
+    // усыхал на каждый повтор). Новые записи — только если сегментов стало БОЛЬШЕ, чем записей
+    // в цепочке; удаления — только лишние записи, когда сегментов стало МЕНЬШЕ.
+    // Деление Обеспечения и копию Полос на новые продолжения выполняет аппликатор (нужны id
+    // новых записей и метаданные ссылок) — здесь только очередь/время/проходы. Вход не мутирует.
     function planCutOperations(cuts, opts){
         opts = opts || {};
         var base = Number(opts.planBaseMidnightMs);
         var merged = mergeContinuationChains(cuts);
+        var chainByLogical = merged.chainByLogical || {};
         var perPass = opts.perPassByCut || {};
         var byMachine = {}, mOrder = [];
         merged.cuts.forEach(function(c){
@@ -2242,7 +2251,9 @@
             if (!byMachine[key]) { byMachine[key] = []; mOrder.push(key); }
             byMachine[key].push(c);
         });
-        var updates = [], creates = [];
+        var updates = [], creates = [], deletes = [];
+        // headId → число использованных записей цепочки (голова + переиспользованные продолжения).
+        var usedByHead = {};
         mOrder.forEach(function(key){
             var ordered = orderCuts(byMachine[key], opts.weights);
             var runsByCut = {};
@@ -2253,16 +2264,38 @@
                 perPassByCut: perPass, runsByCut: runsByCut,
                 lunchStartMin: opts.lunchStartMin, lunchDurationMin: opts.lunchDurationMin
             });
+            // headId → индекс продолжения в цепочке (0=голова, 1,2,… — продолжения по дням).
+            var contIndexByHead = {};
             segs.forEach(function(seg, idx){
                 var ts = scheduleStartTimestamp(base, seg.windowStartMin);
                 if (!seg.isContinuation) {
-                    updates.push({ cutId: String(seg.cutId), sequence: idx + 1, planStartTs: ts, plannedRuns: seg.runs });
+                    var head0 = String(seg.cutId);
+                    contIndexByHead[head0] = 0;
+                    usedByHead[head0] = 1;   // голова цепочки всегда занята первым сегментом
+                    updates.push({ cutId: head0, sequence: idx + 1, planStartTs: ts, plannedRuns: seg.runs });
                 } else {
-                    creates.push({ parentCutId: String(seg.parentCutId), sequence: idx + 1, planStartTs: ts, plannedRuns: seg.runs });
+                    var head = String(seg.parentCutId);
+                    var k = (contIndexByHead[head] = (contIndexByHead[head] || 0) + 1);
+                    var chain = chainByLogical[head] || [head];
+                    var reuseId = chain[k];   // chain[0]=голова, chain[1..]=записи-продолжения
+                    if (reuseId != null) {
+                        usedByHead[head] = k + 1;
+                        updates.push({ cutId: String(reuseId), sequence: idx + 1, planStartTs: ts, plannedRuns: seg.runs });
+                    } else {
+                        creates.push({ parentCutId: head, sequence: idx + 1, planStartTs: ts, plannedRuns: seg.runs });
+                    }
                 }
             });
         });
-        return { updates: updates, creates: creates, deletes: merged.deletes };
+        // Лишние записи цепочки (сегментов стало меньше, чем записей) — на удаление. Цепочки
+        // станков, которые мы НЕ раскладывали (usedByHead нет), не трогаем — данные не теряем.
+        Object.keys(chainByLogical).forEach(function(head){
+            var chain = chainByLogical[head];
+            var used = usedByHead[head];
+            if (used == null) return;
+            for (var k = used; k < chain.length; k++) deletes.push(String(chain[k]));
+        });
+        return { updates: updates, creates: creates, deletes: deletes };
     }
 
     // #3280: разделить рулоны/метраж одной строки Обеспечения между сегментами резки

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -2153,6 +2153,48 @@ assertEqual(ops3421.updates.slice().sort(function(a, b) { return a.sequence - b.
 assertEqual(ops3421.creates, [], 'planCutOperations #3421: один день, без переноса');
 assertEqual(ops3421.deletes, [], 'planCutOperations #3421: без удалений');
 
+// ── #3427: повторная раскладка УЖЕ разбитой цепочки идемпотентна ───────────────
+// Цепочка [A(день0, 10 проходов) → B(день1, 5 проходов)] уже разбита по дням.
+// Повторный planCutOperations должен ПЕРЕИСПОЛЬЗОВАТЬ запись B как update (а не
+// удалить B и создать новое продолжение) — тогда autoSequenceQueue отфильтрует
+// неизменившиеся update'ы и не сделает ни одной записи (нет churn, обеспечение не
+// делится повторно). Прежняя версия всегда давала creates=[B'] + deletes=[B].
+var ops3427 = planning.planCutOperations(
+    [withSig('A', '1780963200', 10), withSig('B', '1781049600', 5)],
+    { perPassByCut: { A: 10, B: 10 }, dayStartMin: 0, dayEndMin: 100,
+      times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000 }
+);
+assertEqual(ops3427.updates,
+    [ { cutId: 'A', sequence: 1, planStartTs: 1780963200, plannedRuns: 10 },
+      { cutId: 'B', sequence: 2, planStartTs: 1781049600, plannedRuns: 5 } ],
+    'planCutOperations #3427: оба сегмента → update существующих записей цепочки (B переиспользована)');
+assertEqual(ops3427.creates, [], 'planCutOperations #3427: продолжение не пересоздаётся');
+assertEqual(ops3427.deletes, [], 'planCutOperations #3427: запись B не удаляется');
+
+// #3427: если раскладка изменилась и сегментов стало БОЛЬШЕ записей в цепочке —
+// первые сегменты переиспользуют записи, лишний сегмент создаётся.
+var ops3427grow = planning.planCutOperations(
+    [withSig('A', '1780963200', 25)],   // одна запись, но 25 проходов не влезают в 2 дня по 10
+    { perPassByCut: { A: 10 }, dayStartMin: 0, dayEndMin: 100,
+      times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000 }
+);
+assertEqual(ops3427grow.updates, [{ cutId: 'A', sequence: 1, planStartTs: 1780963200, plannedRuns: 10 }],
+    'planCutOperations #3427 (рост): голова — update');
+assertEqual(ops3427grow.creates.length, 2, 'planCutOperations #3427 (рост): 2 продолжения создаются (записей цепочки нет)');
+assertEqual(ops3427grow.deletes, [], 'planCutOperations #3427 (рост): без удалений');
+
+// #3427: если сегментов стало МЕНЬШЕ записей в цепочке — лишние записи удаляются.
+// Цепочка [A,B,C] на станке, но теперь всё влезает в один сегмент (день вмещает всё).
+var ops3427shrink = planning.planCutOperations(
+    [withSig('A', '1780963200', 3), withSig('B', '1781049600', 3), withSig('C', '1781136000', 3)],
+    { perPassByCut: { A: 10, B: 10, C: 10 }, dayStartMin: 0, dayEndMin: 10000,
+      times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000 }
+);
+assertEqual(ops3427shrink.updates, [{ cutId: 'A', sequence: 1, planStartTs: 1780963200, plannedRuns: 9 }],
+    'planCutOperations #3427 (сжатие): один сегмент → update головы (9 проходов)');
+assertEqual(ops3427shrink.creates, [], 'planCutOperations #3427 (сжатие): без создания');
+assertEqual(ops3427shrink.deletes, ['B', 'C'], 'planCutOperations #3427 (сжатие): лишние записи B,C удаляются');
+
 // ── #3280: splitSupplyShares — деление Обеспечения по проходам (рулоны целые) ──
 assertEqual(planning.splitSupplyShares(15, 1500, [10, 5]), [{ rolls: 10, footage: 1000 }, { rolls: 5, footage: 500 }], 'splitSupplyShares: 15 рулонов / 1500 м по 10:5 → 10/1000 и 5/500');
 assertEqual(planning.splitSupplyShares(10, 90, [1, 1, 1]), [{ rolls: 4, footage: 30 }, { rolls: 3, footage: 30 }, { rolls: 3, footage: 30 }], 'splitSupplyShares: остаток рулона по наибольшей дробной части; сумма = 10');

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 12);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 13);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3427

## Проблема
Повторное нажатие «Сгенерировать резки» (когда новых необеспеченных позиций нет) churn-ит записи: создаёт/удаляет продолжения и усыхает «Метраж, м» обеспечения, хотя раскладка не изменилась.

Из лога запросов #3427 видно прогрессирующее усыхание метража одной позиции на каждый повтор: `584.416 → 341.542 → 199.602`, плюс лишние `_m_new/1078` (новые продолжения) и `_m_del/69700`.

## Причина
«Сгенерировать резки» без необеспеченных позиций вызывает `autoSequenceQueue → planCutOperations`, который пересобирает очередь и физическое разбиение резок по дням (#3280).

Для разбитых по дням резок `planCutOperations` каждый раз:
1. `mergeContinuationChains` сливал цепочку записей-продолжений в одну логическую резку и помечал все продолжения **на удаление** (`deletes`);
2. `splitMachineQueue` пересоздавал те же сегменты **как новые записи** (`creates`).

→ На каждый прогон продолжения удалялись и создавались заново. `applySplitPlan` при создании продолжения повторно делил **уже делённое** Обеспечение головы (`splitSupplyShares` от `share[0]`, а не от полного метража) — метраж усыхал.

## Фикс
`planCutOperations` теперь **переиспользует существующие записи цепочки** (`chainByLogical`):
- сегменты-продолжения ложатся на уже созданные записи как `updates` (только очередность/время/проходы), а не пересоздаются;
- `creates` — только если сегментов стало **больше**, чем записей в цепочке;
- `deletes` — только лишние записи, когда сегментов стало **меньше**.

При неизменной раскладке `update`-ы совпадают с текущими значениями записей → `autoSequenceQueue` отфильтровывает их как «без изменений» (`changedUpdates`) и не делает **ни одной** записи. Обеспечение и полосы не трогаются → нет churn и усыхания метража.

`VERSION` 12→13 — клиенты однократно перекачают исправленный `production-planning.js` (кеш-бастер `?0{_global_.version}`, #3418).

## Тесты
`experiments/atex-production-planning.test.js` (489 assertions, все зелёные):
- **идемпотентность**: уже разбитая цепочка `[A(день0), B(день1)]` → оба сегмента `update` существующих записей (B переиспользована), `creates=[]`, `deletes=[]`;
- **рост**: сегментов больше записей → голова `update`, лишние сегменты `create`;
- **сжатие**: сегментов меньше записей → лишние записи `delete`.

Прежние тесты #3280/#3421 (разбиение по дням, пересборка очереди) — без изменений, проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)