### PR TITLE
fix(atex): планирование — всегда показывать вкладки всех станков (#3535)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -440,6 +440,33 @@
             });
     }
 
+    // #3535: вкладки очереди по станкам. Возвращает [{ slitter:{id,label}, cuts }]
+    // для КАЖДОГО станка справочника (slitters) в порядке справочника — даже если
+    // у станка нет резок в этот день (тогда cuts:[]). Иначе вкладки «съезжают» и
+    // человек принимает первую вкладку за первый станок. Группы groupBySlitter с
+    // резками без станка (id=null) или с удалённым из справочника станком
+    // дописываются в конце в порядке groupBySlitter, чтобы не потерять задания.
+    //   slitters — справочник [{ id, label, ... }];
+    //   groups   — результат groupBySlitter(filtered).
+    function mergeStationTabs(slitters, groups) {
+        // id станков — числовые строки, поэтому строковый sentinel для «без станка»
+        // (id=null) с ними не коллизит; ключ внутренний, наружу не уходит.
+        function key(g) { return g.slitter.id == null ? 'no-station' : String(g.slitter.id); }
+        var byKey = {};
+        (groups || []).forEach(function(g) { byKey[key(g)] = g; });
+        var tabs = [];
+        var seen = {};
+        (slitters || []).forEach(function(s) {
+            var k = String(s.id);
+            seen[k] = true;
+            tabs.push(byKey[k] || { slitter: { id: s.id, label: s.label }, cuts: [] });
+        });
+        (groups || []).forEach(function(g) {
+            if (!seen[key(g)]) tabs.push(g);
+        });
+        return tabs;
+    }
+
     // Фильтр очереди по слиттеру и статусу (пустой фильтр = «все»).
     function filterCuts(cuts, filters) {
         var f = filters || {};
@@ -3191,6 +3218,7 @@
         resolveNominalWidth: resolveNominalWidth,        // #3408
         mapCutRecord: mapCutRecord,
         groupBySlitter: groupBySlitter,
+        mergeStationTabs: mergeStationTabs,
         filterCuts: filterCuts,
         cutSearchHaystack: cutSearchHaystack,
         cutMatchesQuery: cutMatchesQuery,
@@ -6748,39 +6776,30 @@
         var filtered = filterCuts(visible, this.filter);
         var groups = groupBySlitter(filtered);
 
-        if (!groups.length) {
-            // Показываем вкладки всех станков, даже если резок нет (#3168).
-            if (this.slitters.length) {
-                var allKeys = this.slitters.map(function(s) { return String(s.id); });
-                if (allKeys.indexOf(self.activeSlitter) === -1) self.activeSlitter = allKeys[0];
-                var tabs = el('div', { class: 'atex-pp-tabs' });
-                this.slitters.forEach(function(s) {
-                    var key = String(s.id);
-                    var tab = el('button', { class: 'atex-pp-tab' + (key === self.activeSlitter ? ' is-active' : ''), type: 'button' }, [
-                        el('span', { class: 'atex-pp-tab-label', text: s.label }),
-                        el('span', { class: 'atex-pp-tab-count', text: '0' })
-                    ]);
-                    // #3411: переключение станка очищает панель «Связанные позиции».
-                    tab.addEventListener('click', function() { self.activeSlitter = key; self.selectedCutId = null; self.renderQueue(); self.renderLink(); });
-                    tabs.appendChild(tab);
-                });
-                box.appendChild(tabs);
-                box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Заданий в очереди нет' }));
-            } else {
-                box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Заданий в очереди нет' }));
-            }
+        // #3535: вкладку показываем для КАЖДОГО станка справочника — даже если в
+        // этот день у него нет резок (счётчик 0, пустой список). Иначе вкладки
+        // «съезжают», и человек принимает первую вкладку за первый станок, хотя
+        // станка без резок в ней нет. Порядок вкладок = порядок справочника
+        // станков (this.slitters); группы с резками без станка / с удалённым из
+        // справочника станком дописываем в конце в порядке groupBySlitter,
+        // чтобы не потерять задания. (Раньше вкладки всех станков показывались
+        // только при полностью пустой очереди — #3168.)
+        var tabGroups = mergeStationTabs(this.slitters, groups);
+
+        if (!tabGroups.length) {
+            box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Заданий в очереди нет' }));
             return;
         }
 
         // Закладки по станкам (#3116 п.2): один таб на станок, контент — резки
         // только активного станка. Активный таб в this.activeSlitter (ключ как в
-        // groupBySlitter); если выбранного среди групп нет — берём первый.
+        // groupBySlitter); если выбранного среди вкладок нет — берём первую.
         function groupKey(g) { return g.slitter.id == null ? '\u0000none' : String(g.slitter.id); }
-        var keys = groups.map(groupKey);
+        var keys = tabGroups.map(groupKey);
         if (keys.indexOf(self.activeSlitter) === -1) self.activeSlitter = keys[0];
 
         var tabs = el('div', { class: 'atex-pp-tabs' });
-        groups.forEach(function(g) {
+        tabGroups.forEach(function(g) {
             var key = groupKey(g);
             // #3411: при активном поиске счётчик показывает число совпавших позиций станка.
             var count = groupMatchCount(g);
@@ -6794,7 +6813,7 @@
         });
         box.appendChild(tabs);
 
-        var activeGroup = groups.filter(function(g) { return groupKey(g) === self.activeSlitter; })[0] || groups[0];
+        var activeGroup = tabGroups.filter(function(g) { return groupKey(g) === self.activeSlitter; })[0] || tabGroups[0];
         var groupEl = el('div', { class: 'atex-pp-queue-group' });
 
         // Расписание активного станка: старт/финиш каждой резки от начала смены (08:00).
@@ -7084,6 +7103,9 @@
         // (счётчики на закладках подскажут, где совпадения есть).
         if (hasQuery && !groupEl.childNodes.length) {
             groupEl.appendChild(el('div', { class: 'atex-pp-empty', text: 'В этом станке нет позиций по запросу «' + query + '».' }));
+        } else if (!groupEl.childNodes.length) {
+            // #3535: активный станок без резок в этот день — явная подсказка вместо пустоты.
+            groupEl.appendChild(el('div', { class: 'atex-pp-empty', text: 'Заданий в очереди нет' }));
         }
         box.appendChild(groupEl);
         console.log('[pp] 📊 renderQueue: отрисовано за ' + (Date.now() - t0) + 'мс. групп:', groups.length, 'резок:', self.cuts.length);

--- a/experiments/atex-production-planning-3535.test.js
+++ b/experiments/atex-production-planning-3535.test.js
@@ -1,0 +1,73 @@
+// Unit tests for #3535 — вкладки очереди показывают ВСЕ станки справочника,
+// не пропуская те, у кого нет резок в выбранный день.
+// Контракт mergeStationTabs(slitters, groups):
+//   • один таб на каждый станок справочника в порядке справочника (даже без резок);
+//   • станки без резок получают группу с cuts:[] (счётчик 0);
+//   • группы с резками без станка / с удалённым из справочника станком —
+//     дописываются в конце в исходном порядке groups (не теряем задания).
+//
+// Run with: node experiments/atex-production-planning-3535.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+var merge = planning.mergeStationTabs;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) passed++; else process.exitCode = 1;
+}
+function ids(tabs) { return tabs.map(function(t) { return t.slitter.id; }); }
+function counts(tabs) { return tabs.map(function(t) { return t.cuts.length; }); }
+
+var slitters = [
+    { id: '1', label: 'Слиттер №1' },
+    { id: '2', label: 'Слиттер №2' },
+    { id: '3', label: 'Слиттер №3' }
+];
+
+// Резки есть только у станка №2 → всё равно три вкладки в порядке справочника,
+// у №1 и №3 счётчик 0.
+var groupsOnly2 = [
+    { slitter: { id: '2', label: 'Слиттер №2' }, cuts: [{ id: 'a' }, { id: 'b' }] }
+];
+var t1 = merge(slitters, groupsOnly2);
+assert(JSON.stringify(ids(t1)) === JSON.stringify(['1', '2', '3']), 'все три станка в порядке справочника');
+assert(JSON.stringify(counts(t1)) === JSON.stringify([0, 2, 0]), 'счётчики: только №2 непустой');
+assert(t1[1].cuts === groupsOnly2[0].cuts, 'группа станка №2 — та же ссылка (резки не копируются)');
+
+// Резок нет вообще → три пустые вкладки (раньше так было только для пустой очереди).
+var t2 = merge(slitters, []);
+assert(JSON.stringify(ids(t2)) === JSON.stringify(['1', '2', '3']), 'пустая очередь → все станки видны');
+assert(JSON.stringify(counts(t2)) === JSON.stringify([0, 0, 0]), 'пустая очередь → все счётчики 0');
+
+// Порядок вкладок = порядок справочника, а не алфавит/порядок groups.
+var slittersReordered = [{ id: '3', label: 'В' }, { id: '1', label: 'А' }, { id: '2', label: 'Б' }];
+var t3 = merge(slittersReordered, groupsOnly2);
+assert(JSON.stringify(ids(t3)) === JSON.stringify(['3', '1', '2']), 'порядок вкладок берётся из справочника');
+
+// Группа с резками без станка (id=null) — в конце, не теряется.
+var groupsWithNone = [
+    { slitter: { id: '1', label: 'Слиттер №1' }, cuts: [{ id: 'x' }] },
+    { slitter: { id: null, label: 'Без станка' }, cuts: [{ id: 'y' }] }
+];
+var t4 = merge(slitters, groupsWithNone);
+assert(JSON.stringify(ids(t4)) === JSON.stringify(['1', '2', '3', null]), 'группа «без станка» дописана в конце');
+assert(t4[3].cuts.length === 1, 'резки «без станка» сохранены');
+
+// Резки станка, которого нет в справочнике (удалён) — тоже не теряются.
+var groupsDeleted = [
+    { slitter: { id: '9', label: 'Удалённый' }, cuts: [{ id: 'z' }] }
+];
+var t5 = merge(slitters, groupsDeleted);
+assert(JSON.stringify(ids(t5)) === JSON.stringify(['1', '2', '3', '9']), 'удалённый станок дописан в конце');
+
+// Пустой справочник станков → показываем то, что вернул groupBySlitter (фоллбэк).
+var t6 = merge([], groupsOnly2);
+assert(JSON.stringify(ids(t6)) === JSON.stringify(['2']), 'нет справочника → группы как есть');
+var t7 = merge([], []);
+assert(t7.length === 0, 'нет ни станков, ни резок → пусто (рисуется «Заданий в очереди нет»)');
+
+console.log('\n' + passed + ' passed');

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 35);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 36);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3535.

## Проблема
В рабочем месте «Планирование производства» (`templates/atex/production-planning.html`) очередь резок группировалась по станкам через `groupBySlitter`, и вкладки рисовались **только для станков, у которых есть резки в выбранный день**. Из-за этого вкладки «съезжали»: первой могла оказаться не первый станок, и диспетчер ошибочно принимал её за него.

## Решение
Вкладка теперь показывается для **КАЖДОГО станка справочника** в порядке справочника — даже если у станка нет резок в этот день (счётчик `0`, содержимое — «Заданий в очереди нет»).

- Логика слияния вынесена в чистую функцию `planning.mergeStationTabs(slitters, groups)`:
  - все станки справочника в порядке справочника (плейсхолдер с `cuts:[]`, если резок нет);
  - группы с резками **без станка** (`id=null`) или **с удалённым из справочника** станком дописываются в конце в порядке `groupBySlitter` — задания не теряются.
- Прежняя ветка «показать вкладки всех станков только при полностью пустой очереди» (#3168) поглощена общим путём.
- Добавлена подсказка «Заданий в очереди нет» для активного станка без резок в этот день (раньше панель была пустой).

## Проверка
- Новый юнит-тест `experiments/atex-production-planning-3535.test.js` (11 проверок: порядок вкладок, счётчики, группа «без станка», удалённый станок, пустой справочник) — PASS.
- Весь набор planning-тестов проходит (527 + остальные).
- Бамп `VERSION` 35→36 в `index.php` (cache-bust ассетов, правило #3418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)