### PR TITLE
fix(auth): сбрасывать счётчик попыток входа при успехе + гард дублей логина (#3576)

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,7 +40,10 @@ define("ROLE", 42);
 define("ADMINROLE", 145);
 define("ACTIVITY", 124);
 define("PASSWORD", 20);
-define("RETRIES", 300);
+define("RETRIES", 301); # #3581: счётчик попыток входа должен совпадать с реквизитом
+                        # «Retries» у типа USER (в боевых базах его id=301). Раньше код
+                        # читал/писал t=300 — отдельный, невидимый в админке узел, который
+                        # залипал на лимите и давал «превышено» при «пустом» Retries.
 define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
@@ -10153,12 +10156,11 @@ switch($a)  # Check actions, which don't require authentication
 									." LEFT JOIN $z retries ON retries.up=u.id AND retries.t=".RETRIES
 								." WHERE u.t=".USER." AND u.val='$u' AND pwd.up=u.id AND pwd.t=".PASSWORD;
 		$data_set = Exec_sql($sql, "Authenticate user");
-		# #3576: парольный вход не имел защиты от дублей логина (в отличие от входа по
-		# коду ниже). При нескольких узлах пользователя с одним логином fetch_array брал
-		# ПЕРВУЮ строку — в т.ч. протухший узел со счётчиком retries≥лимита, из-за чего
-		# показывалось «превышено попыток», хотя у видимого пользователя retries пуст.
-		# Считаем РАЗНЫЕ u.id (а не строки: LEFT JOIN tok/act/xsrf/retries может дать
-		# несколько строк на одного пользователя), чтобы не блокировать легитимный вход.
+		# #3576/#3581: «превышено при пустом Retries» вызвано НЕ дублями пользователя, а
+		# рассинхроном типа счётчика (исправлено RETRIES=301 выше). Этот гард оставлен как
+		# защита по аналогии с входом по коду: если в битой базе окажется несколько узлов
+		# одного логина, не блокировать вход по протухшей строке. Считаем РАЗНЫЕ u.id (а не
+		# строки: LEFT JOIN tok/act/xsrf/retries может дать несколько строк на одного юзера).
 		$dupUids = [];
 		while($probe = mysqli_fetch_array($data_set))
 			$dupUids[$probe["uid"]] = true;

--- a/index.php
+++ b/index.php
@@ -10153,6 +10153,25 @@ switch($a)  # Check actions, which don't require authentication
 									." LEFT JOIN $z retries ON retries.up=u.id AND retries.t=".RETRIES
 								." WHERE u.t=".USER." AND u.val='$u' AND pwd.up=u.id AND pwd.t=".PASSWORD;
 		$data_set = Exec_sql($sql, "Authenticate user");
+		# #3576: парольный вход не имел защиты от дублей логина (в отличие от входа по
+		# коду ниже). При нескольких узлах пользователя с одним логином fetch_array брал
+		# ПЕРВУЮ строку — в т.ч. протухший узел со счётчиком retries≥лимита, из-за чего
+		# показывалось «превышено попыток», хотя у видимого пользователя retries пуст.
+		# Считаем РАЗНЫЕ u.id (а не строки: LEFT JOIN tok/act/xsrf/retries может дать
+		# несколько строк на одного пользователя), чтобы не блокировать легитимный вход.
+		$dupUids = [];
+		while($probe = mysqli_fetch_array($data_set))
+			$dupUids[$probe["uid"]] = true;
+		mysqli_data_seek($data_set, 0);
+		if(count($dupUids) > 1){
+			$dupMsg = t9n("[RU]Найдено несколько пользователей с таким логином — обратитесь к администратору.[EN]Multiple users found with this login — contact your administrator.");
+			wlog("Authenticate user: duplicate logins '$u' -> uids ".implode(",", array_keys($dupUids)), "log");
+			if(isApi()){
+				header("HTTP/1.0 409 Conflict");
+				api_dump(json_encode(["error" => $dupMsg], JSON_UNESCAPED_UNICODE));
+			}
+			my_die($dupMsg);
+		}
 		if($row = mysqli_fetch_array($data_set)){
 			if($row["pwd"] !== $pwd){
 				if((int)$row["retries"] >= RETRIES_LIMIT){
@@ -10196,6 +10215,12 @@ switch($a)  # Check actions, which don't require authentication
 				wlog(" Failed", "log");
 		}
 		if($row){
+			# #3576: успешный вход обнуляет счётчик неудачных попыток. Раньше retries
+			# только инкрементился (и паролем, и кодом — счётчик общий) и НИГДЕ не
+			# сбрасывался, поэтому, единожды достигнув RETRIES_LIMIT, «превышено попыток»
+			# залипало навсегда — на каждую опечатку, даже после успешных входов.
+			if(!empty($row["retries_id"]) && (int)$row["retries"] > 0)
+				Update_Val($row["retries_id"], 0);
 			$GLOBALS["GLOBAL_VARS"]["user"] = $row["val"];
 			$GLOBALS["GLOBAL_VARS"]["user_id"] = $row["uid"];
 			if(isset($_POST["change"]))
@@ -10314,6 +10339,9 @@ switch($a)  # Check actions, which don't require authentication
 						die(json_encode(["error" => t9n("[RU]Превышено количество попыток входа с кодом. Войдите с паролем.[EN]Too many code login attempts. Please sign in with your password.")], JSON_UNESCAPED_UNICODE));
 					die(json_encode(["error" => t9n("[RU]Неверный код[EN]Invalid code")], JSON_UNESCAPED_UNICODE));
 				}
+				# #3576: верный код обнуляет общий счётчик неудачных попыток (см. парольный вход).
+				if(!empty($row["retries_id"]) && (int)$row["retries"] > 0)
+					Update_Val($row["retries_id"], 0);
     			$token = secureToken();
     			$xsrf = xsrf($token, $u);
 				Update_Val($row["tok"], $token);


### PR DESCRIPTION
Closes #3576

## Симптом
При обычной **опечатке в пароле** показывается «Превышено количество попыток авторизации. Рекомендуем сбросить пароль», хотя поле **Retries** у пользователя пустое.

## Корень
Сообщение выводится (`index.php`, ~10158) только при `(int)$row["retries"] >= RETRIES_LIMIT` (5). Счётчик `retries` (тип 300) **нигде не сбрасывается** — по всему репозиторию он только инкрементится:
- при неверном **пароле** (`incrementRetries`, ~10166),
- при неверном **коде из письма** (~10312) — причём это **тот же самый** счётчик (`retries.t=300, up=user`).

Сброса нет ни при успешном входе, ни при смене пароля. Значит, единожды достигнув лимита (паролем или кодами — у кода лимит всего 2), значение **застревает навсегда**, и каждая последующая опечатка даёт «превышено» — даже после успешных входов.

Про «Retries пустой»: если поле реально 0/пусто — `0 >= 5` ложно и сообщение бы не вышло. Раз оно выходит, код читает запись со значением ≥ 5, **отличную** от той, что видит администратор. Вероятная причина — **дубликат узла пользователя** с тем же логином. Косвенно: у входа по коду есть защита `num_rows > 1` (~10306), а у парольного входа её **не было** — он молча брал первую (возможно протухшую) строку.

## Изменения (`index.php`)
1. **Сброс retries при успешной авторизации** — и в парольном входе (блок `if($row)`), и при верном коде из письма. `Update_Val(retries_id, 0)` только если запись есть и значение > 0.
2. **Защита от дублей логина в парольном входе** (по аналогии с кодом-логином). Считаем **РАЗНЫЕ `u.id`**, а не сырые строки: `LEFT JOIN tok/act/xsrf/retries` может дать несколько строк на одного пользователя, и наивный `num_rows > 1` ложно заблокировал бы легитимный вход. При >1 разных пользователях — 409/`my_die` с просьбой обратиться к админу + запись в лог с перечнем uid.

## Проверка
- `php -l index.php` — без ошибок на **8.2** и **7.4**.
- Логика: после успешного входа `retries` обнуляется → «превышено» больше не залипает; сообщение появляется только после реальных 5 неудач подряд без успешного входа между ними.

## Замечание по эксплуатации
Фикс предотвращает рецидив и чинит общий случай. Если у конкретного пользователя счётчик застрял на **дубле-узле**, в который он никогда успешно не входит, гард теперь явно об этом сообщит (вместо тихого выбора протухшей строки) — такой дубль нужно почистить в БД. Подскажите БД и логин — помогу найти/убрать дубль.

---

## Дополнение по #3581 (исправлен диагноз)

Репортёр верно указал, что причина **не** в дубликате пользователя (моя первая гипотеза неверна). Разобрал на живой `ateh` по токену:

- В коде счётчик попыток — узел **типа 300** (`define("RETRIES",300)`).
- Но в боевых базах реквизит **«Retries» у типа USER заведён под id 301** (узел `up=18, t=300`, в ateh id=301). Таблица пользователей показывает столбец **301** → он пуст ⇒ admin видит «Retries пустое».
- Реальные данные счётчика — узлы **t=300**, в админке не видны. У `manager` (id 1630) узел **8201** (`t=300`) = **5** ⇒ `5≥RETRIES_LIMIT` ⇒ «превышено». Залипли также `claude`(1200=5) и `admin`(2020=5).

**Фикс:** `RETRIES = 301` — теперь код пишет/читает тот же узел, что видит админка. Старые `t=300` игнорируются ⇒ залипшие пользователи разблокированы без правки данных, а счётчик стал виден/управляем.

Гард дублей логина оставлен как защита (симметрия с входом по коду), но он **не** корень проблемы — комментарий в коде поправлен.

php -l ok на 8.2 и 7.4.
