### PR TITLE
fix(xcom): в массовом подборе показывать артикул SKU вместо ID (#3532)

### DIFF
--- a/download/xcom/js/xcom-mass-match.js
+++ b/download/xcom/js/xcom-mass-match.js
@@ -35,6 +35,7 @@
     // Имена колонок запроса mass_match (JSON_KV — ключи = «Имя в отчёте»).
     var DEFAULT_SKU_ID_KEY = 'SKUID';
     var DEFAULT_SKU_LABEL_KEY = 'Наименование SKU';
+    var DEFAULT_SKU_ARTICLE_KEY = 'Артикул';      // артикул SKU — показываем в таблице вместо ID (issue #3532)
     var DEFAULT_TOKENS_KEY = 'токены';            // совпавшие токены (числитель точности)
     var DEFAULT_TMA_KEY = 'ТММ';                  // флаг точного совпадения артикула
 
@@ -50,6 +51,7 @@
         placeholderOurId: DEFAULT_PLACEHOLDER_OUR_ID,
         skuIdKey: DEFAULT_SKU_ID_KEY,
         skuLabelKey: DEFAULT_SKU_LABEL_KEY,
+        skuArticleKey: DEFAULT_SKU_ARTICLE_KEY,
         tokensKey: DEFAULT_TOKENS_KEY,
         tmaKey: DEFAULT_TMA_KEY,
         names: {},
@@ -373,15 +375,20 @@
         var labelKey = detectKey(first, state.skuLabelKey, function(key) {
             return key !== idKey && !/id$/i.test(key);
         });
+        // Артикул SKU — отдельная колонка отчёта; показываем её в таблице вместо ID (issue #3532).
+        var articleKey = detectKey(first, state.skuArticleKey, function(key) {
+            return /артикул/i.test(key);
+        });
 
         function toItem(row) {
             var id = idKey ? trimValue(row[idKey]) : '';
             var label = labelKey ? trimValue(row[labelKey]) : '';
+            var article = articleKey ? trimValue(row[articleKey]) : '';
             if (!id) {
                 var parsed = parseRefValue(label);
                 if (parsed.refId) { id = parsed.refId; label = parsed.label; }
             }
-            return { id: id, label: label || id };
+            return { id: id, label: label || id, article: article };
         }
 
         var our = toItem(first);
@@ -441,19 +448,25 @@
         }
     }
 
-    // Колонка «Наш артикул» — только ID SKU (issue #3519: текст/наименование SKU не выводим).
-    function ourCell(record) {
-        if (!record.our || !record.our.id) return '';
-        return escapeHtml(record.our.id);
+    // Ячейка SKU: показываем артикул, ID кладём в title для трассировки (issue #3532).
+    // В строку RFP по-прежнему записывается ID (см. writeBack) — артикул только для отображения.
+    function skuCell(item) {
+        var text = item.article || item.id;
+        return '<span title="ID ' + escapeHtml(item.id) + '">' + escapeHtml(text) + '</span>';
     }
 
-    // Колонка «Кандидаты» — только список ID SKU через запятую (issue #3519: без наименований SKU,
-    // по списку ID видно их количество).
+    // Колонка «Наш артикул» — артикул SKU вместо ID (issue #3532; до этого выводился ID, #3519).
+    function ourCell(record) {
+        if (!record.our || !record.our.id) return '';
+        return skuCell(record.our);
+    }
+
+    // Колонка «Кандидаты» — список артикулов SKU через запятую (issue #3532; ранее список ID, #3519).
     function candidatesCell(record) {
         if (!record.candidates || !record.candidates.length) return '';
-        return record.candidates.map(function(item) {
+        return record.candidates.filter(function(item) {
             return item.id;
-        }).filter(Boolean).map(escapeHtml).join(', ');
+        }).map(skuCell).join(', ');
     }
 
     function renderList() {
@@ -1010,6 +1023,7 @@
         state.placeholderOurId = str('data-placeholder-our-id', DEFAULT_PLACEHOLDER_OUR_ID);
         state.skuIdKey = str('data-sku-id-field', DEFAULT_SKU_ID_KEY);
         state.skuLabelKey = str('data-sku-field', DEFAULT_SKU_LABEL_KEY);
+        state.skuArticleKey = str('data-sku-article-field', DEFAULT_SKU_ARTICLE_KEY);
         state.tokensKey = str('data-tokens-field', DEFAULT_TOKENS_KEY);
         state.tmaKey = str('data-tma-field', DEFAULT_TMA_KEY);
         state.names = {
@@ -1044,6 +1058,8 @@
         normalizeRows: normalizeRows,
         normalizeQueryRows: normalizeQueryRows,
         pickMatches: pickMatches,
+        ourCell: ourCell,
+        candidatesCell: candidatesCell,
         buildMatchUrl: buildMatchUrl,
         buildScanUrl: buildScanUrl,
         tuneConcurrency: tuneConcurrency,

--- a/experiments/test-issue-3532-xcom-article-display.js
+++ b/experiments/test-issue-3532-xcom-article-display.js
@@ -1,0 +1,70 @@
+// Тест issue #3532: в таблице массового подбора SKU колонки «Наш артикул» и «Кандидаты»
+// показывают АРТИКУЛ SKU (поле «Артикул» отчёта mass_match) вместо числового SKUID, при этом
+// в строку RFP по-прежнему записывается ID (writeBack пишет item.id — здесь проверяется, что
+// pickMatches сохраняет id, а рендер ячеек выводит артикул и кладёт id в title).
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const root = path.join(__dirname, '..');
+const scriptPath = path.join(root, 'download', 'xcom', 'js', 'xcom-mass-match.js');
+assert(fs.existsSync(scriptPath), 'download/xcom/js/xcom-mass-match.js exists');
+
+const source = fs.readFileSync(scriptPath, 'utf8');
+const sandbox = {
+    window: {},
+    document: {
+        readyState: 'loading',
+        addEventListener: function() {},
+        getElementById: function() { return null; }
+    },
+    console,
+    URLSearchParams,
+    URL,
+    setTimeout,
+    clearTimeout,
+    fetch: function() { throw new Error('fetch should not be called by helper tests'); }
+};
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'xcom-mass-match.js' });
+
+const api = sandbox.window.XcomMassMatchWorkspace;
+assert(api && typeof api.pickMatches === 'function', 'pickMatches exported');
+assert(typeof api.ourCell === 'function', 'ourCell exported');
+assert(typeof api.candidatesCell === 'function', 'candidatesCell exported');
+
+// Ответ отчёта mass_match: первая строка — «Наш артикул», остальные — кандидаты.
+const rows = [
+    { SKUID: '4126386', 'Наименование SKU': 'Ролик Konica Minolta', 'Артикул': 'A5AWR70E11' },
+    { SKUID: '4126390', 'Наименование SKU': 'Ролик bizhub', 'Артикул': 'A5AWR70E12' },
+    { SKUID: '4126391', 'Наименование SKU': 'Ролик подачи', 'Артикул': 'A5AWR70E13' }
+];
+
+const picked = api.pickMatches(rows);
+
+// pickMatches сохраняет ID (для записи в RFP) и захватывает артикул (для показа).
+assert.strictEqual(picked.our.id, '4126386', 'our.id = SKUID (сохраняется для записи)');
+assert.strictEqual(picked.our.article, 'A5AWR70E11', 'our.article = поле «Артикул»');
+assert.strictEqual(picked.candidates.length, 2, 'кандидатов — остальные строки');
+assert.strictEqual(picked.candidates[0].id, '4126390', 'candidate.id = SKUID');
+assert.strictEqual(picked.candidates[0].article, 'A5AWR70E12', 'candidate.article = «Артикул»');
+
+// Рендер: видимый текст — артикул, ID сохраняется в title (а в RFP его пишет writeBack по item.id).
+const ourHtml = api.ourCell({ our: picked.our });
+assert(ourHtml.indexOf('A5AWR70E11') !== -1, 'ourCell показывает артикул');
+assert(ourHtml.indexOf('title="ID 4126386"') !== -1, 'ourCell сохраняет ID в title');
+assert(ourHtml.indexOf('>4126386<') === -1, 'ourCell не выводит ID как текст ячейки');
+
+const candHtml = api.candidatesCell({ candidates: picked.candidates });
+assert(candHtml.indexOf('A5AWR70E12') !== -1 && candHtml.indexOf('A5AWR70E13') !== -1,
+    'candidatesCell показывает артикулы кандидатов');
+assert(candHtml.indexOf('title="ID 4126390"') !== -1, 'candidatesCell сохраняет ID кандидата в title');
+
+// Фоллбэк: если артикул в отчёте пуст — показываем ID (ячейка не пустеет).
+const noArticle = api.pickMatches([{ SKUID: '999', 'Наименование SKU': 'Без артикула' }]);
+assert.strictEqual(noArticle.our.article, '', 'нет колонки «Артикул» → article пуст');
+const fallbackHtml = api.ourCell({ our: noArticle.our });
+assert(fallbackHtml.indexOf('>999<') !== -1, 'при пустом артикуле ourCell выводит ID');
+
+console.log('OK: test-issue-3532-xcom-article-display');


### PR DESCRIPTION
Closes #3532

## Что
В таблице `.xcom-mass-table` (рабочее место «Массовый подбор SKU») колонки **«Наш артикул»** и **«Кандидаты»** выводили числовой `SKUID`. Теперь показываем **артикул SKU** (поле «Артикул» отчёта `mass_match`), а сам ID сохраняется.

## Как
- `pickMatches` дополнительно захватывает колонку «Артикул» отчёта → `item.article`.
- Новая `skuCell(item)`: текст ячейки = `item.article` (фоллбэк на `item.id`, если артикул пуст), `title="ID …"` — для трассировки.
- `ourCell`/`candidatesCell` используют `skuCell`.
- `data-sku-article-field` — переопределение имени колонки (по умолчанию «Артикул»).
- **ID сохраняется**: `writeBack` по-прежнему пишет в строку RFP `item.id` (поля «Наш артикул»/«Кандидаты» в CRM хранят SKUID) — изменилось только отображение.

## Тесты
- `experiments/test-issue-3532-xcom-article-display.js` — артикул в `pickMatches`, артикул в выводе ячеек, ID в `title`, фоллбэк на ID при пустом артикуле. ✅
- `experiments/test-issue-3501-xcom-mass-accuracy.js` — без регрессий. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)