### PR TITLE
fix(atex): планирование — серый бордюр у зафиксированного задания (#3545)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -196,7 +196,10 @@
 .atex-pp-cut.is-fixed:hover { background: rgba(107, 114, 128, .1); }
 .atex-pp-cut.is-active { border-color: var(--pp-accent); box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
 /* Нет подходящей партии сырья — резку нельзя обеспечить (#3120 п.4, Фаза 1a). */
-.atex-pp-cut.is-unreserved { background: rgba(185, 28, 28, .07); border-color: var(--pp-warn); }
+.atex-pp-cut.is-unreserved { background: rgba(185, 28, 28, .07); }
+/* #3545: красный бордюр «нет обеспечения» — только у НЕзафиксированного задания.
+   У зафиксированного бордюр остаётся серым (.is-fixed), сигнал даёт красный фон. */
+.atex-pp-cut.is-unreserved:not(.is-fixed) { border-color: var(--pp-warn); }
 
 /* Информационная строка резки (клик по всей карточке — выбор резки, #3149). */
 .atex-pp-cut-info {

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 37);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 38);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3545.

## Проблема
У зафиксированной карточки очереди (`.atex-pp-cut.is-fixed`) бордюр серый (#3508 п.5). Но если задание нельзя обеспечить сырьём, правило `.atex-pp-cut.is-unreserved` (объявлено ниже, та же специфичность) перекрывало бордюр **красным** (`--pp-warn`).

## Решение
Красный бордюр «нет обеспечения» оставляем только у **незафиксированных** заданий:

```css
.atex-pp-cut.is-unreserved { background: rgba(185, 28, 28, .07); }
.atex-pp-cut.is-unreserved:not(.is-fixed) { border-color: var(--pp-warn); }
```

- У зафиксированного бордюр остаётся **серым** (от `.is-fixed`).
- Сигнал «нет обеспечения» по-прежнему даёт **красный фон** (его не трогаем).
- Активная (выбранная) карточка перекрывает бордюр навигационным акцентом (navy), как и раньше.

## Проверка
Вычисленные стили в браузере (getComputedStyle) на всех комбинациях:

| Карточка | Бордюр |
|---|---|
| `is-fixed` | серый `#9ca3af` ✓ |
| `is-unreserved` (не fixed) | красный ✓ (без изменений) |
| `is-fixed is-unreserved` | **серый** (фон красный) ✓ |
| `is-fixed is-unreserved is-active` | navy (акцент выбора) ✓ |
| `is-unreserved is-active` (не fixed) | красный ✓ (без изменений) |

Бамп `VERSION` 37→38 (cache-bust ассетов, правило #3418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)