### PR TITLE
fix(atex): cut-optimizer — список длины не фильтровать + показывать 450 (#3482)

### DIFF
--- a/download/atex/css/cut-optimizer.css
+++ b/download/atex/css/cut-optimizer.css
@@ -89,6 +89,42 @@
     box-shadow: 0 0 0 2px rgba(19, 65, 116, .15);
 }
 
+/* Комбобокс «Длина рулона» (#3482): свой ввод + полный нефильтруемый список */
+.atex-co-combo { position: relative; }
+.atex-co-combo-input { padding-right: 30px; }
+.atex-co-combo-caret {
+    position: absolute;
+    top: 1px;
+    right: 1px;
+    bottom: 1px;
+    width: 28px;
+    border: 0;
+    background: transparent;
+    color: var(--co-muted);
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1;
+}
+.atex-co-combo-caret:hover { color: var(--co-accent); }
+.atex-co-combo-list {
+    display: none;
+    position: absolute;
+    z-index: 30;
+    left: 0;
+    right: 0;
+    top: calc(100% + 2px);
+    max-height: 220px;
+    overflow: auto;
+    background: var(--co-bg);
+    border: 1px solid var(--co-border);
+    border-radius: 6px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, .14);
+}
+.atex-co-combo.is-open .atex-co-combo-list { display: block; }
+.atex-co-combo-item { padding: 7px 10px; cursor: pointer; }
+.atex-co-combo-item:hover { background: var(--co-surface); }
+.atex-co-combo-item.is-active { background: var(--co-surface); font-weight: 600; color: var(--co-accent); }
+
 .atex-co-rows-head { margin: 6px 0 6px; }
 .atex-co-rows { display: flex; flex-direction: column; gap: 8px; margin-bottom: 8px; }
 .atex-co-row {

--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -75,9 +75,10 @@
     var DEFAULT_POSITION_STATUS = 'Новая';
     var MAX_MAPS = 3;
     // Длина рулона по умолчанию и набор стандартных длин для выбора (можно ввести
-    // свою). Список — по частоте использования в заказах (м).
+    // свою). Список показывается целиком, без фильтрации по введённому значению,
+    // и включает значение по умолчанию (#3482).
     var DEFAULT_LENGTH = 450;
-    var LENGTH_PRESETS = [300, 600, 700, 900, 1000];
+    var LENGTH_PRESETS = [300, 450, 600, 700, 900, 1000];
 
     // ───────────────────────── Чистое ядро расчёта ─────────────────────────
 
@@ -656,20 +657,16 @@
         var dims = el('div', { class: 'atex-co-grid2' });
         this.widthInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
             placeholder: 'напр. 910', value: this.widthValue || '' });
-        // Длина рулона: выбор из стандартного списка с возможностью ввести свою.
-        var lengthListId = 'atex-co-length-list';
-        var lengthList = el('datalist', { id: lengthListId },
-            LENGTH_PRESETS.map(function(v) { return el('option', { value: String(v) }); }));
-        this.lengthInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
-            list: lengthListId, autocomplete: 'off', placeholder: 'напр. 450',
-            value: (this.lengthValue == null || this.lengthValue === '') ? String(DEFAULT_LENGTH) : this.lengthValue });
         this.widthInput.addEventListener('input', function() { self.widthValue = self.widthInput.value; self.maybeRecalc(); });
-        this.lengthInput.addEventListener('input', function() { self.lengthValue = self.lengthInput.value; self.maybeRecalc(); });
+        // Длина рулона: комбобокс — выбор из полного (нефильтруемого) списка
+        // стандартных длин с возможностью ввести свою (#3482).
+        var lengthCombo = this.makeLengthCombo();
+        this.lengthInput = lengthCombo.input;
         dims.appendChild(el('div', { class: 'atex-co-field' }, [
             el('label', { class: 'atex-co-label', text: 'Ширина входа (джамбо), мм' }), this.widthInput
         ]));
         dims.appendChild(el('div', { class: 'atex-co-field' }, [
-            el('label', { class: 'atex-co-label', text: 'Длина рулона, м' }), this.lengthInput, lengthList
+            el('label', { class: 'atex-co-label', text: 'Длина рулона, м' }), lengthCombo.node
         ]));
         form.appendChild(dims);
 
@@ -716,6 +713,49 @@
             });
             box.appendChild(el('div', { class: 'atex-co-row' }, [widthInput, qtyInput, del]));
         });
+    };
+
+    // Комбобокс «Длина рулона»: текстовое поле (свой ввод) + кнопка-стрелка,
+    // открывающая ПОЛНЫЙ список стандартных длин без фильтрации по значению (#3482).
+    AtexCutOptimizer.prototype.makeLengthCombo = function() {
+        var self = this;
+        var input = el('input', { class: 'atex-co-input atex-co-combo-input', type: 'text', inputmode: 'decimal',
+            autocomplete: 'off', placeholder: 'напр. 450', role: 'combobox',
+            value: (this.lengthValue == null || this.lengthValue === '') ? String(DEFAULT_LENGTH) : this.lengthValue });
+        var caret = el('button', { class: 'atex-co-combo-caret', type: 'button', tabindex: '-1',
+            'aria-label': 'Показать список длин', text: '▾' });
+        var listEl = el('div', { class: 'atex-co-combo-list', role: 'listbox' });
+        var wrap = el('div', { class: 'atex-co-combo' }, [input, caret, listEl]);
+
+        function rebuild() {
+            listEl.innerHTML = '';
+            LENGTH_PRESETS.forEach(function(v) {
+                var active = String(v) === String(input.value).trim();
+                var item = el('div', { class: 'atex-co-combo-item' + (active ? ' is-active' : ''),
+                    role: 'option', text: String(v) + ' м' });
+                item.addEventListener('mousedown', function(e) {
+                    e.preventDefault();
+                    input.value = String(v);
+                    self.lengthValue = String(v);
+                    closeList();
+                    self.maybeRecalc();
+                });
+                listEl.appendChild(item);
+            });
+        }
+        function openList() { rebuild(); wrap.classList.add('is-open'); }
+        function closeList() { wrap.classList.remove('is-open'); }
+        function isOpen() { return wrap.classList.contains('is-open'); }
+
+        caret.addEventListener('mousedown', function(e) { e.preventDefault(); if (isOpen()) closeList(); else openList(); input.focus(); });
+        input.addEventListener('focus', openList);
+        // Ввод своей длины: список НЕ фильтруем — показываем целиком (только
+        // подсвечиваем совпадение), значение пересчитывает раскладку.
+        input.addEventListener('input', function() { self.lengthValue = input.value; rebuild(); self.maybeRecalc(); });
+        input.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeList(); });
+        document.addEventListener('mousedown', function(e) { if (!wrap.contains(e.target)) closeList(); });
+
+        return { node: wrap, input: input };
     };
 
     AtexCutOptimizer.prototype.onMaterialChange = function(id) {

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 25);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 26);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Правка поля «Длина рулона, м» рабочего места «Расчёт оптимальной резки» по ideav/crm#3482 (follow-up к #3481).

## Проблема
Поле длины было на нативном `<datalist>`, который **фильтрует** опции по тексту поля: при значении «450» список оказывался пустым (чтобы увидеть его, надо было очистить поле), и **450 в списке не было**.

## Что сделано
- Поле длины переведено на компактный **комбобокс**: текстовое поле (свой ввод сохранён) + кнопка-стрелка, по которой открывается **ПОЛНЫЙ список без фильтрации**.
- **450 добавлено в список**: 300 / 450 / 600 / 700 / 900 / 1000 м; текущее значение подсвечивается.
- Очищать поле, чтобы увидеть список, больше не нужно.

`index.php`: VERSION 25 → 26 (сброс кэша js/css).

## Проверка
- `node experiments/atex-cut-optimizer.test.js` — 47 проверок ядра проходят.
- Браузерный стенд: при значении 450 список открывается целиком (300/450/600/700/900/1000), 450 присутствует и выделен; ввод произвольной длины (напр. 555) список не фильтрует; выбор пункта/ввод пересчитывают раскладку.

Fixes #3482

🤖 Generated with [Claude Code](https://claude.com/claude-code)