### PR TITLE
fix(atex): не планировать резки без партии сырья (#3453)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5093,6 +5093,16 @@
             var plannedRuns = plannedRunsForLayout(lay, posById);
             var runLength = layoutRunLength(lay, posById);
             var batchId = pickBatchFIFOForRun(self.genBatches, lay.mat, runLength, batchRemainingById);
+            // #3453: нет партии сырья (нет активной «Партии сырья» этого вида с остатком) —
+            // не создаём резку с пустой «Партией сырья», а помечаем позиции пропущенными.
+            // pickBatchFIFOForRun при отсутствии партии возвращает null без списания остатка.
+            if (!batchId) {
+                console.warn('[pp] 🔧 runGenerateCuts: раскладка без партии сырья (сырьё ' + lay.mat + ') — пропущена');
+                (lay.positionsCovered || []).forEach(function(pid) {
+                    skipped.push({ positionId: pid, reason: 'нет партии сырья' });
+                });
+                return;
+            }
             var cutMainValue = nextCutMainValue(sequenceCuts, controllerNowMs(self), cutMainState);
             var day = cutPlanDayKey({ planDate: cutMainValue });
             if (!setupGroupsByDay[day]) setupGroupsByDay[day] = {};
@@ -5139,6 +5149,7 @@
             });
         });
         if (layoutPlans.length) self.lastCutMainValue = cutMainState.last;
+        nCuts = layoutPlans.length;   // #3453: раскладки без партии сырья отброшены — считаем по факту
 
         // Create requests stay in layout order, but queue numbers for same-day
         // generated cuts follow the operator-selected planner (#3272).

--- a/experiments/atex-production-planning-3453.test.js
+++ b/experiments/atex-production-planning-3453.test.js
@@ -1,0 +1,46 @@
+// Unit tests for #3453 — не планировать резки без партии сырья.
+// Контракт pickBatchFIFOForRun: возвращает null, если активной «Партии сырья» этого
+// вида с остатком нет. runGenerateCuts на этом null пропускает раскладку (не создаёт
+// резку с пустой «Партией сырья»).
+//
+// Run with: node experiments/atex-production-planning-3453.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+var pick = planning.pickBatchFIFOForRun;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) passed++; else process.exitCode = 1;
+}
+
+var batches = [
+    { id: '10', materialId: 'M1', active: true, dateKey: 20260101, remainder: 500 },
+    { id: '11', materialId: 'M1', active: true, dateKey: 20260102, remainder: 500 },
+    { id: '20', materialId: 'M2', active: false, dateKey: 20260101, remainder: 500 }  // не активна
+];
+
+// Нет ни одной партии этого вида → null (резку не планируем).
+assert(pick(batches, 'M3', 100, null) === null, 'нет партий вида M3 → null');
+
+// Партия есть, но неактивна → null.
+assert(pick(batches, 'M2', 100, null) === null, 'партия M2 неактивна → null');
+
+// Есть активная партия с остатком → FIFO по dateKey (самая ранняя).
+assert(pick(batches, 'M1', 100, null) === '10', 'M1 → самая ранняя партия 10 (FIFO)');
+
+// Остаток исчерпан резервом прогонов → null (нечем обеспечить).
+var rem = { '10': 0, '11': 0 };
+assert(pick(batches, 'M1', 100, rem) === null, 'остаток партий M1 исчерпан → null');
+
+// Частичный остаток: партия 10 пуста, 11 свободна → берём 11.
+var rem2 = { '10': 0, '11': 300 };
+assert(pick(batches, 'M1', 100, rem2) === '11', 'партия 10 пуста → берём 11');
+
+// Пустой справочник партий → null.
+assert(pick([], 'M1', 100, null) === null, 'нет партий вообще → null');
+
+console.log('\n' + passed + ' passed');

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 18);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 19);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3453

## Проблема
При генерации производственная резка получалась с **пустой «Партией сырья»**, если для вида сырья не было активной партии с остатком (`pickBatchFIFOForRun` возвращал `null`, но резка всё равно создавалась).

## Что меняется
`runGenerateCuts`: если для раскладки нет партии сырья (`pickBatchFIFOForRun` → `null`: нет активной партии этого вида с остатком, либо остаток исчерпан резервом прогонов) — резку **не создаём**, а покрываемые позиции помечаем пропущенными с причиной **«нет партии сырья»** (видно в итоговом уведомлении и в отчёте пропущенных). Число резок считаем по факту построенных планов (`layoutPlans.length`).

`pickBatchFIFOForRun` при отсутствии партии возвращает `null` **до** списания остатка, поэтому пропуск не нарушает FIFO-резерв остальных раскладок.

`index.php`: `VERSION` 18→19.

## Проверки
- Новый тест `experiments/atex-production-planning-3453.test.js` — **6 проверок PASS** (контракт `pickBatchFIFOForRun`: null при отсутствии партии/активности/остатка, FIFO по дате, частичный остаток).
- Регрессий нет: `atex-production-planning.test.js` (511), `atex-cut-layout.test.js` (27) — PASS.
- `node --check` — ОК.

## Примечание
Партия выбирается на шаге генерации (после диалога), поэтому диалог «Создать N резок?» может показать N до отсева — итоговое уведомление и отчёт пропущенных отражают реальный результат с причиной «нет партии сырья». Перенос отсева на этап планирования (в счётчик диалога) удобнее сделать в рамках рефактора планирования (#3424).

🤖 Generated with [Claude Code](https://claude.com/claude-code)