### PR TITLE
feat(atex): «Сгенерировать резки» перезапрашивает positions_list перед планированием (#3444)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -4832,13 +4832,6 @@
         if (this.busy) return;
         console.log('[pp] ⚙️ generateCuts: начало генерации резок...');
 
-        // #(no-srok-when-on-time): срок учитываем (дробим позиции по окну) только если
-        // есть просроченные относительно даты планирования. Если все позиции укладываются
-        // в свой срок (dueKey ≥ planDateKey), окно не нужно — объединяем в один кластер.
-        var planBaseMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
-        var pbmD = new Date(planBaseMs);
-        var planDateKey = pbmD.getFullYear() * 10000 + (pbmD.getMonth() + 1) * 100 + pbmD.getDate();
-
         var layoutCore = (typeof window !== 'undefined' && window.AtexCutLayout && window.AtexCutLayout.layout) || null;
         if (!layoutCore || typeof layoutCore.planLayouts !== 'function') {
             console.error('[pp] ⚙️ generateCuts: модуль cut-layout не загружен');
@@ -4850,6 +4843,42 @@
             this.notify('Не найдены метаданные таблиц (Резка/Обеспечение/Партия ГП)', 'error');
             return;
         }
+
+        // #3444: перед планированием перезапросить позиции (report/positions_list) и
+        // обеспечение/резки — в соседней вкладке могли загрузить новые заказы или сменить
+        // дату, и по кэшу мы бы перепланировали старые позиции вместо генерации новых
+        // резок. Прежнее подтверждение убираем и показываем заново на свежих данных.
+        if (this._genRefreshing) return;
+        var refreshHost = actionsEl || (this.root && this.root.querySelector('.atex-pp-panel-actions'));
+        var oldBar = refreshHost && refreshHost.querySelector && refreshHost.querySelector('.atex-pp-confirm-bar');
+        if (oldBar && oldBar.parentNode) oldBar.parentNode.removeChild(oldBar);
+        this._genRefreshing = true;
+        this.setGenBusy(true);
+        Promise.all([this.loadPositions(), this.reload()]).then(function() {
+            self._genRefreshing = false;
+            self.setGenBusy(false);
+            self.render();
+            self.planAndConfirmCuts(actionsEl);
+        }).catch(function(err) {
+            self._genRefreshing = false;
+            self.setGenBusy(false);
+            console.error('[pp] ⚙️ generateCuts: не удалось обновить данные перед планированием', err);
+            self.notify('Не удалось обновить данные перед планированием: ' + (err && err.message || err), 'error');
+        });
+    };
+
+    // #3444: планирование + подтверждение (вызывается после перезапроса позиций/обеспечения).
+    AtexProductionPlanning.prototype.planAndConfirmCuts = function(actionsEl) {
+        var self = this;
+        var layoutCore = (typeof window !== 'undefined' && window.AtexCutLayout && window.AtexCutLayout.layout) || null;
+        if (!layoutCore || typeof layoutCore.planLayouts !== 'function') return;
+
+        // #(no-srok-when-on-time): срок учитываем (дробим позиции по окну) только если
+        // есть просроченные относительно даты планирования. Если все позиции укладываются
+        // в свой срок (dueKey ≥ planDateKey), окно не нужно — объединяем в один кластер.
+        var planBaseMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
+        var pbmD = new Date(planBaseMs);
+        var planDateKey = pbmD.getFullYear() * 10000 + (pbmD.getMonth() + 1) * 100 + pbmD.getDate();
 
         // Необеспеченные позиции, сгруппированные по совместимому профилю:
         // сырьё + направление намотки + длина намотки.
@@ -4951,10 +4980,10 @@
 
             // #3253: в подтверждении не считаем полосы/ножи — только число резок.
             var nCuts = allLayouts.length;
+            // #3444: вопрос «Создать N резок?» — в конце, после «Пропущено N».
             var msg = el('span', { class: 'atex-pp-confirm-msg' });
             msg.appendChild(document.createTextNode(
-                'Не обеспечено резками и складом позиций: ' + unsup.length +
-                '. Создать ' + nCuts + ' резок? '));
+                'Не обеспечено резками и складом позиций: ' + unsup.length + '. '));
             if (skipped.length) {
                 var skipLink = el('a', { class: 'atex-pp-skipped-link', href: '#',
                     text: 'Пропущено ' + skipped.length,
@@ -4964,10 +4993,11 @@
                     self.openSkippedReport(skipped);
                 });
                 msg.appendChild(skipLink);
-                msg.appendChild(document.createTextNode('.'));
+                msg.appendChild(document.createTextNode('. '));
             } else {
-                msg.appendChild(document.createTextNode('Пропущено 0.'));
+                msg.appendChild(document.createTextNode('Пропущено 0. '));
             }
+            msg.appendChild(document.createTextNode('Создать ' + nCuts + ' резок?'));
 
             // Единая кнопка генерации. Очередь строим по минимуму переналадки (#3268)
             // с ножами по убыванию (#3130) — стратегия SETUP. Прежняя «сложные раньше»

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 16);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 17);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3444.

## 1. Перезапрос позиций перед планированием
По кнопке «Сгенерировать резки» теперь сначала заново запрашиваются `report/positions_list?JSON_KV` (`loadPositions`) и обеспечение/резки (`reload`), затем перерисовка очереди и показ подтверждения на свежих данных.

Зачем: в соседней вкладке могли загрузить новые заказы или сменить дату. По кэшу `genPositions`/`supplies` мы бы перепланировали старые позиции вместо генерации новых резок. Теперь берём актуальные данные → уже обеспеченные/созданные в другой вкладке позиции не перепланируются.

Реализация: тело планирования вынесено в `planAndConfirmCuts(actionsEl)`; `generateCuts` стал оркестратором (guards → убрать прежнюю `.atex-pp-confirm-bar` → refresh → render → planAndConfirmCuts). Защита от двойного клика (`_genRefreshing`), спиннер генерации на время запроса. `queueActions` (контейнер подтверждения) переживает `render()` — он создаётся один раз в `start()`.

## 2. Вопрос в конце сообщения
Было: `Не обеспечено резками и складом позиций: 14. Создать 10 резок? Пропущено 0.`
Стало: `Не обеспечено резками и складом позиций: 14. Пропущено 0. Создать 10 резок?`

## Прочее
VERSION 16→17 (правка js → клиенты подтянут production-planning.js). Если PR #3443 уже поднял до 17 — тривиальный конфликт в одну строку (оставить 17). Все 12 atex-тестов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)