### PR TITLE
fix(atex): cut-optimizer — «Итого рулонов: N из M», выделить N (что сообщают клиенту)

### DIFF
--- a/download/atex/css/cut-optimizer.css
+++ b/download/atex/css/cut-optimizer.css
@@ -304,6 +304,10 @@
 }
 .atex-co-metric.is-primary .atex-co-metric-label { color: var(--co-accent); }
 .atex-co-metric.is-primary .atex-co-metric-value { color: var(--co-accent); font-size: 26px; }
+/* «Итого рулонов»: «получится» (то, что сообщают клиенту) выделено крупно;
+   «из <желаемо>» — мельче и приглушённо. */
+.atex-co-rolls-got { font-size: 32px; font-weight: 800; }
+.atex-co-rolls-of { font-size: 15px; font-weight: 600; color: var(--co-muted); }
 
 .atex-co-nominal { color: var(--co-muted); }
 

--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -842,7 +842,13 @@
     AtexCutOptimizer.prototype.renderSummary = function(p) {
         var summary = el('div', { class: 'atex-co-summary' });
         // Главные параметры (req #3474.5) — выделены классом is-primary (цветом).
-        summary.appendChild(metric('Итого рулонов', p.totalProduced + ' / ' + p.totalDesired, true));
+        // «Итого рулонов» — «<получится> из <желаемо>»; число «получится» это то,
+        // что сообщают клиенту, поэтому выделено отдельно (atex-co-rolls-got).
+        var rolls = el('span', { class: 'atex-co-rolls' }, [
+            el('span', { class: 'atex-co-rolls-got', text: String(p.totalProduced) }),
+            el('span', { class: 'atex-co-rolls-of', text: ' из ' + p.totalDesired })
+        ]);
+        summary.appendChild(metric('Итого рулонов', rolls, true));
         summary.appendChild(metric('Общий отход, м²', p.rollLength > 0 ? p.totalWasteAreaM2 : '—', true));
         summary.appendChild(metric('Карт раскроя', p.mapCount));
         summary.appendChild(metric('Всего резок', p.totalPasses));
@@ -850,9 +856,12 @@
         return summary;
 
         function metric(label, value, primary) {
+            var valueEl = el('span', { class: 'atex-co-metric-value' });
+            if (value && value.nodeType) valueEl.appendChild(value);
+            else valueEl.textContent = String(value);
             return el('div', { class: 'atex-co-metric' + (primary ? ' is-primary' : '') }, [
                 el('span', { class: 'atex-co-metric-label', text: label }),
-                el('span', { class: 'atex-co-metric-value', text: String(value) })
+                valueEl
             ]);
         }
     };

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 23);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 24);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Правка сводки рабочего места «Расчёт оптимальной резки» (`/atex/cut-optimizer`).

## Что сделано
- Метрика «Итого рулонов» теперь выводится как **«75 из 70»** (было «75 / 70»).
- Число **«получится»** (например 75) — это то, что сообщают клиенту, поэтому выделено отдельно: крупно (32px) и жирным; «из 70» — мельче (15px) и приглушённым цветом.

`index.php`: VERSION 23 → 24 (сброс кэша js/css).

## Проверка
- `node experiments/atex-cut-optimizer.test.js` — 47 проверок ядра проходят (ядро не менялось).
- Браузерный стенд: сводка выводит «<получится> из <желаемо>», первое число выделено крупно/жирным, «из <желаемо>» — мельче и приглушённо.

🤖 Generated with [Claude Code](https://claude.com/claude-code)