### PR TITLE
feat(table): поиск по ID для первой колонки + диапазон двумя полями (#3542)

### DIFF
--- a/css/integram-table.css
+++ b/css/integram-table.css
@@ -685,6 +685,23 @@ span.integram-title-link:not(.integram-parent-record-link):hover {
     color: var(--md-text-hint);
 }
 
+/* Range filter: two from/to fields side by side instead of one comma input (issue #3542) */
+.filter-range-wrapper .filter-range-input {
+    flex: 1 1 0;
+    min-width: 0;
+    width: auto;
+}
+/* The right ("to") field has no icon, so it doesn't need the icon's left padding */
+.filter-range-wrapper .filter-range-input[data-range-part="to"] {
+    padding-left: 4px;
+}
+.filter-range-sep {
+    flex: 0 0 auto;
+    padding: 0 4px;
+    color: var(--md-text-secondary);
+    font-size: 0.875rem;
+}
+
 /* Reference field filter dropdown trigger button (issue #795, #797) */
 .filter-ref-trigger {
     flex: 1;

--- a/experiments/test-issue-3542-table-filter.js
+++ b/experiments/test-issue-3542-table-filter.js
@@ -1,0 +1,94 @@
+// Тест issue #3542 (js/integram-table.js):
+// 1) первой (главной) колонке любого типа доступен поиск по ID (@ / !@), как у ссылочных;
+// 2) диапазон (...) собирает значение из двух полей from/to, поддерживает открытые границы.
+// Методы класса чистые — инстанс создаём через Object.create без конструктора (он требует DOM).
+const path = require('path');
+const assert = require('assert');
+
+const IntegramTable = require(path.join(__dirname, '..', 'js', 'integram-table.js'));
+assert(typeof IntegramTable === 'function', 'IntegramTable exported');
+
+const t = Object.create(IntegramTable.prototype);
+
+// Минимальный набор операторов (как в конструкторе — здесь это просто данные).
+t.filterTypes = {
+    'SHORT': [
+        { symbol: '^', name: 'начинается с...', format: 'FR_{ T }={ X }%' },
+        { symbol: '=', name: 'равно', format: 'FR_{ T }={ X }' }
+    ],
+    'NUMBER': [
+        { symbol: '=', name: 'равно', format: 'FR_{ T }={ X }' },
+        { symbol: '...', name: 'в диапазоне', format: 'FR_{ T }={ X1 }&TO_{ T }={ X2 }' },
+        { symbol: '%', name: 'не пустое', format: 'FR_{ T }=%' },
+        { symbol: '!%', name: 'пустое', format: 'FR_{ T }=!%' }
+    ],
+    'REF': [
+        { symbol: '=', name: 'равно', format: 'FR_{ T }={ X }' },
+        { symbol: '@', name: 'по ID: включая', format: 'FR_{ T }=@{ X }' },
+        { symbol: '!@', name: 'по ID: исключая', format: 'FR_{ T }=!@{ X }' }
+    ]
+};
+
+t.columns = [
+    { id: '100', format: 'SHORT' },   // первая (главная) колонка
+    { id: '200', format: 'NUMBER' },  // обычная числовая
+    { id: '300', format: 'REF' }      // ссылочная
+];
+
+// --- isFirstColumn ---
+assert.strictEqual(t.isFirstColumn(t.columns[0]), true, 'columns[0] — первая колонка');
+assert.strictEqual(t.isFirstColumn(t.columns[1]), false, 'columns[1] — не первая');
+assert.strictEqual(t.isFirstColumn({ id: '999', format: 'SHORT' }), false, 'неизвестная колонка — не первая');
+
+// --- getColumnFilterTypes: первая колонка любого типа получает @ / !@ ---
+const firstOps = t.getColumnFilterTypes(t.columns[0]).map(f => f.symbol);
+assert(firstOps.includes('@') && firstOps.includes('!@'), 'первая колонка: добавлены @ и !@');
+assert(firstOps.includes('^'), 'первая колонка: базовые операторы сохранены');
+const numOps = t.getColumnFilterTypes(t.columns[1]).map(f => f.symbol);
+assert(!numOps.includes('@'), 'обычная колонка: @ НЕ добавляется');
+
+// REF-колонка уже имеет @ — не дублируем (даже если бы была первой)
+const refFirst = Object.create(IntegramTable.prototype);
+refFirst.filterTypes = t.filterTypes;
+refFirst.columns = [{ id: '300', format: 'REF' }];
+const refOps = refFirst.getColumnFilterTypes(refFirst.columns[0]).map(f => f.symbol);
+assert.strictEqual(refOps.filter(s => s === '@').length, 1, 'REF: @ не дублируется');
+
+// --- applyFilter: поиск по ID на первой колонке ---
+function run(column, filter) {
+    const p = new URLSearchParams();
+    t.applyFilter(p, column, filter);
+    return p;
+}
+
+let p = run(t.columns[0], { type: '@', value: '5' });
+assert.strictEqual(p.get('FR_100'), '@5', '@ один ID → FR_100=@5');
+
+p = run(t.columns[0], { type: '@', value: '5, 6, abc' });
+assert.strictEqual(p.get('FR_100'), '@(5,6)', '@ несколько ID → FR_100=@(5,6) (нечисловые отброшены)');
+
+p = run(t.columns[0], { type: '!@', value: '7' });
+assert.strictEqual(p.get('FR_100'), '!@7', '!@ → FR_100=!@7');
+
+// На обычной (не первой) колонке @ недоступен → фильтр не добавляется
+p = run(t.columns[1], { type: '@', value: '5' });
+assert.strictEqual(p.get('FR_200'), null, 'на не-первой колонке @ игнорируется');
+
+// --- applyFilter: диапазон из двух значений ---
+p = run(t.columns[1], { type: '...', value: '1,5' });
+assert.strictEqual(p.get('FR_200'), '1', 'диапазон: FR_200=1');
+assert.strictEqual(p.get('TO_200'), '5', 'диапазон: TO_200=5');
+
+p = run(t.columns[1], { type: '...', value: '1,' });
+assert.strictEqual(p.get('FR_200'), '1', 'открытый диапазон (только от): FR_200=1');
+assert.strictEqual(p.get('TO_200'), null, 'открытый диапазон (только от): TO не задан');
+
+p = run(t.columns[1], { type: '...', value: ',5' });
+assert.strictEqual(p.get('FR_200'), null, 'открытый диапазон (только до): FR не задан');
+assert.strictEqual(p.get('TO_200'), '5', 'открытый диапазон (только до): TO_200=5');
+
+p = run(t.columns[1], { type: '...', value: ',' });
+assert.strictEqual(p.get('FR_200'), null, 'пустой диапазон: FR не задан');
+assert.strictEqual(p.get('TO_200'), null, 'пустой диапазон: TO не задан');
+
+console.log('OK: test-issue-3542-table-filter');

--- a/experiments/test-issue-3542-table-filter.js
+++ b/experiments/test-issue-3542-table-filter.js
@@ -65,7 +65,7 @@ let p = run(t.columns[0], { type: '@', value: '5' });
 assert.strictEqual(p.get('FR_100'), '@5', '@ один ID → FR_100=@5');
 
 p = run(t.columns[0], { type: '@', value: '5, 6, abc' });
-assert.strictEqual(p.get('FR_100'), '@(5,6)', '@ несколько ID → FR_100=@(5,6) (нечисловые отброшены)');
+assert.strictEqual(p.get('FR_100'), '@IN(5,6)', '@ несколько ID → FR_100=@IN(5,6) (формат IN, нечисловые отброшены)');
 
 p = run(t.columns[0], { type: '!@', value: '7' });
 assert.strictEqual(p.get('FR_100'), '!@7', '!@ → FR_100=!@7');

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1583,11 +1583,13 @@ class IntegramTable{
             if (type === '@' || type === '!@') {
                 // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819).
                 // Available on reference columns and on the first column of any type (issue #3542).
+                // Multiple IDs use the IN(...) form — the bare @(id,id) form is NOT understood by
+                // the backend (verified on live: returns nothing for both REF and first columns) (issue #3542).
                 const ids = value.split(',').map(v => v.trim()).filter(v => /^\d+$/.test(v));
                 if (ids.length === 0) return;
                 const formatted = ids.length === 1
                     ? `${type}${ids[0]}`
-                    : `${type}(${ids.join(',')})`;
+                    : `${type}IN(${ids.join(',')})`;
                 params.append(`FR_${ colId }`, formatted);
             } else if (type === '...') {
                 // Range: two separate values from/to (issue #3542). Either side may be empty

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1541,19 +1541,48 @@ class IntegramTable{
             return equalDefaultFormats.includes(format) ? '=' : '^';
         }
 
+        /**
+         * Is this the first (main value) column of the table?
+         * The first built column carries the record's own identity (id === metadata.id),
+         * so it can be filtered by record ID like a reference column (issue #3542).
+         */
+        isFirstColumn(column) {
+            return !!(column && Array.isArray(this.columns) && this.columns.length > 0 &&
+                column.id === this.columns[0].id);
+        }
+
+        /**
+         * Filter operators available for a column.
+         * Base set comes from the column format; the first column of ANY type additionally
+         * gets ID-based search (@ / !@), the same way reference columns do (issue #3542).
+         * REF already includes @ / !@, so it is not augmented.
+         */
+        getColumnFilterTypes(column) {
+            const format = column.format || 'SHORT';
+            const baseTypes = this.filterTypes[format] || this.filterTypes['SHORT'];
+            if (this.isFirstColumn(column) && format !== 'REF') {
+                return baseTypes.concat([
+                    { symbol: '@', name: 'по ID: включая', format: 'FR_{ T }=@{ X }' },
+                    { symbol: '!@', name: 'по ID: исключая', format: 'FR_{ T }=!@{ X }' }
+                ]);
+            }
+            return baseTypes;
+        }
+
         applyFilter(params, column, filter) {
             const type = filter.type || '^';
             const value = filter.value;
             const colId = column.id;
 
             const format = column.format || 'SHORT';
-            const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
+            const filterGroup = this.getColumnFilterTypes(column);
             const filterDef = filterGroup.find(f => f.symbol === type);
 
             if (!filterDef) return;
 
             if (type === '@' || type === '!@') {
-                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819)
+                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819).
+                // Available on reference columns and on the first column of any type (issue #3542).
                 const ids = value.split(',').map(v => v.trim()).filter(v => /^\d+$/.test(v));
                 if (ids.length === 0) return;
                 const formatted = ids.length === 1
@@ -1561,11 +1590,13 @@ class IntegramTable{
                     : `${type}(${ids.join(',')})`;
                 params.append(`FR_${ colId }`, formatted);
             } else if (type === '...') {
-                const values = value.split(',').map(v => v.trim());
-                if (values.length >= 2) {
-                    params.append(`FR_${ colId }`, values[0]);
-                    params.append(`TO_${ colId }`, values[1]);
-                }
+                // Range: two separate values from/to (issue #3542). Either side may be empty
+                // for an open-ended range — append only the bounds that were filled in.
+                const values = value.split(',');
+                const from = (values[0] || '').trim();
+                const to = (values[1] || '').trim();
+                if (from) params.append(`FR_${ colId }`, from);
+                if (to) params.append(`TO_${ colId }`, to);
             } else if (type === '%' || type === '!%') {
                 params.append(`FR_${ colId }`, type === '%' ? '%' : '!%');
             } else {
@@ -1659,6 +1690,8 @@ class IntegramTable{
             if (focusedElement && focusedElement.classList.contains('filter-input-with-icon')) {
                 focusState = {
                     columnId: focusedElement.dataset.columnId,
+                    // Range cells have two inputs sharing a columnId — remember which one (issue #3542)
+                    rangePart: focusedElement.dataset.rangePart || null,
                     selectionStart: focusedElement.selectionStart,
                     selectionEnd: focusedElement.selectionEnd
                 };
@@ -1903,7 +1936,10 @@ class IntegramTable{
             // position when a filter input lives outside the visible scroll viewport
             // (issue #2744).
             if (focusState) {
-                const newInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${focusState.columnId}"]`);
+                const selector = focusState.rangePart
+                    ? `.filter-range-input[data-column-id="${focusState.columnId}"][data-range-part="${focusState.rangePart}"]`
+                    : `.filter-input-with-icon[data-column-id="${focusState.columnId}"]`;
+                const newInput = this.container.querySelector(selector);
                 if (newInput) {
                     newInput.focus({ preventScroll: true });
                     // Restore cursor position (only for text inputs, not date pickers)
@@ -2023,6 +2059,49 @@ class IntegramTable{
                                    data-column-id="${ column.id }"
                                    data-is-datetime="${ isDateTime ? '1' : '0' }"
                                    value="${ html5Value }">
+                        </div>
+                    </td>
+                `;
+            }
+
+            // Range filter ('...'): two separate from/to fields instead of one comma-separated
+            // input — the comma syntax was unclear (issue #3542). Stored value stays "from,to".
+            if (currentFilter.type === '...') {
+                const isDate = dateFormats.includes(format);
+                const isDateTime = format === 'DATETIME';
+                let inputType = 'text';
+                if (isDate) inputType = isDateTime ? 'datetime-local' : 'date';
+                else if (format === 'NUMBER' || format === 'SIGNED') inputType = 'number';
+
+                const parts = (currentFilter.value || '').split(',');
+                const rawFrom = (parts[0] || '').trim();
+                const rawTo = (parts[1] || '').trim();
+                const fromVal = isDate ? (rawFrom ? this.formatDateForHtml5(rawFrom, isDateTime) : '') : rawFrom;
+                const toVal = isDate ? (rawTo ? this.formatDateForHtml5(rawTo, isDateTime) : '') : rawTo;
+                const dtAttr = isDate ? ` data-is-datetime="${ isDateTime ? '1' : '0' }"` : '';
+                const escAttr = v => String(v).replace(/"/g, '&quot;');
+
+                return `
+                    <td>
+                        <div class="filter-cell-wrapper filter-range-wrapper">
+                            <span class="filter-icon-inside" data-column-id="${ column.id }">
+                                ${ currentFilter.type }
+                            </span>
+                            <input type="${ inputType }"
+                                   class="filter-input-with-icon filter-range-input"
+                                   data-column-id="${ column.id }"
+                                   data-range-part="from"${ dtAttr }
+                                   value="${ escAttr(fromVal) }"
+                                   placeholder="от"
+                                   autocomplete="off">
+                            <span class="filter-range-sep">—</span>
+                            <input type="${ inputType }"
+                                   class="filter-input-with-icon filter-range-input"
+                                   data-column-id="${ column.id }"
+                                   data-range-part="to"${ dtAttr }
+                                   value="${ escAttr(toVal) }"
+                                   placeholder="до"
+                                   autocomplete="off">
                         </div>
                     </td>
                 `;
@@ -4015,6 +4094,8 @@ class IntegramTable{
             filterInputs.forEach(input => {
                 // Skip date pickers — they are handled separately via 'change' event (issue #1008)
                 if (input.classList.contains('filter-date-picker')) return;
+                // Skip range from/to inputs — handled separately below (issue #3542)
+                if (input.classList.contains('filter-range-input')) return;
                 // Use 'input' event to apply filter on text change
                 input.addEventListener('input', (e) => {
                     const colId = input.dataset.columnId;
@@ -4068,6 +4149,44 @@ class IntegramTable{
                     delete this.filters[colId].displayValue;
 
                     this.handleFilterOverride(colId, displayValue);
+
+                    clearTimeout(this.filterTimeout);
+                    this.filterTimeout = setTimeout(() => {
+                        this.data = [];
+                        this.loadedRecords = 0;
+                        this.hasMore = true;
+                        this.totalRows = null;
+                        this.loadData(false);
+                    }, 500);
+                });
+            });
+
+            // Range filter from/to inputs (issue #3542): combine both halves into the stored
+            // "from,to" value. Date inputs fire 'change'; number/text inputs fire 'input'.
+            const filterRangeInputs = this.container.querySelectorAll('.filter-range-input');
+            filterRangeInputs.forEach(input => {
+                const evtName = (input.type === 'date' || input.type === 'datetime-local') ? 'change' : 'input';
+                input.addEventListener(evtName, () => {
+                    const colId = input.dataset.columnId;
+                    if (!this.filters[colId]) {
+                        this.filters[colId] = { type: '...', value: '' };
+                    }
+                    const wrapper = input.closest('.filter-cell-wrapper');
+                    const readPart = part => {
+                        const el = wrapper && wrapper.querySelector(`.filter-range-input[data-range-part="${ part }"]`);
+                        if (!el || !el.value) return '';
+                        // Date inputs carry data-is-datetime → convert HTML5 value to display format
+                        if (el.dataset.isDatetime === '1' || el.dataset.isDatetime === '0') {
+                            return this.convertHtml5DateToDisplay(el.value, el.dataset.isDatetime === '1');
+                        }
+                        return el.value.trim();
+                    };
+                    const from = readPart('from');
+                    const to = readPart('to');
+                    this.filters[colId].value = `${ from },${ to }`;
+                    delete this.filters[colId].displayValue;
+
+                    this.handleFilterOverride(colId, this.filters[colId].value);
 
                     clearTimeout(this.filterTimeout);
                     this.filterTimeout = setTimeout(() => {
@@ -7400,7 +7519,7 @@ class IntegramTable{
         showFilterTypeMenu(target, columnId) {
             const column = this.columns.find(c => c.id === columnId);
             const format = column.format || 'SHORT';
-            const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
+            const filterGroup = this.getColumnFilterTypes(column);
 
             document.querySelectorAll('.filter-type-menu').forEach(m => m.remove());
 
@@ -7464,6 +7583,14 @@ class IntegramTable{
                             this.render();
                             return;
                         }
+                    }
+
+                    // Switching to/from range ('...') changes the cell from one input to two
+                    // from/to fields (issue #3542) — clear the value and re-render to swap inputs.
+                    if ((symbol === '...') !== (oldType === '...')) {
+                        this.filters[columnId].value = '';
+                        this.render();
+                        return;
                     }
 
                     // For Empty (%) and Not Empty (!%) filters, clear input and apply immediately


### PR DESCRIPTION
Closes #3542

Два изменения фильтра таблицы (`js/integram-table.js`).

## 1. Поиск по ID для первой колонки любого типа
Раньше операторы «@ по ID: включая» / «!@ по ID: исключая» были только у ссылочных (REF) колонок. Теперь они доступны и для **первой (главной) колонки** любого типа (фильтр по ID самой записи).

- `getColumnFilterTypes(column)` — новый источник операторов: база по формату + `@`/`!@` для первой колонки (REF уже их содержит → не дублируется). Используется в меню операторов и в `applyFilter`.
- `isFirstColumn(column)` — первая колонка = `columns[0]` (главное значение записи, `id === metadata.id`).
- `applyFilter` строит `FR_{id}=@5` / `FR_{id}=@IN(5,6)` / `FR_{id}=!@7`.

### ✅ Проверено на боевой базе (ideav.ru/ateh, таблица 1078)
Заодно выяснилось, что прежний мульти-формат `@(id1,id2)` (текстовый @-ввод, #1819) **бэкендом не понимается** — возвращал пусто и для ссылок, и для главной колонки. Исправлено на `@IN(...)`.

| | single | multi «включая» | multi «исключая» |
|---|---|---|---|
| Ссылочная колонка | `@id` / `!@id` ✓ | `@IN(..)` ✓ | `!@IN(..)` ✓ |
| **Первая колонка** | `@id` / `!@id` ✓ | `@IN(..)` ✓ | `!@IN(..)` ⚠️ SQL-ошибка на бэкенде |

То есть «по ID: включая» (один/несколько) и «исключая» (один) на первой колонке работают. Исключение нескольких ID по первой колонке — ограничение бэкенда (редкий кейс «показать все записи, кроме этих N по их id»); одиночное исключение работает.

## 2. Диапазон — два поля вместо запятой
Оператор «в диапазоне» (`...`) для чисел/дат больше не требует ввода через запятую. Теперь две отдельные ячейки **«от»** и **«до»**:
- даты/дата-время → два пикера; числа → два `number`-поля; остальное → текст;
- хранимое значение остаётся `"from,to"` (обратная совместимость URL/состояния);
- любую границу можно оставить пустой → **открытый диапазон** (шлём только заданную сторону: `FR_` и/или `TO_`).

Технически: ветка двух полей в `renderFilterCell`; отдельные слушатели `.filter-range-input`; общий обработчик инпутов их пропускает; ре-рендер при переключении на/с `...`; восстановление фокуса учитывает `data-range-part`; стили в `css/integram-table.css`.

## Тесты
- `experiments/test-issue-3542-table-filter.js` — `isFirstColumn`, augment операторов (первая/обычная/REF), `applyFilter` для `@`/`!@` (формат `IN`) и диапазона (оба значения, только от, только до, пусто). ✅
- `experiments/test-filter-fix.js`, `experiments/test-date-filter.js` — без регрессий. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)