### PR TITLE
fix(atex): кнопка подтверждения генерации — «Создать» вместо «Сгенерировать»

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5412,7 +5412,7 @@
             // (FATIGUE) по route-score давала ножи по ВОЗРАСТАНИЮ (6,16,16), вопреки
             // #3130 (ideav/crm#3421). inline:true — именованная inline-кнопка, без модалки.
             self.confirmAction(msg, actionsEl, [
-                { label: 'Сгенерировать', primary: true, inline: true, onConfirm: function() {
+                { label: 'Создать', primary: true, inline: true, onConfirm: function() {
                     self.runGenerateCuts(allLayouts, skipped, PLANNING_STRATEGY_SETUP);
                 } }
             ]);
@@ -7186,4 +7186,4 @@
 
  
  
-// @version 2026-06-20-issue-3508
+// @version 2026-06-20-atex-gen-confirm-label


### PR DESCRIPTION
В плашке подтверждения генерации (`.atex-pp-confirm-msg`) вопрос — «Создать производственные задания?», а кнопка подтверждения называлась «Сгенерировать». Переименовал кнопку в **«Создать»** для согласованности с текстом.

Затрагивает только подпись inline-кнопки в `generateCuts` (`download/atex/js/production-planning.js`). Тулбарная кнопка «Сгенерировать» не меняется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)