### PR TITLE
fix(atex): планирование — очередь по убыванию ножей как первичный критерий (#3568)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2981,7 +2981,13 @@
     function sequenceForStrategy(cuts, options){
         var opts = options || {};
         if (planningStrategy(opts) === PLANNING_STRATEGY_FATIGUE) return fatigueAwareSequence(cuts, opts);
-        return greedySequence(cuts, planningChangeTimes(opts));
+        // SETUP (#3568): «ножи по убыванию к концу дня» (#3130) — ПЕРВИЧНЫЙ критерий, а не
+        // мягкий тай-брейк. byKnifeCountDesc стабильно сортирует жадную (минимум переналадки)
+        // цепочку по knifeCount↓; среди резок с равным числом ножей сохраняется greedy-порядок
+        // (переналадка остаётся вторичной). Без этого враппера cmpKnifeDescSeq внутри greedy
+        // срабатывал лишь при РАВНОЙ стоимости цепочек, а после позиционной стоимости ножей
+        // (#3472) равенство почти не встречается → очередь шла по ВОЗРАСТАНИЮ ножей (#3568).
+        return byKnifeCountDesc(greedySequence(cuts, planningChangeTimes(opts)));
     }
 
     // Упорядочить резки станка: не-Фольга, затем Фольга; внутри каждой группы —

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -501,17 +501,23 @@ var outMat = planning.orderCuts(inMat).map(function(c){return c.materialId;});
 // число границ смены сырья = (различных − 1) = 1
 var bnd = 0; for (var i=1;i<outMat.length;i++) if (outMat[i]!==outMat[i-1]) bnd++;
 assertEqual(bnd, 1, 'orderCuts: сырьё сгруппировано (1 граница)');
-// #3268: реальные минуты переналадки важнее механической сортировки по ножам.
-// #3472: A-high → A-low → B-mid = 4 + 17 = 21 мин; A-high → B-mid → A-low = 17 + 17 = 34 мин.
+// #3568: «ножи по убыванию» (#3130) — ПЕРВИЧНЫЙ критерий очереди, даже если это
+// разбивает группировку сырья (#3268). Ножи 8/7/6 различны → строгое убывание
+// A-high → B-mid → A-low, хотя сырьё A при этом перестаёт быть сгруппированным
+// (минимум переналадки дал бы A-high → A-low → B-mid = 4+17 мин, но он теперь
+// вторичен). Минимизация переналадки (#3268/#3472) остаётся тай-брейком ТОЛЬКО
+// среди резок с равным числом ножей. До #3568 правило ножей↓ было лишь мягким
+// тай-брейком внутри greedy и после позиционной стоимости ножей (#3472) не
+// срабатывало → очередь шла по возрастанию ножей.
 var setupMinuteCuts = [
     cut('A-high', { m:'A', b:'bA', k:8, kw:[60] }),
     cut('B-mid',  { m:'B', b:'bB', k:7, kw:[60] }),
     cut('A-low',  { m:'A', b:'bA', k:6, kw:[60] })
 ];
-assertEqual(planning.orderCuts(setupMinuteCuts).map(function(c){ return c.id; }), ['A-high', 'A-low', 'B-mid'],
-    'orderCuts #3268: минимизирует минуты переналадки до сортировки по ножам');
-assertEqual(planning.orderCuts(setupMinuteCuts, { strategy: planning.PLANNING_STRATEGY_SETUP }).map(function(c){ return c.id; }), ['A-high', 'A-low', 'B-mid'],
-    'orderCuts #3272: явный вариант setup сохраняет минимизацию переналадки');
+assertEqual(planning.orderCuts(setupMinuteCuts).map(function(c){ return c.id; }), ['A-high', 'B-mid', 'A-low'],
+    'orderCuts #3568: ножи по убыванию первичны (8,7,6), переналадка вторична');
+assertEqual(planning.orderCuts(setupMinuteCuts, { strategy: planning.PLANNING_STRATEGY_SETUP }).map(function(c){ return c.knifeCount; }), [8, 7, 6],
+    'orderCuts #3568: явный SETUP — число ножей строго убывает');
 // Фольга строго в конце
 var inFoil = [ cut('1',{m:'A',foil:true}), cut('2',{m:'A'}), cut('3',{m:'A'}) ];
 var outFoil = planning.orderCuts(inFoil).map(function(c){return c.id;});


### PR DESCRIPTION
Closes #3568

## Проблема
Очередь заданий по станкам снова шла **по возрастанию** числа ножей вопреки #3130 («ножи по убыванию к концу дня — переналаживать тяжелее, делаем сложное, пока смена свежая»). На живой ateh (10.06.2026): **Станок 3 = 10 → 15 → 16**, Станок 2 = 10, 8, 8, 12, 14.

## Корень
В #3268 из `orderCuts` убрали внешний враппер `byKnifeCountDesc` (исходный механизм #3130), оставив «ножи↓» лишь **мягким тай-брейком** `cmpKnifeDescSeq` внутри `greedySequence` — он срабатывал только когда у двух цепочек **равная** суммарная стоимость переналадки. После позиционной стоимости ножей (#3472) равенство почти не встречается → тай-брейк не срабатывает → ножи пошли по возрастанию. Сама функция `byKnifeCountDesc` осталась определена и экспортирована, но **нигде не вызывалась** (мёртвый код).

Это объясняет «опять» в заголовке issue: #3412/#3415/#3421 латали тот же симптом, но не делали ножи↓ первичными.

> NB: переключение генерации на стратегию FATIGUE не подходит — её route-score сам даёт ножи по возрастанию (6,16,16), из-за чего от FATIGUE ушли в #3421.

## Фикс
Возвращаю `byKnifeCountDesc` в SETUP-ветку `sequenceForStrategy`:
- «ножи по убыванию» (#3130) снова **первичны**;
- минимум переналадки (#3268/#3472) — тай-брейк **среди резок с равным числом ножей**;
- покрывает и генерацию, и `autoSequenceQueue` (обе идут через SETUP).

## Проверка
- `node experiments/atex-production-planning.test.js` → **521 assertions passed**.
- Тесты #3268 (`setupMinuteCuts`) переписаны под новый контракт: было `A-high, A-low, B-mid` (сырьё сгруппировано), стало `A-high, B-mid, A-low` (ножи 8 → 7 → 6).
- Тесты #3412 (`16,16,6`) и #3421 (FATIGUE даёт `6,16,16`, SETUP — `16,16,6`) — зелёные.

## Эксплуатационное замечание
Изменение влияет на **новую** генерацию/переочерёдность. Уже **зафиксированные** (🔒) задания текущего дня — «стены», их порядок не перестраивается до снятия фиксации/перегенерации.