### PR TITLE
fix(atex): менеджерская модель раскроя + позиционная стоимость ножей (#3472)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -224,6 +224,17 @@
     text-align: right;
     white-space: nowrap;
 }
+/* #3472: лидер резки. Смешанные лидеры (легаси) — предупреждающий стиль. */
+.atex-pp-cut-leader {
+    flex: 0 0 auto;
+    font-size: 12px;
+    color: var(--pp-muted);
+    white-space: nowrap;
+}
+.atex-pp-cut-leader-mixed {
+    color: var(--pp-danger, #c0392b);
+    font-weight: 600;
+}
 /* #3354 п.1: сводка полос по ширинам под первой строкой карточки. Контейнер —
    .atex-pp-cut-material (переиспользован), одна текстовая строка на ширину. */
 .atex-pp-cut-material {

--- a/download/atex/js/cut-layout.js
+++ b/download/atex/js/cut-layout.js
@@ -209,10 +209,53 @@
     return String(materialId == null ? '' : materialId) + '|' + parts.join('+');
   }
 
-  // planLayouts: оркестратор раскладки. input = {jumboWidth, positions, preferred, options:{windowDays=3, tolerance}}.
-  // Группирует позиции по окну срока, для каждого кластера composeLayout; пока overflow непустой
-  // и есть прогресс — повторный composeLayout на overflow → доп. раскладка. Позиции шире джамбо
-  // (overflow без прогресса) → skipped 'шире джамбо'. Вход не мутирует, детерминировано.
+  // ───────────────────── #3472: цель раскроя ─────────────────────
+  // Менеджер минимизирует РАСХОД джамбо (число прогонов ≡ метраж сырья), затем СКРАП
+  // (перепроизводство НЕзапасных ширин — рулоны сверх заказа, которые некуда деть).
+  // Эти две величины — лексикографическая цель оптимизатора (отход первичен, #3472):
+  // 110×8 + 89×10 раздельно = 18 прогонов выгоднее, чем 4+4 слитно = 20.
+
+  // orderStripQty: полос назначения «Заказ» данной ширины (миррор
+  // nonStockStripQtyForWidth в production-planning — добор «Склад» не считаем).
+  function orderStripQty(strips, width){
+    var key = round3(toNumber(width));
+    return (strips || []).reduce(function(sum, s){
+      if (s.purpose !== 'Заказ') return sum;
+      return round3(toNumber(s.width)) === key ? sum + toNumber(s.qty) : sum;
+    }, 0);
+  }
+
+  // layoutRuns: прогоны раскладки = max по заказанным ширинам ⌈спрос/полос⌉
+  // (как plannedRunsForLayout). demandByWidth: { ключ_ширины: суммарный спрос }.
+  function layoutRuns(strips, demandByWidth){
+    var runs = 1;
+    Object.keys(demandByWidth || {}).forEach(function(k){
+      var out = orderStripQty(strips, Number(k));
+      if (out > 0) runs = Math.max(runs, Math.ceil(demandByWidth[k] / out));
+    });
+    return runs;
+  }
+
+  // layoutScrap: скрап раскладки = Σ перепроизводство НЕзапасных ширин × ширина
+  // (запасное перепроизводство уходит в «Склад» и отходом не считается).
+  function layoutScrap(strips, runs, demandByWidth, stockableByWidth){
+    var scrap = 0;
+    Object.keys(demandByWidth || {}).forEach(function(k){
+      if (stockableByWidth && stockableByWidth[k]) return;
+      var out = orderStripQty(strips, Number(k));
+      var over = out * runs - demandByWidth[k];
+      if (over > 0) scrap = round3(scrap + over * Number(k));
+    });
+    return scrap;
+  }
+
+  // planLayouts: оркестратор раскладки (#3472). input = {jumboWidth, positions,
+  // preferred, options:{windowDays=3, tolerance}}. Группирует позиции по окну срока;
+  // ВНУТРИ окна — менеджерская модель: каждый заказ (различная ширина) сначала идёт
+  // ОТДЕЛЬНОЙ раскладкой (seed «1 заказ = 1 резка», макс. заполнение джамбо). Затем
+  // ограниченный перебор слияний: две раскладки сливаются в комбо ТОЛЬКО если это
+  // лексикографически снижает цель (прогоны, затем скрап) — заказ не дробится,
+  // объединение лишь по выгоде. Позиции шире джамбо → skipped. Вход не мутирует.
   function planLayouts(input){
     input = input || {};
     var W = toNumber(input.jumboWidth);
@@ -225,44 +268,94 @@
                dueKey: isFinite(p.dueKey) ? p.dueKey : Infinity, stockable: !!p.stockable };
     });
 
-    var groups = dueWindowGroups(positions, windowDays);
+    var MERGE_BUILD_LIMIT = 20000;
+    var buildCalls = 0;
+
+    // buildGroup: уложить набор demands (одна/несколько ширин) в одну раскладку и
+    // посчитать её цену (прогоны, скрап). demands: [{width, qty, positionId, stockable}].
+    function buildGroup(demands){
+      buildCalls++;
+      var result = composeLayout(W, demands, preferred, tolerance);
+      var demandByWidth = {}, stockableByWidth = {};
+      demands.forEach(function(dm){
+        var w = toNumber(dm.width);
+        if (w <= 0 || w > W) return;                 // шире джамбо → в overflow, не в спрос
+        var k = String(round3(w));
+        demandByWidth[k] = round3((demandByWidth[k] || 0) + toNumber(dm.qty));
+        if (stockableByWidth[k] == null) stockableByWidth[k] = true;
+        if (!dm.stockable) stockableByWidth[k] = false;
+      });
+      var covered = [];
+      result.strips.forEach(function(s){
+        if (s.purpose !== 'Заказ') return;
+        s.positionIds.forEach(function(pid){ if (covered.indexOf(pid) < 0) covered.push(pid); });
+      });
+      var runs = layoutRuns(result.strips, demandByWidth);
+      return {
+        demands: demands, result: result, demandByWidth: demandByWidth,
+        stockableByWidth: stockableByWidth, positionsCovered: covered,
+        runs: runs, scrap: layoutScrap(result.strips, runs, demandByWidth, stockableByWidth),
+        overflow: result.overflow
+      };
+    }
+
+    var clusters = dueWindowGroups(positions, windowDays);
     var layouts = [];
     var skipped = [];
 
-    groups.forEach(function(cluster){
+    clusters.forEach(function(cluster){
       var clusterDueKey = Infinity;
       cluster.forEach(function(p){ if (p.dueKey < clusterDueKey) clusterDueKey = p.dueKey; });
 
-      var pending = cluster.map(function(p){ return { width: p.width, qty: p.qty, positionId: p.id, stockable: p.stockable }; });
+      // seed: одна раскладка на каждую РАЗЛИЧНУЮ ширину (одинаковая ширина — один продукт,
+      // склейка бесплатна; разные ширины — отдельные резки по умолчанию, без дробления заказа).
+      var widthOrder = [], byWidth = {};
+      cluster.forEach(function(p){
+        var k = String(round3(p.width));
+        if (!byWidth[k]) { byWidth[k] = []; widthOrder.push(k); }
+        byWidth[k].push({ width: p.width, qty: p.qty, positionId: p.id, stockable: p.stockable });
+      });
+      var groups = widthOrder.map(function(k){ return buildGroup(byWidth[k]); });
+
+      // refine: пока есть лексикографически улучшающее слияние пары — сливаем (B&B по парам).
       var guard = 0;
-      while (pending.length && guard++ < 100000) {
-        var result = composeLayout(W, pending, preferred, tolerance);
-        var ordered = [];
-        result.strips.forEach(function(s){
-          if (s.purpose === 'Заказ') {
-            s.positionIds.forEach(function(pid){ if (ordered.indexOf(pid) < 0) ordered.push(pid); });
+      while (guard++ < 1000 && buildCalls < MERGE_BUILD_LIMIT) {
+        var best = null;   // { i, j, group, dr, ds }
+        for (var i = 0; i < groups.length; i++) {
+          for (var j = i + 1; j < groups.length && buildCalls < MERGE_BUILD_LIMIT; j++) {
+            var gi = groups[i], gj = groups[j];
+            if (!gi.positionsCovered.length || !gj.positionsCovered.length) continue;
+            var merged = buildGroup(gi.demands.concat(gj.demands));
+            if (merged.overflow.length) continue;                 // не влезли вместе → не слить
+            if (merged.positionsCovered.length < gi.positionsCovered.length + gj.positionsCovered.length) continue;
+            var dr = merged.runs - (gi.runs + gj.runs);
+            var ds = round3(merged.scrap - (gi.scrap + gj.scrap));
+            var improves = dr < 0 || (dr === 0 && ds < 0);        // строго лучше по (прогоны, скрап)
+            if (!improves) continue;
+            if (!best || dr < best.dr || (dr === best.dr && ds < best.ds)) {
+              best = { i: i, j: j, group: merged, dr: dr, ds: ds };
+            }
           }
-        });
-        // прогресс: хотя бы одна заказанная полоса уложена
-        var madeProgress = ordered.length > 0;
-        if (madeProgress) {
+        }
+        if (!best) break;
+        groups.splice(best.j, 1);
+        groups.splice(best.i, 1, best.group);
+      }
+
+      // эмиссия раскладок + пропусков (ширина шире джамбо)
+      groups.forEach(function(g){
+        if (g.positionsCovered.length) {
           layouts.push({
-            positionsCovered: ordered,
-            strips: result.strips,
-            used: result.used,
-            remainder: result.remainder,
-            withinTolerance: result.withinTolerance,
+            positionsCovered: g.positionsCovered,
+            strips: g.result.strips,
+            used: g.result.used,
+            remainder: g.result.remainder,
+            withinTolerance: g.result.withinTolerance,
             dueKey: clusterDueKey
           });
         }
-        if (!result.overflow.length) break;
-        if (!madeProgress) {
-          // ничего не уложилось → остаток overflow не лезет (шире джамбо)
-          result.overflow.forEach(function(o){ skipped.push({ positionId: o.positionId, reason: 'шире джамбо' }); });
-          break;
-        }
-        pending = result.overflow.map(function(o){ return { width: o.width, qty: o.qty, positionId: o.positionId, stockable: o.stockable }; });
-      }
+        g.overflow.forEach(function(o){ skipped.push({ positionId: o.positionId, reason: 'шире джамбо' }); });
+      });
     });
 
     return { layouts: layouts, skipped: skipped };
@@ -270,6 +363,7 @@
 
   var layout = { toNumber: toNumber, round3: round3, dayDiff: dayDiff, dueWindowGroups: dueWindowGroups,
                  bestFill: bestFill, composeLayout: composeLayout,
+                 orderStripQty: orderStripQty, layoutRuns: layoutRuns, layoutScrap: layoutScrap,
                  combinationSignature: combinationSignature, planLayouts: planLayouts };
 
   if (typeof module !== 'undefined' && module.exports) module.exports = { layout: layout };

--- a/download/atex/js/cut-layout.js
+++ b/download/atex/js/cut-layout.js
@@ -255,7 +255,9 @@
   // ОТДЕЛЬНОЙ раскладкой (seed «1 заказ = 1 резка», макс. заполнение джамбо). Затем
   // ограниченный перебор слияний: две раскладки сливаются в комбо ТОЛЬКО если это
   // лексикографически снижает цель (прогоны, затем скрап) — заказ не дробится,
-  // объединение лишь по выгоде. Позиции шире джамбо → skipped. Вход не мутирует.
+  // объединение лишь по выгоде. Комбо ограничено (#3472 п.3): не более
+  // options.maxWidthsPerCut (3) ширин и options.maxPositionsPerCut (3) заказов.
+  // Позиции шире джамбо → skipped. Вход не мутирует.
   function planLayouts(input){
     input = input || {};
     var W = toNumber(input.jumboWidth);
@@ -263,6 +265,11 @@
     var opts = input.options || {};
     var windowDays = (opts.windowDays == null) ? 3 : opts.windowDays;
     var tolerance = toNumber(opts.tolerance);
+    // #3472 п.3: разумные ограничения комбо-резки — отсекают бессмысленные слияния и
+    // держат резку дружелюбной к оператору/упаковщику. Дефолты: ≤3 ширин, ≤3 позиций.
+    // 0/Infinity → ограничение снято (toNumber делает не-конечное 0).
+    var maxWidths = (opts.maxWidthsPerCut == null) ? 3 : toNumber(opts.maxWidthsPerCut);
+    var maxPositions = (opts.maxPositionsPerCut == null) ? 3 : toNumber(opts.maxPositionsPerCut);
     var positions = (input.positions || []).map(function(p){
       return { id: p.id, width: toNumber(p.width), qty: toNumber(p.qty),
                dueKey: isFinite(p.dueKey) ? p.dueKey : Infinity, stockable: !!p.stockable };
@@ -328,6 +335,9 @@
             var merged = buildGroup(gi.demands.concat(gj.demands));
             if (merged.overflow.length) continue;                 // не влезли вместе → не слить
             if (merged.positionsCovered.length < gi.positionsCovered.length + gj.positionsCovered.length) continue;
+            // #3472 п.3: комбо-резка — не более maxWidths ширин и maxPositions заказов.
+            if (maxWidths > 0 && Object.keys(merged.demandByWidth).length > maxWidths) continue;
+            if (maxPositions > 0 && merged.positionsCovered.length > maxPositions) continue;
             var dr = merged.runs - (gi.runs + gj.runs);
             var ds = round3(merged.scrap - (gi.scrap + gj.scrap));
             var improves = dr < 0 || (dr === 0 && ds < 0);        // строго лучше по (прогоны, скрап)

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -743,9 +743,16 @@
                     timing: str(rowValue(row, CUT_TIMING_COLUMNS)),
                     isFoil: /фольг/i.test(str(row.cut_material)),
                     orderId: str(row.order_id),
-                    orderApprovalDate: str(row.order_approval_date || row.item_approval_date)
+                    orderApprovalDate: str(row.order_approval_date || row.item_approval_date),
+                    // #3472: лидеры резки (из cut_leader по всем строкам). Новые резки —
+                    // один лидер; легаси (до ограничения по лидеру) могут мешать несколько.
+                    leaders: []
                 };
                 order.push(cutId);
+            }
+            if (cutId && cutsById[cutId]) {
+                var leaderVal = str(row.cut_leader).trim();
+                if (leaderVal && cutsById[cutId].leaders.indexOf(leaderVal) < 0) cutsById[cutId].leaders.push(leaderVal);
             }
             var supplyId = str(row.supply_id);
             if (supplyId) {
@@ -6434,6 +6441,18 @@
             // он стоял по центру (равный flex-gap слева и справа): «MR194 IN — 600 х 7».
             infoChildren.push(el('span', { class: 'atex-pp-cut-dash', text: '—' }));
             infoChildren.push(el('span', { class: 'atex-pp-cut-runs', text: formatCutDimensions(c, runLengthForCut) }));
+            // #3472: лидер резки — после размеров (перед связями, которые прижаты вправо).
+            // Один лидер — обычная плашка; несколько (легаси-смешение до ограничения по
+            // лидеру) — выделяем предупреждением.
+            var cutLeaders = (c.leaders || []).filter(function(s) { return s; });
+            if (cutLeaders.length) {
+                var mixed = cutLeaders.length > 1;
+                infoChildren.push(el('span', {
+                    class: 'atex-pp-cut-leader' + (mixed ? ' atex-pp-cut-leader-mixed' : ''),
+                    title: (mixed ? 'В резке смешаны разные лидеры: ' : 'Лидер: ') + cutLeaders.join(', '),
+                    text: 'лидер: ' + cutLeaders.join(', ')
+                }));
+            }
             infoChildren.push(el('span', { class: 'atex-pp-cut-supplies', text: supplies ? ('связей: ' + supplies) : 'нет связей' }));
             cardPanel.appendChild(el('div', { class: 'atex-pp-cut-info' }, infoChildren));
 

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1096,10 +1096,14 @@
     // Времена переналадок (мин) — по умолчанию (fallback). Реальные берутся из таблицы
     // «Время операции, мин» (13588) по кодам (loadOperationTimes → this.changeTimes):
     //   MATERIAL_WINDING — смена сырья/намотки/партии/неудобный остаток (одна операция);
-    //   KNIFE — смена ножей / сужение ролика; BETWEEN_CUTS — лидер между резками (база);
+    //   KNIFE_MOVE — стоимость ОДНОГО перемещения ножа (#3472, позиционная модель: цена
+    //     ножей = KNIFE_MOVE × число переставленных ножей; идентичные полосы → 0);
+    //   KNIFE — устар.: прежняя плоская «смена ножей» (оставлен для совместимости настроек);
+    //   BETWEEN_CUTS — лидер между резками (база);
     //   CLEANUP_SHIFT — уборка в конце рабочего дня (#3155, ставится после последней резки дня).
-    // Так нож (30) дороже смены сырья (15) — приоритет «беречь ножи» (ideav/crm#3130).
-    var DEFAULT_OP_TIMES = { MATERIAL_WINDING: 15, KNIFE: 30, BETWEEN_CUTS: 2, CLEANUP_SHIFT: 30 };
+    // #3472: приоритет — неизменность полос (0), затем меньше перемещений (2×ножи),
+    // смена сырья (15); полная смена ~16 ножей ≈ 32 ≈ прежняя «смена ножей» 30.
+    var DEFAULT_OP_TIMES = { MATERIAL_WINDING: 15, KNIFE: 30, KNIFE_MOVE: 2, BETWEEN_CUTS: 2, CLEANUP_SHIFT: 30 };
     var KNIFE_SCALE = 8;     // нормировка ножевой компоненты (переставленных ножей до «максимума»)
     var WIDTH_SCALE = 100;   // нормировка ширины (мм «сужения» до «максимума»)
     var REMAINDER_OK_M = 600;
@@ -1121,6 +1125,31 @@
         return d;
     }
 
+    // #3472: число НОЖЕЙ для перестановки prev→next. Нож, чья ширина есть в ОБОИХ
+    // наборах, сохраняется (не двигается) — это приоритет неизменности полос. Поэтому
+    // moves = max(|prev|, |next|) − |пересечение мультимножеств ширин|: добавить/убрать
+    // нож = 1 перемещение, сменить ширину = 1, идентичный набор = 0. (Смена количества —
+    // частный случай перемещений, отдельно не штрафуем.)
+    function knifeMoves(prevWidths, nextWidths){
+        function tally(arr){ var m = {}; (arr || []).forEach(function(x){ var k = String(x); m[k] = (m[k] || 0) + 1; }); return m; }
+        var a = prevWidths || [], b = nextWidths || [];
+        var ta = tally(a), tb = tally(b), inter = 0;
+        Object.keys(ta).forEach(function(k){ if (tb[k]) inter += Math.min(ta[k], tb[k]); });
+        return Math.max(a.length, b.length) - inter;
+    }
+
+    // Ширины ножей резки для knifeMoves. В реальных данных knifeWidths развёрнут по числу
+    // ножей (длина == knifeCount, см. aggregateStrips). Если ширины не развёрнуты
+    // (placeholder/пусто), а число ножей задано — дополняем сентинелом «нож без известной
+    // ширины», чтобы перестановка считалась по числу ножей (фоллбэк совместимости).
+    function effKnifeWidths(cut){
+        var w = (cut && cut.knifeWidths) || [];
+        var keys = w.map(function(x){ return String(Number(x)); });
+        var n = Number(cut && cut.knifeCount) || 0;
+        while (keys.length < n) keys.push('·');
+        return keys;
+    }
+
     // Неудобный остаток джамбо: 0 < m < REMAINDER_OK_M (не дорезан до ≈0 и не оставлен крупным).
     function awkwardRemainder(m){ var x = Number(m); return !isNaN(x) && x > 1e-6 && x < REMAINDER_OK_M; }
 
@@ -1134,17 +1163,20 @@
     function changeoverParts(prev, next, times){
         var t = times || DEFAULT_OP_TIMES;
         var matWind = Number(t.MATERIAL_WINDING != null ? t.MATERIAL_WINDING : DEFAULT_OP_TIMES.MATERIAL_WINDING) || 0;
-        var knife = Number(t.KNIFE != null ? t.KNIFE : DEFAULT_OP_TIMES.KNIFE) || 0;
+        var moveCost = Number(t.KNIFE_MOVE != null ? t.KNIFE_MOVE : DEFAULT_OP_TIMES.KNIFE_MOVE) || 0;
         var parts = [];
         if (!prev || !next) return parts;
         var matWindChange = String(prev.materialId) !== String(next.materialId)
             || normWinding(prev.winding) !== normWinding(next.winding)
             || String(prev.batchId) !== String(next.batchId);
         if (matWindChange && matWind > 0) parts.push({ code: 'MATERIAL_WINDING', label: 'смена сырья / намотки / партии', minutes: round3(matWind) });
-        var knifeChange = (Number(prev.knifeCount) || 0) !== (Number(next.knifeCount) || 0)
-            || widthSetDistance(prev.knifeWidths, next.knifeWidths) > 0
-            || (Number(prev.rollerWidth) || 0) > (Number(next.rollerWidth) || 0);   // сужение ролика
-        if (knifeChange && knife > 0) parts.push({ code: 'KNIFE', label: 'смена ножей / сужение ролика', minutes: round3(knife) });
+        // #3472: стоимость ножей = KNIFE_MOVE × число переставленных ножей (позиционно;
+        // нож с сохранённой шириной не двигаем — приоритет неизменности полос). Сужение
+        // ролика требует переустановки края → минимум одно перемещение.
+        var moves = knifeMoves(effKnifeWidths(prev), effKnifeWidths(next));
+        if ((Number(prev.rollerWidth) || 0) > (Number(next.rollerWidth) || 0)) moves = Math.max(moves, 1);
+        var knifeMin = round3(moveCost * moves);
+        if (knifeMin > 0) parts.push({ code: 'KNIFE', label: 'перестановка ножей / сужение ролика', minutes: knifeMin });
         return parts;
     }
 
@@ -3059,6 +3091,7 @@
         PLANNING_STRATEGY_FATIGUE: PLANNING_STRATEGY_FATIGUE,
         normWinding: normWinding,
         widthSetDistance: widthSetDistance,
+        knifeMoves: knifeMoves,
         awkwardRemainder: awkwardRemainder,
         changeoverParts: changeoverParts,
         changeoverCost: changeoverCost,
@@ -3751,6 +3784,8 @@
             self.changeTimes = {
                 MATERIAL_WINDING: raw.MATERIAL_WINDING != null ? raw.MATERIAL_WINDING : DEFAULT_OP_TIMES.MATERIAL_WINDING,
                 KNIFE: Math.max(Number(raw.KNIFE_220_59) || 0, Number(raw.KNIFE_LE_59) || 0) || DEFAULT_OP_TIMES.KNIFE,
+                // #3472: стоимость одного перемещения ножа (код «KNIFE_MOVE»); дефолт 2 мин.
+                KNIFE_MOVE: raw.KNIFE_MOVE != null ? raw.KNIFE_MOVE : DEFAULT_OP_TIMES.KNIFE_MOVE,
                 BETWEEN_CUTS: raw.BETWEEN_CUTS != null ? raw.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS,
                 CLEANUP_SHIFT: raw.CLEANUP_SHIFT != null ? raw.CLEANUP_SHIFT : DEFAULT_OP_TIMES.CLEANUP_SHIFT
             };

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -881,6 +881,11 @@
                 length: length,
                 windDir: normWinding(row.wind_dir || row.position_wind_dir || row.position_winding),
                 windLength: windLengthValue(windLengthRaw),
+                // #3472: «Лидер» заказа — отдельное измерение профиля планирования (заказы
+                // с разным лидером нельзя класть в одну резку, она заправляется одним
+                // лидером). Отчёт positions_list пока может не отдавать колонку — тогда
+                // пусто и разбиения по лидеру нет (как order_id в #3433).
+                leader: rowFirstValue(row, ['position_leader', 'order_leader']),
                 // #3340: тип втулки и готовность приходят прямо из positions_list:
                 // sleeve_id — id записи «Диаметр втулки»; sleeve_ready (непустое) — уже нарезано.
                 sleeveId: row.sleeve_id == null ? '' : String(row.sleeve_id).trim(),
@@ -926,22 +931,33 @@
         return true;
     }
 
+    function planningLeaderKey(p) {
+        return String(p && p.leader != null ? p.leader : '').trim();
+    }
+
+    // #3472: профиль планирования = сырьё + намотка + длина + ЛИДЕР. Лидер добавлен как
+    // отдельное измерение — заказы с разным лидером идут в разные резки (резка заправляется
+    // одним лидером). group.key (для добора ходовыми) остаётся БЕЗ лидера: ходовые ширины
+    // от лидера не зависят. Пустой лидер у всех (отчёт ещё не отдаёт колонку) → разбиения нет.
     function groupPositionsByPlanningProfile(positions) {
         var groups = {};
         var order = [];
         (positions || []).forEach(function(p) {
-            var key = preferredWidthsKey(p && p.materialId, p && p.windDir, p && p.windLength);
-            if (!groups[key]) {
-                groups[key] = {
-                    key: key,
+            var prefKey = preferredWidthsKey(p && p.materialId, p && p.windDir, p && p.windLength);
+            var leader = planningLeaderKey(p);
+            var groupKey = prefKey + '|L=' + leader;
+            if (!groups[groupKey]) {
+                groups[groupKey] = {
+                    key: prefKey,
+                    leader: leader,
                     materialId: p && p.materialId != null ? String(p.materialId) : '',
                     windDir: normWinding(p && p.windDir),
                     windLength: windLengthValue(p && p.windLength),
                     positions: []
                 };
-                order.push(key);
+                order.push(groupKey);
             }
-            groups[key].positions.push(p);
+            groups[groupKey].positions.push(p);
         });
         return order.map(function(key) { return groups[key]; });
     }

--- a/experiments/atex-cut-layout-3472.test.js
+++ b/experiments/atex-cut-layout-3472.test.js
@@ -81,4 +81,32 @@ var split = false;
 issue.layouts.forEach(function(l){ l.positionsCovered.forEach(function(pid){ if (seen[pid]) split = true; seen[pid] = 1; }); });
 assertEqual(split, false, 'issue: ни один заказ не дроблён на две раскладки');
 
+// ── #3472 п.3: разумные ограничения комбо-резки (≤3 ширин, ≤3 заказов по умолчанию). ──
+// Вход, который БЕЗ ограничения сливается в одну раскладку из 4 ширин / 4 позиций.
+var capPos = [[110, 50], [70, 30], [50, 20], [40, 10]].map(function(p, i){
+  return { id: 'c' + i, width: p[0], qty: p[1], dueKey: 20260601 };
+});
+function capPlan(cap){
+  return layout.planLayouts({ jumboWidth: 910, positions: capPos, preferred: [],
+    options: { windowDays: 3, tolerance: 0, maxWidthsPerCut: cap, maxPositionsPerCut: cap } });
+}
+function widthsOf(l){ var w = {}; l.strips.forEach(function(s){ if (s.purpose === 'Заказ') w[s.width] = 1; }); return Object.keys(w).length; }
+function maxOver(res, fn){ return res.layouts.reduce(function(m, l){ return Math.max(m, fn(l)); }, 0); }
+
+// без ограничения (большой cap) — все 4 ширины в одной резке (контроль кейса).
+var uncapped = capPlan(1e9);
+assertEqual(uncapped.layouts.length === 1 && widthsOf(uncapped.layouts[0]) === 4, true,
+  'cap: без ограничения 4 ширины сливаются в одну резку (контроль)');
+
+// дефолт (ограничения не переданы → 3): ни одна резка не превышает 3 ширин/3 позиций.
+var def = layout.planLayouts({ jumboWidth: 910, positions: capPos, preferred: [], options: { windowDays: 3, tolerance: 0 } });
+assertEqual(maxOver(def, widthsOf) <= 3, true, 'cap #3472: дефолт — не более 3 ширин в резке');
+assertEqual(maxOver(def, function(l){ return l.positionsCovered.length; }) <= 3, true, 'cap #3472: дефолт — не более 3 заказов в резке');
+// все позиции по-прежнему покрыты (ограничение не теряет заказы).
+var defCovered = {}; def.layouts.forEach(function(l){ l.positionsCovered.forEach(function(pid){ defCovered[pid] = 1; }); });
+assertEqual(Object.keys(defCovered).length, 4, 'cap: все 4 заказа покрыты, несмотря на ограничение');
+
+// жёстче (2): ни одна резка не превышает 2 ширин.
+assertEqual(maxOver(capPlan(2), widthsOf) <= 2, true, 'cap #3472: maxWidthsPerCut=2 соблюдается');
+
 console.log('\n' + passed + ' assertions passed');

--- a/experiments/atex-cut-layout-3472.test.js
+++ b/experiments/atex-cut-layout-3472.test.js
@@ -1,0 +1,84 @@
+// Unit-тесты #3472 — менеджерская модель раскроя: «1 заказ = 1 резка» + слияние
+// только по выгоде. Цель лексикографическая: прогоны (расход джамбо) → скрап.
+//
+// Run with: node experiments/atex-cut-layout-3472.test.js
+
+var layout = require('../download/atex/js/cut-layout.js').layout;
+var passed = 0;
+function assertEqual(actual, expected, name){
+  var ok = JSON.stringify(actual) === JSON.stringify(expected);
+  console.log((ok?'PASS':'FAIL')+' — '+name);
+  if(ok) passed++; else { console.log('  exp:',JSON.stringify(expected)); console.log('  got:',JSON.stringify(actual)); process.exitCode=1; }
+}
+function assert(cond, name){ assertEqual(!!cond, true, name); }
+
+// ── Пример из issue: MR192, джамбо 910, два заказа одного профиля ──
+//   3673 · 110мм · 80 шт  →  «110мм х 8» (880, отход 30), 10 прогонов
+//   3672 · 89мм  · 80 шт  →  «89мм х 10» (890, отход 20),  8 прогонов
+// Менеджерский эталон: РАЗДЕЛЬНО (Σ 18 прогонов), НЕ слитно 4+4 (Σ 20 прогонов).
+var issue = layout.planLayouts({
+  jumboWidth: 910,
+  positions: [
+    { id: '3673', width: 110, qty: 80, dueKey: 20260601 },
+    { id: '3672', width: 89,  qty: 80, dueKey: 20260601 }
+  ],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 0 }
+});
+
+assertEqual(issue.layouts.length, 2, 'issue: две раскладки (каждый заказ — своя резка)');
+// каждая раскладка покрывает РОВНО одну позицию (заказ не дроблён, заказы не слиты)
+assertEqual(issue.layouts.map(function(l){ return l.positionsCovered.slice().sort(); }),
+            [['3672'], ['3673']], 'issue: 1 заказ = 1 резка (без дробления и слияния)');
+// ни одна раскладка не содержит ОБЕ ширины (нет «балансного» 4+4)
+var mixed = issue.layouts.some(function(l){
+  return layout.orderStripQty(l.strips, 110) > 0 && layout.orderStripQty(l.strips, 89) > 0;
+});
+assertEqual(mixed, false, 'issue: 110 и 89 НЕ смешаны в одной резке');
+
+// найдём раскладки по ширине
+function byWidth(layouts, w){ return layouts.filter(function(l){ return layout.orderStripQty(l.strips, w) > 0; })[0]; }
+var L110 = byWidth(issue.layouts, 110), L89 = byWidth(issue.layouts, 89);
+assertEqual(layout.orderStripQty(L110.strips, 110), 8, 'issue: 110мм → 8 полос (как в каталоге)');
+assertEqual(layout.orderStripQty(L89.strips, 89), 10, 'issue: 89мм → 10 полос (как в каталоге)');
+assertEqual(L110.used, 880, 'issue: 110×8 = 880 использовано');
+assertEqual(L89.used, 890, 'issue: 89×10 = 890 использовано');
+assertEqual(layout.layoutRuns(L110.strips, { '110': 80 }), 10, 'issue: 110 → 10 прогонов');
+assertEqual(layout.layoutRuns(L89.strips, { '89': 80 }), 8, 'issue: 89 → 8 прогонов');
+// суммарный расход джамбо: 18 прогонов (раздельно) < 20 (слитно 4+4)
+var sepRuns = layout.layoutRuns(L110.strips, {'110':80}) + layout.layoutRuns(L89.strips, {'89':80});
+assertEqual(sepRuns, 18, 'issue: Σ прогонов раздельно = 18 (оптимум, не 20)');
+
+// ── Слияние ПО ВЫГОДЕ: 110×50 + 70×30. Раздельно 110 даёт скрап (8×7=56, −50=6),
+//    слитно 5×110+3×70 (10 прогонов, скрап 0) — те же прогоны, меньше скрапа → слить.
+var merge = layout.planLayouts({
+  jumboWidth: 910,
+  positions: [
+    { id: 'a', width: 110, qty: 50, dueKey: 20260601 },
+    { id: 'b', width: 70,  qty: 30, dueKey: 20260601 }
+  ],
+  preferred: [{ width: 50, popularity: 8 }],
+  options: { windowDays: 3, tolerance: 0 }
+});
+assertEqual(merge.layouts.length, 1, 'merge: 110+70 выгодно слить (меньше скрапа) → одна раскладка');
+assertEqual(merge.layouts[0].positionsCovered.slice().sort(), ['a', 'b'], 'merge: обе позиции в одной резке');
+
+// ── Маленький НЕзапасной заказ не перепроизводится (как было в #3423, одиночно). ──
+var small = layout.planLayouts({
+  jumboWidth: 910,
+  positions: [{ id: 's', width: 110, qty: 5, dueKey: 20260601 }],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 0 }
+});
+assertEqual(small.layouts.length, 1, 'small: одна раскладка');
+var sStrips = layout.orderStripQty(small.layouts[0].strips, 110);
+var sRuns = layout.layoutRuns(small.layouts[0].strips, { '110': 5 });
+assertEqual(sStrips * sRuns, 5, 'small: 5 шт нарезано ровно под заказ (без перепроизводства)');
+
+// ── Заказ НИКОГДА не появляется в двух раскладках (жёсткое правило: не дробить). ──
+var seen = {};
+var split = false;
+issue.layouts.forEach(function(l){ l.positionsCovered.forEach(function(pid){ if (seen[pid]) split = true; seen[pid] = 1; }); });
+assertEqual(split, false, 'issue: ни один заказ не дроблён на две раскладки');
+
+console.log('\n' + passed + ' assertions passed');

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -909,9 +909,14 @@ var grp = planning.rowsToGenPositions([
   { position_id:'11', position_material_id:'5', position_width:'', position_qty:'', position_length:'', sleeve_id:'8192', sleeve_ready:'X' }
 ]);
 assertEqual(grp, [
-  { id:'10', materialId:'5', width:60, qty:30, length:1200, windDir:'', windLength:1200, sleeveId:'35561', sleeveReady:false, dueKey: Infinity, orderId:'900', approved:false },
-  { id:'11', materialId:'5', width:0, qty:0, length:0, windDir:'', windLength:0, sleeveId:'8192', sleeveReady:true, dueKey: Infinity, orderId:'', approved:false }
+  { id:'10', materialId:'5', width:60, qty:30, length:1200, windDir:'', windLength:1200, leader:'', sleeveId:'35561', sleeveReady:false, dueKey: Infinity, orderId:'900', approved:false },
+  { id:'11', materialId:'5', width:0, qty:0, length:0, windDir:'', windLength:0, leader:'', sleeveId:'8192', sleeveReady:true, dueKey: Infinity, orderId:'', approved:false }
 ], 'rowsToGenPositions #3340/#3433: sleeve_id/sleeve_ready + order_id («ID заказа»); пустые ширина/кол-во/длина → 0');
+// #3472: «Лидер» читается из колонки отчёта (order_leader/position_leader); нет колонки → пусто.
+assertEqual(planning.rowsToGenPositions([{ position_id:'1', order_leader:'Софмикс' }])[0].leader, 'Софмикс',
+    'rowsToGenPositions #3472: лидер из order_leader');
+assertEqual(planning.rowsToGenPositions([{ position_id:'2' }])[0].leader, '',
+    'rowsToGenPositions #3472: нет колонки лидера → пусто (без разбиения)');
 
 // rowsToGenPositions читает срок изготовления → dueKey (batchDateKey)
 var grpDue = planning.rowsToGenPositions([
@@ -948,6 +953,18 @@ assertEqual(planning.groupPositionsByPlanningProfile([
   { materialId:'3000', windDir:'OUT', windLength:600, ids:['p4'] },
   { materialId:'2086', windDir:'OUT', windLength:450, ids:['p5'] }
 ], 'groupPositionsByPlanningProfile #3219: сырьё+намотка+метраж должны совпадать');
+// #3472: лидер — отдельное измерение профиля. Совпадают сырьё/намотка/длина, но разный
+// лидер → разные группы (резка заправляется одним лидером). group.key (ходовые) без лидера.
+assertEqual(planning.groupPositionsByPlanningProfile([
+  { id:'l1', materialId:'2086', windDir:'OUT', windLength:600, leader:'Софмикс' },
+  { id:'l2', materialId:'2086', windDir:'OUT', windLength:600, leader:'Этикетка37' },
+  { id:'l3', materialId:'2086', windDir:'OUT', windLength:600, leader:'Софмикс' },
+  { id:'l4', materialId:'2086', windDir:'OUT', windLength:600 }
+]).map(function(g) { return { leader:g.leader, key:g.key, ids:g.positions.map(function(p) { return p.id; }) }; }), [
+  { leader:'Софмикс',    key:'2086|OUT|600', ids:['l1','l3'] },
+  { leader:'Этикетка37', key:'2086|OUT|600', ids:['l2'] },
+  { leader:'',           key:'2086|OUT|600', ids:['l4'] }
+], 'groupPositionsByPlanningProfile #3472: разный лидер → разные резки, key (ходовые) без лидера');
 assertEqual(planning.preferredWidthsKey('2086', 'out', '600.00'), '2086|OUT|600',
     'preferredWidthsKey #3219: cache key normalizes material/winding/length');
 

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -465,17 +465,21 @@ assertEqual(planning.awkwardRemainder(-5), false, 'awkward: отриц → false
 // DEFAULT_OP_TIMES экспортирован (минуты-фоллбэк из таблицы «Время операции»)
 assertEqual(planning.DEFAULT_OP_TIMES.MATERIAL_WINDING, 15, 'дефолт: смена сырья/намотки = 15 мин');
 assertEqual(planning.DEFAULT_OP_TIMES.KNIFE, 30, 'дефолт: смена ножей = 30 мин');
-// changeoverCost в минутах: сырьё/намотка/партия → MATERIAL_WINDING(15); ножи/сужение ролика → KNIFE(30)
+assertEqual(planning.DEFAULT_OP_TIMES.KNIFE_MOVE, 2, 'дефолт #3472: перемещение ножа = 2 мин');
+// #3472: changeoverCost в минутах: сырьё/намотка/партия → MATERIAL_WINDING(15);
+// ножи → KNIFE_MOVE(2) × число переставленных ножей (нож с сохранённой шириной не двигаем).
 var base = { materialId:'1', winding:'IN', batchId:'b1', jumboRemainingM:0, knifeCount:4, knifeWidths:[60,60,60,60], rollerWidth:60 };
 function clone(o,patch){ var c={}; for(var k in o) c[k]=o[k]; for(var k in (patch||{})) c[k]=patch[k]; return c; }
 assertEqual(planning.changeoverCost(base, clone(base), null), 0, 'cost: идентичные → 0');
 assertEqual(planning.changeoverCost(base, clone(base,{materialId:'2'}), null), 15, 'cost: смена сырья = 15');
 assertEqual(planning.changeoverCost(base, clone(base,{winding:'OUT'}), null), 15, 'cost: смена намотки = 15 (та же операция)');
 assertEqual(planning.changeoverCost(base, clone(base,{batchId:'b2'}), null), 15, 'cost: смена партии = смена сырья = 15');
-assertEqual(planning.changeoverCost(base, clone(base,{knifeCount:20, knifeWidths:[20,20,20]}), null), 30, 'cost: смена ножей = 30');
-assertEqual(planning.changeoverCost(base, clone(base,{rollerWidth:40}), null), 30, 'cost: сужение ролика = смена ножей = 30');
-assertEqual(planning.changeoverCost(base, clone(base,{materialId:'2', knifeCount:20, knifeWidths:[20,20,20]}), null), 45, 'cost: сырьё+ножи = 15+30 = 45');
-assertEqual(planning.changeoverCost(base, clone(base,{materialId:'2'}), { MATERIAL_WINDING:7, KNIFE:99 }), 7, 'cost: времена берутся из переданной таблицы');
+// #3472: 4 ножа[60] → набор 20 ножей[20] (общих ширин нет) = 20 перестановок × 2 = 40.
+assertEqual(planning.changeoverCost(base, clone(base,{knifeCount:20, knifeWidths:[20,20,20]}), null), 40, 'cost #3472: полная смена 20 ножей = 40');
+// #3472: ножи те же, ролик сужается → минимум одно перемещение = 2.
+assertEqual(planning.changeoverCost(base, clone(base,{rollerWidth:40}), null), 2, 'cost #3472: сужение ролика = 2 (минимум 1 перемещение)');
+assertEqual(planning.changeoverCost(base, clone(base,{materialId:'2', knifeCount:20, knifeWidths:[20,20,20]}), null), 55, 'cost #3472: сырьё+ножи = 15+40 = 55');
+assertEqual(planning.changeoverCost(base, clone(base,{materialId:'2'}), { MATERIAL_WINDING:7, KNIFE_MOVE:99 }), 7, 'cost: времена берутся из переданной таблицы');
 
 // ── orderCuts: жадное упорядочивание, Фольга в конец, настройка весов ──
 function cut(id,o){ return { id:id, materialId:o.m, winding:o.w||'IN', batchId:o.b||('B'+id), jumboRemainingM:o.r==null?0:o.r, knifeCount:o.k||4, knifeWidths:o.kw||[60], isFoil:!!o.foil, rollerWidth:o.rw||60 }; }
@@ -487,7 +491,7 @@ var outMat = planning.orderCuts(inMat).map(function(c){return c.materialId;});
 var bnd = 0; for (var i=1;i<outMat.length;i++) if (outMat[i]!==outMat[i-1]) bnd++;
 assertEqual(bnd, 1, 'orderCuts: сырьё сгруппировано (1 граница)');
 // #3268: реальные минуты переналадки важнее механической сортировки по ножам.
-// A-high → A-low → B-mid = 30 + 45 = 75 мин; A-high → B-mid → A-low = 45 + 45 = 90 мин.
+// #3472: A-high → A-low → B-mid = 4 + 17 = 21 мин; A-high → B-mid → A-low = 17 + 17 = 34 мин.
 var setupMinuteCuts = [
     cut('A-high', { m:'A', b:'bA', k:8, kw:[60] }),
     cut('B-mid',  { m:'B', b:'bB', k:7, kw:[60] }),
@@ -501,9 +505,9 @@ assertEqual(planning.orderCuts(setupMinuteCuts, { strategy: planning.PLANNING_ST
 var inFoil = [ cut('1',{m:'A',foil:true}), cut('2',{m:'A'}), cut('3',{m:'A'}) ];
 var outFoil = planning.orderCuts(inFoil).map(function(c){return c.id;});
 assertEqual(outFoil[outFoil.length-1], '1', 'orderCuts: Фольга в конце');
-// нож (30) дороже смены сырья (15): смена набора ножей штрафуется сильнее, чем смена сырья.
+// #3472: полная смена набора ножей дороже смены сырья (9 перестановок = 18 > 15).
 assertEqual(planning.changeoverCost(base, clone(base,{knifeCount:9, knifeWidths:[10,10,10,10,10,10,10,10,10]}), null) >
-            planning.changeoverCost(base, clone(base,{materialId:'9'}), null), true, 'changeoverCost: смена ножей (30) дороже смены сырья (15)');
+            planning.changeoverCost(base, clone(base,{materialId:'9'}), null), true, 'changeoverCost #3472: полная смена ножей (18) дороже смены сырья (15)');
 // sequence 1..N и вход не мутируется
 var src = [ cut('1',{m:'A'}), cut('2',{m:'A'}) ];
 var res = planning.orderCuts(src);
@@ -534,7 +538,7 @@ assertEqual(planning.orderCuts(cuts3412).map(function(c){ return c.knifeCount; }
 // Минимизация переналадки (#3268) не страдает: цепочка по-прежнему оптимальна по минутам.
 assertEqual(planning.orderedChangeoverCost(cuts3412), planning.orderedChangeoverCost(cuts3412.slice().reverse()),
     'orderCuts #3412: стоимость переналадки не зависит от исходного порядка (детерминированный минимум)');
-assertEqual(planning.orderedChangeoverCost(cuts3412), 45, 'orderCuts #3412: суммарная переналадка минимальна (45 мин)');
+assertEqual(planning.orderedChangeoverCost(cuts3412), 47, 'orderCuts #3412: суммарная переналадка минимальна (#3472: 15 + 16×2 = 47)');
 
 // #3421: генерация хардкодила стратегию FATIGUE («сложные раньше»), которая по
 // route-score выдаёт ножи по ВОЗРАСТАНИЮ (6,16,16) на данных скриншота — вопреки
@@ -555,9 +559,11 @@ assertEqual(planning.fatiguePositionWeight(0, 3, 2), 1, 'fatiguePositionWeight #
 assertEqual(planning.fatiguePositionWeight(2, 3, 2), 3, 'fatiguePositionWeight #3272: последняя позиция = 1 + alpha');
 assertEqual(planning.estimatedKnifeCount({ rollerWidth: 25 }, 1600), 64, 'estimatedKnifeCount #3272: Wmax / width');
 assertEqual(planning.estimatedKnifeCount({ knifeCount: 7, rollerWidth: 25 }, 1600), 7, 'estimatedKnifeCount #3272: явное число ножей важнее оценки по ширине');
+// #3472: наборы ножей заданы явно (узкая = 30 ножей по 25, широкая = 4 по 200) — стоимость
+// маршрута теперь отражает реальные перестановки; estimatedKnifeCount по-прежнему от ширины ролика.
 var fatigueNarrowFirst = [
-    { id: 'narrow', materialId: 'M', winding: 'IN', batchId: 'b', rollerWidth: 25, knifeCount: 0, knifeWidths: [] },
-    { id: 'wide', materialId: 'M', winding: 'IN', batchId: 'b', rollerWidth: 200, knifeCount: 0, knifeWidths: [] }
+    { id: 'narrow', materialId: 'M', winding: 'IN', batchId: 'b', rollerWidth: 25, knifeCount: 0, knifeWidths: w3412([[25, 30]]) },
+    { id: 'wide', materialId: 'M', winding: 'IN', batchId: 'b', rollerWidth: 200, knifeCount: 0, knifeWidths: w3412([[200, 4]]) }
 ];
 assertEqual(planning.fatigueRouteScore(fatigueNarrowFirst, { machineWidth: 1600, fatigueFactor: 2, startCost: 45 }) <
             planning.fatigueRouteScore(fatigueNarrowFirst.slice().reverse(), { machineWidth: 1600, fatigueFactor: 2, startCost: 45 }),
@@ -1153,8 +1159,8 @@ assertEqual(planning.changeoverParts(toBase, toClone({materialId:'2'}), null),
     [{code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}],
     'changeoverParts: смена сырья → MATERIAL_WINDING 15');
 assertEqual(planning.changeoverParts(toBase, toClone({materialId:'2', knifeCount:9, knifeWidths:[10,10,10,10,10,10,10,10,10]}), null),
-    [{code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}, {code:'KNIFE', label:'смена ножей / сужение ролика', minutes:30}],
-    'changeoverParts: сырьё+ножи → две операции (15+30)');
+    [{code:'MATERIAL_WINDING', label:'смена сырья / намотки / партии', minutes:15}, {code:'KNIFE', label:'перестановка ножей / сужение ролика', minutes:18}],
+    'changeoverParts #3472: сырьё+ножи → две операции (15 + 9×2=18)');
 assertEqual(planning.changeoverParts(null, toBase, null), [], 'changeoverParts: нет предыдущей → []');
 assertEqual(planning.setupBreakdown(null, toBase, null),
     [{code:'BETWEEN_CUTS', label:'лидер между резками', minutes:2}],

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -205,14 +205,25 @@ assertEqual(plan.cuts, [
       planDate: '06.05.2026', status: 'В работе', sequence: null,
       materialId: '', materialName: '', batchId: '',
       jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, length: 0, plannedRuns: 0, duration: 0, timing: '', isFoil: false,
-      orderId: '', orderApprovalDate: '' },
+      orderId: '', orderApprovalDate: '', leaders: [] },
     { id: '20', number: '27.05.2026', slitter: { id: null, label: '' },
       materialBatch: { id: null, label: '' },
       planDate: '27.05.2026', status: 'Ожидает', sequence: null,
       materialId: '', materialName: '', batchId: '',
       jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, length: 0, plannedRuns: 0, duration: 0, timing: '', isFoil: false,
-      orderId: '', orderApprovalDate: '' }
+      orderId: '', orderApprovalDate: '', leaders: [] }
 ], 'rowsToPlanning dedups cuts by cut_id, slitter без id → {id:null}, #3242 number=cut_plan_date');
+// #3472: cut_leader собирается в leaders[] (различные); легаси-смешение → несколько.
+var leadPlan = planning.rowsToPlanning([
+    { cut_id:'31', cut_plan_date:'x', supply_id:'s1', supply_position_id:'p1', cut_leader:'Софмикс' },
+    { cut_id:'31', cut_plan_date:'x', supply_id:'s2', supply_position_id:'p2', cut_leader:'Софмикс' },
+    { cut_id:'32', cut_plan_date:'y', supply_id:'s3', supply_position_id:'p3', cut_leader:'Этикетка37' },
+    { cut_id:'32', cut_plan_date:'y', supply_id:'s4', supply_position_id:'p4', cut_leader:'MONOCHROME' },
+    { cut_id:'33', cut_plan_date:'z', supply_id:'s5', supply_position_id:'p5' }
+]);
+assertEqual(leadPlan.cuts.map(function(c){ return c.leaders; }),
+    [['Софмикс'], ['Этикетка37','MONOCHROME'], []],
+    'rowsToPlanning #3472: leaders[] — различные лидеры резки (легаси-смешение видно)');
 assertEqual(plan.supplies, [
     { id: '900', positionId: '700', cutId: '10', finishedBatchId: '', footage: 0, rolls: 0 },
     { id: '901', positionId: '701', cutId: '10', finishedBatchId: '', footage: 0, rolls: 0 }


### PR DESCRIPTION
Закрывает #3472.

## Концерн 1 — раскрой (`cut-layout.js`)

`planLayouts` переписан с «склеить весь кластер позиций одного сырья в одну
раскладку» на **менеджерскую модель**:

- **seed «1 заказ = 1 резка»** — каждая различная ширина идёт отдельной
  раскладкой с максимальным заполнением джамбо (полос = ⌊джамбо/ширина⌋,
  прогонов = ⌈кол-во/полос⌉);
- **ограниченный B&B-перебор слияний** — две раскладки сливаются в комбо
  только если это **лексикографически** снижает цель: сперва расход джамбо
  (Σ прогонов), затем скрап (перепроизводство незапасных ширин);
- заказ **не дробится** на разные композиции; заказы объединяются **только по
  выгоде**, не «без надобности».

Пример из задачи теперь даёт план менеджера:

| | Резка | Полос | Использовано (джамбо 910) | Отход |
|---|---|---|---|---|
| Было (слитно) | 110 + 89 | 4 + 4 | 796 | 114 |
| **Стало** | 3673 · 110 | **8** | 880 | 30 |
| | 3672 · 89 | **10** | 890 | 20 |

Раздельно Σ 18 прогонов вместо 20 слитно. Отход 95мм → 20–30мм, как в экселе менеджера.

## Концерн 2 — стоимость переналадки ножей (`production-planning.js`)

Плоская `KNIFE = 30` заменена на **позиционную модель**: цена ножей =
`KNIFE_MOVE (2) × число переставленных ножей`. Нож с сохранённой шириной не
двигаем → **приоритет неизменности полос** (идентичные полосы = 0). Смена
количества — частный случай перемещений.

- `knifeMoves(a, b) = max(|a|, |b|) − |пересечение мультимножеств ширин|`;
- `effKnifeWidths` — фоллбэк по `knifeCount`, когда ширины не развёрнуты;
- полная смена ~16 ножей ≈ 32 ≈ прежняя «смена ножей» 30 (масштаб сохранён);
- порядок очереди в расписании сохранён (одинаковые наборы ножей = 0).

Лексикографика подтверждена пользователем: **отход первичен, переналадка вторична**.

## Тесты

- новый `experiments/atex-cut-layout-3472.test.js` (15) — пример issue, выгодное
  слияние, отсутствие дробления/перепроизводства;
- обновлены ассерты переналадки в `atex-production-planning.test.js` под новую модель;
- все наборы зелёные: `cut-layout 27`, `production-planning 513`, `slitter 115`,
  `pp-3391 32`, `cut-map 21`.

> Примечание: `test-atex-pp-cut-for-position.js` имеет 3 пред­существующих
> падения (лидер×проходы, #3401) — к этому PR отношения не имеют, его числа не
> меняются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)