### PR TITLE
fix(atex): «Сгенерировать резки» не перепланирует запланированные резки (#3449)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -4893,14 +4893,11 @@
         var unsup = uncoveredPositions(this.genPositions, this.supplies).filter(function(p) { return p.approved; });
         console.log('[pp] ⚙️ generateCuts: всего позиций:', this.genPositions.length, ', необеспеченных согласованных:', unsup.length);
         if (!unsup.length) {
-            // Новых резок нет, но «Сгенерировать резки» всё равно приводит очередь в
-            // нормальный вид (#3421): пересобираем «Очередность» уже созданных резок
-            // (в т.ч. сохранённых старой генерацией как 6,16,16 → 16,16,6).
-            console.log('[pp] ⚙️ generateCuts: необеспеченных нет — пересобираю очередь существующих резок');
-            this.autoSequenceQueue(PLANNING_STRATEGY_SETUP).then(function(changed) {
-                self.notify(changed ? 'Очередь резок пересобрана (минимум переналадок)'
-                                    : 'Нет необеспеченных позиций; очередь уже в нужном порядке', 'info');
-            });
+            // #3449: «Сгенерировать резки» только вытаскивает незапланированные позиции.
+            // Если таких нет — ничего не делаем: уже запланированные резки не трогаем и
+            // очередь не пересобираем (это оператор сделает сам, удалив резки и Партии ГП).
+            console.log('[pp] ⚙️ generateCuts: незапланированных позиций нет — очередь не трогаем');
+            self.notify('Нет незапланированных позиций для генерации резок', 'info');
             return;
         }
         var profiles = groupPositionsByPlanningProfile(unsup);
@@ -5434,10 +5431,9 @@
                 ', заданий на втулки ' + nSleeveTasks +
                 (sleeveMin > 0 ? ' (' + sleeveMin + ' мин)' : '') +
                 ', пропущено ' + skipped.length + ' позиций' + (reasons ? ' (' + reasons + ')' : ''), 'success');
-            // #3421: свести новые резки с уже существующими в единую правильную очередь
-            // (перемежить по станко-дням, ножи по убыванию). Если порядок уже верный —
-            // no-op без записи. applySplitPlan сам делает reload+render.
-            return self.autoSequenceQueue(PLANNING_STRATEGY_SETUP);
+            // #3449: уже запланированные резки не трогаем и очередь не пересобираем.
+            // Новые резки получают «Очередность»/плановое время при создании (дописываются
+            // после существующих в своей группе слиттер/день), reload+render уже сделаны выше.
         }).catch(function(err) {
             self.hideProgress();
             self.setBusy(false);
@@ -6598,8 +6594,9 @@
         genBtn.addEventListener('click', function() { self.generateCuts(queueActions); });
         this.genBtn = genBtn;
         this.genSpinner = genSpinner;
-        // Отдельной кнопки «Автопланирование» нет (#3421): «Сгенерировать резки» само
-        // приводит очередь в нормальный вид (autoSequenceQueue в generateCuts).
+        // «Сгенерировать резки» только создаёт резки для незапланированных позиций и
+        // дописывает их в конец очереди (#3449); уже запланированные резки не трогает.
+        // Перестановку очереди оператор делает вручную (↑↓).
         var addBtn = el('button', { class: 'atex-pp-btn atex-pp-btn-primary atex-pp-add', type: 'button', text: '+ Новая резка' });
         addBtn.addEventListener('click', function() { self.openForm(); });
         queueActions.appendChild(genSpinner);

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 17);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 18);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3449

## Проблема
По кнопке «Сгенерировать резки» происходила пересборка очереди уже запланированных резок (сообщение «Очередь резок пересобрана (минимум переналадок)»), чего оператор не просил.

## Что меняется
Кнопка теперь **только** вытаскивает незапланированные позиции и создаёт под них резки; уже запланированные резки не трогает и очередь не пересобирает.

- **Нет незапланированных позиций** → уведомление «Нет незапланированных позиций для генерации резок», без `autoSequenceQueue` (убрано «Очередь резок пересобрана»).
- **После создания новых резок** очередь не переоптимизируем (`autoSequenceQueue` убран из `runGenerateCuts`). Новые резки и так получают «Очередность»/плановое время при создании: `sequenceCuts` сидируется существующими резками, `nextSequenceForCuts` даёт `max+1` в группе слиттер/день — то есть новые **дописываются после** существующих, не сдвигая их.
- Перестановку очереди оператор делает вручную (↑↓). Нужна пересборка — удалит резки и Партии ГП и сгенерирует заново.

`index.php`: `VERSION` 17→18 — cache-bust `production-planning.js`.

## Проверки
- `node --check download/atex/js/production-planning.js` — ОК.
- `autoSequenceQueue` больше не вызывается из генерации (определение оставлено как helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)