### PR TITLE
fix(xcom): вернуть артикул в таблицу массового подбора — потерян при merge #3536 (#3537)

### DIFF
--- a/download/xcom/js/xcom-mass-match.js
+++ b/download/xcom/js/xcom-mass-match.js
@@ -391,6 +391,7 @@
             return {
                 id: id,
                 label: label || id,
+                article: article,   // показываем в таблице вместо ID (issue #3532); потерян при merge #3536, восстановлен в #3537
                 tokens: state.tokensKey && row[state.tokensKey] != null ? trimValue(row[state.tokensKey]) : '',
                 tma: state.tmaKey && row[state.tmaKey] != null ? trimValue(row[state.tmaKey]) : ''
             };


### PR DESCRIPTION
Closes #3537

## Что случилось
При мерже PR #3536 (#3534, пропуск служебной строки) был конфликт с уже влитым #3533 (#3532, артикул вместо ID) в функции `toItem`. При разрешении в `return` осталась версия #3534 — `{ id, label, tokens, tma }`. Поле **`article` вычислялось, но не попадало в возвращаемый объект** (мёртвая переменная).

Из-за этого `skuCell(item.article || item.id)` уходил в фоллбэк → таблица снова показывала **ID вместо артикулов**. Нули при этом ушли корректно — фикс #3534 не задет.

## Фикс
Одна строка — вернул `article: article` в `return` функции `toItem`. Всё остальное (`skuCell`, `ourCell`/`candidatesCell`, экспорт, `data-sku-article-field`, детект `articleKey`) уже на месте с #3533.

Итог: **артикулы выводятся** (как просили в #3532) **и** заглушка «0» не пишется при наличии кандидатов (#3534).

## Тесты
- `experiments/test-issue-3532-xcom-article-display.js` — ловил регресс (`article=undefined`), теперь ✅
- `experiments/test-issue-3534-xcom-skip-empty-sku.js` — ✅
- `experiments/test-issue-3501-xcom-mass-accuracy.js` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)