### PR TITLE
xcom: подсказки title для «с подбором» / «без подбора» + проверка расчёта точности (#3530)

### DIFF
--- a/templates/xcom/mass_match.html
+++ b/templates/xcom/mass_match.html
@@ -59,8 +59,8 @@
         <div id="xcom-mass-stats" class="xcom-mass-stats" hidden>
             <div class="xcom-mass-stat"><b id="xcom-mass-stat-time">0:00</b><span>время</span></div>
             <div class="xcom-mass-stat"><b id="xcom-mass-stat-total">0</b><span>обработано</span></div>
-            <div class="xcom-mass-stat xcom-mass-stat-ok"><b id="xcom-mass-stat-matched">0</b><span>с подбором</span></div>
-            <div class="xcom-mass-stat"><b id="xcom-mass-stat-nomatch">0</b><span>без подбора</span></div>
+            <div class="xcom-mass-stat xcom-mass-stat-ok" title="Строки, для которых нашёлся хотя бы один SKU-кандидат — записаны «Кандидаты» и «Точность подбора»"><b id="xcom-mass-stat-matched">0</b><span>с подбором</span></div>
+            <div class="xcom-mass-stat" title="Строки, обработанные без ошибок, но без единого подходящего SKU — кандидатов не нашлось"><b id="xcom-mass-stat-nomatch">0</b><span>без подбора</span></div>
             <div class="xcom-mass-stat xcom-mass-stat-err"><b id="xcom-mass-stat-errors">0</b><span>ошибки</span></div>
             <div class="xcom-mass-stat"><b id="xcom-mass-stat-speed">0</b><span>строк/мин</span></div>
             <div class="xcom-mass-stat"><b id="xcom-mass-stat-concurrency">5</b><span>потоков</span></div>


### PR DESCRIPTION
## Что и зачем

В панели массового подбора SKU (`templates/xcom/mass_match.html`) значения статистики **«с подбором»** и **«без подбора»** были непонятны без контекста. Добавлены подсказки `title` на блоки `.xcom-mass-stat` (показываются при наведении на число или подпись):

- **с подбором** — «Строки, для которых нашёлся хотя бы один SKU-кандидат — записаны "Кандидаты" и "Точность подбора"»;
- **без подбора** — «Строки, обработанные без ошибок, но без единого подходящего SKU — кандидатов не нашлось».

Остальные значения (время, обработано, ошибки, строк/мин, потоков) самоочевидны — без подсказок.

## Проверка расчёта точности (issue #3530)

В рамках issue проверена формула `computeAccuracy` в `download/xcom/js/xcom-mass-match.js`. Соответствует описанию:

- **знаменатель** = полусумма длин алфавитно-цифровых токенов «Наименование RFP» и «Наименование SKU» (`(alnumLength(skuName) + alnumLength(rfpName)) / 2`), не-буквенно-цифровые символы исключены;
- **числитель** = `alnumLength(matchedTokens)` — длина **сцепленной** цепочки совпавших токенов, разделители (в т.ч. запятые) отброшены.

Расчёт корректен, правок в логику точности не требуется.

Closes #3530