### PR TITLE
fix(upload): экранировать значение ячейки в формуле — перевод строки не ломает импорт (#3440)

### DIFF
--- a/experiments/test-issue-3440-import-formula-linebreaks.js
+++ b/experiments/test-issue-3440-import-formula-linebreaks.js
@@ -1,0 +1,125 @@
+// Regression test for issue #3440.
+//
+// "https://github.com/ideav/crm/pull/3394/changes Ломается импорт если есть
+//  переводы строк."
+//
+// PR #3394 (issue #3390) only fixed how an in-cell line break is *displayed* in
+// the preview (CSS white-space: pre-line). Parsing is fine — PapaParse keeps a
+// quoted multi-line field as ONE record. The break that remained is in the
+// FORMULA path: templates/upload.html lets a user attach a JS formula to an
+// output column, with `[ColumnName]` placeholders. The placeholder is replaced
+// by the raw cell value and the whole expression is run through eval().
+//
+// When a referenced cell carries an in-cell line break (e.g.
+//   "52мм х 17 / 21 резок (884мм)\nФМ лоджистик")
+// and the formula wraps the placeholder in quotes (the usual way to use a text
+// column, e.g. '[Примечание]'), the raw "\n" lands inside a JS string literal
+// and turns it into an UNTERMINATED multi-line literal → eval() throws
+// SyntaxError → the preview cell is painted yellow (cell-error) and the row is
+// counted as an error (the "ошибок: 74" in the issue screenshot).
+//
+// The fix: escapeFormulaValue() escapes the substituted value so it is safe
+// inside a JS string literal (', " or `), while leaving plain numeric/unquoted
+// values untouched and PRESERVING the embedded newline in the resulting string.
+//
+// This test extracts the REAL escapeFormulaValue() from the template and
+// replays the exact substitute→eval pipeline from importDoParse().
+
+var fs = require('fs');
+var path = require('path');
+
+var passed = 0, failed = 0;
+function check(name, ok){
+  console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+  if (ok) passed++; else { failed++; process.exitCode = 1; }
+}
+
+var template = fs.readFileSync(path.join(__dirname, '..', 'templates', 'upload.html'), 'utf8');
+
+function extractFn(name){
+  var start = template.indexOf('function ' + name + '(');
+  if (start < 0) throw new Error(name + '() not found in template');
+  var depth = 0, end = -1;
+  for (var i = template.indexOf('{', start); i < template.length; i++) {
+    if (template[i] === '{') depth++;
+    else if (template[i] === '}') { depth--; if (depth === 0) { end = i + 1; break; } }
+  }
+  return template.slice(start, end);
+}
+
+// Materialise the real helper from the template.
+var escapeFormulaValue =
+  new Function('return ' + extractFn('escapeFormulaValue').replace(/^function\s+\w+/, 'function'))();
+
+// The exact substitution+eval that importDoParse() runs for a formula column.
+// `row` is the parsed source record; `colIndex` maps a [Name] placeholder to a
+// column. Returns {value} on success or {error} on a thrown eval (mirrors the
+// evalErrs branch that paints the cell yellow).
+function runFormula(formula, row, colIndex, useFix){
+  var expr = formula.replace(/\[(.+?)\]/mug, function($1, $2){
+    if (colIndex[$2] !== undefined)
+      return useFix ? escapeFormulaValue(row[colIndex[$2]]) : row[colIndex[$2]];
+    return '[' + $2 + ']';
+  });
+  try { return { value: eval(expr) }; }       // eslint-disable-line no-eval
+  catch (e){ return { error: e }; }
+}
+
+// Issue data: 4th column carries an in-cell line break.
+var MULTILINE = '52мм х 17 / 21 резок (884мм)\nФМ лоджистик';
+var row = ['2910', '', 'MR192 52 х 450 OUT (П)', MULTILINE, '07.05.2026', '', '', '357'];
+var colIndex = { 'Примечание': 3, 'Кол-во': 7, 'Название': 2 };
+
+// ── 0. Confirm the original break still happens WITHOUT the fix ──────────────
+(function(){
+  var r = runFormula("'[Примечание]'", row, colIndex, /*useFix=*/false);
+  check('without the fix, a quoted multi-line cell makes eval() throw (the bug)',
+    !!r.error && r.error instanceof SyntaxError);
+})();
+
+// ── 1. With the fix, the same formula evaluates and keeps the newline ────────
+(function(){
+  var r = runFormula("'[Примечание]'", row, colIndex, /*useFix=*/true);
+  check('with the fix, quoted multi-line cell evaluates without error',
+    !r.error);
+  check('with the fix, the evaluated value equals the original cell (newline kept)',
+    r.value === MULTILINE && r.value.indexOf('\n') !== -1);
+})();
+
+// ── 2. Works regardless of which quote style the author used ─────────────────
+(function(){
+  var single = runFormula("'[Примечание]'", row, colIndex, true);
+  var dbl    = runFormula('"[Примечание]"', row, colIndex, true);
+  var tick   = runFormula('`[Примечание]`', row, colIndex, true);
+  check('fix works for single/double/backtick-quoted placeholders',
+    !single.error && !dbl.error && !tick.error &&
+    single.value === MULTILINE && dbl.value === MULTILINE && tick.value === MULTILINE);
+})();
+
+// ── 3. Quotes/backslashes inside the value no longer break eval ──────────────
+(function(){
+  var tricky = ["o'b\\rien", '', 'x', 'a"b`c\\d', '', '', '', '1'];
+  var r = runFormula("'[Примечание]'", tricky, colIndex, true);
+  check('values with quotes/backslashes evaluate verbatim under the fix',
+    !r.error && r.value === 'a"b`c\\d');
+})();
+
+// ── 4. Numeric / unquoted formulas are unchanged (backward compatible) ───────
+(function(){
+  var r = runFormula('[Кол-во]*2', row, colIndex, true);
+  check('numeric unquoted formula [Кол-во]*2 still evaluates (357*2 = 714)',
+    !r.error && r.value === 714);
+
+  var concat = runFormula("'[Название]'+' / '+[Кол-во]", row, colIndex, true);
+  check('mixed text+number formula still works',
+    !concat.error && concat.value === 'MR192 52 х 450 OUT (П) / 357');
+})();
+
+// ── 5. The escape helper itself: no special chars left to break a literal ────
+(function(){
+  var out = escapeFormulaValue(MULTILINE);
+  check('escapeFormulaValue() removes raw newline (turns it into the \\n escape)',
+    out.indexOf('\n') === -1 && out.indexOf('\\n') !== -1);
+})();
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -690,6 +690,26 @@ function parseUploadText(text,options){
     }
     Papa.parse(parseText,parseOptions);
 }
+// issue #3440: значение колонки подставляется в текст формулы и выполняется через
+// eval(). Если ячейка содержит перевод строки (многострочное значение из Excel/CSV,
+// напр. "52мм … (884мм)\nФМ лоджистик"), а в формуле плейсхолдер обёрнут в кавычки
+// ('[Примечание]'), то сырой \n внутри строкового литерала рвёт его и eval падает с
+// SyntaxError — в превью ячейка подсвечивается жёлтым (cell-error) и строка считается
+// ошибочной. Поэтому подставляемое значение экранируем так, чтобы оно было безопасным
+// внутри строкового литерала JS (', " или `): спецсимволы и переводы строк уходят в
+// escape-последовательности. Числовые/незакавыченные значения (357, [Кол-во]*2) не
+// содержат спецсимволов и остаются как есть; перевод строки сохраняется в значении.
+function escapeFormulaValue(v){
+    return String(v===undefined||v===null?'':v)
+        .replace(/\\/g,'\\\\')
+        .replace(/'/g,"\\'")
+        .replace(/"/g,'\\"')
+        .replace(/`/g,'\\`')
+        .replace(/\r/g,'\\r')
+        .replace(/\n/g,'\\n')
+        .replace(/\u2028/g,'\\u2028')
+        .replace(/\u2029/g,'\\u2029');
+}
 function escapeSlashesNSemicolons(v){
     return serializeUploadCellValue(v).replace(/\\/gm,'\\\\').replace(/;/gm,'\\;');
 //    return v.replace(/\\/gm,'\\\\').replace(/;/gm,'\\;');
@@ -1296,7 +1316,7 @@ function importDoParse(input){
                     if(formulas[sourceMap[j].id]){
                         expr=formulas[sourceMap[j].id].replace(/\[(.+?)\]/mug,function($1,$2){
                                 if(reverseMap[$2]!==undefined)
-                                    return input.data[i][reverseMap[$2]];
+                                    return escapeFormulaValue(input.data[i][reverseMap[$2]]);
                                 return '['+$2+']';
                             });
                         try{


### PR DESCRIPTION
## Что и почему

Issue #3440: при импорте «ломается» строка, если ячейка содержит **перевод строки внутри значения** (4-я колонка строк 2910–2912 в данных issue: `"52мм х 17 / 21 резок (884мм)\nФМ лоджистик"`). В превью такие строки помечаются жёлтым как ошибочные («ошибок: 74» на скриншоте).

### Где была проблема (и где её НЕ было)

- **Парсинг не виноват.** PapaParse 5.3.1 с теми же опциями, что и в `importParse()`, держит закавыченное многострочное поле как **одну** запись из 8 полей, `\n` сохраняется (проверено на данных из issue).
- **PR #3394 (issue #3390) починил только отображение** (`white-space: pre-line`) — это верно для парсинга, но осталось ещё одно звено.
- Сломанная строка 2910 на скриншоте на самом деле распарсена корректно (все колонки на месте). Жёлтой была **только колонка с формулой**, а жёлтый в превью бывает исключительно от ошибки `eval` формулы (`evalErrs`).

### Корень

`templates/upload.html`: колонке импорта можно задать JS-формулу с плейсхолдерами `[Имя колонки]`. Значение ячейки подставляется **в сыром виде прямо в текст формулы** и выполняется через `eval()`:

```js
expr=formulas[...].replace(/\[(.+?)\]/mug,function($1,$2){
    if(reverseMap[$2]!==undefined)
        return input.data[i][reverseMap[$2]];   // ← сырое значение в исходник
    ...
});
toImport[l][jMap]=serializeUploadCellValue(eval(expr));
```

Когда значение многострочное, а в формуле плейсхолдер обёрнут в кавычки (обычный способ работы с текстовой колонкой, `'[Примечание]'`), сырой `\n` попадает внутрь строкового литерала и делает его незакрытым → `eval` падает с `SyntaxError: Invalid or unexpected token` → ячейка жёлтая, строка в «ошибки».

### Что изменено

Добавлен `escapeFormulaValue()`, которым экранируется подставляемое значение, чтобы оно было безопасно внутри строкового литерала JS (`'`, `"` или `` ` ``): `\`, кавычки, `\r`, `\n`, `U+2028`/`U+2029` уходят в escape-последовательности.

- Числовые/незакавыченные формулы (`[Кол-во]*2`) не содержат спецсимволов → результат не меняется.
- Перевод строки **сохраняется** в итоговом значении (как и задумано в #3390) и дальше доходит до `.bki` без изменений (`escapeSlashesNSemicolons` уже держит `\n`).

## Как воспроизвести

1. Импорт (`templates/upload.html`), вставить данные из issue (4-я колонка — перевод строки внутри кавычек), на текстовой колонке задать формулу с плейсхолдером в кавычках (`'[Примечание]'`).
2. **До:** ячейка формулы жёлтая, строка в «ошибки» (`SyntaxError`).
3. **После:** формула выполняется, значение с переводом строки сохраняется.

## Тест

`experiments/test-issue-3440-import-formula-linebreaks.js` — извлекает реальный `escapeFormulaValue()` из шаблона и повторяет цепочку подстановка→`eval` из `importDoParse()`:

- без фикса `eval` бросает `SyntaxError` (baseline, подтверждает баг);
- с фиксом формула выполняется и сохраняет `\n`;
- работают одинарные/двойные/обратные кавычки, значения с кавычками и бэкслешами;
- числовые формулы (`[Кол-во]*2` = 714) и `текст+число` не сломаны.

`8 passed, 0 failed`. Регресс-тест #3390 — по-прежнему `8 passed`.

Fixes #3440