### PR TITLE
fix(xcom): массовый подбор — хранить Артикул вместо ID в «Наш артикул» и «Кандидаты» (#3547)

### DIFF
--- a/download/xcom/js/xcom-mass-match.js
+++ b/download/xcom/js/xcom-mass-match.js
@@ -4,8 +4,8 @@
     // Рабочее место массового подбора SKU для строк каталога контрагента (таблица RFP).
     // Пачками выбирает необработанные строки RFP (серверный фильтр: пустое «Наш артикул»),
     // для каждой строки запускает запрос mass_match (фильтр FR_RFPID={id строки}) и записывает
-    // обратно в RFP три поля ОДНИМ запросом _m_set: «Наш артикул» (ID SKU), «Кандидаты»
-    // (список ID SKU через запятую) и «Точность подбора». Обработанные строки выпадают из
+    // обратно в RFP три поля ОДНИМ запросом _m_set: «Наш артикул» (артикул SKU), «Кандидаты»
+    // (список артикулов SKU через запятую) и «Точность подбора». Обработанные строки выпадают из
     // выборки. «Старт» обрабатывает пачки подряд (по batchSize), автоматически подгружая
     // следующие, пока не нажмут «Стоп» или сервер не вернёт пустой список (issue #3512).
 
@@ -463,7 +463,7 @@
     }
 
     // Ячейка SKU: показываем артикул, ID кладём в title для трассировки (issue #3532).
-    // В строку RFP по-прежнему записывается ID (см. writeBack) — артикул только для отображения.
+    // В строку RFP теперь тоже записывается артикул (см. writeBack, issue #3547).
     function skuCell(item) {
         var text = item.article || item.id;
         return '<span title="ID ' + escapeHtml(item.id) + '">' + escapeHtml(text) + '</span>';
@@ -715,29 +715,43 @@
         });
     }
 
-    // Записать результат в строку RFP ОДНИМ запросом _m_set (issue #3512): «Наш артикул»,
-    // «Кандидаты», «Точность подбора» — все три поля сразу, а не по одному. Обе колонки текстовые:
-    // «Наш артикул» (type 3, ref=null) — первый SKUID как текст (или заглушка для несопоставленных);
-    // «Кандидаты» (type 8, строка) — остальные SKUID одной строкой через запятую с пробелом.
-    function writeBack(record) {
+    // Значение SKU для записи в строку RFP: артикул, фоллбэк на ID, если артикул пуст (issue #3547).
+    // Тот же выбор, что и в отображении (skuCell: item.article || item.id) — храним то, что видно.
+    // У заглушки «нет совпадений» артикула нет, поэтому пишется её id ('0') — маркер обработанной строки.
+    function skuStoredValue(item) {
+        if (!item) return '';
+        return trimValue(item.article) || trimValue(item.id);
+    }
+
+    // Собрать значения для _m_set по строке RFP: «Наш артикул», «Кандидаты», «Точность подбора».
+    // Выделено из writeBack для тестируемости (issue #3547) — чистая функция без сетевых запросов.
+    function buildWriteValues(record) {
         var fields = state.fields;
         var values = {};
 
-        if (fields.our && record.our && record.our.id) {
-            values[fields.our.id] = record.our.id;
+        if (fields.our && record.our) {
+            var ourValue = skuStoredValue(record.our);
+            if (ourValue) values[fields.our.id] = ourValue;
         }
         if (fields.candidates && record.candidates && record.candidates.length) {
-            var candidateIds = record.candidates.map(function(item) {
-                return item.id;
-            }).filter(Boolean);
-            if (candidateIds.length) {
-                values[fields.candidates.id] = candidateIds.join(', ');
+            var candidateValues = record.candidates.map(skuStoredValue).filter(Boolean);
+            if (candidateValues.length) {
+                values[fields.candidates.id] = candidateValues.join(', ');
             }
         }
         if (fields.accuracy && record.accuracy != null) {
             values[fields.accuracy.id] = record.accuracy;
         }
+        return values;
+    }
 
+    // Записать результат в строку RFP ОДНИМ запросом _m_set (issue #3512): «Наш артикул»,
+    // «Кандидаты», «Точность подбора» — все три поля сразу, а не по одному. Обе колонки текстовые:
+    // «Наш артикул» (type 3, ref=null) — артикул первого SKU (или заглушка '0' для несопоставленных);
+    // «Кандидаты» (type 8, строка) — артикулы остальных SKU через запятую с пробелом (issue #3547,
+    // раньше хранились SKUID — #3519).
+    function writeBack(record) {
+        var values = buildWriteValues(record);
         if (!Object.keys(values).length) return Promise.resolve();
         return postSetMany(record.id, values);
     }
@@ -1074,6 +1088,8 @@
         pickMatches: pickMatches,
         ourCell: ourCell,
         candidatesCell: candidatesCell,
+        skuStoredValue: skuStoredValue,
+        buildWriteValues: buildWriteValues,
         buildMatchUrl: buildMatchUrl,
         buildScanUrl: buildScanUrl,
         tuneConcurrency: tuneConcurrency,

--- a/experiments/test-issue-3547-xcom-store-article.js
+++ b/experiments/test-issue-3547-xcom-store-article.js
@@ -1,0 +1,85 @@
+// Тест issue #3547: в строку RFP записывается АРТИКУЛ SKU (а не числовой SKUID) — в оба поля
+// «Наш артикул» и «Кандидаты». До этого writeBack хранил item.id (#3519); теперь, как и в
+// отображении (#3532), храним то, что видно — артикул, с фоллбэком на ID, если артикул пуст.
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const root = path.join(__dirname, '..');
+const scriptPath = path.join(root, 'download', 'xcom', 'js', 'xcom-mass-match.js');
+assert(fs.existsSync(scriptPath), 'download/xcom/js/xcom-mass-match.js exists');
+
+const source = fs.readFileSync(scriptPath, 'utf8');
+const sandbox = {
+    window: {},
+    document: {
+        readyState: 'loading',
+        addEventListener: function() {},
+        getElementById: function() { return null; }
+    },
+    console,
+    URLSearchParams,
+    URL,
+    setTimeout,
+    clearTimeout,
+    fetch: function() { throw new Error('fetch should not be called by helper tests'); }
+};
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'xcom-mass-match.js' });
+
+const api = sandbox.window.XcomMassMatchWorkspace;
+assert(api && typeof api.pickMatches === 'function', 'pickMatches exported');
+assert(typeof api.buildWriteValues === 'function', 'buildWriteValues exported');
+assert(typeof api.skuStoredValue === 'function', 'skuStoredValue exported');
+
+// Поля таблицы RFP, в которые пишет _m_set (id реквизитов произвольные — важна привязка значений).
+api._state.fields = {
+    our: { id: '111', index: 4 },
+    candidates: { id: '222', index: 5 },
+    accuracy: { id: '333', index: 6 }
+};
+
+// Ответ отчёта mass_match: первая строка — «Наш артикул», остальные — кандидаты.
+const rows = [
+    { SKUID: '4126386', 'Наименование SKU': 'Ролик Konica Minolta', 'Артикул': 'A5AWR70E11' },
+    { SKUID: '4126390', 'Наименование SKU': 'Ролик bizhub', 'Артикул': 'A5AWR70E12' },
+    { SKUID: '4126391', 'Наименование SKU': 'Ролик подачи', 'Артикул': 'A5AWR70E13' }
+];
+const picked = api.pickMatches(rows);
+const record = { id: '900', our: picked.our, candidates: picked.candidates, accuracy: 87 };
+
+const values = api.buildWriteValues(record);
+
+// «Наш артикул» — артикул первого SKU, а НЕ его SKUID.
+assert.strictEqual(values['111'], 'A5AWR70E11', '«Наш артикул» = артикул первого SKU');
+assert.notStrictEqual(values['111'], '4126386', '«Наш артикул» — не SKUID');
+
+// «Кандидаты» — артикулы остальных SKU через запятую, а НЕ их SKUID.
+assert.strictEqual(values['222'], 'A5AWR70E12, A5AWR70E13', '«Кандидаты» = артикулы через запятую');
+assert.strictEqual(values['222'].indexOf('4126390'), -1, '«Кандидаты» не содержат SKUID');
+
+// «Точность подбора» пишется как есть.
+assert.strictEqual(values['333'], 87, '«Точность подбора» = число');
+
+// skuStoredValue: артикул в приоритете, фоллбэк на ID при пустом артикуле.
+assert.strictEqual(api.skuStoredValue({ id: '5', article: 'ART-5' }), 'ART-5', 'артикул в приоритете');
+assert.strictEqual(api.skuStoredValue({ id: '5', article: '' }), '5', 'пустой артикул → ID');
+assert.strictEqual(api.skuStoredValue({ id: '5' }), '5', 'нет поля article → ID');
+
+// Фоллбэк на ID в записи: SKU без артикула — в RFP уходит его SKUID (поле не пустеет).
+const noArticle = api.pickMatches([
+    { SKUID: '999', 'Наименование SKU': 'Без артикула' },
+    { SKUID: '1000', 'Наименование SKU': 'Кандидат без артикула' }
+]);
+const noArtValues = api.buildWriteValues({ id: '901', our: noArticle.our, candidates: noArticle.candidates, accuracy: 10 });
+assert.strictEqual(noArtValues['111'], '999', 'нет артикула → пишем SKUID (поле непустое)');
+assert.strictEqual(noArtValues['222'], '1000', 'кандидат без артикула → его SKUID');
+
+// Заглушка «нет совпадений»: пишется '0' (placeholderOurId), строка помечается обработанной.
+const placeholderRecord = { id: '902', our: { id: '0', label: 'нет совпадений', placeholder: true }, candidates: [], accuracy: 0 };
+const phValues = api.buildWriteValues(placeholderRecord);
+assert.strictEqual(phValues['111'], '0', 'заглушка без совпадений → «Наш артикул» = 0');
+assert.strictEqual(phValues['222'], undefined, 'у заглушки нет кандидатов → поле «Кандидаты» не пишем');
+
+console.log('OK: test-issue-3547-xcom-store-article');


### PR DESCRIPTION
Closes #3547

## Что меняется
В рабочем месте «Массовый подбор SKU» (`templates/xcom/mass_match.html` + `download/xcom/js/xcom-mass-match.js`) обратная запись в строку RFP теперь сохраняет **артикул SKU**, а не числовой SKUID — в оба поля **«Наш артикул»** и **«Кандидаты»**.

Это приводит хранимое значение в соответствие с тем, что уже показывается в таблице (артикул — с #3532). Раньше отображался артикул, а в базу писался ID.

## Как
- `writeBack` собирает значения через новую чистую функцию `buildWriteValues` (+ `skuStoredValue`).
- `skuStoredValue(item)` = `item.article || item.id` — тот же выбор, что и в `skuCell` для отображения.
- **Фоллбэк на ID**, если у SKU пустой артикул → поле остаётся непустым (это маркер «обработанной» строки для серверного фильтра выборки).
- Заглушка «нет совпадений» по-прежнему пишет `'0'` (артикула у неё нет → фоллбэк на её id).
- «Точность подбора» — без изменений.

## ⚠️ Изменение поведения
Это сознательно отменяет прежний инвариант «в RFP всегда пишется SKUID» (#3519). Если где-то ниже по потоку поля «Наш артикул»/«Кандидаты» парсятся как ID — нужно учесть.

## Тесты
- Новый: `experiments/test-issue-3547-xcom-store-article.js` — проверяет, что пишутся артикулы (не ID), фоллбэк на ID при пустом артикуле, заглушка `'0'`.
- Прогнаны без регрессий: `test-issue-3501`, `test-issue-3527`, `test-issue-3532`, `test-issue-3534`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)