### PR TITLE
refactor(xcom): убрать статус-строку .xcom-mass-summary из массового подбора (#3551)

### DIFF
--- a/download/xcom/css/xcom-mass-match.css
+++ b/download/xcom/css/xcom-mass-match.css
@@ -41,8 +41,7 @@
     font-weight: 650;
 }
 
-.xcom-mass-head p,
-.xcom-mass-summary {
+.xcom-mass-head p {
     margin: 0.25rem 0 0;
     color: var(--text-secondary, #64748b);
     font-size: 0.85rem;
@@ -54,10 +53,6 @@
     gap: 0.5rem;
     flex-wrap: wrap;
     justify-content: flex-end;
-}
-
-.xcom-mass-actions .xcom-mass-summary {
-    margin: 0;
 }
 
 .xcom-mass-progress {
@@ -81,6 +76,12 @@
     border-radius: 999px;
     background: var(--button-primary, #2563eb);
     transition: width 0.2s ease;
+}
+
+.xcom-mass-progress-label {
+    margin: 0;
+    color: var(--text-secondary, #64748b);
+    font-size: 0.85rem;
 }
 
 /* Поле ключевого слова для фильтра по наименованию RFP (issue #3523) */

--- a/download/xcom/js/xcom-mass-match.js
+++ b/download/xcom/js/xcom-mass-match.js
@@ -829,7 +829,6 @@
             if (hasPending) {
                 prepared = Promise.resolve(state.records.length);
             } else {
-                setText('xcom-mass-summary', 'Загрузка следующей пачки…');
                 prepared = fetchBatch().then(function(count) {
                     if (count < 0) return 0;          // запрос устарел
                     renderList();
@@ -869,9 +868,6 @@
             renderStats();
             setControls('idle');
             updateProgress();
-            var processed = Object.keys(state.outcomes).length;
-            setText('xcom-mass-summary', (state.stopRequested ? 'Остановлено' : 'Готово') +
-                ' · обработано за прогон: ' + processed + ' за ' + formatDuration(state.endTime - state.startTime));
             if (!state.records.length) renderList();
         });
     }
@@ -928,17 +924,14 @@
     function loadBatch() {
         setControls('loading');
         renderMessage('Загрузка строк RFP…', 'loading');
-        setText('xcom-mass-summary', 'Загрузка…');
 
         return fetchBatch().then(function(count) {
             if (count < 0) return;
             renderList();
-            setText('xcom-mass-summary', count + ' необработанных');
             setControls('idle');
             updateProgress();
         }).catch(function(error) {
             renderMessage(error && error.message ? error.message : 'Не удалось загрузить строки RFP.', 'error');
-            setText('xcom-mass-summary', 'Ошибка');
             setControls('idle');
         });
     }
@@ -970,7 +963,6 @@
             return loadBatch();
         }).catch(function(error) {
             renderMessage(error && error.message ? error.message : 'Не удалось загрузить метаданные RFP.', 'error');
-            setText('xcom-mass-summary', 'Ошибка');
             setControls('loading');
             setDisabled('xcom-mass-reload', false);
         });

--- a/templates/xcom/mass_match.html
+++ b/templates/xcom/mass_match.html
@@ -20,7 +20,6 @@
                     <input id="xcom-mass-keyword" class="xcom-mass-keyword-input" type="search"
                            placeholder="Ключевое слово в наименовании RFP" autocomplete="off">
                 </label>
-                <span id="xcom-mass-summary" class="xcom-mass-summary">Загрузка…</span>
                 <label class="xcom-mass-concurrency" title="Стартовое число одновременных запросов (в авто-режиме подстраивается по скорости)">
                     <span>Потоков</span>
                     <select id="xcom-mass-concurrency" class="xcom-mass-select">
@@ -54,7 +53,7 @@
             <div class="xcom-mass-progress-track">
                 <div id="xcom-mass-progress-bar" class="xcom-mass-progress-bar"></div>
             </div>
-            <span id="xcom-mass-progress-label" class="xcom-mass-summary">Обработано 0 из 0</span>
+            <span id="xcom-mass-progress-label" class="xcom-mass-progress-label">Обработано 0 из 0</span>
         </div>
         <div id="xcom-mass-stats" class="xcom-mass-stats" hidden>
             <div class="xcom-mass-stat"><b id="xcom-mass-stat-time">0:00</b><span>время</span></div>


### PR DESCRIPTION
Closes #3551.

## Что и почему

`#xcom-mass-summary` — текстовая «сводка» в шапке рабочего места «Массовый подбор SKU». Появилась с первой версии (#3467). После того как добавили **блок статистики** (#3522: время / обработано / с подбором / без подбора / ошибки / строк-мин / потоков) и **прогресс-бар** с подписью «Обработано N из M», её текст («Загрузка…», «N необработанных», «Готово · обработано за прогон…», «Ошибка») стал дублировать эти блоки — назначение перестало читаться. Убрал.

## Изменения

- **`templates/xcom/mass_match.html`** — удалён `<span id="xcom-mass-summary">`.
- **`download/xcom/js/xcom-mass-match.js`** — сняты 6 мёртвых `setText('xcom-mass-summary', …)` и ставшая ненужной `var processed`. Ошибки и состояния загрузки и так выводятся в таблицу через `renderMessage(...,'error'/'loading')`.
- **`download/xcom/css/xcom-mass-match.css`** — удалены правила `.xcom-mass-summary`. Подпись прогресс-бара (`#xcom-mass-progress-label`) переиспользовала этот класс для оформления — ей дан собственный `.xcom-mass-progress-label` с тем же цветом/размером (margin 0 — центрируется в flex-полосе прогресса).

## Заметка для ревью

Единственная информация, которой больше нет нигде в UI, — счётчик **«N необработанных»** (сколько строк RFP ещё без «Наш артикул») в idle-состоянии. Если он нужен — лучше вынести его в блок статистики отдельной плиткой, а не возвращать неясную строку. Скажите — добавлю.

## Проверка

- `node --check` JS — OK.
- xcom-тесты mass-match (`experiments/test-issue-3501/3527/3532/3534/3547/3549`) — все зелёные.
- Ссылок на `xcom-mass-summary` в репозитории не осталось.
- (`test-issue-2827-xcom-match.js` падает и до этого PR — он про *одиночный* подбор `xcom-match.js`, к этим изменениям не относится.)