### PR TITLE
fix(atex): пульт слиттера — клик по доступной резке не работал из-за disabled="undefined" (#3553)

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -695,6 +695,9 @@
     function el(tag, attrs, children) {
         var node = document.createElement(tag);
         if (attrs) Object.keys(attrs).forEach(function(k) {
+            // null/undefined → атрибут не ставим: иначе setAttribute('disabled', undefined)
+            // даёт disabled="undefined" (булев атрибут блокирует элемент). #3553
+            if (attrs[k] == null) return;
             if (k === 'class') node.className = attrs[k];
             else if (k === 'text') node.textContent = attrs[k];
             else if (k === 'html') node.innerHTML = attrs[k];

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 38);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 39);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
## Проблема (#3553)

Кнопка доступной (первой в очереди) резки в пульте слиттера рендерилась как

```html
<button class="atex-sl-cut-item is-next" type="button" disabled="undefined">…
```

`disabled` — булев атрибут: его наличие с **любым** значением (включая строку `"undefined"`) делает кнопку неактивной. Поэтому клик не срабатывал, хотя обработчик `click` был навешан (по логике резка `.is-next` не заблокирована).

## Причина

Хелпер `el()` в `download/atex/js/slitter.js` для каждого ключа звал `node.setAttribute(k, attrs[k])`, не отсеивая `undefined`. Вызов на строке:

```js
disabled: disabled ? 'disabled' : undefined
```

давал `setAttribute('disabled', undefined)` → атрибут `disabled="undefined"`.

## Фикс

В `el()` пропускаем атрибуты со значением `null`/`undefined` — тогда `disabled` не ставится вовсе, когда резка доступна. Реально заблокированные резки (`disabled: 'disabled'`) блокируются как прежде.

Бамп `VERSION` 38→39 — cache-bust ассетов.

## Проверка

В headless-браузере воспроизведён баг и подтверждён фикс на эмуляции вызова `el()` из места рендера:

| | старый `el()` | новый `el()` |
|---|---|---|
| HTML кнопки `.is-next` | `disabled="undefined"` | без `disabled` |
| `button.disabled` | `true` | `false` |
| клик сработал | ❌ | ✅ |
| реально заблокированная резка | `true` | `true` |

Closes #3553