### PR TITLE
fix(atex): пробить VERSION 15→16 — клиенты подтянут жёлтую плашку подтверждения

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 15);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 16);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
## Симптом
Жёлтая плашка подтверждения генерации (`.atex-pp-confirm-bar`) после мержа не видна у пользователей.

## Причина
CSS жёлтой плашки лежит в `production-planning.css` (есть в `main` — реверты её не потеряли). Но `VERSION` не бился, когда CSS менялся:
- #3434 (`b8f03303`) поднял `VERSION` 14→15 и **не трогал** `production-planning.css` → клиенты закэшировали `production-planning.css?015` = **серая** плашка.
- Жёлтый CSS приехал в #3436, но `VERSION` остался 15 (уже был 15 от #3433). Один и тот же URL `?015`, другое содержимое → браузер отдаёт серую плашку из кэша.

## Фикс
`VERSION` 15→16 — клиенты перезапросят `production-planning.css?016` с жёлтой плашкой.

Файлов CSS/JS не трогаю — они уже корректны в `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)