### PR TITLE
fix(atex): планирование — убрать ◀ ручного сдвига старта зафиксированного (#3540)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -386,23 +386,6 @@
 .atex-pp-cut-fix.is-active { background: rgba(107, 114, 128, .14); border-color: #9ca3af; }
 .atex-pp.is-busy .atex-pp-cut-fix { pointer-events: none; opacity: .4; }
 
-/* #3508 п.6: ◀▶ — сдвиг планового старта зафиксированного задания на ±15 мин
-   (в пределах 90 мин от естественного старта). Компактные, как стрелки очереди. */
-.atex-pp-cut-nudge {
-    border: 1px solid var(--pp-border);
-    border-radius: 6px;
-    background: var(--pp-bg);
-    padding: 5px 9px;
-    cursor: pointer;
-    font: inherit;
-    color: inherit;
-    line-height: 1;
-}
-.atex-pp-cut-nudge:hover { background: var(--pp-surface); }
-.atex-pp-cut-nudge:disabled { opacity: .4; cursor: default; }
-.atex-pp-cut-nudge:disabled:hover { background: var(--pp-bg); }
-.atex-pp.is-busy .atex-pp-cut-nudge { pointer-events: none; opacity: .4; }
-
 /* #3508 п.3: пометка «только просмотр» в панели полос зафиксированного задания. */
 .atex-pp-strip-locked-note {
     margin: 6px 0 4px;

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2168,11 +2168,6 @@
         return out;
     }
 
-    // #3508 п.6: на сколько максимум можно отодвинуть плановый старт зафиксированного
-    // задания от «естественного» (90 мин) и шаг кнопок сдвига ◀▶ (15 мин).
-    var PIN_MAX_DELAY_MIN = 90;
-    var PIN_STEP_MIN = 15;
-
     // #3508 п.6: плановый старт (главное значение «Задания в производство», t1078) как
     // unix-штамп в СЕКУНДАХ. planDate приходит штампом (сек или мс) — нормализуем к сек.
     // null, если не штамп.
@@ -2198,18 +2193,6 @@
             map[String(c.id)] = (ts * 1000 - base) / 60000;
         });
         return map;
-    }
-
-    // #3508 п.6: ограничить желаемый плановый старт зафиксированного задания окном
-    // [natural, natural + maxDelay]: не раньше «естественного» (упакованного) старта —
-    // иначе наложение на предыдущее — и не позже него более чем на maxDelay минут (90).
-    function clampPinnedStart(naturalMin, desiredMin, maxDelayMin) {
-        var nat = Number(naturalMin);
-        var d = Number(desiredMin);
-        if (!isFinite(nat)) return d;
-        if (!isFinite(d)) return nat;
-        var hi = nat + (isFinite(Number(maxDelayMin)) ? Number(maxDelayMin) : 0);
-        return Math.max(nat, Math.min(hi, d));
     }
 
     // #3342: параметры плавающего обеда из opts, валидные только если обед попадает
@@ -3342,7 +3325,6 @@
         buildSchedule: buildSchedule,
         pinnedStartMinByCut: pinnedStartMinByCut,
         pinTimestampSeconds: pinTimestampSeconds,
-        clampPinnedStart: clampPinnedStart,
         freeSlotForQueue: freeSlotForQueue,
         dayCleanups: dayCleanups,
         formatClock: formatClock,
@@ -4508,38 +4490,6 @@
             });
         });
         return tsByCut;
-    };
-
-    // #3508 п.6: сдвинуть плановый старт зафиксированного задания на deltaMin минут,
-    // в пределах [natural, natural + 90] (natural — окно-старт без пина, передаёт карточка).
-    // Пишем t1078 (главное значение). На границе ничего не пишем.
-    AtexProductionPlanning.prototype.nudgeCutStart = function(cut, deltaMin, naturalWindowStartMin) {
-        var self = this;
-        if (this.busy || !cut || !cut.fixed) return;
-        var mainKey = (this.meta.cut && this.meta.cut.id != null) ? 't' + this.meta.cut.id : null;
-        if (!mainKey) { this.notify('Не найдена таблица «' + TABLE.cut + '»', 'error'); return; }
-        var nat = Number(naturalWindowStartMin);
-        if (!isFinite(nat)) return;
-        var planBaseMidnightMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
-        var ts = pinTimestampSeconds(cut);
-        var curMin = (ts != null) ? (ts * 1000 - planBaseMidnightMs) / 60000 : nat;
-        var clamped = clampPinnedStart(nat, curMin + Number(deltaMin || 0), PIN_MAX_DELAY_MIN);
-        if (Math.abs(clamped - curMin) < 1e-6) return;   // упёрлись в границу
-        var newTs = scheduleStartTimestamp(planBaseMidnightMs, clamped);
-        var fields = {}; fields[mainKey] = String(newTs);
-        this.setBusy(true);
-        this.showProgress('Сдвиг планового старта…', 1);
-        this.post('_m_set/' + encodeURIComponent(cut.id) + '?JSON', fields).then(function() {
-            self.updateProgress(1);
-            return self.reload();
-        }).then(function() {
-            self.hideProgress(); self.setBusy(false); self.render();
-            self.notify('Плановый старт сдвинут на ' + (deltaMin > 0 ? '+' : '') + deltaMin + ' мин', 'info');
-        }).catch(function(err) {
-            self.hideProgress(); self.setBusy(false);
-            self.reload().then(function() { self.render(); }).catch(function() {});
-            self.notify('Ошибка сдвига старта: ' + (err && err.message || err), 'error');
-        });
     };
 
     // #3508 п.2/п.4: проставить/снять флаг «Зафиксировано» у набора заданий. Пишем булев
@@ -6845,12 +6795,6 @@
         var pinnedMinByCut = pinnedStartMinByCut(activeGroup.cuts, planBaseMidnightMs);
         var schedule = buildSchedule(activeGroup.cuts, Object.assign({ pinnedStartMinByCut: pinnedMinByCut }, schedOpts));
         schedule.forEach(function(sc) { schedById[sc.cutId] = sc; });
-        // #3508 п.6: расписание БЕЗ пинов даёт «естественный» окно-старт каждого задания —
-        // нижняя граница сдвига зафиксированного (верхняя = natural + 90 мин).
-        var natWindowStartByCut = {};
-        buildSchedule(activeGroup.cuts, schedOpts).forEach(function(sc) {
-            natWindowStartByCut[String(sc.cutId)] = sc.startMin - sc.setupMin;
-        });
         self._timingByCut = {};   // #3240: пересобираем контекст тайминга модалки для активного станка
         var dayCutsByKey = {};
         activeGroup.cuts.forEach(function(c) {
@@ -7059,21 +7003,9 @@
             controls.appendChild(down);
             controls.appendChild(strips);
             controls.appendChild(fix);
-            // #3508 п.6: у зафиксированного — кнопка ◀ сдвига планового старта на 15 мин
-            // раньше, в пределах [естественный старт, +90 мин]. Полезна, когда перед
-            // заданием освободилось окно (удалили другое) — встроить в это пустое место.
-            // #3540: кнопку ▶ («позже на 15 мин, в пределах 90 мин») убрали — ручная
-            // задержка планового старта не нужна.
-            if (c.fixed) {
-                var natWS = natWindowStartByCut[String(c.id)];
-                var pinTs = pinTimestampSeconds(c);
-                var curWS = (pinTs != null && isFinite(natWS)) ? (pinTs * 1000 - planBaseMidnightMs) / 60000 : natWS;
-                var canEarlier = isFinite(natWS) && isFinite(curWS) && curWS > natWS + 1e-6;
-                var earlier = el('button', { class: 'atex-pp-cut-nudge', type: 'button', text: '◀', title: 'Сдвинуть старт раньше на ' + PIN_STEP_MIN + ' мин (в освободившееся окно)' });
-                if (!canEarlier) earlier.disabled = true;
-                earlier.addEventListener('click', function(e) { if (e && e.stopPropagation) e.stopPropagation(); if (self.busy) return; self.nudgeCutStart(c, -PIN_STEP_MIN, natWS); });
-                controls.appendChild(earlier);
-            }
+            // #3540: кнопки ◀▶ ручного сдвига планового старта зафиксированного задания
+            // (#3508 п.6) убраны — двигать время вручную не требуется. Фиксация по-прежнему
+            // прикалывает задание к его плановому старту в расписании (pinnedStartMinByCut).
             controls.appendChild(del);
             cardPanel.appendChild(controls);
 

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1365,10 +1365,6 @@ assertEqual(planning.pinTimestampSeconds({ planDate: '' }), null, 'pinTimestampS
 assertEqual(planning.pinnedStartMinByCut(
     [ { id:'A', fixed:true, planDate:String(pinTs3508) }, { id:'B', fixed:false, planDate:String(pinTs3508) } ], pinBase3508),
     { A: 540 }, 'pinnedStartMinByCut: только зафиксированные → окно-старт 09:00 = 540 мин');
-// clampPinnedStart: окно [natural, natural+90].
-assertEqual(planning.clampPinnedStart(540, 600, 90), 600, 'clampPinnedStart: 600 ∈ [540,630]');
-assertEqual(planning.clampPinnedStart(540, 500, 90), 540, 'clampPinnedStart: раньше natural → natural');
-assertEqual(planning.clampPinnedStart(540, 700, 90), 630, 'clampPinnedStart: позже natural+90 → natural+90');
 
 // ── #3342: плавающий обед (LUNCH_START / LUNCH_DURATION) ──
 var wwLunch = planning.resolveWorkingWindow({ DAY_START_HOUR:'8:00', DAY_END_HOUR:'16:40', LUNCH_START:'12:20', LUNCH_DURATION:'40' }, 30);

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 36);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 37);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3540 (продолжение #3541).

## Уточнение задачи
В #3541 убрали только кнопку **▶** («Сдвинуть старт позже»). По уточнению автора в #3540 двигать плановый старт вручную не нужно **вовсе** — убираем и оставшуюся кнопку **◀** («Сдвинуть старт раньше на 15 мин») и всю обвязку под-фичи ручного сдвига (#3508 п.6).

## Что удалено
- UI-блок кнопки **◀** в карточке очереди (`renderQueue`);
- метод `nudgeCutStart` (запись `t1078` со сдвигом);
- чистая `clampPinnedStart` (+ экспорт из `planning` + 3 ассерта в тесте);
- константы `PIN_MAX_DELAY_MIN` (90) и `PIN_STEP_MIN` (15);
- второй проход `buildSchedule` без пинов (`natWindowStartByCut`) — расписание активного станка теперь строится **один раз** (мелкий выигрыш по производительности);
- мёртвые CSS-правила `.atex-pp-cut-nudge`.

## Что НЕ тронуто
Фиксация задания («Зафиксировать») работает как раньше: зафиксированное задание по-прежнему «прикалывается» к своему плановому старту в расписании (`pinnedStartMinByCut` → `buildSchedule`). Убрана только ручная подвижка времени кнопками.

## Проверка
- `node --check` — синтаксис ОК; осиротевших ссылок (`grep`) не осталось.
- Весь набор planning-тестов проходит (524 ассерта в основном + остальные).
- Бамп `VERSION` 36→37 в `index.php` (cache-bust ассетов, правило #3418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)