### PR TITLE
feat(atex): планирование — автогенерация двигает зафиксированные задания (#3562)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2121,7 +2121,6 @@
         var times = opts.times || DEFAULT_OP_TIMES;
         var leader = Number(times.BETWEEN_CUTS != null ? times.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS) || 0;
         var runLen = opts.runLengthByCut || {};
-        var pins = opts.pinnedStartMinByCut || {};   // #3508 п.6: окно-старт (мин от полуночи дня 0) зафиксированных
         var shiftStart = Number(opts.shiftStartMin != null ? opts.shiftStartMin : SHIFT_START_MIN) || 0;
         var shiftEnd = Number(opts.shiftEndMin != null ? opts.shiftEndMin : SHIFT_END_MIN) || 0;
         var hasWindow = shiftEnd > shiftStart;
@@ -2135,14 +2134,10 @@
             // #3401: лидер заправляют перед каждой резкой цуга → лидер × «Кол-во план».
             var setup = leader * cutLeaderRuns(c) + (i > 0 ? changeoverCost(cuts[i-1], c, times) : 0);
             var dur = scheduleDurationMinutes(c, Number(runLen[String(c.id)]) || 0, wind);
-            // #3508 п.6: зафиксированное задание может быть «приколото» к плановому старту
-            // (pin — окно-старт в минутах от полуночи дня 0). Встать раньше финиша предыдущего
-            // нельзя → windowStart = max(pin, cursor); пин позже cursor оставляет пустое окно
-            // (то самое «пустое место»). Без пина пакуем встык: windowStart = cursor.
-            var pin = pins[String(c.id)];
-            var hasPin = pin != null && isFinite(Number(pin));
-            var windowStart = hasPin ? Math.max(Number(pin), t) : t;
-            var start = windowStart + setup;
+            // #3562: задания пакуются встык по очереди. Зафиксированные больше не «прикалываются»
+            // к плановому старту — автогенерация двигает их по времени в течение дня и меняет
+            // очередность (пины #3508 п.6 убраны).
+            var start = t + setup;
             var day = Math.floor(start / 1440);
             if (start < day * 1440 + shiftStart) start = day * 1440 + shiftStart;   // до 08:00 → ждём открытия
             // #3342: резка стартует в/после LUNCH_START и обед ещё не был → пауза перед ней.
@@ -2166,33 +2161,6 @@
             t = finish;
         });
         return out;
-    }
-
-    // #3508 п.6: плановый старт (главное значение «Задания в производство», t1078) как
-    // unix-штамп в СЕКУНДАХ. planDate приходит штампом (сек или мс) — нормализуем к сек.
-    // null, если не штамп.
-    function pinTimestampSeconds(cut) {
-        var s = String((cut && (cut.planDate != null ? cut.planDate : cut.number)) || '').trim();
-        if (!/^\d{9,13}$/.test(s)) return null;
-        var num = Number(s);
-        if (!isFinite(num) || num <= 0) return null;
-        return num >= 1e12 ? Math.floor(num / 1000) : num;   // мс → сек
-    }
-
-    // #3508 п.6: карта «пинов» для buildSchedule — окно-старт зафиксированных заданий в
-    // минутах от полуночи дня 0 (planBaseMidnightMs). Берётся из их планового старта
-    // (t1078). Незафиксированные и записи без валидного штампа пропускаются.
-    function pinnedStartMinByCut(cuts, planBaseMidnightMs) {
-        var base = Number(planBaseMidnightMs);
-        var map = {};
-        if (!isFinite(base)) return map;
-        (cuts || []).forEach(function(c) {
-            if (!c || !c.fixed) return;
-            var ts = pinTimestampSeconds(c);
-            if (ts == null) return;
-            map[String(c.id)] = (ts * 1000 - base) / 60000;
-        });
-        return map;
     }
 
     // #3342: параметры плавающего обеда из opts, валидные только если обед попадает
@@ -3323,8 +3291,6 @@
         parseClockMinutes: parseClockMinutes,
         resolveWorkingWindow: resolveWorkingWindow,
         buildSchedule: buildSchedule,
-        pinnedStartMinByCut: pinnedStartMinByCut,
-        pinTimestampSeconds: pinTimestampSeconds,
         freeSlotForQueue: freeSlotForQueue,
         dayCleanups: dayCleanups,
         formatClock: formatClock,
@@ -4465,37 +4431,10 @@
         });
     };
 
-    // #3508 п.6: текущий плановый окно-старт (Unix сек, формат t1078) каждого ВИДИМОГО
-    // задания по действующему расписанию — для «захвата» пина при фиксации. Считаем по
-    // каждому станку тем же расписанием, что и renderQueue (учитывая уже зафиксированные).
-    AtexProductionPlanning.prototype.scheduleWindowStartTsByCut = function() {
-        var self = this;
-        var planBaseMidnightMs = planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this));
-        if (!isFinite(planBaseMidnightMs)) return {};
-        var windPoints = windingPointsFromTimes(this.opTimes || {});
-        var dayWindow = this.workingWindow();
-        var visible = (this.cuts || []).filter(function(c) { return isCutVisible(c, self.filter.date); });
-        var runLenByCut = {};
-        visible.forEach(function(c) { runLenByCut[String(c.id)] = cutRunLength(c, self.supplies, self.footageBySupply); });
-        var schedOpts = {
-            windPoints: windPoints, times: this.changeTimes, runLengthByCut: runLenByCut,
-            shiftStartMin: dayWindow.startMin, shiftEndMin: dayWindow.cutEndMin,
-            lunchStartMin: dayWindow.lunchStartMin, lunchDurationMin: dayWindow.lunchDurationMin
-        };
-        var tsByCut = {};
-        groupBySlitter(visible).forEach(function(g) {
-            var pins = pinnedStartMinByCut(g.cuts, planBaseMidnightMs);
-            buildSchedule(g.cuts, Object.assign({ pinnedStartMinByCut: pins }, schedOpts)).forEach(function(sc) {
-                tsByCut[String(sc.cutId)] = scheduleStartTimestamp(planBaseMidnightMs, sc.startMin - sc.setupMin);
-            });
-        });
-        return tsByCut;
-    };
-
     // #3508 п.2/п.4: проставить/снять флаг «Зафиксировано» у набора заданий. Пишем булев
-    // реквизит (t{id}='1'/'0') командой _m_set; при фиксации захватываем плановый старт в
-    // t1078 (п.6, opts.startTsByCut), затем перечитываем очередь — серая кайма/блокировки
-    // (п.3/п.5) обновятся по источнику истины.
+    // реквизит (t{id}='1'/'0') командой _m_set, затем перечитываем очередь — серая кайма/
+    // блокировки (п.3/п.5) обновятся по источнику истины. #3562: плановый старт при фиксации
+    // больше не «захватывается» — автогенерация вольна двигать задание по времени и очереди.
     AtexProductionPlanning.prototype.setCutsFixed = function(cutIds, value, opts) {
         var self = this;
         var o = opts || {};
@@ -4513,11 +4452,6 @@
         }
         var fieldKey = 't' + fixedReqId;
         var flag = value ? '1' : '0';
-        // #3508 п.6: при фиксации «захватываем» текущий плановый старт в t1078 (главное
-        // значение «Задания в производство»), чтобы пин совпал с видимой позицией и
-        // карточка не прыгнула. tsByCut — Unix-сек окна-старта по текущему расписанию.
-        var tsByCut = o.startTsByCut || {};
-        var mainKey = (this.meta.cut && this.meta.cut.id != null) ? 't' + this.meta.cut.id : null;
         this.setBusy(true);
         this.showProgress((value ? 'Фиксация' : 'Снятие фиксации') + ' заданий…', ids.length);
         var done = 0;
@@ -4525,8 +4459,6 @@
         ids.forEach(function(id) {
             chain = chain.then(function() {
                 var fields = {}; fields[fieldKey] = flag;
-                var ts = Number(tsByCut[id]);
-                if (value && mainKey && isFinite(ts) && ts > 0) fields[mainKey] = String(ts);
                 return self.post('_m_set/' + encodeURIComponent(id) + '?JSON', fields)
                     .then(function() { self.updateProgress(++done); });
             });
@@ -4565,8 +4497,7 @@
         if (!dayCuts.length) { this.notify('Нет заданий за ' + dateLabel + ' для фиксации', 'info'); return; }
         if (!toFix.length) { this.notify('Все задания за ' + dateLabel + ' уже зафиксированы', 'info'); return; }
         self.setCutsFixed(toFix.map(function(c) { return c.id; }), true, {
-            successMessage: 'Зафиксированы задания за ' + dateLabel + ': ' + toFix.length,
-            startTsByCut: self.scheduleWindowStartTsByCut()   // #3508 п.6: захват текущего старта в пин
+            successMessage: 'Зафиксированы задания за ' + dateLabel + ': ' + toFix.length
         });
     };
 
@@ -4574,10 +4505,7 @@
     // (зафиксировано ↔ снято), чтобы можно было и поставить, и снять флаг.
     AtexProductionPlanning.prototype.toggleCutFixed = function(cut) {
         if (!cut) return;
-        // #3508 п.6: при фиксации захватываем текущий плановый старт в пин (чтобы карточка
-        // не прыгнула); при снятии — не нужно.
         var o = { successMessage: (cut.fixed ? 'Снята фиксация задания' : 'Задание зафиксировано') };
-        if (!cut.fixed) o.startTsByCut = this.scheduleWindowStartTsByCut();
         this.setCutsFixed([cut.id], !cut.fixed, o);
     };
 
@@ -6790,10 +6718,9 @@
             lunchStartMin: dayWindow.lunchStartMin,
             lunchDurationMin: dayWindow.lunchDurationMin
         };
-        // #3508 п.6: зафиксированные задания «прикалываются» к плановому старту (t1078) —
-        // расписание их пинует, остальные обтекают.
-        var pinnedMinByCut = pinnedStartMinByCut(activeGroup.cuts, planBaseMidnightMs);
-        var schedule = buildSchedule(activeGroup.cuts, Object.assign({ pinnedStartMinByCut: pinnedMinByCut }, schedOpts));
+        // #3562: зафиксированные задания планируются наравне со всеми — автогенерация может
+        // двигать их по времени в течение дня и менять очередность (пины #3508 п.6 убраны).
+        var schedule = buildSchedule(activeGroup.cuts, schedOpts);
         schedule.forEach(function(sc) { schedById[sc.cutId] = sc; });
         self._timingByCut = {};   // #3240: пересобираем контекст тайминга модалки для активного станка
         var dayCutsByKey = {};
@@ -7003,9 +6930,9 @@
             controls.appendChild(down);
             controls.appendChild(strips);
             controls.appendChild(fix);
-            // #3540: кнопки ◀▶ ручного сдвига планового старта зафиксированного задания
-            // (#3508 п.6) убраны — двигать время вручную не требуется. Фиксация по-прежнему
-            // прикалывает задание к его плановому старту в расписании (pinnedStartMinByCut).
+            // #3540: кнопки ◀▶ ручного сдвига планового старта убраны — двигать время вручную
+            // не требуется. #3562: пин планового старта тоже убран — автогенерация двигает
+            // зафиксированное задание по времени в течение дня и меняет его очередность.
             controls.appendChild(del);
             cardPanel.appendChild(controls);
 

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1341,30 +1341,22 @@ assertEqual(planning.resolveWorkingWindow({ DAY_START_HOUR:'9:15', DAY_END_HOUR:
     { startMin:555, endMin:1080, cutEndMin:1035, cleanupMin:45, lunchStartMin:null, lunchDurationMin:0 },
     'resolveWorkingWindow #3215: произвольное окно и CLEANUP_SHIFT');
 
-// ── #3508 п.6: «пины» зафиксированных заданий в buildSchedule ──
+// ── #3562: зафиксированные задания больше не «прикалываются» — buildSchedule пакует встык ──
 // Очередь A,B,C по 60 мин, без лидера/переналадки (BETWEEN_CUTS:0): встык 480/540/600.
-var pinCuts3508 = [ { id:'A', duration:60 }, { id:'B', duration:60 }, { id:'C', duration:60 } ];
-var pinOpts3508 = { windPoints: pts, runLengthByCut: {}, times: { BETWEEN_CUTS: 0 }, shiftStartMin: 480 };
-var pinNone = planning.buildSchedule(pinCuts3508, pinOpts3508);
-assertEqual(pinNone.map(function(s){ return [s.startMin, s.finishMin]; }), [[480,540],[540,600],[600,660]],
-    'buildSchedule #3508: без пинов — встык 480/540/600');
-// Пин B позже cursor (580 > 540) → зазор 40 мин перед B, C сдвигается за B.
-var pinDelay = planning.buildSchedule(pinCuts3508, Object.assign({ pinnedStartMinByCut: { B: 580 } }, pinOpts3508));
-assertEqual(pinDelay.map(function(s){ return [s.startMin, s.finishMin]; }), [[480,540],[580,640],[640,700]],
-    'buildSchedule #3508: пин B=580 → зазор перед B (то самое пустое место), C за ним');
-// Пин B раньше cursor (500 < 540) → clamp к естественному старту (наложения нет).
-var pinClamp = planning.buildSchedule(pinCuts3508, Object.assign({ pinnedStartMinByCut: { B: 500 } }, pinOpts3508));
-assertEqual([pinClamp[1].startMin, pinClamp[1].finishMin], [540,600],
-    'buildSchedule #3508: пин раньше cursor → clamp к естественному (без наложения)');
-// pinTimestampSeconds / pinnedStartMinByCut: штамп → окно-старт в минутах от полуночи дня 0.
-var pinBase3508 = Date.UTC(2026, 5, 20);                 // полночь 2026-06-20 (в тестах TZ=UTC)
-var pinTs3508 = Math.floor((pinBase3508 + 540 * 60000) / 1000);   // 09:00 в секундах
-assertEqual(planning.pinTimestampSeconds({ planDate: String(pinTs3508) }), pinTs3508, 'pinTimestampSeconds: unix-сек как есть');
-assertEqual(planning.pinTimestampSeconds({ planDate: String(pinTs3508 * 1000) }), pinTs3508, 'pinTimestampSeconds: мс → сек');
-assertEqual(planning.pinTimestampSeconds({ planDate: '' }), null, 'pinTimestampSeconds: пусто → null');
-assertEqual(planning.pinnedStartMinByCut(
-    [ { id:'A', fixed:true, planDate:String(pinTs3508) }, { id:'B', fixed:false, planDate:String(pinTs3508) } ], pinBase3508),
-    { A: 540 }, 'pinnedStartMinByCut: только зафиксированные → окно-старт 09:00 = 540 мин');
+// B зафиксирована — слот под неё НЕ резервируется (автогенерация двигает её по времени/очереди).
+var packCuts3562 = [ { id:'A', duration:60 }, { id:'B', duration:60, fixed:true }, { id:'C', duration:60 } ];
+var packOpts3562 = { windPoints: pts, runLengthByCut: {}, times: { BETWEEN_CUTS: 0 }, shiftStartMin: 480 };
+assertEqual(planning.buildSchedule(packCuts3562, packOpts3562).map(function(s){ return [s.startMin, s.finishMin]; }),
+    [[480,540],[540,600],[600,660]],
+    'buildSchedule #3562: зафиксированное B пакуется встык (слот не резервируется)');
+// Прежняя опция пинов (#3508 п.6) больше не влияет на расписание — игнорируется.
+assertEqual(planning.buildSchedule(packCuts3562, Object.assign({ pinnedStartMinByCut: { B: 580 } }, packOpts3562))
+    .map(function(s){ return [s.startMin, s.finishMin]; }),
+    [[480,540],[540,600],[600,660]],
+    'buildSchedule #3562: опция pinnedStartMinByCut игнорируется (пины убраны)');
+// Пин-хелперы удалены из API.
+assertEqual(typeof planning.pinnedStartMinByCut, 'undefined', '#3562: pinnedStartMinByCut удалён из API');
+assertEqual(typeof planning.pinTimestampSeconds, 'undefined', '#3562: pinTimestampSeconds удалён из API');
 
 // ── #3342: плавающий обед (LUNCH_START / LUNCH_DURATION) ──
 var wwLunch = planning.resolveWorkingWindow({ DAY_START_HOUR:'8:00', DAY_END_HOUR:'16:40', LUNCH_START:'12:20', LUNCH_DURATION:'40' }, 30);

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 39);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 40);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
## Изменение требования

Closes #3562. Меняет требование #3508 п.6.

**Было:** «Задание с флагом *Зафиксировано* может быть подвинуто вперёд/назад по времени, если перед ним есть пустое место, но только в пределах 90 минут». Реализовано как «пин»: расписание прикалывало зафиксированное задание к его плановому старту (t1078), резервируя слот и оставляя пустое место.

**Стало:** «Автоматическая генерация может двигать зафиксированное задание по времени в течение дня и менять его очередность».

## Что сделано

- **`buildSchedule`** больше не резервирует слот под зафиксированное задание — пакует встык по очереди, как все. → автогенерация двигает его по времени.
- Удалён механизм пинов: `pinnedStartMinByCut`, `pinTimestampSeconds`, `scheduleWindowStartTsByCut` и их экспорты; рендер и `scheduleWindowStartTsByCut` больше не строят пины.
- **Фиксация** (`setCutsFixed` / `fixDayTasks` / `toggleCutFixed`) больше не «захватывает» плановый старт в `t1078` — задание свободно для автогенерации (по времени и очереди; `planCutOperations` зафиксированные и так не защищал).
- Флаг **«Зафиксировано» по-прежнему** защищает от удаления (`п.3`), ручной смены очереди (↑↓, `moveInQueue`), правки полос (`п.3`) и помечает карточку серой каймой (`п.5`). Меняется только поведение **автогенерации**.
- `VERSION` 39 → 40 (cache-bust ассетов atex).

Эволюция требования: #3508 п.6 (ручной сдвиг ±90 мин + пин) → #3540 (убран ручной сдвиг ◀▶, пин остался) → **#3562 (убран и пин)**.

## Проверка

`node experiments/atex-production-planning.test.js` — **521 проверка проходит**. Блок пин-тестов #3508 п.6 заменён на #3562:
- зафиксированное задание пакуется встык (слот не резервируется);
- прежняя опция `pinnedStartMinByCut` в `buildSchedule` игнорируется;
- пин-хелперы удалены из API.

Остальные тест-файлы планирования (3391/3453/3475/3486/3535) — без FAIL. `node --check` модуля — OK. Висячих ссылок на удалённый API не осталось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)