### PR TITLE
fix(xcom): авто-регулировка потоков — прирост от исторического максимума скорости (#3549)

### DIFF
--- a/download/xcom/js/xcom-mass-match.js
+++ b/download/xcom/js/xcom-mass-match.js
@@ -70,7 +70,8 @@
         timer: null,        // id setInterval живого таймера
         // issue #3527: авто-регулировка числа потоков по скорости пачки
         autoConcurrency: true, // вкл/выкл авто-регулировку (по умолчанию вкл)
-        prevSpeed: null,    // скорость (строк/сек) предыдущей пачки
+        prevSpeed: null,    // скорость (строк/сек) предыдущей пачки — база для оценки ПАДЕНИЯ
+        maxSpeed: null,     // исторический максимум скорости за прогон — база для оценки ПРИРОСТА (issue #3549)
         lastTuneUp: false,  // увеличивали ли потоки ПЕРЕД последней пачкой (оценка пробы)
         tuneCooldown: 0     // сколько пачек ждать до следующей пробы повышения
     };
@@ -598,30 +599,34 @@
     // --- Авто-регулировка числа потоков по скорости пачки (issue #3527) ------
 
     // Решение по числу потоков после очередной пачки. batchSpeed — строк/сек этой пачки.
-    // Правила: (1) пробуем +1 от текущего; (2) пока скорость растёт после повышения — повышаем
-    // дальше; (3) если прироста нет — возвращаем обратно и ждём TUNE_COOLDOWN_BATCHES пачек до
-    // следующей пробы; (4) если скорость упала ≥10% к прошлой пачке — понижаем.
+    // Правила: (1) пробуем +1 от текущего; (2) пока повышение даёт НОВЫЙ исторический максимум —
+    // повышаем дальше; (3) если максимум не побит — возвращаем обратно и ждём TUNE_COOLDOWN_BATCHES
+    // пачек до следующей пробы; (4) если скорость упала ≥10% к ПОСЛЕДНЕЙ пачке — понижаем.
+    // issue #3549: прирост меряем относительно исторического максимума (maxSpeed), а падение —
+    // относительно последней пачки (prevSpeed). Иначе после revert/wait на сниженных потоках
+    // следующая проба сравнивалась бы с деградированной базой и «прирост» засчитывался ложно.
     // Возвращает { action, from, to } (для логов/тестов).
     function tuneConcurrency(batchSpeed) {
-        var prev = state.prevSpeed;     // скорость предыдущей пачки (или null для первой)
+        var prev = state.prevSpeed;     // скорость предыдущей пачки (или null для первой) — для падения
+        var max = state.maxSpeed;       // исторический максимум за прогон (или null) — для прироста (issue #3549)
         var wasUp = state.lastTuneUp;   // повышали ли потоки ПЕРЕД этой пачкой
         var before = state.concurrency;
         var action;
 
         if (prev != null && batchSpeed <= prev * SPEED_DROP_RATIO) {
-            // (4) скорость упала на 10% и больше — понижаем
+            // (4) скорость упала на 10% и больше ОТНОСИТЕЛЬНО ПОСЛЕДНЕЙ пачки — понижаем
             state.concurrency = Math.max(MIN_CONCURRENCY, state.concurrency - 1);
             state.lastTuneUp = false;
             state.tuneCooldown = TUNE_COOLDOWN_BATCHES;
             action = 'down';
         } else if (wasUp) {
-            if (prev == null || batchSpeed > prev) {
-                // (2) повышение помогло — продолжаем повышать
+            if (max == null || batchSpeed > max) {
+                // (2) повышение дало НОВЫЙ исторический максимум — продолжаем повышать (issue #3549)
                 state.concurrency = Math.min(MAX_CONCURRENCY, state.concurrency + 1);
                 state.lastTuneUp = true;
                 action = 'up';
             } else {
-                // (3) прироста нет — возвращаем обратно и ждём перед следующей пробой
+                // (3) исторический максимум не побит — возвращаем обратно и ждём перед следующей пробой
                 state.concurrency = Math.max(MIN_CONCURRENCY, state.concurrency - 1);
                 state.lastTuneUp = false;
                 state.tuneCooldown = TUNE_COOLDOWN_BATCHES;
@@ -643,6 +648,8 @@
         }
 
         state.prevSpeed = batchSpeed;
+        // обновляем исторический максимум ПОСЛЕ оценки (сравнивали с максимумом до этой пачки)
+        state.maxSpeed = (max == null || batchSpeed > max) ? batchSpeed : max;
         return { action: action, from: before, to: state.concurrency };
     }
 
@@ -788,8 +795,9 @@
         state.outcomes = {};
         state.startTime = Date.now();
         state.endTime = 0;
-        // сброс авто-регулировки потоков на каждый прогон (issue #3527)
+        // сброс авто-регулировки потоков на каждый прогон (issue #3527, #3549)
         state.prevSpeed = null;
+        state.maxSpeed = null;
         state.lastTuneUp = false;
         state.tuneCooldown = 0;
         setHidden('xcom-mass-stats', false);

--- a/experiments/test-issue-3527-xcom-auto-concurrency.js
+++ b/experiments/test-issue-3527-xcom-auto-concurrency.js
@@ -24,9 +24,11 @@ assert(api && typeof api.tuneConcurrency === 'function', 'tuneConcurrency is exp
 const state = api._state;
 const tune = api.tuneConcurrency;
 
-function reset(concurrency, prevSpeed, lastTuneUp, cooldown) {
+function reset(concurrency, prevSpeed, lastTuneUp, cooldown, maxSpeed) {
     state.concurrency = concurrency;
     state.prevSpeed = prevSpeed === undefined ? null : prevSpeed;
+    // issue #3549: исторический максимум — отдельная база; в этих сценариях по умолчанию = prevSpeed.
+    state.maxSpeed = maxSpeed === undefined ? state.prevSpeed : maxSpeed;
     state.lastTuneUp = !!lastTuneUp;
     state.tuneCooldown = cooldown || 0;
 }

--- a/experiments/test-issue-3549-xcom-max-speed.js
+++ b/experiments/test-issue-3549-xcom-max-speed.js
@@ -1,0 +1,78 @@
+// Тест issue #3549: авто-регулировка числа потоков запоминает ИСТОРИЧЕСКИ МАКСИМАЛЬНУЮ скорость
+// пачки и меряет ПРИРОСТ относительно неё, а ПАДЕНИЕ — относительно ПОСЛЕДНЕЙ пачки.
+// До #3549 прирост сравнивался с прошлой пачкой (prevSpeed): после revert/wait на сниженных
+// потоках следующая проба сравнивалась с деградированной базой и «прирост» засчитывался ложно.
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const root = path.join(__dirname, '..');
+const scriptPath = path.join(root, 'download', 'xcom', 'js', 'xcom-mass-match.js');
+const source = fs.readFileSync(scriptPath, 'utf8');
+const sandbox = {
+    window: {},
+    document: { readyState: 'loading', addEventListener() {}, getElementById() { return null; } },
+    console, URLSearchParams, URL, setTimeout, clearTimeout, setInterval, clearInterval, Date,
+    fetch() { throw new Error('fetch should not be called'); }
+};
+vm.createContext(sandbox);
+vm.runInContext(source, sandbox, { filename: 'xcom-mass-match.js' });
+
+const api = sandbox.window.XcomMassMatchWorkspace;
+assert(api && typeof api.tuneConcurrency === 'function', 'tuneConcurrency is exported');
+const state = api._state;
+const tune = api.tuneConcurrency;
+
+function reset(concurrency, prevSpeed, maxSpeed, lastTuneUp, cooldown) {
+    state.concurrency = concurrency;
+    state.prevSpeed = prevSpeed === undefined ? null : prevSpeed;
+    state.maxSpeed = maxSpeed === undefined ? null : maxSpeed;
+    state.lastTuneUp = !!lastTuneUp;
+    state.tuneCooldown = cooldown || 0;
+}
+
+// --- Прирост относительно МАКСИМУМА, а не последней пачки --------------------
+// Был исторический максимум 20, после revert+wait опустились до c=6, последняя пачка дала 12.
+// Проба повышения даёт 15: это БОЛЬШЕ прошлой пачки (12), но МЕНЬШЕ исторического максимума (20).
+// До #3549: 15 > 12 → ложный «прирост» → up. После #3549: 15 не побило 20 → revert.
+reset(6, /*prev*/ 12, /*max*/ 20, /*lastTuneUp*/ true, 0);
+let r = tune(15);
+assert.strictEqual(r.action, 'revert', 'прирост меряем vs максимум: 15<20 → revert (а не up)');
+assert.strictEqual(state.concurrency, 5, '6 → 5 (возврат)');
+assert.strictEqual(state.tuneCooldown, 3, 'после возврата ждём 3 пачки');
+assert.strictEqual(state.maxSpeed, 20, 'максимум держится (15 его не побило)');
+
+// --- Новый максимум после повышения → продолжаем повышать -------------------
+// Проба дала 21 — это НОВЫЙ исторический максимум (>20) → up, максимум обновляется на 21.
+reset(6, /*prev*/ 18, /*max*/ 20, /*lastTuneUp*/ true, 0);
+r = tune(21);
+assert.strictEqual(r.action, 'up', 'новый максимум (21>20) → up');
+assert.strictEqual(state.concurrency, 7, '6 → 7');
+assert.strictEqual(state.maxSpeed, 21, 'максимум обновился до 21');
+
+// --- Падение меряем относительно ПОСЛЕДНЕЙ пачки, а не максимума ------------
+// Последняя пачка 10, исторический максимум 20. Текущая 11: относительно последней (10) это РОСТ
+// (не падение), хотя относительно максимума (20) было бы «−45%». Значит down НЕ срабатывает —
+// падение считается от последней пачки. Идёт обычная проба повышения.
+reset(7, /*prev*/ 10, /*max*/ 20, /*lastTuneUp*/ false, 0);
+r = tune(11);
+assert.strictEqual(r.action, 'probe-up', 'падение меряем vs последней: 11>10 → не down, обычная проба');
+assert.strictEqual(state.concurrency, 8, '7 → 8 (проба)');
+
+// --- Падение относительно последней пачки по-прежнему понижает --------------
+// Последняя 20, текущая 14: −30% к последней → down. Исторический максимум держится.
+reset(5, /*prev*/ 20, /*max*/ 20, /*lastTuneUp*/ false, 0);
+r = tune(14);
+assert.strictEqual(r.action, 'down', 'падение ≥10% к последней → down');
+assert.strictEqual(state.concurrency, 4, '5 → 4');
+assert.strictEqual(state.maxSpeed, 20, 'максимум переживает понижение');
+
+// --- Первая пачка: максимум инициализируется из null -----------------------
+reset(5, /*prev*/ undefined, /*max*/ undefined, /*lastTuneUp*/ false, 0);
+r = tune(10);
+assert.strictEqual(r.action, 'probe-up', 'первая пачка → проба');
+assert.strictEqual(state.prevSpeed, 10, 'prevSpeed = скорость первой пачки');
+assert.strictEqual(state.maxSpeed, 10, 'maxSpeed инициализирован первой пачкой');
+
+console.log('OK: test-issue-3549-xcom-max-speed');


### PR DESCRIPTION
Closes #3549

## Что меняется
Авто-регулировка числа потоков в «Массовый подбор SKU» (`download/xcom/js/xcom-mass-match.js`, функция `tuneConcurrency`, появилась в #3527) теперь **запоминает исторически максимальную скорость пачки** за прогон и меряет результат пробы повышения относительно неё.

- **Прирост** (повышение потоков «сработало») → меряется относительно `maxSpeed` (исторический максимум): продолжаем повышать только если пачка дала **новый рекорд**.
- **Падение** → по-прежнему относительно `prevSpeed` (последняя пачка).

Ровно как просит issue: «Прирост мерять относительно неё [максимальной], а уменьшение — относительно последней».

## Зачем
Раньше прирост сравнивался с прошлой пачкой. После `revert`/`wait` потоки снижались, скорость падала — и следующая проба повышения сравнивалась с этой **деградированной** базой. Небольшой отскок засчитывался как «прирост», и регулятор полз вверх, хотя исторического максимума не достигал. Теперь проба «прилипает» только при новом рекорде.

## Реализация
- Новое поле `state.maxSpeed` (сбрасывается на каждый прогон в `runAuto`).
- В `tuneConcurrency` ветка оценки пробы (`wasUp`) сравнивает `batchSpeed > max` вместо `> prev`.
- Ветка падения (`down`) без изменений — `batchSpeed <= prev * SPEED_DROP_RATIO`.
- `maxSpeed` обновляется после оценки (сравнение идёт с максимумом *до* текущей пачки).

## Тесты
- Новый `experiments/test-issue-3549-xcom-max-speed.js`: прирост vs максимум (15<20 → revert, а не up), новый максимум → up, падение vs последней (а не максимума), максимум переживает понижение, инициализация из null.
- Обновлён `reset()` в `test-issue-3527` (сброс `maxSpeed` между сценариями) — все прежние правила #3527 проходят.
- Без регрессий: `test-issue-3501`, `test-issue-3532`, `test-issue-3534`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)