### PR TITLE
feat(atex): кнопка «🗑» удаления задания (резки) с обеспечениями (#3486)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -331,6 +331,21 @@
 }
 .atex-pp-strips:hover { background: var(--pp-surface); }
 
+/* #3486: «🗑» — удалить задание (резку). В одном ряду с ↑↓/Полосы; акцент-цвет
+   только на ховере, чтобы случайно не притягивать клик. Клик не выбирает резку. */
+.atex-pp-cut-del {
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    padding: 5px 11px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    line-height: 1;
+}
+.atex-pp-cut-del:hover { background: var(--pp-attn-bg); border-color: var(--pp-attn-border); }
+.atex-pp.is-busy .atex-pp-cut-del { pointer-events: none; opacity: .4; }
+
 /* Инлайн-редактор полос резки */
 .atex-pp-strip-panel {
     border: 1px solid var(--pp-accent);

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -538,6 +538,30 @@
         return { cuts: dayCuts, supplies: daySupplies };
     }
 
+    // #3486: строки отчёта 81463 (cut → fulfillment, JSON_KV) → массив id «Обеспечений»
+    // удаляемой резки. Отчёт фильтруется серверно (FR_cutID), но если cutId передан —
+    // подстраховываемся и отбрасываем чужие строки. Берём колонку fulfillmentID,
+    // дедуплицируем и пропускаем пустые. Чистая функция — покрывается тестами.
+    function fulfillmentIdsFromRows(rows, cutId) {
+        var want = (cutId == null || cutId === '') ? null : String(cutId);
+        var seen = {};
+        var out = [];
+        (rows || []).forEach(function(row) {
+            if (!row) return;
+            if (want != null) {
+                var rc = row.cutID != null ? row.cutID : (row.cut_id != null ? row.cut_id : row.cutId);
+                if (rc != null && rc !== '' && String(rc) !== want) return;
+            }
+            var fid = row.fulfillmentID != null ? row.fulfillmentID
+                    : (row.fulfillment_id != null ? row.fulfillment_id : row.fulfillmentId);
+            fid = (fid == null) ? '' : String(fid).trim();
+            if (fid === '' || fid === 'null' || seen[fid]) return;
+            seen[fid] = true;
+            out.push(fid);
+        });
+        return out;
+    }
+
     // Текущая дата как «ГГГГ-ММ-ДД» для <input type=date> (только браузер).
     function todayISO() {
         var d = new Date();
@@ -3100,6 +3124,7 @@
         cutMatchesQuery: cutMatchesQuery,
         isCutVisible: isCutVisible,
         dayDeletionTargets: dayDeletionTargets,
+        fulfillmentIdsFromRows: fulfillmentIdsFromRows,   // #3486
         planDateDayKey: planDateDayKey,
         buildFields: buildFields,
         maxNumericCutNumber: maxNumericCutNumber,
@@ -4418,6 +4443,89 @@
             // Часть записей могла удалиться — перечитываем очередь, чтобы UI не врал.
             self.reload().then(function() { self.render(); }).catch(function() {});
             self.notify('Ошибка удаления заданий дня: ' + (err && err.message || err), 'error');
+        });
+    };
+
+    // #3486: подпись резки для подтверждения/тоста удаления. Берём сырьё и плановую
+    // дату (если есть), иначе — id. Без обращения к сети.
+    function cutTaskLabel(cut) {
+        if (!cut) return '';
+        var name = String(cut.materialName || '').trim();
+        var day = formatPlanDayLabel(String(cut.planDate || '').trim());
+        if (name && day) return name + ' · ' + day;
+        return name || day || ('#' + cut.id);
+    }
+
+    // #3486: id всех «Обеспечений» резки отчётом 81463 (cut → fulfillment). Они
+    // ссылаются на «Партии ГП» резки; пока ссылки живы, _m_del резки вернёт 409
+    // (DeleteTreeRefsCount в index.php), поэтому удалять их нужно ДО самой резки.
+    // Возвращает Promise<массив id>. LIMIT с запасом — резок с тысячами связей нет.
+    AtexProductionPlanning.prototype.loadCutFulfillments = function(cutId) {
+        return this.getJson('report/81463?JSON_KV&LIMIT=0,1000&FR_cutID=' + encodeURIComponent(cutId))
+            .then(function(rows) { return fulfillmentIdsFromRows(rows, cutId); });
+    };
+
+    // #3486: кнопка «🗑» в карточке резки. Сначала тянем id «Обеспечений» резки
+    // (report/81463), показываем подтверждение с их числом, по согласию — удаляем.
+    AtexProductionPlanning.prototype.deleteCutTask = function(cut, cardEl) {
+        var self = this;
+        if (this.busy || !cut) return;
+        var cutId = String(cut.id);
+        var label = cutTaskLabel(cut);
+        this.setBusy(true);
+        this.loadCutFulfillments(cutId).then(function(fulfillmentIds) {
+            self.setBusy(false);
+            var msg = el('span', { class: 'atex-pp-confirm-msg', text:
+                'Удалить задание «' + label + '»? Будет удалено обеспечений — ' +
+                fulfillmentIds.length + '. Действие необратимо.' });
+            self.confirmAction(msg, cardEl, [
+                { label: 'Удалить', warning: true, onConfirm: function() {
+                    self.runDeleteCutTask(cutId, fulfillmentIds, label);
+                } }
+            ]);
+        }).catch(function(err) {
+            self.setBusy(false);
+            self.notify('Не удалось получить обеспечения резки: ' + (err && err.message || err), 'error');
+        });
+    };
+
+    // #3486: удаление одной резки. Порядок как у заданий дня (#3475): сперва все
+    // «Обеспечение» (снимаем ссылки на «Партии ГП»), затем сама «Производственная
+    // резка» — backend каскадом (BatchDelete) сносит подчинённые Партии ГП/Полосы/Расход.
+    AtexProductionPlanning.prototype.runDeleteCutTask = function(cutId, fulfillmentIds, label) {
+        var self = this;
+        if (this.busy) return;
+        var ids = (fulfillmentIds || []).map(function(x) { return String(x); })
+            .filter(function(id) { return id && id !== 'null'; });
+        var total = ids.length + 1;   // обеспечения + сама резка
+
+        this.setBusy(true);
+        this.showProgress('Удаление задания «' + label + '»…', total);
+        var done = 0;
+        function del(id) {
+            return self.post('_m_del/' + encodeURIComponent(id) + '?JSON', {}).then(function() {
+                self.updateProgress(++done);
+            });
+        }
+        // Цепочка: сначала обеспечения, потом резка (см. комментарий выше).
+        var chain = Promise.resolve();
+        ids.forEach(function(id) { chain = chain.then(function() { return del(id); }); });
+        chain = chain.then(function() { return del(cutId); });
+
+        chain.then(function() {
+            return self.reload();
+        }).then(function() {
+            self.hideProgress();
+            self.setBusy(false);
+            if (String(self.selectedCutId) === String(cutId)) self.selectedCutId = null;
+            self.render();
+            self.notify('Задание удалено: обеспечений — ' + ids.length, 'success');
+        }).catch(function(err) {
+            self.hideProgress();
+            self.setBusy(false);
+            // Часть записей могла удалиться — перечитываем очередь, чтобы UI не врал.
+            self.reload().then(function() { self.render(); }).catch(function() {});
+            self.notify('Ошибка удаления задания: ' + (err && err.message || err), 'error');
         });
     };
 
@@ -6618,9 +6726,19 @@
                 if (self.busy) return;
                 self.openStrips(c, cardPanel);
             });
+            // #3486: «🗑» — удалить задание (резку) с её «Обеспечениями». stopPropagation,
+            // чтобы клик по кнопке не выбирал резку (см. #3149: клики по контролам не
+            // выбирают карточку). Подтверждение и удаление — в deleteCutTask.
+            var del = el('button', { class: 'atex-pp-cut-del', type: 'button', text: '🗑', title: 'Удалить задание' });
+            del.addEventListener('click', function(e) {
+                if (e && e.stopPropagation) e.stopPropagation();
+                if (self.busy) return;
+                self.deleteCutTask(c, cardPanel);
+            });
             controls.appendChild(up);
             controls.appendChild(down);
             controls.appendChild(strips);
+            controls.appendChild(del);
             cardPanel.appendChild(controls);
 
             groupEl.appendChild(cardPanel);

--- a/experiments/atex-production-planning-3486.test.js
+++ b/experiments/atex-production-planning-3486.test.js
@@ -1,0 +1,87 @@
+// Unit tests for fulfillmentIdsFromRows (ideav/crm#3486).
+// Кнопка «🗑» в карточке резки удаляет задание: сначала «Обеспечения» резки, затем
+// саму резку. Id «Обеспечений» приходят отчётом report/81463?JSON_KV&FR_cutID=<id>
+// в виде [{ cutID, fulfillmentID }, ...]. Чистый помощник fulfillmentIdsFromRows
+// извлекает из этих строк список id «Обеспечений»:
+//   • колонка fulfillmentID → массив id (порядок отчёта сохраняется);
+//   • дубли схлопываются, пустые/'null' пропускаются;
+//   • при заданном cutId чужие строки отбрасываются (подстраховка к серверному FR_cutID);
+//   • без cutId возвращаются все fulfillmentID;
+//   • терпимость к alt-именам (cut_id/fulfillment_id) и пустым входам.
+//
+// Run with: node experiments/atex-production-planning-3486.test.js
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) {
+        passed++;
+    } else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// Ответ отчёта 81463 из тикета: одна резка 76337 → семь обеспечений.
+var rows = [
+    { cutID: '76337', fulfillmentID: '76414' },
+    { cutID: '76337', fulfillmentID: '76419' },
+    { cutID: '76337', fulfillmentID: '76424' },
+    { cutID: '76337', fulfillmentID: '76429' },
+    { cutID: '76337', fulfillmentID: '76434' },
+    { cutID: '76337', fulfillmentID: '76439' },
+    { cutID: '76337', fulfillmentID: '76444' }
+];
+assertEqual(planning.fulfillmentIdsFromRows(rows, '76337'),
+    ['76414', '76419', '76424', '76429', '76434', '76439', '76444'],
+    'все fulfillmentID резки 76337 в порядке отчёта');
+
+// Без cutId — берём всё, что есть в строках.
+assertEqual(planning.fulfillmentIdsFromRows(rows, null),
+    ['76414', '76419', '76424', '76429', '76434', '76439', '76444'],
+    'без cutId — все fulfillmentID');
+
+// Подстраховка: если отчёт вернул строки разных резок, оставляем только запрошенную.
+var mixed = [
+    { cutID: '76337', fulfillmentID: '76414' },
+    { cutID: '99999', fulfillmentID: '88888' },   // чужая резка — отбросить
+    { cutID: '76337', fulfillmentID: '76419' }
+];
+assertEqual(planning.fulfillmentIdsFromRows(mixed, '76337'), ['76414', '76419'],
+    'чужие cutID отброшены при заданном cutId');
+
+// Дубли схлопываются, пустые/'null' пропускаются.
+var dirty = [
+    { cutID: '76337', fulfillmentID: '76414' },
+    { cutID: '76337', fulfillmentID: '76414' },   // дубль
+    { cutID: '76337', fulfillmentID: '' },        // пусто
+    { cutID: '76337', fulfillmentID: null },      // null
+    { cutID: '76337', fulfillmentID: 'null' },    // строка 'null'
+    { cutID: '76337', fulfillmentID: '76419' }
+];
+assertEqual(planning.fulfillmentIdsFromRows(dirty, '76337'), ['76414', '76419'],
+    'дедуп + пропуск пустых/null');
+
+// Числовые значения приводятся к строке.
+assertEqual(planning.fulfillmentIdsFromRows([{ cutID: 76337, fulfillmentID: 76414 }], 76337),
+    ['76414'], 'числовые cutID/fulfillmentID приводятся к строке');
+
+// Терпимость к alt-именам колонок (snake_case).
+assertEqual(planning.fulfillmentIdsFromRows([{ cut_id: '76337', fulfillment_id: '76414' }], '76337'),
+    ['76414'], 'alt-имена cut_id/fulfillment_id');
+
+// Строки без явного cutID не отбрасываются (FR_cutID уже отфильтровал серверно).
+assertEqual(planning.fulfillmentIdsFromRows([{ fulfillmentID: '76414' }], '76337'),
+    ['76414'], 'строка без cutID не отбрасывается');
+
+// Пустые/битые входы не падают.
+assertEqual(planning.fulfillmentIdsFromRows(null, '76337'), [], 'null-строки → []');
+assertEqual(planning.fulfillmentIdsFromRows([], '76337'), [], 'пустой массив → []');
+assertEqual(planning.fulfillmentIdsFromRows([null, undefined], '76337'), [], 'null-элементы пропускаются');
+
+console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Closes #3486

## Задача
В карточке резки на странице «Планирование производства» (atex) добавить кнопку «Удалить», которая удаляет «Производственную резку», но **сначала** — связанные через «Партию ГП» «Обеспечения» (иначе `_m_del` резки вернёт `409`, `DeleteTreeRefsCount` в `index.php`). Id обеспечений — отчётом `report/81463?JSON_KV&FR_cutID=<id>`.

## Решение
Точечная версия удаления заданий дня (#3476) для одной резки, тот же порядок и каскад.

- **Кнопка «🗑 Удалить задание»** в `.atex-pp-cut-controls` — в ряду с ↑↓/«Полосы». Клик не выбирает резку (`stopPropagation`, #3149).
- **`loadCutFulfillments(cutId)`** → `GET report/81463?JSON_KV&LIMIT=0,1000&FR_cutID=<id>` — id всех «Обеспечений» резки.
- **`fulfillmentIdsFromRows(rows, cutId)`** — чистый помощник: извлекает `fulfillmentID`, дедуп, пропуск пустых, и **дополнительно фильтрует по `cutID` на клиенте** — страховка на случай, если у колонки отчёта нет «Имени в отчёте» и `FR_cutID` молча проигнорируется (docs предупреждают об этом).
- **`deleteCutTask`** → подтверждение с числом обеспечений (`confirmAction`: модалка либо инлайн-плашка) → **`runDeleteCutTask`**: `_m_del` каждого «Обеспечения», затем `_m_del` резки (backend каскадом `BatchDelete` сносит Партии ГП / Полосы / Расход сырья). Прогресс-бар, `reload`, тост.
- Ошибки fail-closed: если отчёт недоступен/не-JSON — резка не удаляется, тост об ошибке.

## Файлы
- `download/atex/js/production-planning.js` (+118)
- `download/atex/css/production-planning.css` (+15, `.atex-pp-cut-del`)
- `experiments/atex-production-planning-3486.test.js` (+87)

## Проверки
- `node --check download/atex/js/production-planning.js` ✓
- `node experiments/atex-production-planning-3486.test.js` — 10/10 ✓
- регресс `atex-production-planning-3475.test.js` — 7/7 ✓
- бэкенд не менялся (`_m_del` и `report/` уже есть)

## Примечания
- `.atex-pp-cut-controls` рендерит `production-planning.js` (как ↑↓/«Полосы»), а не `.html` — поэтому правка в JS, хотя в заголовке issue указан `templates/atex/production-planning.html`.
- Зависимость от числового id отчёта **81463** (cut → fulfillment) — по тикету; docs рекомендуют вызов отчётов по числовому id. Живьём на инстансе atex путь `report/81463` не проверял (нет доступа к БД из среды) — стоит подтвердить при ревью.

🤖 Generated with [Claude Code](https://claude.com/claude-code)