### PR TITLE
feat(atex): задания «Зафиксировано» — фиксация, блокировки, стрелки даты, нумерация (#3508)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -161,6 +161,22 @@
 .atex-pp-filters .atex-pp-field { margin-bottom: 0; }
 /* #3411: быстрый поиск занимает ту же ширину, что и остальные фильтры. */
 .atex-pp-search { width: 100%; }
+/* #3508 п.1: поле «Дата плана» со стрелками листания ‹/› по бокам (±1 день). */
+.atex-pp-date-field { display: flex; align-items: stretch; gap: 6px; }
+.atex-pp-date-field .atex-pp-input { flex: 1 1 auto; min-width: 0; }
+.atex-pp-date-nav {
+    flex: 0 0 auto;
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    color: inherit;
+    cursor: pointer;
+    padding: 0 11px;
+    font: inherit;
+    font-size: 18px;
+    line-height: 1;
+}
+.atex-pp-date-nav:hover { background: var(--pp-surface); }
 
 .atex-pp-queue-group { margin-bottom: 16px; }
 
@@ -174,6 +190,10 @@
     cursor: pointer; /* клик по всей карточке выбирает резку (#3149) */
 }
 .atex-pp-cut:hover { background: var(--pp-surface); }
+/* #3508 п.5: зафиксированное задание — серая кайма (видно, что менять нельзя). Объявлено
+   ДО .is-active, чтобы у выбранной зафиксированной карточки выделение-акцент перекрывало. */
+.atex-pp-cut.is-fixed { border-color: #9ca3af; background: rgba(107, 114, 128, .06); box-shadow: inset 0 0 0 1px #cbd1d9; }
+.atex-pp-cut.is-fixed:hover { background: rgba(107, 114, 128, .1); }
 .atex-pp-cut.is-active { border-color: var(--pp-accent); box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
 /* Нет подходящей партии сырья — резку нельзя обеспечить (#3120 п.4, Фаза 1a). */
 .atex-pp-cut.is-unreserved { background: rgba(185, 28, 28, .07); border-color: var(--pp-warn); }
@@ -337,7 +357,7 @@
     border: 1px solid var(--pp-border);
     border-radius: 6px;
     background: var(--pp-bg);
-    padding: 5px 11px;
+    padding: 6px 12px;   /* #3508 п.4: размер как у кнопки «Полосы» — иконки в ряду ровные */
     cursor: pointer;
     font: inherit;
     color: inherit;
@@ -345,6 +365,37 @@
 }
 .atex-pp-cut-del:hover { background: var(--pp-attn-bg); border-color: var(--pp-attn-border); }
 .atex-pp.is-busy .atex-pp-cut-del { pointer-events: none; opacity: .4; }
+/* #3508 п.3: зафиксированное задание удалить нельзя — кнопка приглушена и не реагирует. */
+.atex-pp-cut-del.is-disabled,
+.atex-pp-cut-del:disabled { opacity: .4; cursor: default; }
+.atex-pp-cut-del:disabled:hover { background: var(--pp-bg); border-color: var(--pp-border); }
+
+/* #3508 п.4: «🔒» — зафиксировать/снять фиксацию ОДНОГО задания. Тот же размер, что у
+   «Полосы»/«🗑». is-active — задание уже зафиксировано (подсветка-«замок»). */
+.atex-pp-cut-fix {
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    padding: 6px 12px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    line-height: 1;
+}
+.atex-pp-cut-fix:hover { background: var(--pp-surface); }
+.atex-pp-cut-fix.is-active { background: rgba(107, 114, 128, .14); border-color: #9ca3af; }
+.atex-pp.is-busy .atex-pp-cut-fix { pointer-events: none; opacity: .4; }
+
+/* #3508 п.3: пометка «только просмотр» в панели полос зафиксированного задания. */
+.atex-pp-strip-locked-note {
+    margin: 6px 0 4px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: rgba(107, 114, 128, .1);
+    color: var(--pp-muted, #6b7280);
+    font-size: 13px;
+}
+.atex-pp-strip-panel.is-readonly .atex-pp-strip-table { opacity: .75; }
 
 /* Инлайн-редактор полос резки */
 .atex-pp-strip-panel {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -94,7 +94,8 @@
         timing: 'Тайминг',
         actualRuns: 'Кол-во факт',
         length: 'Метраж, м',
-        winding: 'Тип намотки'
+        winding: 'Тип намотки',
+        fixed: 'Зафиксировано'   // #3508: булев флаг (id 81530, type 11) — задание нельзя менять/удалять
     };
     var CUT_PLANNED_RUN_COLUMNS = [
         'cut_planned_runs',
@@ -527,6 +528,7 @@
         var dayCuts = (cuts || []).filter(function(c) {
             if (!c) return false;
             if (String(c.status || '').trim() === 'Завершён') return false;
+            if (c.fixed) return false;   // #3508 п.3: зафиксированные задания при удалении дня пропускаем
             var pd = String(c.planDate || '').trim();
             if (pd === '') return false;
             return planDateDayKey(pd) === dayKey;
@@ -569,6 +571,17 @@
         var m = String(d.getMonth() + 1); if (m.length < 2) m = '0' + m;
         var day = String(d.getDate()); if (day.length < 2) day = '0' + day;
         return d.getFullYear() + '-' + m + '-' + day;
+    }
+
+    // #3508 п.1: сдвиг даты фильтра «ГГГГ-ММ-ДД» на ±N дней (стрелки листания).
+    // Пустую/чужую дату трактуем как сегодня — первый клик задаёт конкретный день.
+    function shiftPlanDate(dateStr, deltaDays) {
+        var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim());
+        var d = m ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0) : new Date();
+        d.setDate(d.getDate() + deltaDays);
+        var mm = String(d.getMonth() + 1); if (mm.length < 2) mm = '0' + mm;
+        var dd = String(d.getDate()); if (dd.length < 2) dd = '0' + dd;
+        return d.getFullYear() + '-' + mm + '-' + dd;
     }
 
     // #3475: «ГГГГ-ММ-ДД» → «ДД.ММ.ГГГГ» для подписей (подтверждение/тост удаления дня).
@@ -785,6 +798,7 @@
                     planDate: str(row.cut_plan_date),
                     status: str(row.cut_status),
                     sequence: (seqVal == null || seqVal === '') ? null : Number(seqVal),
+                    fixed: false,   // #3508: уточняется из object/ в loadPlanning (отчёт флаг не отдаёт)
                     materialId: str(row.cut_material_id),
                     materialName: str(row.cut_material),
                     batchId: '',
@@ -3016,6 +3030,10 @@
         var arr = (orderedCuts || []).slice();
         var target = index + dir;
         if (index < 0 || index >= arr.length || target < 0 || target >= arr.length) return [];
+        // #3508 п.3: зафиксированные задания — «стены». Нельзя двигать сам зафиксированный
+        // и нельзя перепрыгивать через зафиксированного соседа: их относительный порядок и
+        // «Очередность» неизменны, нумерация остальных 1..N остаётся сплошной (без дублей).
+        if ((arr[index] && arr[index].fixed) || (arr[target] && arr[target].fixed)) return [];
         var tmp = arr[index]; arr[index] = arr[target]; arr[target] = tmp;
         var changed = [];
         arr.forEach(function(c, i){ var seq = i + 1; if (Number(c.sequence) !== seq) changed.push({ cutId: c.id, sequence: seq }); });
@@ -3672,23 +3690,31 @@
         });
     };
 
-    // Прямая карта очередности из object/ «Задание в производство». Нужна как источник
-    // истины после _m_set: отчёт cut_planning может отставать или отдать старый alias.
+    // Прямые карты очередности и флага «Зафиксировано» из object/ «Задание в
+    // производство». Нужны как источник истины после _m_set: отчёт cut_planning может
+    // отставать/отдать старый alias и вовсе НЕ содержит «Зафиксировано» (#3508).
+    // Возвращает { seq: { cutId: число|строка }, fixed: { cutId: bool } }.
     AtexProductionPlanning.prototype.loadCutSequences = function() {
         var meta = this.meta.cut;
-        if (!meta) return Promise.resolve({});
+        if (!meta) return Promise.resolve({ seq: {}, fixed: {} });
         var seqIdx = columnIndex(meta, CUT_REQ.sequence);
-        if (seqIdx < 0) return Promise.resolve({});
+        var fixedIdx = columnIndex(meta, CUT_REQ.fixed);   // #3508
+        if (seqIdx < 0 && fixedIdx < 0) return Promise.resolve({ seq: {}, fixed: {} });
         return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,5000').then(function(rows) {
-            var map = {};
+            var seq = {}, fixed = {};
             (rows || []).forEach(function(rec) {
                 var r = rec.r || [];
-                var raw = r[seqIdx];
-                if (raw == null || String(raw).trim() === '') return;
-                var n = Number(raw);
-                map[String(rec.i)] = isFinite(n) ? n : String(raw);
+                var id = String(rec.i);
+                if (seqIdx >= 0) {
+                    var raw = r[seqIdx];
+                    if (raw != null && String(raw).trim() !== '') {
+                        var n = Number(raw);
+                        seq[id] = isFinite(n) ? n : String(raw);
+                    }
+                }
+                if (fixedIdx >= 0) fixed[id] = truthyFlag(r[fixedIdx]);   // #3508
             });
-            return map;
+            return { seq: seq, fixed: fixed };
         });
     };
 
@@ -3944,7 +3970,9 @@
             this.loadCutSequences()
         ]).then(function(results) {
             var rows = results[0];
-            var sequenceByCut = results[1] || {};
+            var seqResult = results[1] || {};
+            var sequenceByCut = seqResult.seq || {};
+            var fixedByCut = seqResult.fixed || {};   // #3508
             self.reportCutPlanningDiagnostics(rows || []);
             var p = rowsToPlanning(rows || []);
             var agg = self.stripAgg || {};
@@ -3955,6 +3983,7 @@
                 if (Object.prototype.hasOwnProperty.call(sequenceByCut, String(cut.id))) {
                     cut.sequence = sequenceByCut[String(cut.id)];
                 }
+                cut.fixed = !!fixedByCut[String(cut.id)];   // #3508: флаг «Зафиксировано»
             });
             if (!self.footageBySupply) self.footageBySupply = {};
             p.supplies.forEach(function(supply) {
@@ -4370,6 +4399,84 @@
         });
     };
 
+    // #3508 п.2/п.4: проставить/снять флаг «Зафиксировано» у набора заданий. Пишем
+    // булев реквизит (t{id}='1'/'0') командой _m_set последовательно, затем перечитываем
+    // очередь — чтобы серая кайма/блокировки (п.3/п.5) обновились по источнику истины.
+    AtexProductionPlanning.prototype.setCutsFixed = function(cutIds, value, opts) {
+        var self = this;
+        var o = opts || {};
+        if (this.busy) return Promise.resolve(false);
+        var ids = (cutIds || []).map(function(x) { return String(x); })
+            .filter(function(id) { return id && id !== 'null'; });
+        if (!ids.length) {
+            if (!o.silent) self.notify(o.emptyMessage || 'Нет заданий для фиксации', 'info');
+            return Promise.resolve(false);
+        }
+        var fixedReqId = reqIdByName(this.meta.cut, CUT_REQ.fixed);
+        if (!fixedReqId) {
+            self.notify('Реквизит «' + CUT_REQ.fixed + '» не найден в метаданных', 'error');
+            return Promise.resolve(false);
+        }
+        var fieldKey = 't' + fixedReqId;
+        var flag = value ? '1' : '0';
+        this.setBusy(true);
+        this.showProgress((value ? 'Фиксация' : 'Снятие фиксации') + ' заданий…', ids.length);
+        var done = 0;
+        var chain = Promise.resolve();
+        ids.forEach(function(id) {
+            chain = chain.then(function() {
+                var fields = {}; fields[fieldKey] = flag;
+                return self.post('_m_set/' + encodeURIComponent(id) + '?JSON', fields)
+                    .then(function() { self.updateProgress(++done); });
+            });
+        });
+        return chain.then(function() {
+            return self.reload();
+        }).then(function() {
+            self.hideProgress(); self.setBusy(false); self.render();
+            if (!o.silent) {
+                self.notify(o.successMessage ||
+                    ((value ? 'Зафиксировано заданий: ' : 'Снята фиксация заданий: ') + ids.length), 'success');
+            }
+            return true;
+        }).catch(function(err) {
+            self.hideProgress(); self.setBusy(false);
+            self.reload().then(function() { self.render(); }).catch(function() {});
+            self.notify('Ошибка фиксации заданий: ' + (err && err.message || err), 'error');
+            return false;
+        });
+    };
+
+    // #3508 п.2: «Зафиксировать» — проставить флаг всем заданиям выбранного дня (все
+    // станки). День берём из фильтра «Дата плана». Уже зафиксированные не трогаем.
+    AtexProductionPlanning.prototype.fixDayTasks = function() {
+        var self = this;
+        if (this.busy) return;
+        var dateStr = String(this.filter && this.filter.date || '').trim();
+        if (dateStr === '') {
+            this.notify('Выберите «Дату плана», чтобы зафиксировать задания дня', 'error');
+            return;
+        }
+        var dayKey = planDateDayKey(dateStr);
+        var dayCuts = (this.cuts || []).filter(function(c) { return planDateDayKey(c.planDate) === dayKey; });
+        var toFix = dayCuts.filter(function(c) { return !c.fixed; });
+        var dateLabel = formatPlanDayLabel(dateStr);
+        if (!dayCuts.length) { this.notify('Нет заданий за ' + dateLabel + ' для фиксации', 'info'); return; }
+        if (!toFix.length) { this.notify('Все задания за ' + dateLabel + ' уже зафиксированы', 'info'); return; }
+        self.setCutsFixed(toFix.map(function(c) { return c.id; }), true, {
+            successMessage: 'Зафиксированы задания за ' + dateLabel + ': ' + toFix.length
+        });
+    };
+
+    // #3508 п.4: иконка «🔒» в карточке — переключить фиксацию одного задания
+    // (зафиксировано ↔ снято), чтобы можно было и поставить, и снять флаг.
+    AtexProductionPlanning.prototype.toggleCutFixed = function(cut) {
+        if (!cut) return;
+        this.setCutsFixed([cut.id], !cut.fixed, {
+            successMessage: (cut.fixed ? 'Снята фиксация задания' : 'Задание зафиксировано')
+        });
+    };
+
     // #3475: «Удалить» — снести все задания выбранного дня. Показывает подтверждение
     // (сколько резок/обеспечений будет удалено), затем зовёт runDeleteDayTasks. День —
     // «Дата плана» из фильтра (this.filter.date); без даты удалять нечего (неоднозначно).
@@ -4746,12 +4853,30 @@
             var original = loaded.map(function(s) { return { id: s.id, width: s.width, qty: s.qty }; });
             var strips = loaded.map(function(s) { return { id: s.id, width: s.width, qty: s.qty }; });
             self.renderStripPanel(panel, cut, strips, original);
+            if (cut.fixed) self.lockStripPanel(panel);   // #3508 п.3: зафиксированное — только просмотр
         }).catch(function(err) {
             if (panel.parentNode) {
                 panel.innerHTML = '';
                 panel.appendChild(el('div', { class: 'atex-pp-empty', text: 'Ошибка загрузки полос: ' + err.message }));
             }
         });
+    };
+
+    // #3508 п.3: панель полос зафиксированного задания — только просмотр. Глушим все
+    // инпуты/кнопки, кроме крестика закрытия, и показываем пометку. Изменения состава
+    // невозможны (как и удаление/перепланирование/смена очередности зафиксированного).
+    AtexProductionPlanning.prototype.lockStripPanel = function(panel) {
+        if (!panel) return;
+        panel.classList.add('is-readonly');
+        var nodes = panel.querySelectorAll('input, select, textarea, button');
+        Array.prototype.forEach.call(nodes, function(n) {
+            if (n.classList && n.classList.contains('atex-pp-strip-close')) return;
+            n.disabled = true;
+        });
+        var note = el('div', { class: 'atex-pp-strip-locked-note', text: '🔒 Задание зафиксировано — изменение полос недоступно' });
+        var header = panel.querySelector('.atex-pp-strip-header');
+        if (header && header.parentNode) header.parentNode.insertBefore(note, header.nextSibling);
+        else panel.appendChild(note);
     };
 
     // Рендер содержимого панели редактора полос (таблица + сводка + ходовые + кнопки).
@@ -6430,6 +6555,18 @@
             self.renderQueue();
             self.renderLink();
         });
+        // #3508 п.1: стрелки ‹/› по бокам поля «Дата плана» — листание на ±1 день.
+        function shiftFilterDate(delta) {
+            self.filter.date = shiftPlanDate(self.filter.date || todayISO(), delta);
+            self.selectedCutId = null;   // как и при ручной смене даты
+            self.renderQueue();
+            self.renderLink();
+        }
+        var datePrev = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '‹', title: 'Предыдущий день' });
+        var dateNext = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '›', title: 'Следующий день' });
+        datePrev.addEventListener('click', function() { if (!self.busy) shiftFilterDate(-1); });
+        dateNext.addEventListener('click', function() { if (!self.busy) shiftFilterDate(1); });
+        var dateNav = el('div', { class: 'atex-pp-date-field' }, [datePrev, dateFilter, dateNext]);
         // #3411: быстрый поиск между «Дата плана» и «Статус». Фильтрует карточки очереди
         // и пересчитывает счётчики на закладках станков (видно, в каком станке сколько
         // совпавших позиций). Поиск идёт по сырью/намотке/статусу и подписям связанных
@@ -6448,7 +6585,7 @@
         });
         searchInput.addEventListener('focus', function() { self._searchFocused = true; });
         searchInput.addEventListener('blur', function() { self._searchFocused = false; });
-        filters.appendChild(field('Дата плана', dateFilter));
+        filters.appendChild(field('Дата плана', dateNav));
         filters.appendChild(field('Поиск', searchInput));
         filters.appendChild(field('Статус', statusFilter));
         box.appendChild(filters);
@@ -6599,7 +6736,8 @@
                     if (resLin + 1e-6 < needLin) unreserved = true;
                 }
             }
-            var cardPanel = el('div', { class: 'atex-pp-cut' + (active ? ' is-active' : '') + (unreserved ? ' is-unreserved' : ''), dataset: { cutId: String(c.id) } });
+            // #3508 п.5: зафиксированное задание — класс is-fixed (серая кайма, видно, что менять нельзя).
+            var cardPanel = el('div', { class: 'atex-pp-cut' + (active ? ' is-active' : '') + (unreserved ? ' is-unreserved' : '') + (c.fixed ? ' is-fixed' : ''), dataset: { cutId: String(c.id) } });
 
             var materialText = c.materialName || (c.materialId ? ('#' + c.materialId) : '—');
             var sc = schedById[String(c.id)];
@@ -6649,7 +6787,13 @@
             // #3354 п.1: первая строка карточки —
             // {номер по порядку} {время} {название сырья} {тип намотки} — {длина} х {резок};
             // справа прижата сводка связей (.atex-pp-cut-supplies).
-            var seqText = (c.sequence != null && !isNaN(c.sequence)) ? String(c.sequence) : String(idx + 1);
+            // #3508 п.7: «Очередность» в карточке = позиция задания в очереди станка за день
+            // (1..N по dayCutsByKey), а НЕ хранимое значение «Очередности»: хранимые могли
+            // задвоиться (два «первых» и т.п.), позиционная нумерация всегда сплошная и
+            // уникальная. Хранимые значения дочищаются при перестановке ↑↓ / генерации.
+            var sameDayCuts = dayCutsByKey[cutPlanDayKey(c)] || activeGroup.cuts;
+            var dayIdx = sameDayCuts.indexOf(c);
+            var seqText = String((dayIdx >= 0 ? dayIdx : idx) + 1);
             var windingText = normWinding(c.winding) || String(c.winding == null ? '' : c.winding).trim() || '—';
             var infoChildren = [
                 el('span', { class: 'atex-pp-cut-seq', title: cutNumTitle, text: '№ ' + seqText })
@@ -6708,37 +6852,58 @@
             var controls = el('div', { class: 'atex-pp-cut-controls' });
             var up = el('button', { class: 'atex-pp-move', type: 'button', text: '↑', title: 'Выше' });
             var down = el('button', { class: 'atex-pp-move', type: 'button', text: '↓', title: 'Ниже' });
-            var sameDayCuts = dayCutsByKey[cutPlanDayKey(c)] || activeGroup.cuts;
-            var dayIdx = sameDayCuts.indexOf(c);
-            if (dayIdx === 0) up.disabled = true;
-            if (dayIdx === sameDayCuts.length - 1) down.disabled = true;
+            // sameDayCuts/dayIdx вычислены выше (для seqText #3508 п.7) — переиспользуем.
+            // #3508 п.3: зафиксированное задание нельзя двигать по очереди (↑↓ заблокированы).
+            if (dayIdx === 0 || c.fixed) up.disabled = true;
+            if (dayIdx === sameDayCuts.length - 1 || c.fixed) down.disabled = true;
             up.addEventListener('click', function() {
-                if (self.busy) return;
+                if (self.busy || c.fixed) return;
                 var p = moveInQueue(sameDayCuts, dayIdx, -1);
                 if (p.length) self.saveSequences(p);
             });
             down.addEventListener('click', function() {
-                if (self.busy) return;
+                if (self.busy || c.fixed) return;
                 var p = moveInQueue(sameDayCuts, dayIdx, 1);
                 if (p.length) self.saveSequences(p);
             });
             var strips = el('button', { class: 'atex-pp-strips', type: 'button', text: stripsButtonLabel(c.knifeCount), title: 'Полосы резки (количество полос)' });
             strips.addEventListener('click', function() {
                 if (self.busy) return;
-                self.openStrips(c, cardPanel);
+                self.openStrips(c, cardPanel);   // #3508 п.3: для зафиксированных панель полос открывается только на просмотр
+            });
+            // #3508 п.4: «🔒» — переключить фиксацию ОДНОГО задания (зафиксировать ↔ снять).
+            // Левее «🗑». is-active — когда задание уже зафиксировано (визуальный замок).
+            var fix = el('button', {
+                class: 'atex-pp-cut-fix' + (c.fixed ? ' is-active' : ''),
+                type: 'button',
+                text: '🔒',
+                title: c.fixed ? 'Снять фиксацию задания' : 'Зафиксировать задание'
+            });
+            fix.addEventListener('click', function(e) {
+                if (e && e.stopPropagation) e.stopPropagation();
+                if (self.busy) return;
+                self.toggleCutFixed(c);
             });
             // #3486: «🗑» — удалить задание (резку) с её «Обеспечениями». stopPropagation,
             // чтобы клик по кнопке не выбирал резку (см. #3149: клики по контролам не
             // выбирают карточку). Подтверждение и удаление — в deleteCutTask.
-            var del = el('button', { class: 'atex-pp-cut-del', type: 'button', text: '🗑', title: 'Удалить задание' });
+            // #3508 п.3: зафиксированное задание удалить нельзя — кнопка заблокирована.
+            var del = el('button', {
+                class: 'atex-pp-cut-del' + (c.fixed ? ' is-disabled' : ''),
+                type: 'button',
+                text: '🗑',
+                title: c.fixed ? 'Зафиксированное задание удалить нельзя (снимите фиксацию)' : 'Удалить задание'
+            });
+            if (c.fixed) del.disabled = true;
             del.addEventListener('click', function(e) {
                 if (e && e.stopPropagation) e.stopPropagation();
-                if (self.busy) return;
+                if (self.busy || c.fixed) return;
                 self.deleteCutTask(c, cardPanel);
             });
             controls.appendChild(up);
             controls.appendChild(down);
             controls.appendChild(strips);
+            controls.appendChild(fix);
             controls.appendChild(del);
             cardPanel.appendChild(controls);
 
@@ -6917,6 +7082,10 @@
         // #3475: «Добавить вручную» — второстепенная кнопка (без -primary).
         var addBtn = el('button', { class: 'atex-pp-btn atex-pp-add', type: 'button', text: 'Добавить вручную' });
         addBtn.addEventListener('click', function() { self.openForm(); });
+        // #3508 п.2: «Зафиксировать» — проставить флаг всем заданиям выбранного дня
+        // (все станки). Между «Добавить вручную» и «Удалить».
+        var fixBtn = el('button', { class: 'atex-pp-btn atex-pp-fix-day', type: 'button', text: 'Зафиксировать' });
+        fixBtn.addEventListener('click', function() { self.fixDayTasks(); });
         // #3475: «Удалить» (warning, жёлтая) — удаляет все задания выбранного дня:
         // сначала «Обеспечение» (снимаем ссылки на «Партии ГП»), затем «Производственную
         // резку» (BatchDelete каскадом снимет подчинённые Партии ГП/Полосы/Расход).
@@ -6925,6 +7094,7 @@
         queueActions.appendChild(genSpinner);
         queueActions.appendChild(genBtn);
         queueActions.appendChild(addBtn);
+        queueActions.appendChild(fixBtn);
         queueActions.appendChild(delBtn);
         var queueHead = el('div', { class: 'atex-pp-panel-head' }, [
             el('h2', { class: 'atex-pp-form-title', text: 'Очередь заданий по станкам' }),
@@ -7016,4 +7186,4 @@
 
  
  
-// @version 2026-06-19-issue-3475
+// @version 2026-06-20-issue-3508

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -202,13 +202,13 @@ var plan = planning.rowsToPlanning(reportRows);
 assertEqual(plan.cuts, [
     { id: '10', number: '06.05.2026', slitter: { id: '101', label: 'Станок 1' },
       materialBatch: { id: null, label: '' },
-      planDate: '06.05.2026', status: 'В работе', sequence: null,
+      planDate: '06.05.2026', status: 'В работе', sequence: null, fixed: false,
       materialId: '', materialName: '', batchId: '',
       jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, length: 0, plannedRuns: 0, duration: 0, timing: '', isFoil: false,
       orderId: '', orderApprovalDate: '', leaders: [] },
     { id: '20', number: '27.05.2026', slitter: { id: null, label: '' },
       materialBatch: { id: null, label: '' },
-      planDate: '27.05.2026', status: 'Ожидает', sequence: null,
+      planDate: '27.05.2026', status: 'Ожидает', sequence: null, fixed: false,
       materialId: '', materialName: '', batchId: '',
       jumboRemainingM: 0, knifeCount: 0, knifeWidths: [], winding: '', rollerWidth: 0, length: 0, plannedRuns: 0, duration: 0, timing: '', isFoil: false,
       orderId: '', orderApprovalDate: '', leaders: [] }


### PR DESCRIPTION
Решает 6 из 7 пунктов ideav/crm#3508 для `download/atex/js/production-planning.js`. Пункт 6 — отдельным PR (см. ниже).

## Что сделано

- **п.1** — стрелки `‹/›` по бокам фильтра «Дата плана»: листание на ±1 день.
- **п.2** — кнопка **«Зафиксировать»** (между «Добавить вручную» и «Удалить») проставляет флаг «Зафиксировано» всем заданиям выбранного дня по всем станкам.
- **п.3** — зафиксированные задания: не удаляются (ни «Удалить» дня, ни 🗑 в карточке), не меняются при перепланировании (генерация и так трогает только новые позиции, #3449), не правятся вручную (панель «Полосы» открывается только на просмотр), не меняют очередность (↑↓ заблокированы + зафиксированные стали «стенами» в `moveInQueue`).
- **п.4** — иконка **🔒** в карточке (левее 🗑) переключает фиксацию одного задания; иконки 🗑/🔒 приведены к размеру кнопки «Полосы».
- **п.5** — зафиксированные панели с серой каймой (`.atex-pp-cut.is-fixed`).
- **п.7** — «Очередность» в карточке теперь = позиция задания в очереди станка за день (1..N), а не возможно-задвоенное хранимое значение; хранимые значения дочищаются при следующей перестановке ↑↓ / генерации.

## Как устроен флаг

Реквизит «Зафиксировано» (таблица «Задание в производство», id 81530, тип bool) **не приходит в отчёте `cut_planning`**, поэтому читается тем же `object/`-чтением, что уже грузит «Очередность» (`loadCutSequences` расширен до `{ seq, fixed }`) — без лишнего запроса. Запись — `_m_set t{id}='1'/'0'`, реквизит резолвится по имени из метаданных.

## Тесты

`node experiments/atex-production-planning.test.js` — 517 assertions passed. `node -c` чисто. (Файл теста под `.gitignore`, добавлен через `git add -f`.)

## п.6 — отдельным PR

«Сдвиг зафиксированного задания ±90 мин в пустое место» требует, чтобы `buildSchedule` закреплял старт зафиксированных по хранимому `t1078`, а остальные обтекали. Сейчас расписание строится упаковкой по порядку очереди и `t1078` игнорирует (пустых мест в этой модели не бывает). Это изменение ядра планировщика — выносится в отдельный PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)