### PR TITLE
fix(atex): пульт слиттера — подписывать все полосы в раскладке ножей (#3555)

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -1447,8 +1447,10 @@
                 dataset: { width: String(seg.width) }
             });
             segNode.style.width = pct + '%';
-            // Подпись ширины — прямо на полосе (требование #3460).
-            if (pct >= 4) segNode.appendChild(el('span', { class: 'atex-sl-cm-seg-label', text: String(seg.width) }));
+            // Подпись ширины — прямо на полосе для всех полос, без порога (#3555).
+            // Узкие сегменты обрезаются по ширине ячейки (overflow:hidden);
+            // полную ширину дублируют title-подсказка и легенда ниже.
+            segNode.appendChild(el('span', { class: 'atex-sl-cm-seg-label', text: String(seg.width) }));
             bar.appendChild(segNode);
         });
         if (lay.remainder > 0) {

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 38);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 39);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
## Проблема (#3555)

В блоке «Раскладка ножей» пульта слиттера подпись ширины показывалась только у достаточно широких полос. При множестве узких одинаковых полос (на скриншоте из issue — 29 × 34 мм при ширине входа 990 мм) **ни одна** полоса не была подписана.

## Причина

В `download/atex/js/slitter.js` (`renderCutMap`) подпись добавлялась с порогом:

```js
if (pct >= 4) segNode.appendChild(el('span', { class: 'atex-sl-cm-seg-label', text: String(seg.width) }));
```

`pct` — доля ширины входа в %. Порог 4% при входе ~990 мм ≈ 40 мм, поэтому полосы 34 мм (3.4%) оставались без подписи.

## Фикс

Убираем порог — подпись ширины рисуется у **каждой** полосы. Очень узкие сегменты обрезаются по ширине своей ячейки (`overflow:hidden`), их полную ширину дублируют `title`-подсказка сегмента и легенда под раскладкой.

Бамп `VERSION` 38→39 — cache-bust ассетов.

## Проверка

Отрендерил реальную разметку раскладки с CSS слиттера в headless-браузере при ширине панели ~900 px:

- **Кейс из issue (29 × 34 мм):** все 29 полос подписаны «34», 0 обрезанных подписей, ячейка ~31 px — читается чисто.
- **Стресс (полосы 6–55 мм):** широкие полосы подписаны полностью; обрезаются только подписи у полос ~6 мм (≈6 px) — для них остаются tooltip и легенда.

Closes #3555