### PR TITLE
fix(atex): «ID заказа» для партий на несколько заказов (#3435) + жёлтая плашка подтверждения

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -14,6 +14,10 @@
     --pp-info-text: #3730a3;
     --pp-warn: var(--color-error, #b91c1c);
     --pp-ok: var(--color-success, #15803d);
+    /* Жёлтая плашка подтверждения генерации — чтобы её было видно. */
+    --pp-attn-bg: #fef08a;       /* amber-200 */
+    --pp-attn-border: #eab308;   /* amber-500 */
+    --pp-attn-text: #713f12;     /* amber-900 — читаемо на жёлтом */
     color: var(--text-primary, #1f2933);
     font-size: 14px;
     box-sizing: border-box;
@@ -22,6 +26,9 @@
 [data-theme="dark"] .atex-pp {
     --pp-info-bg: rgba(129, 140, 248, 0.18);
     --pp-info-text: #c4b5fd;
+    --pp-attn-bg: rgba(234, 179, 8, 0.22);
+    --pp-attn-border: #eab308;
+    --pp-attn-text: #fde68a;
 }
 
 .atex-pp *,
@@ -130,13 +137,13 @@
     flex-wrap: wrap;
     width: 100%;
     padding: 8px;
-    border: 1px solid var(--pp-border-soft);
+    border: 1px solid var(--pp-attn-border);
     border-radius: 6px;
-    background: var(--pp-surface);
+    background: var(--pp-attn-bg);
 }
 .atex-pp-confirm-msg {
     flex: 1 1 220px;
-    color: var(--pp-muted);
+    color: var(--pp-attn-text);
 }
 .atex-pp-panel-actions .atex-pp-confirm-bar {
     flex-basis: 100%;

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -284,19 +284,19 @@
         return round3(s * (runs > 0 ? runs : 1));
     }
 
-    // #3433: «ID заказа» партии = заказ, если все её непустые заказы совпадают (один
-    // заказ); запас или несколько заказов → '' (свободная партия, заполнится при
-    // подхватывании при расчёте резки). orderIds — список id заказов покрытых позиций.
-    function singleOrderId(orderIds) {
-        var seen = '';
+    // #3433/#3435: «ID заказа» партии = заказы покрытых позиций (под заказ). Партия,
+    // покрывающая спрос, ДОЛЖНА иметь непустой «ID заказа», иначе её ошибочно сочтут
+    // свободной (запас) и переиспользуют. Один заказ → его id; несколько разных →
+    // через запятую (партия делится между заказами); спроса нет (запас) → '' (заполнится
+    // при подхватывании свободной партии). orderIds — список id заказов покрытых позиций.
+    function batchOrderId(orderIds) {
+        var seen = [];
         var list = orderIds || [];
         for (var i = 0; i < list.length; i++) {
             var id = String(list[i] == null ? '' : list[i]).trim();
-            if (id === '') continue;
-            if (seen === '') seen = id;
-            else if (seen !== id) return '';
+            if (id !== '' && seen.indexOf(id) === -1) seen.push(id);
         }
-        return seen;
+        return seen.join(',');
     }
 
     // #3242/#3431/#3433: поля записи «Партия ГП» (состав резки): Ширина, Кол-во полос
@@ -3025,7 +3025,7 @@
         buildSupplyFieldsForFinishedBatch: buildSupplyFieldsForFinishedBatch,
         buildFinishedBatchFields: buildFinishedBatchFields,
         finishedBatchRolls: finishedBatchRolls,
-        singleOrderId: singleOrderId,
+        batchOrderId: batchOrderId,
         layoutPositionGroups: layoutPositionGroups,
         rowsToPlanning: rowsToPlanning,
         cutPlanningReportDiagnostics: cutPlanningReportDiagnostics,
@@ -5285,10 +5285,10 @@
                     var batchChain = Promise.resolve();
                     producedBatchesForLayout(lay, runLength).forEach(function(batch) {
                         batchChain = batchChain.then(function() {
-                            // #3431/#3433: «Кол-во полос» = полос за проход (batch.strips);
+                            // #3431/#3433/#3435: «Кол-во полос» = полос за проход (batch.strips);
                             // «Кол-во план» = полосы × проходов сегмента; «Кол-во рулонов» =
-                            // спрос обеспечений этой ширины; «ID заказа» = их общий заказ
-                            // (несколько/нет — пусто = в запас).
+                            // спрос обеспечений этой ширины; «ID заказа» = заказы покрытых
+                            // позиций (несколько → через запятую; спроса нет → пусто = запас).
                             var key = stripWidthKey(batch.width);
                             var demand = demandByWidth[key];
                             var fields = buildFinishedBatchFields(finishedBatchMeta, {
@@ -5296,7 +5296,7 @@
                                 strips: batch.strips,
                                 planned: finishedBatchRolls(batch.strips, plannedRuns),
                                 rolls: demand > 0 ? demand : '',
-                                orderId: singleOrderId(ordersByWidth[key]),
+                                orderId: batchOrderId(ordersByWidth[key]),
                                 footage: batch.length > 0 ? batch.length : '',
                                 active: '1'
                             });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -752,11 +752,14 @@ assertEqual(planning.buildFinishedBatchFields(fbMeta3433,
   { t1186: 110, t70190: 2, t70575: 12, t1192: '1' },
   'buildFinishedBatchFields #3433: пустой спрос/ID заказа (запас) → поля пропущены');
 
-// #3433: singleOrderId — общий заказ списка позиций или '' (запас/несколько заказов).
-assertEqual(planning.singleOrderId(['7', '7', '']), '7', 'singleOrderId: один заказ (пустые игнорируются)');
-assertEqual(planning.singleOrderId(['7', '9']), '', 'singleOrderId: несколько заказов → пусто');
-assertEqual(planning.singleOrderId(['', '']), '', 'singleOrderId: все пустые → пусто');
-assertEqual(planning.singleOrderId([]), '', 'singleOrderId: пусто → пусто');
+// #3433/#3435: batchOrderId — заказы покрытых позиций; несколько → через запятую,
+// спроса нет → '' (запас). Партия под заказ ОБЯЗАНА иметь непустой «ID заказа».
+assertEqual(planning.batchOrderId(['7', '7', '']), '7', 'batchOrderId: один заказ (дубли/пустые свернуты)');
+assertEqual(planning.batchOrderId(['7', '9']), '7,9', 'batchOrderId #3435: несколько заказов → через запятую (не пусто)');
+assertEqual(planning.batchOrderId(['7', '', '9', '7']), '7,9', 'batchOrderId #3435: различные id, сохранён порядок появления');
+assertEqual(planning.batchOrderId(['', '']), '', 'batchOrderId: все пустые → пусто (запас)');
+assertEqual(planning.batchOrderId([]), '', 'batchOrderId: пусто → пусто (запас)');
+assertEqual(planning.batchOrderId(undefined), '', 'batchOrderId: undefined → пусто');
 var supMeta3242 = { id: '1077', val: 'Обеспечение', reqs: [
   { id: '1149', val: 'Метраж, м' }, { id: '1154', val: 'В работе' },
   { id: '15016', val: 'Партия ГП', ref: '1081' }, { id: '16424', val: 'Кол-во рулонов' }


### PR DESCRIPTION
Follow-up к #3433 (PR #3434). Эти два коммита были запушены уже **после** squash-мержа #3434, поэтому не попали в `main` — возвращаем отдельным PR.

## fix #3435 — «ID заказа» «Партии ГП» на несколько заказов

Когда одна ширина «Партии ГП» консолидирует спрос позиций **разных заказов** (напр. ширина 110: позиция → заказ 3067 и позиция → заказ 3068), прежняя `singleOrderId` возвращала `''` → «ID заказа» пустой → партия под заказ ошибочно считалась свободной (запас) и переиспользовалась/задваивалась.

`singleOrderId` → `batchOrderId`: объединяет различные id заказов через запятую (`"3067,3068"`). Пусто остаётся **только** когда спроса нет вовсе (чистый запас/впрок). Так партия под заказ всегда имеет непустой «ID заказа».

## style — жёлтая плашка подтверждения генерации (`atex-pp-confirm-bar`)

Плашка «Создать N резок?» была на `--pp-surface` с мягкой рамкой — почти не видна. Делаем жёлтой (amber-токены `--pp-attn-*`, светлая и тёмная темы), текст `--pp-attn-text` для читаемости.

## Тесты

Все 12 atex-тестов зелёные; ассерты `batchOrderId` (несколько заказов → через запятую, запас → пусто) в `atex-production-planning.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)