### PR TITLE
fix(atex): в колонке «№» заказов выводить order_no, а не order_id (#3447)

### DIFF
--- a/download/atex/js/orders.js
+++ b/download/atex/js/orders.js
@@ -903,7 +903,7 @@
             var main = '<tr class="atex-orders-row" data-order-id="' + escapeHtml(order.id) + '">' +
                 '<td class="atex-orders-toggle-cell"><button type="button" class="atex-orders-toggle" data-toggle="' + escapeHtml(order.id) + '" title="Позиции">' +
                 '<i class="pi ' + (isOpen ? 'pi-chevron-down' : 'pi-chevron-right') + '"></i></button></td>' +
-                '<td>' + escapeHtml(order.id) + '</td>' +
+                '<td>' + escapeHtml(order.values.no || '') + '</td>' +
                 '<td>' + escapeHtml(order.values.client || '') + '</td>' +
                 '<td>' + escapeHtml(order.values.manager || '') + '</td>' +
                 orderDisplayCell(order, 'created') +

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 17);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 18);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3447

## Что
В рабочем месте «Заказы» (`templates/atex/orders.html` → `download/atex/js/orders.js`) колонка **«№»** выводила внутренний `order_id` записи. Теперь выводим человекочитаемый номер заказа `order_no` (`order.values.no`).

## Как
- `orders.js`, рендер строки заказа: ячейка «№» — `order.id` → `order.values.no || ''`.
- Внутренний `order.id` остаётся в `data-order-id` / `data-toggle` / `data-approve-order` (действия и API) и в поиске — не трогаем.
- `index.php`: `VERSION` 17→18 — cache-bust, клиенты подтянут обновлённый `orders.js`.

## Проверки
- `node --check download/atex/js/orders.js` — синтаксис ОК.
- `order.values.no` заполняется в `rowsToOrders` из `order_no` отчёта `orders_list` — данные уже есть, доп. запросов не нужно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)