### PR TITLE
feat(atex): п.6 — сдвиг зафиксированного задания по времени ±90 мин (#3508)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -386,6 +386,23 @@
 .atex-pp-cut-fix.is-active { background: rgba(107, 114, 128, .14); border-color: #9ca3af; }
 .atex-pp.is-busy .atex-pp-cut-fix { pointer-events: none; opacity: .4; }
 
+/* #3508 п.6: ◀▶ — сдвиг планового старта зафиксированного задания на ±15 мин
+   (в пределах 90 мин от естественного старта). Компактные, как стрелки очереди. */
+.atex-pp-cut-nudge {
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    padding: 5px 9px;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    line-height: 1;
+}
+.atex-pp-cut-nudge:hover { background: var(--pp-surface); }
+.atex-pp-cut-nudge:disabled { opacity: .4; cursor: default; }
+.atex-pp-cut-nudge:disabled:hover { background: var(--pp-bg); }
+.atex-pp.is-busy .atex-pp-cut-nudge { pointer-events: none; opacity: .4; }
+
 /* #3508 п.3: пометка «только просмотр» в панели полос зафиксированного задания. */
 .atex-pp-strip-locked-note {
     margin: 6px 0 4px;

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2094,6 +2094,7 @@
         var times = opts.times || DEFAULT_OP_TIMES;
         var leader = Number(times.BETWEEN_CUTS != null ? times.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS) || 0;
         var runLen = opts.runLengthByCut || {};
+        var pins = opts.pinnedStartMinByCut || {};   // #3508 п.6: окно-старт (мин от полуночи дня 0) зафиксированных
         var shiftStart = Number(opts.shiftStartMin != null ? opts.shiftStartMin : SHIFT_START_MIN) || 0;
         var shiftEnd = Number(opts.shiftEndMin != null ? opts.shiftEndMin : SHIFT_END_MIN) || 0;
         var hasWindow = shiftEnd > shiftStart;
@@ -2107,7 +2108,14 @@
             // #3401: лидер заправляют перед каждой резкой цуга → лидер × «Кол-во план».
             var setup = leader * cutLeaderRuns(c) + (i > 0 ? changeoverCost(cuts[i-1], c, times) : 0);
             var dur = scheduleDurationMinutes(c, Number(runLen[String(c.id)]) || 0, wind);
-            var start = t + setup;
+            // #3508 п.6: зафиксированное задание может быть «приколото» к плановому старту
+            // (pin — окно-старт в минутах от полуночи дня 0). Встать раньше финиша предыдущего
+            // нельзя → windowStart = max(pin, cursor); пин позже cursor оставляет пустое окно
+            // (то самое «пустое место»). Без пина пакуем встык: windowStart = cursor.
+            var pin = pins[String(c.id)];
+            var hasPin = pin != null && isFinite(Number(pin));
+            var windowStart = hasPin ? Math.max(Number(pin), t) : t;
+            var start = windowStart + setup;
             var day = Math.floor(start / 1440);
             if (start < day * 1440 + shiftStart) start = day * 1440 + shiftStart;   // до 08:00 → ждём открытия
             // #3342: резка стартует в/после LUNCH_START и обед ещё не был → пауза перед ней.
@@ -2126,10 +2134,55 @@
                 }
             }
             var finish = start + dur;
+            // Форму sc не расширяем (её сверяют тесты целиком): окно-старт = startMin − setupMin.
             out.push({ cutId: String(c.id), startMin: round3(start), finishMin: round3(finish), setupMin: round3(setup), durationMin: dur });
             t = finish;
         });
         return out;
+    }
+
+    // #3508 п.6: на сколько максимум можно отодвинуть плановый старт зафиксированного
+    // задания от «естественного» (90 мин) и шаг кнопок сдвига ◀▶ (15 мин).
+    var PIN_MAX_DELAY_MIN = 90;
+    var PIN_STEP_MIN = 15;
+
+    // #3508 п.6: плановый старт (главное значение «Задания в производство», t1078) как
+    // unix-штамп в СЕКУНДАХ. planDate приходит штампом (сек или мс) — нормализуем к сек.
+    // null, если не штамп.
+    function pinTimestampSeconds(cut) {
+        var s = String((cut && (cut.planDate != null ? cut.planDate : cut.number)) || '').trim();
+        if (!/^\d{9,13}$/.test(s)) return null;
+        var num = Number(s);
+        if (!isFinite(num) || num <= 0) return null;
+        return num >= 1e12 ? Math.floor(num / 1000) : num;   // мс → сек
+    }
+
+    // #3508 п.6: карта «пинов» для buildSchedule — окно-старт зафиксированных заданий в
+    // минутах от полуночи дня 0 (planBaseMidnightMs). Берётся из их планового старта
+    // (t1078). Незафиксированные и записи без валидного штампа пропускаются.
+    function pinnedStartMinByCut(cuts, planBaseMidnightMs) {
+        var base = Number(planBaseMidnightMs);
+        var map = {};
+        if (!isFinite(base)) return map;
+        (cuts || []).forEach(function(c) {
+            if (!c || !c.fixed) return;
+            var ts = pinTimestampSeconds(c);
+            if (ts == null) return;
+            map[String(c.id)] = (ts * 1000 - base) / 60000;
+        });
+        return map;
+    }
+
+    // #3508 п.6: ограничить желаемый плановый старт зафиксированного задания окном
+    // [natural, natural + maxDelay]: не раньше «естественного» (упакованного) старта —
+    // иначе наложение на предыдущее — и не позже него более чем на maxDelay минут (90).
+    function clampPinnedStart(naturalMin, desiredMin, maxDelayMin) {
+        var nat = Number(naturalMin);
+        var d = Number(desiredMin);
+        if (!isFinite(nat)) return d;
+        if (!isFinite(d)) return nat;
+        var hi = nat + (isFinite(Number(maxDelayMin)) ? Number(maxDelayMin) : 0);
+        return Math.max(nat, Math.min(hi, d));
     }
 
     // #3342: параметры плавающего обеда из opts, валидные только если обед попадает
@@ -3259,6 +3312,9 @@
         parseClockMinutes: parseClockMinutes,
         resolveWorkingWindow: resolveWorkingWindow,
         buildSchedule: buildSchedule,
+        pinnedStartMinByCut: pinnedStartMinByCut,
+        pinTimestampSeconds: pinTimestampSeconds,
+        clampPinnedStart: clampPinnedStart,
         freeSlotForQueue: freeSlotForQueue,
         dayCleanups: dayCleanups,
         formatClock: formatClock,
@@ -4399,9 +4455,69 @@
         });
     };
 
-    // #3508 п.2/п.4: проставить/снять флаг «Зафиксировано» у набора заданий. Пишем
-    // булев реквизит (t{id}='1'/'0') командой _m_set последовательно, затем перечитываем
-    // очередь — чтобы серая кайма/блокировки (п.3/п.5) обновились по источнику истины.
+    // #3508 п.6: текущий плановый окно-старт (Unix сек, формат t1078) каждого ВИДИМОГО
+    // задания по действующему расписанию — для «захвата» пина при фиксации. Считаем по
+    // каждому станку тем же расписанием, что и renderQueue (учитывая уже зафиксированные).
+    AtexProductionPlanning.prototype.scheduleWindowStartTsByCut = function() {
+        var self = this;
+        var planBaseMidnightMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
+        if (!isFinite(planBaseMidnightMs)) return {};
+        var windPoints = windingPointsFromTimes(this.opTimes || {});
+        var dayWindow = this.workingWindow();
+        var visible = (this.cuts || []).filter(function(c) { return isCutVisible(c, self.filter.date); });
+        var runLenByCut = {};
+        visible.forEach(function(c) { runLenByCut[String(c.id)] = cutRunLength(c, self.supplies, self.footageBySupply); });
+        var schedOpts = {
+            windPoints: windPoints, times: this.changeTimes, runLengthByCut: runLenByCut,
+            shiftStartMin: dayWindow.startMin, shiftEndMin: dayWindow.cutEndMin,
+            lunchStartMin: dayWindow.lunchStartMin, lunchDurationMin: dayWindow.lunchDurationMin
+        };
+        var tsByCut = {};
+        groupBySlitter(visible).forEach(function(g) {
+            var pins = pinnedStartMinByCut(g.cuts, planBaseMidnightMs);
+            buildSchedule(g.cuts, Object.assign({ pinnedStartMinByCut: pins }, schedOpts)).forEach(function(sc) {
+                tsByCut[String(sc.cutId)] = scheduleStartTimestamp(planBaseMidnightMs, sc.startMin - sc.setupMin);
+            });
+        });
+        return tsByCut;
+    };
+
+    // #3508 п.6: сдвинуть плановый старт зафиксированного задания на deltaMin минут,
+    // в пределах [natural, natural + 90] (natural — окно-старт без пина, передаёт карточка).
+    // Пишем t1078 (главное значение). На границе ничего не пишем.
+    AtexProductionPlanning.prototype.nudgeCutStart = function(cut, deltaMin, naturalWindowStartMin) {
+        var self = this;
+        if (this.busy || !cut || !cut.fixed) return;
+        var mainKey = (this.meta.cut && this.meta.cut.id != null) ? 't' + this.meta.cut.id : null;
+        if (!mainKey) { this.notify('Не найдена таблица «' + TABLE.cut + '»', 'error'); return; }
+        var nat = Number(naturalWindowStartMin);
+        if (!isFinite(nat)) return;
+        var planBaseMidnightMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
+        var ts = pinTimestampSeconds(cut);
+        var curMin = (ts != null) ? (ts * 1000 - planBaseMidnightMs) / 60000 : nat;
+        var clamped = clampPinnedStart(nat, curMin + Number(deltaMin || 0), PIN_MAX_DELAY_MIN);
+        if (Math.abs(clamped - curMin) < 1e-6) return;   // упёрлись в границу
+        var newTs = scheduleStartTimestamp(planBaseMidnightMs, clamped);
+        var fields = {}; fields[mainKey] = String(newTs);
+        this.setBusy(true);
+        this.showProgress('Сдвиг планового старта…', 1);
+        this.post('_m_set/' + encodeURIComponent(cut.id) + '?JSON', fields).then(function() {
+            self.updateProgress(1);
+            return self.reload();
+        }).then(function() {
+            self.hideProgress(); self.setBusy(false); self.render();
+            self.notify('Плановый старт сдвинут на ' + (deltaMin > 0 ? '+' : '') + deltaMin + ' мин', 'info');
+        }).catch(function(err) {
+            self.hideProgress(); self.setBusy(false);
+            self.reload().then(function() { self.render(); }).catch(function() {});
+            self.notify('Ошибка сдвига старта: ' + (err && err.message || err), 'error');
+        });
+    };
+
+    // #3508 п.2/п.4: проставить/снять флаг «Зафиксировано» у набора заданий. Пишем булев
+    // реквизит (t{id}='1'/'0') командой _m_set; при фиксации захватываем плановый старт в
+    // t1078 (п.6, opts.startTsByCut), затем перечитываем очередь — серая кайма/блокировки
+    // (п.3/п.5) обновятся по источнику истины.
     AtexProductionPlanning.prototype.setCutsFixed = function(cutIds, value, opts) {
         var self = this;
         var o = opts || {};
@@ -4419,6 +4535,11 @@
         }
         var fieldKey = 't' + fixedReqId;
         var flag = value ? '1' : '0';
+        // #3508 п.6: при фиксации «захватываем» текущий плановый старт в t1078 (главное
+        // значение «Задания в производство»), чтобы пин совпал с видимой позицией и
+        // карточка не прыгнула. tsByCut — Unix-сек окна-старта по текущему расписанию.
+        var tsByCut = o.startTsByCut || {};
+        var mainKey = (this.meta.cut && this.meta.cut.id != null) ? 't' + this.meta.cut.id : null;
         this.setBusy(true);
         this.showProgress((value ? 'Фиксация' : 'Снятие фиксации') + ' заданий…', ids.length);
         var done = 0;
@@ -4426,6 +4547,8 @@
         ids.forEach(function(id) {
             chain = chain.then(function() {
                 var fields = {}; fields[fieldKey] = flag;
+                var ts = Number(tsByCut[id]);
+                if (value && mainKey && isFinite(ts) && ts > 0) fields[mainKey] = String(ts);
                 return self.post('_m_set/' + encodeURIComponent(id) + '?JSON', fields)
                     .then(function() { self.updateProgress(++done); });
             });
@@ -4464,7 +4587,8 @@
         if (!dayCuts.length) { this.notify('Нет заданий за ' + dateLabel + ' для фиксации', 'info'); return; }
         if (!toFix.length) { this.notify('Все задания за ' + dateLabel + ' уже зафиксированы', 'info'); return; }
         self.setCutsFixed(toFix.map(function(c) { return c.id; }), true, {
-            successMessage: 'Зафиксированы задания за ' + dateLabel + ': ' + toFix.length
+            successMessage: 'Зафиксированы задания за ' + dateLabel + ': ' + toFix.length,
+            startTsByCut: self.scheduleWindowStartTsByCut()   // #3508 п.6: захват текущего старта в пин
         });
     };
 
@@ -4472,9 +4596,11 @@
     // (зафиксировано ↔ снято), чтобы можно было и поставить, и снять флаг.
     AtexProductionPlanning.prototype.toggleCutFixed = function(cut) {
         if (!cut) return;
-        this.setCutsFixed([cut.id], !cut.fixed, {
-            successMessage: (cut.fixed ? 'Снята фиксация задания' : 'Задание зафиксировано')
-        });
+        // #3508 п.6: при фиксации захватываем текущий плановый старт в пин (чтобы карточка
+        // не прыгнула); при снятии — не нужно.
+        var o = { successMessage: (cut.fixed ? 'Снята фиксация задания' : 'Задание зафиксировано') };
+        if (!cut.fixed) o.startTsByCut = this.scheduleWindowStartTsByCut();
+        this.setCutsFixed([cut.id], !cut.fixed, o);
     };
 
     // #3475: «Удалить» — снести все задания выбранного дня. Показывает подтверждение
@@ -6686,7 +6812,7 @@
         // День 0 = дата фильтра (.atex-pp-input), на которую отфильтрована очередь, а не
         // «сегодня»; иначе title показывал текущую дату вместо плановой (напр. 10.06 вместо 01.06).
         var planBaseMidnightMs = planBaseMidnightFrom(self.filter && self.filter.date, controllerNowMs(self));
-        var schedule = buildSchedule(activeGroup.cuts, {
+        var schedOpts = {
             windPoints: windPoints,
             times: self.changeTimes,
             runLengthByCut: runLenByCut,
@@ -6694,8 +6820,18 @@
             shiftEndMin: dayWindow.cutEndMin,
             lunchStartMin: dayWindow.lunchStartMin,
             lunchDurationMin: dayWindow.lunchDurationMin
-        });
+        };
+        // #3508 п.6: зафиксированные задания «прикалываются» к плановому старту (t1078) —
+        // расписание их пинует, остальные обтекают.
+        var pinnedMinByCut = pinnedStartMinByCut(activeGroup.cuts, planBaseMidnightMs);
+        var schedule = buildSchedule(activeGroup.cuts, Object.assign({ pinnedStartMinByCut: pinnedMinByCut }, schedOpts));
         schedule.forEach(function(sc) { schedById[sc.cutId] = sc; });
+        // #3508 п.6: расписание БЕЗ пинов даёт «естественный» окно-старт каждого задания —
+        // нижняя граница сдвига зафиксированного (верхняя = natural + 90 мин).
+        var natWindowStartByCut = {};
+        buildSchedule(activeGroup.cuts, schedOpts).forEach(function(sc) {
+            natWindowStartByCut[String(sc.cutId)] = sc.startMin - sc.setupMin;
+        });
         self._timingByCut = {};   // #3240: пересобираем контекст тайминга модалки для активного станка
         var dayCutsByKey = {};
         activeGroup.cuts.forEach(function(c) {
@@ -6904,6 +7040,24 @@
             controls.appendChild(down);
             controls.appendChild(strips);
             controls.appendChild(fix);
+            // #3508 п.6: у зафиксированного — кнопки ◀▶ сдвига планового старта на ±15 мин
+            // в пределах [естественный старт, +90 мин]. «◀» (раньше) полезна, когда перед
+            // заданием освободилось окно (удалили другое) — встроить в это пустое место.
+            if (c.fixed) {
+                var natWS = natWindowStartByCut[String(c.id)];
+                var pinTs = pinTimestampSeconds(c);
+                var curWS = (pinTs != null && isFinite(natWS)) ? (pinTs * 1000 - planBaseMidnightMs) / 60000 : natWS;
+                var canEarlier = isFinite(natWS) && isFinite(curWS) && curWS > natWS + 1e-6;
+                var canLater = isFinite(natWS) && isFinite(curWS) && curWS < natWS + PIN_MAX_DELAY_MIN - 1e-6;
+                var earlier = el('button', { class: 'atex-pp-cut-nudge', type: 'button', text: '◀', title: 'Сдвинуть старт раньше на ' + PIN_STEP_MIN + ' мин (в освободившееся окно)' });
+                var later = el('button', { class: 'atex-pp-cut-nudge', type: 'button', text: '▶', title: 'Сдвинуть старт позже на ' + PIN_STEP_MIN + ' мин (в пределах 90 мин)' });
+                if (!canEarlier) earlier.disabled = true;
+                if (!canLater) later.disabled = true;
+                earlier.addEventListener('click', function(e) { if (e && e.stopPropagation) e.stopPropagation(); if (self.busy) return; self.nudgeCutStart(c, -PIN_STEP_MIN, natWS); });
+                later.addEventListener('click', function(e) { if (e && e.stopPropagation) e.stopPropagation(); if (self.busy) return; self.nudgeCutStart(c, PIN_STEP_MIN, natWS); });
+                controls.appendChild(earlier);
+                controls.appendChild(later);
+            }
             controls.appendChild(del);
             cardPanel.appendChild(controls);
 
@@ -7186,4 +7340,4 @@
 
  
  
-// @version 2026-06-20-issue-3508
+// @version 2026-06-20-issue-3508-p6

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1341,6 +1341,35 @@ assertEqual(planning.resolveWorkingWindow({ DAY_START_HOUR:'9:15', DAY_END_HOUR:
     { startMin:555, endMin:1080, cutEndMin:1035, cleanupMin:45, lunchStartMin:null, lunchDurationMin:0 },
     'resolveWorkingWindow #3215: произвольное окно и CLEANUP_SHIFT');
 
+// ── #3508 п.6: «пины» зафиксированных заданий в buildSchedule ──
+// Очередь A,B,C по 60 мин, без лидера/переналадки (BETWEEN_CUTS:0): встык 480/540/600.
+var pinCuts3508 = [ { id:'A', duration:60 }, { id:'B', duration:60 }, { id:'C', duration:60 } ];
+var pinOpts3508 = { windPoints: pts, runLengthByCut: {}, times: { BETWEEN_CUTS: 0 }, shiftStartMin: 480 };
+var pinNone = planning.buildSchedule(pinCuts3508, pinOpts3508);
+assertEqual(pinNone.map(function(s){ return [s.startMin, s.finishMin]; }), [[480,540],[540,600],[600,660]],
+    'buildSchedule #3508: без пинов — встык 480/540/600');
+// Пин B позже cursor (580 > 540) → зазор 40 мин перед B, C сдвигается за B.
+var pinDelay = planning.buildSchedule(pinCuts3508, Object.assign({ pinnedStartMinByCut: { B: 580 } }, pinOpts3508));
+assertEqual(pinDelay.map(function(s){ return [s.startMin, s.finishMin]; }), [[480,540],[580,640],[640,700]],
+    'buildSchedule #3508: пин B=580 → зазор перед B (то самое пустое место), C за ним');
+// Пин B раньше cursor (500 < 540) → clamp к естественному старту (наложения нет).
+var pinClamp = planning.buildSchedule(pinCuts3508, Object.assign({ pinnedStartMinByCut: { B: 500 } }, pinOpts3508));
+assertEqual([pinClamp[1].startMin, pinClamp[1].finishMin], [540,600],
+    'buildSchedule #3508: пин раньше cursor → clamp к естественному (без наложения)');
+// pinTimestampSeconds / pinnedStartMinByCut: штамп → окно-старт в минутах от полуночи дня 0.
+var pinBase3508 = Date.UTC(2026, 5, 20);                 // полночь 2026-06-20 (в тестах TZ=UTC)
+var pinTs3508 = Math.floor((pinBase3508 + 540 * 60000) / 1000);   // 09:00 в секундах
+assertEqual(planning.pinTimestampSeconds({ planDate: String(pinTs3508) }), pinTs3508, 'pinTimestampSeconds: unix-сек как есть');
+assertEqual(planning.pinTimestampSeconds({ planDate: String(pinTs3508 * 1000) }), pinTs3508, 'pinTimestampSeconds: мс → сек');
+assertEqual(planning.pinTimestampSeconds({ planDate: '' }), null, 'pinTimestampSeconds: пусто → null');
+assertEqual(planning.pinnedStartMinByCut(
+    [ { id:'A', fixed:true, planDate:String(pinTs3508) }, { id:'B', fixed:false, planDate:String(pinTs3508) } ], pinBase3508),
+    { A: 540 }, 'pinnedStartMinByCut: только зафиксированные → окно-старт 09:00 = 540 мин');
+// clampPinnedStart: окно [natural, natural+90].
+assertEqual(planning.clampPinnedStart(540, 600, 90), 600, 'clampPinnedStart: 600 ∈ [540,630]');
+assertEqual(planning.clampPinnedStart(540, 500, 90), 540, 'clampPinnedStart: раньше natural → natural');
+assertEqual(planning.clampPinnedStart(540, 700, 90), 630, 'clampPinnedStart: позже natural+90 → natural+90');
+
 // ── #3342: плавающий обед (LUNCH_START / LUNCH_DURATION) ──
 var wwLunch = planning.resolveWorkingWindow({ DAY_START_HOUR:'8:00', DAY_END_HOUR:'16:40', LUNCH_START:'12:20', LUNCH_DURATION:'40' }, 30);
 assertEqual({ s:wwLunch.startMin, e:wwLunch.cutEndMin, ls:wwLunch.lunchStartMin, ld:wwLunch.lunchDurationMin },


### PR DESCRIPTION
Реализует **пункт 6** ideav/crm#3508 для `download/atex/js/production-planning.js`. Перебазирован на main после мержа #3511 — дифф содержит только п.6.

## Задача (п.6)
> Зафиксированное задание можно подвинуть вперёд/назад по времени, если перед ним есть пустое место (удалили другое задание), но в пределах 90 минут — чтобы встроить в это окно.

## Подход
Раньше `buildSchedule` строил времена упаковкой по порядку очереди и игнорировал хранимый `t1078` — «пустых мест» не было. Теперь:

- **`buildSchedule` учитывает «пины»** (`opts.pinnedStartMinByCut`): зафиксированное задание прикалывается к своему плановому старту — `windowStart = max(pin, cursor)` (раньше финиша предыдущего встать нельзя; пин позже cursor оставляет пустое окно). Незафиксированные обтекают. **Без пинов поведение идентично** — существующие тесты не меняются.
- **Захват при фиксации:** при простановке флага записываем `t1078` = текущий плановый старт по расписанию (`scheduleWindowStartTsByCut`), чтобы пин совпал с видимой позицией и карточка не прыгнула.
- **Контролы ◀▶** на зафиксированной карточке: сдвиг планового старта на ±15 мин, ограниченный `[естественный старт, +90]` (`clampPinnedStart`). «◀» (раньше) активна, когда перед заданием освободилось окно — встроить в пустое место удалённого задания. Персист — `t1078`. На границах кнопки заблокированы.

## Тесты
`node experiments/atex-production-planning.test.js` — 527 assertions passed (добавлено 10 по пинам). `node -c` чисто. (Тест под `.gitignore` — `git add -f`.)

## Ограничения / на ревью
- Граница ±90 считается от «естественного» старта без учёта пинов *других* заданий (для нескольких зафиксированных подряд граница может быть чуть свободнее) — наложения исключены: `buildSchedule` клампит к `max(pin, cursor)`.
- Тест-база ateh сейчас пуста (0 заданий) — поведение проверено юнит-тестами чистого ядра, не вживую.

🤖 Generated with [Claude Code](https://claude.com/claude-code)