### PR TITLE
feat(atex): cut-optimizer — список подходящих партий сырья внизу формы

### DIFF
--- a/download/atex/css/cut-optimizer.css
+++ b/download/atex/css/cut-optimizer.css
@@ -131,6 +131,40 @@
 }
 .atex-co-btn-primary:hover { filter: brightness(1.08); background: var(--co-accent); }
 
+/* Подходящие партии сырья (внизу формы) */
+.atex-co-batches { margin-top: 16px; border-top: 1px solid var(--co-border-soft); padding-top: 12px; }
+.atex-co-batches-hint { font-size: 12px; color: var(--co-muted); margin-top: 6px; }
+.atex-co-batch {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 8px;
+    align-items: center;
+    padding: 7px 10px;
+    margin-bottom: 6px;
+    border: 1px solid var(--co-border);
+    border-radius: 6px;
+    background: var(--co-bg);
+    font-size: 13px;
+}
+.atex-co-batch-no { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.atex-co-batch-rem { color: var(--co-muted); white-space: nowrap; }
+.atex-co-batch-flag {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--co-ok);
+    border: 1px solid var(--co-ok);
+    border-radius: 999px;
+    padding: 1px 8px;
+    white-space: nowrap;
+}
+/* Остатка не хватает — партия неактивна (предложить клиенту) */
+.atex-co-batch.is-insufficient {
+    opacity: .5;
+    background: var(--co-surface);
+    pointer-events: none;
+}
+.atex-co-batch.is-insufficient .atex-co-batch-flag { color: var(--co-muted); border-color: var(--co-border); }
+
 /* Правая колонка — результат */
 .atex-co-view {
     border: 1px solid var(--co-border);

--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -475,6 +475,7 @@
         this.orders = [];         // [{ id, number }]
         this.actualWidthIndex = {};
         this.materialId = '';
+        this.batches = [];        // [{ id, no, materialId, remainderM2, active, … }]
         this.rows = [{ width: '', qty: '1' }]; // желаемые полосы (UI-состояние)
         this.lengthValue = String(DEFAULT_LENGTH); // длина рулона по умолчанию (#3474-fix)
         this.plan = null;
@@ -583,6 +584,27 @@
         }).catch(function() { return []; });
     };
 
+    // Партии сырья — отчёт material_batches (JSON_KV): № партии, вид сырья (id+имя),
+    // остаток (м²), флаг «В работе» (is_active). Нет отчёта/доступа → пустой список.
+    AtexCutOptimizer.prototype.loadMaterialBatches = function() {
+        var self = this;
+        this.batches = [];
+        return this.getJson('report/material_batches?JSON_KV&LIMIT=0,5000').then(function(rows) {
+            self.batches = (Array.isArray(rows) ? rows : []).map(function(row) {
+                return {
+                    id: row.batch_id == null ? '' : String(row.batch_id),
+                    no: row.batch_no == null ? '' : String(row.batch_no).trim(),
+                    materialId: row.batch_material_id == null ? '' : String(row.batch_material_id).trim(),
+                    materialName: row.batch_material == null ? '' : String(row.batch_material).trim(),
+                    remainderM2: toNumber(row.batch_remainder_m2),
+                    remainderM: toNumber(row.batch_remainder_m),
+                    warehouse: row['Склад'] == null ? '' : String(row['Склад']).trim(),
+                    active: String(row.is_active == null ? '' : row.is_active).trim() !== ''
+                };
+            });
+        }).catch(function() { self.batches = []; });
+    };
+
     AtexCutOptimizer.prototype.materialById = function(id) {
         var wanted = String(id);
         return this.materials.filter(function(m) { return String(m.id) === wanted; })[0] || null;
@@ -616,7 +638,8 @@
                     self.loadRefList(self.meta.client).then(function(l) { self.clients = l; }),
                     self.loadRefList(self.meta.order).then(function(l) {
                         self.orders = l.map(function(o) { return { id: o.id, number: o.label }; });
-                    })
+                    }),
+                    self.loadMaterialBatches()
                 ]);
             })
             .then(function() { self.renderForm(); })
@@ -693,6 +716,53 @@
         form.addEventListener('keydown', function(e) {
             if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); self.calculate(); }
         });
+
+        // Подходящие партии сырья (внизу формы).
+        this.batchesEl = el('div', { class: 'atex-co-batches' });
+        form.appendChild(this.batchesEl);
+        this.renderBatches();
+    };
+
+    // Список подходящих партий сырья выбранного вида: только «В работе», по
+    // возрастанию остатка (м²). Партии, чьего остатка не хватает на текущий план
+    // (площадь джамбо = ширина × длина × число резок), показываются неактивными —
+    // их остаток лучше предложить клиенту, а не пускать в работу.
+    AtexCutOptimizer.prototype.renderBatches = function() {
+        var box = this.batchesEl;
+        if (!box) return;
+        box.innerHTML = '';
+        box.appendChild(el('div', { class: 'atex-co-rows-head' }, [
+            el('span', { class: 'atex-co-label', text: 'Подходящие партии сырья' })
+        ]));
+        if (!this.materialId) {
+            box.appendChild(el('div', { class: 'atex-co-batches-hint', text: 'Выберите вид сырья, чтобы увидеть партии.' }));
+            return;
+        }
+        var matId = String(this.materialId);
+        var list = this.batches
+            .filter(function(b) { return b.active && String(b.materialId) === matId; })
+            .sort(function(a, b) { return a.remainderM2 - b.remainderM2; });
+        if (!list.length) {
+            box.appendChild(el('div', { class: 'atex-co-batches-hint', text: 'Нет партий «В работе» по этому виду сырья.' }));
+            return;
+        }
+        // Сколько м² сырья нужно на план: ширина джамбо × длина рулона × число резок.
+        var p = this.plan;
+        var neededM2 = (p && p.feasible && p.inputWidth > 0 && p.rollLength > 0)
+            ? round3(p.inputWidth / 1000 * p.rollLength * p.totalPasses) : 0;
+        list.forEach(function(b) {
+            var insufficient = neededM2 > 0 && b.remainderM2 < neededM2;
+            var row = el('div', { class: 'atex-co-batch' + (insufficient ? ' is-insufficient' : '') });
+            if (insufficient) row.title = 'Остатка не хватает на резку (нужно ' + neededM2 + ' м²) — предложить клиенту.';
+            row.appendChild(el('span', { class: 'atex-co-batch-no', text: b.no || ('#' + b.id) }));
+            row.appendChild(el('span', { class: 'atex-co-batch-rem', text: b.remainderM2 + ' м²' }));
+            row.appendChild(el('span', { class: 'atex-co-batch-flag', text: 'В работе' }));
+            box.appendChild(row);
+        });
+        if (neededM2 > 0) {
+            box.appendChild(el('div', { class: 'atex-co-batches-hint',
+                text: 'Серые — остатка < ' + neededM2 + ' м² (на план), их лучше продать клиенту.' }));
+        }
     };
 
     AtexCutOptimizer.prototype.renderRows = function() {
@@ -727,6 +797,7 @@
             if (this.widthInput) this.widthInput.value = String(m.width || '');
             this.widthValue = String(m.width || '');
         }
+        this.renderBatches();
         this.maybeRecalc();
     };
 
@@ -743,6 +814,7 @@
         });
         this.calculated = true;   // после первого расчёта правки полей пересчитывают раскладку (#3478)
         this.renderResult();
+        this.renderBatches();     // достаточность остатка зависит от плана
     };
 
     // Живой пересчёт раскладки при изменении полей — только после первого

--- a/experiments/atex-cut-optimizer.fixture.html
+++ b/experiments/atex-cut-optimizer.fixture.html
@@ -55,6 +55,14 @@ var ACTUAL = [
 var SLEEVES = [ { i: 401, r: ['76 мм'] }, { i: 402, r: ['152 мм'] } ];
 var CLIENTS = [ { i: 501, r: ['ООО «Ромашка»'] }, { i: 502, r: ['ИП Петров'] } ];
 var ORDERS = [ { i: 601, r: ['1001'] }, { i: 602, r: ['1002'] } ];
+// Партии сырья (report/material_batches как в ateh): is_active 'X' = «В работе».
+var BATCHES = [
+    { batch_id: '701', batch_no: '1781000001', batch_material: 'Алюминий 1.0мм', batch_material_id: '202', batch_remainder_m2: '12000', batch_remainder_m: '', is_active: 'X', 'Склад': 'Производство' },
+    { batch_id: '702', batch_no: '1781000002', batch_material: 'Алюминий 1.0мм', batch_material_id: '202', batch_remainder_m2: '5000',  batch_remainder_m: '', is_active: 'X', 'Склад': 'Производство' },
+    { batch_id: '703', batch_no: '1781000003', batch_material: 'Алюминий 1.0мм', batch_material_id: '202', batch_remainder_m2: '900',   batch_remainder_m: '', is_active: 'X', 'Склад': 'Производство' },
+    { batch_id: '704', batch_no: '1781000004', batch_material: 'Алюминий 1.0мм', batch_material_id: '202', batch_remainder_m2: '50',    batch_remainder_m: '', is_active: '',  'Склад': 'Производство' }, // не «В работе» — не показывается
+    { batch_id: '705', batch_no: '1781000005', batch_material: 'Сталь 0.5мм',    batch_material_id: '201', batch_remainder_m2: '8000',  batch_remainder_m: '', is_active: 'X', 'Склад': 'Производство' }
+];
 
 window.fetch = function(url, opts) {
     var u = String(url);
@@ -72,6 +80,7 @@ window.fetch = function(url, opts) {
     if (/\/object\/103\//.test(u)) return json(CLIENTS);
     if (/\/object\/107\//.test(u)) return json(ORDERS);
     if (/\/report\/nextOrder/i.test(u)) return json([{ 'Заказ': '3690' }]); // как в БД ateh
+    if (/\/report\/material_batches/i.test(u)) return json(BATCHES);
     return json([]);
 };
 </script>

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 25);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 26);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Добавляет внизу формы рабочего места «Расчёт оптимальной резки» (`/atex/cut-optimizer`) список подходящих **партий сырья**.

## Что сделано
- Внизу формы — блок **«Подходящие партии сырья»** по выбранному виду сырья (отчёт `report/material_batches`).
- Только партии **«В работе»** (`is_active`), у каждой — отметка «В работе».
- Сортировка **по возрастанию остатка** (м²).
- Партии, чьего остатка **не хватает** на текущий план (нужная площадь джамбо = ширина × длина рулона × число резок, м²), показываются **неактивными** (серыми) — чтобы менеджер предложил эти остатки клиенту, а не пускал в работу.
- Список обновляется при выборе вида сырья и при пересчёте плана.

`index.php`: VERSION 25 → 26 (сброс кэша js/css).

## Источник данных
`report/material_batches?JSON_KV` (как в ateh): `batch_id`, `batch_no`, `batch_material_id` (фильтр по виду сырья), `batch_remainder_m2` (остаток, сортировка/достаточность), `is_active` («X» = «В работе»). Нет отчёта/доступа → список пуст (фича тихо деградирует).

## Проверка
- `node experiments/atex-cut-optimizer.test.js` — 47 проверок ядра проходят.
- Браузерный стенд: для Алюминия показаны 3 партии «В работе» по возрастанию (900 / 5000 / 12000 м²); партия другого сырья и не-«В работе» скрыты; после расчёта (нужно 4095 м²) партия 900 м² становится серой/неактивной с подсказкой «предложить клиенту».

🤖 Generated with [Claude Code](https://claude.com/claude-code)