### PR TITLE
feat(atex): смену слиттера открывать отдельно для каждого станка (#3522)

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -361,13 +361,26 @@
         return eventUserId(event) === uid;
     }
 
-    function hasOpenShift(events, userId, date) {
+    // #3522: станок события смены. «Начало/Конец смены» пишут «Примечания» вида
+    // «{станок} · {дата}» — станок = первый сегмент до « · ». Пусто, если метки нет.
+    function shiftEventSlitterLabel(event) {
+        var notes = String(event && event.notes != null ? event.notes : '').trim();
+        if (!notes) return '';
+        return notes.split('·')[0].trim();
+    }
+
+    // #3522: смена считается ОТДЕЛЬНО для каждого станка. Если slitterLabel задан —
+    // учитываем только события смены этого станка (по метке в «Примечаниях»);
+    // без него (старые вызовы/тесты) фильтр по станку не применяется.
+    function hasOpenShift(events, userId, date, slitterLabel) {
         var targetDay = dateKey(date || todayISO());
+        var sl = String(slitterLabel == null ? '' : slitterLabel).trim();
         var last = null;
         (events || []).forEach(function(event, i) {
             if (!eventMatchesUser(event, userId)) return;
             if (dateKey(event.when) !== targetDay) return;
             if (!isShiftStartType(event.type) && !isShiftEndType(event.type)) return;
+            if (sl && shiftEventSlitterLabel(event) !== sl) return;
             var order = String(event.when || '') + '#' + i;
             if (!last || order > last.order) last = { event: event, order: order };
         });
@@ -655,6 +668,7 @@
         dateKey: dateKey,
         prepareCutQueue: prepareCutQueue,
         hasOpenShift: hasOpenShift,
+        shiftEventSlitterLabel: shiftEventSlitterLabel,
         runLengthForCut: runLengthForCut,
         plannedRunsForCut: plannedRunsForCut,
         batchPasses: batchPasses,
@@ -1201,7 +1215,9 @@
     };
 
     AtexSlitter.prototype.isShiftOpen = function() {
-        return core.hasOpenShift(this.shiftEvents, this.userId, this.selectedDate);
+        // #3522: смена — на конкретный станок. Без выбранного станка смены нет.
+        if (!this.selectedSlitterId) return false;
+        return core.hasOpenShift(this.shiftEvents, this.userId, this.selectedDate, this.selectedSlitterLabel());
     };
 
     AtexSlitter.prototype.eventDateTime = function() {

--- a/experiments/atex-slitter.test.js
+++ b/experiments/atex-slitter.test.js
@@ -152,6 +152,26 @@ assertEqual(core.hasOpenShift([
     { when: '2026-06-11 08:00:00', type: 'Начало смены', userId: '702' }
 ], '701', '2026-06-11'), false, 'hasOpenShift ignores another operator');
 
+// ── #3522: смена отдельно для каждого станка (станок — в «Примечаниях» события) ──
+assertEqual(core.shiftEventSlitterLabel({ notes: 'Станок 1 · 2026-06-11' }), 'Станок 1',
+    'shiftEventSlitterLabel: первый сегмент до « · »');
+assertEqual(core.shiftEventSlitterLabel({ notes: 'Станок 1' }), 'Станок 1',
+    'shiftEventSlitterLabel: только метка без даты');
+assertEqual(core.shiftEventSlitterLabel({ notes: '' }), '', 'shiftEventSlitterLabel: пусто → пусто');
+var twoMachineEvents = [
+    { when: '2026-06-11 08:00:00', type: 'Начало смены', userId: '701', notes: 'Станок 1 · 2026-06-11' },
+    { when: '2026-06-11 09:00:00', type: 'Начало смены', userId: '701', notes: 'Станок 2 · 2026-06-11' },
+    { when: '2026-06-11 16:30:00', type: 'Конец смены',  userId: '701', notes: 'Станок 2 · 2026-06-11' }
+];
+assertEqual(core.hasOpenShift(twoMachineEvents, '701', '2026-06-11', 'Станок 1'), true,
+    'hasOpenShift: на «Станок 1» смена открыта (свой станок)');
+assertEqual(core.hasOpenShift(twoMachineEvents, '701', '2026-06-11', 'Станок 2'), false,
+    'hasOpenShift: на «Станок 2» смена закрыта (своё «Конец смены»), хотя «Станок 1» открыт');
+assertEqual(core.hasOpenShift(twoMachineEvents, '701', '2026-06-11', 'Станок 3'), false,
+    'hasOpenShift: на «Станок 3» смены нет (нет событий этого станка)');
+assertEqual(core.hasOpenShift(twoMachineEvents, '701', '2026-06-11'), false,
+    'hasOpenShift: без станка — глобально последнее событие «Конец смены» → закрыта (а per-станок «Станок 1» открыт)');
+
 // ── партии сырья: FIFO, только В работе, остатка хватает минимум на один проход ──
 var rawBatches = [
     { id: 'new', date: '2026-06-05', remainderM: 950, materialId: 'm1', active: '1', barcode: 'NEW' },


### PR DESCRIPTION
Closes #3522.

## Было
Статус смены считался по **(оператор, дата)** — `hasOpenShift(events, userId, date)`. Открыл смену — она «открыта» для всех станков сразу.

## Стало
Смена — **отдельно для каждого станка**. Событие «Начало/Конец смены» уже пишет станок в «Примечаниях» («{станок} · {дата}»), теперь это учитывается при определении статуса:

- `hasOpenShift(events, userId, date, slitterLabel)` — при переданном станке учитывает только события смены этого станка (по метке из «Примечаний»); без станка — прежнее поведение (обратная совместимость).
- `isShiftOpen()` передаёт выбранный станок; без выбранного станка возвращает `false` (смена всегда на конкретный станок).
- `shiftEventSlitterLabel(event)` — извлекает станок из «Примечаний» (экспортирован, покрыт тестами).

Переключение станка в шапке уже перезагружает события и перерисовывает пульт → статус смены пересчитывается под выбранный станок.

## Тесты
`node experiments/atex-slitter.test.js` — 122 assertions passed (добавлено 7: `shiftEventSlitterLabel` + сценарий двух станков, где на одном смена открыта, на другом закрыта). `node -c` чисто.

Независимо от #3520 (удаление «Расход сырья») — правки в разных частях `slitter.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)