### PR TITLE
fix(atex): cut-optimizer — поле кол-ва числовое (шаг 5) + живой пересчёт (#3478)

### DIFF
--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -653,6 +653,8 @@
             placeholder: 'напр. 910', value: this.widthValue || '' });
         this.lengthInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
             placeholder: 'напр. 4000', value: this.lengthValue || '' });
+        this.widthInput.addEventListener('input', function() { self.widthValue = self.widthInput.value; self.maybeRecalc(); });
+        this.lengthInput.addEventListener('input', function() { self.lengthValue = self.lengthInput.value; self.maybeRecalc(); });
         dims.appendChild(el('div', { class: 'atex-co-field' }, [
             el('label', { class: 'atex-co-label', text: 'Ширина входа (джамбо), мм' }), this.widthInput
         ]));
@@ -670,7 +672,7 @@
         this.renderRows();
 
         var addBtn = el('button', { class: 'atex-co-btn atex-co-btn-secondary', type: 'button', text: '+ Добавить ширину' });
-        addBtn.addEventListener('click', function() { self.rows.push({ width: '', qty: '1' }); self.renderRows(); });
+        addBtn.addEventListener('click', function() { self.rows.push({ width: '', qty: '1' }); self.renderRows(); self.maybeRecalc(); });
         form.appendChild(addBtn);
 
         var calcBtn = el('button', { class: 'atex-co-btn atex-co-btn-primary', type: 'button', text: 'Рассчитать' });
@@ -690,15 +692,17 @@
         this.rows.forEach(function(row, idx) {
             var widthInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
                 placeholder: 'ширина, мм', value: row.width });
-            widthInput.addEventListener('input', function() { row.width = widthInput.value; });
-            var qtyInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'numeric',
-                placeholder: 'кол-во', value: row.qty });
-            qtyInput.addEventListener('input', function() { row.qty = qtyInput.value; });
+            widthInput.addEventListener('input', function() { row.width = widthInput.value; self.maybeRecalc(); });
+            // Кол-во — целое, числовое, шаг 5 (#3478).
+            var qtyInput = el('input', { class: 'atex-co-input', type: 'number', inputmode: 'numeric',
+                min: '0', step: '5', placeholder: 'кол-во', value: row.qty });
+            qtyInput.addEventListener('input', function() { row.qty = qtyInput.value; self.maybeRecalc(); });
             var del = el('button', { class: 'atex-co-row-del', type: 'button', title: 'Удалить', text: '×' });
             del.addEventListener('click', function() {
                 self.rows.splice(idx, 1);
                 if (!self.rows.length) self.rows.push({ width: '', qty: '1' });
                 self.renderRows();
+                self.maybeRecalc();
             });
             box.appendChild(el('div', { class: 'atex-co-row' }, [widthInput, qtyInput, del]));
         });
@@ -713,6 +717,7 @@
             this.widthValue = String(m.width || '');
             this.lengthValue = String(m.length || '');
         }
+        this.maybeRecalc();
     };
 
     // ── Расчёт ──
@@ -726,7 +731,17 @@
             actualWidthIndex: this.actualWidthIndex,
             maxMaps: MAX_MAPS
         });
+        this.calculated = true;   // после первого расчёта правки полей пересчитывают раскладку (#3478)
         this.renderResult();
+    };
+
+    // Живой пересчёт раскладки при изменении полей — только после первого
+    // «Рассчитать» (#3478). Дебаунс, чтобы не пересчитывать на каждое нажатие.
+    AtexCutOptimizer.prototype.maybeRecalc = function() {
+        if (!this.calculated) return;
+        var self = this;
+        if (this._recalcTimer) clearTimeout(this._recalcTimer);
+        this._recalcTimer = setTimeout(function() { self._recalcTimer = null; self.calculate(); }, 200);
     };
 
     AtexCutOptimizer.prototype.renderResult = function() {

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 23);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 24);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Исправления к рабочему месту «Расчёт оптимальной резки» по ideav/crm#3478 (follow-up к #3477).

## Что сделано
1. **Поле «Кол-во» — числовое, целое, шаг 5.** `type="number"`, `min="0"`, `step="5"`, `inputmode="numeric"` (было `type="text"`).
2. **Живой пересчёт раскладки.** После первого «Рассчитать» изменение количества (а также ширины полосы, ширины/длины джамбо, добавление/удаление ширины, смены вида сырья) автоматически пересчитывает карты раскроя и сводку — без повторного клика. Дебаунс 200 мс, чтобы не пересчитывать на каждое нажатие; левая форма не перерисовывается, фокус в поле сохраняется.

`index.php`: VERSION 23 → 24 (сброс кэша js).

## Проверка
- `node experiments/atex-cut-optimizer.test.js` — 47 проверок ядра проходят (ядро расчёта не менялось).
- Браузерный стенд `experiments/atex-cut-optimizer.fixture.html`: поле «Кол-во» имеет `type=number/step=5/min=0`; правка количества на лету (14→28) обновляет план (15/15 → 50/29) без клика «Рассчитать».

Fixes #3478

🤖 Generated with [Claude Code](https://claude.com/claude-code)