### PR TITLE
fix(atex): планирование — убрать кнопку «сдвинуть старт позже» (#3540)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -7040,23 +7040,20 @@
             controls.appendChild(down);
             controls.appendChild(strips);
             controls.appendChild(fix);
-            // #3508 п.6: у зафиксированного — кнопки ◀▶ сдвига планового старта на ±15 мин
-            // в пределах [естественный старт, +90 мин]. «◀» (раньше) полезна, когда перед
+            // #3508 п.6: у зафиксированного — кнопка ◀ сдвига планового старта на 15 мин
+            // раньше, в пределах [естественный старт, +90 мин]. Полезна, когда перед
             // заданием освободилось окно (удалили другое) — встроить в это пустое место.
+            // #3540: кнопку ▶ («позже на 15 мин, в пределах 90 мин») убрали — ручная
+            // задержка планового старта не нужна.
             if (c.fixed) {
                 var natWS = natWindowStartByCut[String(c.id)];
                 var pinTs = pinTimestampSeconds(c);
                 var curWS = (pinTs != null && isFinite(natWS)) ? (pinTs * 1000 - planBaseMidnightMs) / 60000 : natWS;
                 var canEarlier = isFinite(natWS) && isFinite(curWS) && curWS > natWS + 1e-6;
-                var canLater = isFinite(natWS) && isFinite(curWS) && curWS < natWS + PIN_MAX_DELAY_MIN - 1e-6;
                 var earlier = el('button', { class: 'atex-pp-cut-nudge', type: 'button', text: '◀', title: 'Сдвинуть старт раньше на ' + PIN_STEP_MIN + ' мин (в освободившееся окно)' });
-                var later = el('button', { class: 'atex-pp-cut-nudge', type: 'button', text: '▶', title: 'Сдвинуть старт позже на ' + PIN_STEP_MIN + ' мин (в пределах 90 мин)' });
                 if (!canEarlier) earlier.disabled = true;
-                if (!canLater) later.disabled = true;
                 earlier.addEventListener('click', function(e) { if (e && e.stopPropagation) e.stopPropagation(); if (self.busy) return; self.nudgeCutStart(c, -PIN_STEP_MIN, natWS); });
-                later.addEventListener('click', function(e) { if (e && e.stopPropagation) e.stopPropagation(); if (self.busy) return; self.nudgeCutStart(c, PIN_STEP_MIN, natWS); });
                 controls.appendChild(earlier);
-                controls.appendChild(later);
             }
             controls.appendChild(del);
             cardPanel.appendChild(controls);

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 35);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 36);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3540.

## Проблема
У зафиксированного задания в очереди «Планирования производства» была пара кнопок ◀▶ ручного сдвига планового старта (#3508 п.6). Кнопка **▶** с подсказкой «Сдвинуть старт позже на 15 мин (в пределах 90 мин)» не запрашивалась — ручная задержка старта не нужна.

## Решение
- Убрана кнопка **▶** и её ветка: `canLater`, обработчик клика, `appendChild(later)`.
- Кнопка **◀** («раньше») **оставлена** — у неё есть рабочий сценарий: когда перед заданием освободилось окно (удалили другое), вернуть задание в это пустое место.
- `nudgeCutStart` / `clampPinnedStart` / `PIN_MAX_DELAY_MIN` сохранены — нужны для ◀; окно `[естественный старт, +90 мин]` по-прежнему ограничивает сдвиг.
- CSS `.atex-pp-cut-nudge` без изменений (используется ◀).

## Проверка
- `node --check` — синтаксис ОК.
- Весь набор planning-тестов проходит (527 + остальные), включая `clampPinnedStart`.
- Бамп `VERSION` 35→36 в `index.php` (cache-bust ассетов, правило #3418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)