### PR TITLE
fix(atex): «Сгенерировать резки» не теряет фактическую ширину резки после перезапроса позиций (#3457)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -4864,6 +4864,11 @@
         Promise.all([this.loadPositions(), this.reload()]).then(function() {
             self._genRefreshing = false;
             self.setGenBusy(false);
+            // #3457: loadPositions() пересоздал genPositions с НОМИНАЛЬНОЙ шириной заказа —
+            // заново проставляем фактическую ширину резки (#3372: справочник 66190), иначе
+            // планирование/раскладка/Партии ГП пойдут по номиналу (60мм вместо 59мм).
+            // Справочники (actualWidthIndex/jumboWidthByMaterial/sleeveInchesById) живут с start().
+            self.annotatePositionsCutWidth();
             self.render();
             self.planAndConfirmCuts(actionsEl);
         }).catch(function(err) {
@@ -6692,4 +6697,4 @@
 
  
  
-// @version 2026-06-15-issue-3411
+// @version 2026-06-17-issue-3457

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -2263,6 +2263,40 @@ assertEqual(planning.splitSupplyShares(10, 90, [1, 1, 1]), [{ rolls: 4, footage:
 assertEqual(planning.splitSupplyShares(7, 700, []), [], 'splitSupplyShares: нет сегментов → []');
 assertEqual(planning.splitSupplyShares(7, 700, [0, 0]), [{ rolls: 7, footage: 700 }, { rolls: 0, footage: 0 }], 'splitSupplyShares: нулевые проходы → всё в сегмент 0');
 
+// #3457: generateCuts перезапрашивает позиции (loadPositions сбрасывает genPositions к
+// НОМИНАЛЬНОЙ ширине заказа). Раньше фактическая ширина резки (#3372, справочник 66190)
+// терялась, т.к. annotatePositionsCutWidth вызывался только в start(). Проверяем, что к
+// моменту планирования (planAndConfirmCuts) ширина уже фактическая (60 → 59).
+function runGenerateCutsReannotatesActualWidthTest() {
+    var prevWindow = global.window;
+    global.window = { AtexCutLayout: { layout: { planLayouts: function() {} } } };
+    var controller = Object.create(api.Controller.prototype);
+    controller.meta = { cut: {}, supply: {}, finishedBatch: {} };
+    controller.actualWidthIndex = planning.buildActualWidthIndex([{ order: 60, actual: 59, code: '' }]);
+    controller.jumboWidthByMaterial = {};
+    controller.sleeveInchesById = {};
+    controller.setGenBusy = function() {};
+    controller.render = function() {};
+    controller.reload = function() { return Promise.resolve(); };
+    // Как настоящий loadPositions: пересоздаёт genPositions с НОМИНАЛЬНОЙ шириной заказа.
+    controller.loadPositions = function() {
+        controller.genPositions = [{ id: 'p1', materialId: 'M', width: 60, qty: 1 }];
+        return Promise.resolve();
+    };
+    var widthsAtPlanning = null;
+    controller.planAndConfirmCuts = function() {
+        widthsAtPlanning = controller.genPositions.map(function(p) {
+            return { width: p.width, orderWidth: p.orderWidth };
+        });
+    };
+    controller.generateCuts({ querySelector: function() { return null; } });
+    return new Promise(function(resolve) { setTimeout(resolve, 0); }).then(function() {
+        assertEqual(widthsAtPlanning, [{ width: 59, orderWidth: 60 }],
+            'generateCuts #3457: после перезапроса позиций фактическая ширина (60→59) проставлена до планирования');
+        global.window = prevWindow;
+    });
+}
+
 runSaveSequencesT1078Test()
     .then(runApplySplitPlanTest)
     .then(runPreferredWidthsFilterTest)
@@ -2272,6 +2306,7 @@ runSaveSequencesT1078Test()
     .then(runGenerateCutsFatigueStrategyTest)
     .then(runCreateCutPayloadDiagnosticsTest)
     .then(runCreateCutMainValueTest)
+    .then(runGenerateCutsReannotatesActualWidthTest)
     .then(function() {
     console.log('\n' + passed + ' assertions passed');
 }).catch(function(err) {

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 18);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 19);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3457

## Симптом
В `templates/atex/production-planning.html` не применялась «Фактическая ширина резки» из справочника (table/66190): например, номинал 60мм должен резаться по 59мм, но резки/полосы планировались по 60мм.

## Причина
Фича #3372 проставляет позициям фактическую ширину через `annotatePositionsCutWidth` (номинал заказа → факт по справочнику 66190 с учётом джамбо/втулки). Эта аннотация вызывалась **только в `start()`**.

#3444 (перезапрос позиций перед планированием) добавил в `generateCuts` повторный `loadPositions()`, который **пересоздаёт `genPositions` с номинальной шириной заказа** и `annotatePositionsCutWidth` после этого не вызывал. В итоге планирование/раскладка/«Партии ГП»/обеспечение шли по номиналу (60мм вместо 59мм).

## Фикс
В `generateCuts`, после перезапроса `Promise.all([loadPositions, reload])`, заново вызываем `annotatePositionsCutWidth()` — до `render()` и `planAndConfirmCuts()`. Справочники (`actualWidthIndex` / `jumboWidthByMaterial` / `sleeveInchesById`) живут с `start()` и `reload()` их не трогает, так что повторного запроса не требуется.

## Тесты
- Новый регрессионный тест `runGenerateCutsReannotatesActualWidthTest`: после перезапроса позиций к моменту планирования ширина уже фактическая (60→59). Падает без фикса, проходит с ним.
- Весь набор `experiments/atex-production-planning.test.js` — 512 assertions зелёные.

`VERSION` 18→19 (правка atex js).

🤖 Generated with [Claude Code](https://claude.com/claude-code)