### PR TITLE
fix(xcom): пропускать служебную строку без SKU в массовом подборе (#3534)

### DIFF
--- a/download/xcom/js/xcom-mass-match.js
+++ b/download/xcom/js/xcom-mass-match.js
@@ -381,20 +381,33 @@
                 var parsed = parseRefValue(label);
                 if (parsed.refId) { id = parsed.refId; label = parsed.label; }
             }
-            return { id: id, label: label || id };
+            return {
+                id: id,
+                label: label || id,
+                tokens: state.tokensKey && row[state.tokensKey] != null ? trimValue(row[state.tokensKey]) : '',
+                tma: state.tmaKey && row[state.tmaKey] != null ? trimValue(row[state.tmaKey]) : ''
+            };
         }
 
-        var our = toItem(first);
-        var candidates = rows.slice(1).map(toItem).filter(function(item) {
+        // Берём только строки с реальным SKU (непустой SKUID). Отчёт mass_match иногда возвращает
+        // ведущую служебную строку без SKU (пустые SKUID/Артикул/Наименование, в «токенах» —
+        // требования RFP): раньше она становилась «Наш артикул», our → null, и в строку RFP
+        // писалась заглушка «0», хотя кандидаты были (issue #3534). Теперь её пропускаем:
+        // «Наш артикул» = первый настоящий SKU, точность считаем по ЕГО токенам, а не по служебной строке.
+        var items = rows.map(toItem).filter(function(item) {
             return item.id;
         });
+        if (!items.length) return { our: null, candidates: [], tokens: '', tma: '' };
+
+        var our = items[0];
+        var candidates = items.slice(1);
         if (state.maxCandidates > 0) candidates = candidates.slice(0, state.maxCandidates);
 
         return {
-            our: our.id ? our : null,
+            our: our,
             candidates: candidates,
-            tokens: state.tokensKey && first[state.tokensKey] != null ? trimValue(first[state.tokensKey]) : '',
-            tma: state.tmaKey && first[state.tmaKey] != null ? trimValue(first[state.tmaKey]) : ''
+            tokens: our.tokens,
+            tma: our.tma
         };
     }
 

--- a/experiments/test-issue-3534-xcom-skip-empty-sku.js
+++ b/experiments/test-issue-3534-xcom-skip-empty-sku.js
@@ -1,0 +1,75 @@
+// Тест issue #3534: отчёт mass_match иногда возвращает ведущую служебную строку без SKU
+// (пустые SKUID/Артикул/Наименование, в «токенах» — требования RFP). Раньше она становилась
+// «Наш артикул» → our=null → в строку RFP писалась заглушка «0», хотя реальные кандидаты были.
+// Теперь pickMatches пропускает строки без SKUID: «Наш артикул» = первый настоящий SKU,
+// точность считается по ЕГО токенам.
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const root = path.join(__dirname, '..');
+const scriptPath = path.join(root, 'download', 'xcom', 'js', 'xcom-mass-match.js');
+assert(fs.existsSync(scriptPath), 'download/xcom/js/xcom-mass-match.js exists');
+
+const source = fs.readFileSync(scriptPath, 'utf8');
+const sandbox = {
+    window: {},
+    document: {
+        readyState: 'loading',
+        addEventListener: function() {},
+        getElementById: function() { return null; }
+    },
+    console,
+    URLSearchParams,
+    URL,
+    setTimeout,
+    clearTimeout,
+    fetch: function() { throw new Error('fetch should not be called by helper tests'); }
+};
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'xcom-mass-match.js' });
+
+const api = sandbox.window.XcomMassMatchWorkspace;
+assert(api && typeof api.pickMatches === 'function', 'pickMatches exported');
+
+// Реальный ответ mass_match для RFP 10462220-1 (из issue #3534): первая строка пустая, дальше — SKU.
+const rows = [
+    { RFP: '10462220-1', 'Наименование SKU': '', 'токены': '2000стр,быть,ГК,должен,изготовлен,компанией,печатного,производителем,расходный', 'Вес': '9', 'ТММ': '0', 'Артикул': '', SKUID: '' },
+    { RFP: '10462220-1', 'Наименование SKU': 'Картридж Sakura SA12016SE для Lexmark E120/E120n, черный, 2000 к.', 'токены': '120,E,Lexmark,N,Картридж', 'Вес': '7', 'ТММ': '0', 'Артикул': 'SA12016SE', SKUID: '4174263' },
+    { RFP: '10462220-1', 'Наименование SKU': 'Картридж Cactus CS-LX120 для Lexmark E120N, 2000 стр.', 'токены': '120,E,Lexmark,N,Картридж', 'Вес': '7', 'ТММ': '0', 'Артикул': 'CS-LX120', SKUID: '4195432' },
+    { RFP: '10462220-1', 'Наименование SKU': 'Картридж Lexmark 12016SE для принтера E120/E120n на 2000 страниц', 'токены': '120,E,Lexmark,N,Картридж', 'Вес': '7', 'ТММ': '0', 'Артикул': '12016SE', SKUID: '4145074' }
+];
+
+const picked = api.pickMatches(rows);
+
+// «Наш артикул» = ПЕРВЫЙ настоящий SKU, а не пустая служебная строка (раньше тут был null → «0»).
+assert(picked.our, 'our не должен быть null — кандидаты есть');
+assert.strictEqual(picked.our.id, '4174263', 'our.id = SKUID первого настоящего SKU');
+assert.strictEqual(picked.our.label, 'Картридж Sakura SA12016SE для Lexmark E120/E120n, черный, 2000 к.', 'our.label = наименование SKU');
+
+// Кандидаты — остальные настоящие SKU (без служебной строки).
+assert.strictEqual(picked.candidates.length, 2, 'кандидатов — 2 (служебная строка отброшена)');
+assert.deepStrictEqual(picked.candidates.map(function(c) { return c.id; }), ['4195432', '4145074'], 'id кандидатов');
+
+// Точность считается по токенам «нашего» SKU, а не по служебной строке (там были требования RFP).
+assert.strictEqual(picked.tokens, '120,E,Lexmark,N,Картридж', 'tokens берутся из строки «нашего» SKU');
+assert.strictEqual(picked.tma, '0', 'tma берётся из строки «нашего» SKU');
+
+// Нормальный случай (все строки с SKUID) — первая строка по-прежнему «Наш артикул».
+const normal = api.pickMatches([
+    { 'Наименование SKU': 'A', 'токены': 'x', 'ТММ': '1', SKUID: '11' },
+    { 'Наименование SKU': 'B', 'токены': 'y', 'ТММ': '0', SKUID: '22' }
+]);
+assert.strictEqual(normal.our.id, '11', 'обычный случай: our = первая строка');
+assert.strictEqual(normal.candidates.length, 1, 'обычный случай: 1 кандидат');
+assert.strictEqual(normal.tokens, 'x', 'обычный случай: tokens из первой строки');
+
+// Подлинно пустой результат (нет ни одного SKU) → our=null (legit-заглушка «0» в processRecord).
+const empty = api.pickMatches([
+    { 'Наименование SKU': '', 'токены': 'req', 'ТММ': '0', SKUID: '' }
+]);
+assert.strictEqual(empty.our, null, 'нет ни одного SKU → our=null (далее пишется заглушка)');
+assert.strictEqual(empty.candidates.length, 0, 'нет кандидатов');
+
+console.log('OK: test-issue-3534-xcom-skip-empty-sku');


### PR DESCRIPTION
Closes #3534

## Почему «0» для 10462220-1
Отчёт `mass_match` для этой строки вернул **ведущую служебную строку без SKU** (пустые `SKUID`/`Артикул`/`Наименование SKU`, в `токенах` — слова требования RFP, `Вес: 9`), а дальше — настоящие SKU-кандидаты с `SKUID`.

`pickMatches` считал первую строку «нашим артикулом»: у неё пустой `SKUID` → `our → null` → ветка «нет совпадений» писала в строку RFP заглушку **`0`**, а реальные кандидаты выбрасывались.

## Фикс
`pickMatches` отбирает только строки с непустым `SKUID`:
- **«Наш артикул»** = первый настоящий SKU (был `SA12016SE`/`4174263`);
- **«Кандидаты»** = остальные настоящие SKU;
- **точность** считается по токенам «нашего» SKU (а не служебной строки — там были требования RFP);
- подлинно пустой результат (ни одного SKU) по-прежнему даёт `our=null` → легитимную заглушку `0`.

`toItem` теперь переносит `токены`/`ТММ` в item, чтобы взять их из строки выбранного SKU.

## Тесты
- `experiments/test-issue-3534-xcom-skip-empty-sku.js` — реальные данные из issue: служебная строка отброшена, our=`4174263`, 2 кандидата, токены из «нашего» SKU; + обычный случай и подлинно пустой. ✅
- `experiments/test-issue-3501-xcom-mass-accuracy.js` — без регрессий. ✅

> Примечание: пересекается по `pickMatches`/`toItem` с открытым PR #3533 (#3532, артикул вместо ID). Конфликт при мерже — только в строке `return` функции `toItem` (объединить поля `article` + `tokens`/`tma`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)