### PR TITLE
fix(atex): слиттер — следующее задание заблокировано, пока предыдущее не завершено (#3579)

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -290,11 +290,6 @@
         return '';
     }
 
-    function cutStartedValue(cut) {
-        if (!cut) return '';
-        return String(cut.startedAt || cut.started || cut.actualStart || '').trim();
-    }
-
     function sequenceKey(cut) {
         var n = Number(cut && cut.sequence);
         return isFinite(n) ? n : Infinity;
@@ -325,17 +320,12 @@
             return compareCutsForQueue(a.cut, b.cut) || a.i - b.i;
         }).map(function(x) { return x.cut; });
 
+        // #3579: «первая открытая» в очереди = первая НЕ завершённая резка. Пока она не
+        // завершена (в работе/наладке/перерыве/ожидает), все следующие «Ожидает» заблокированы
+        // (isCutLocked) — нельзя запускать следующее задание, пока предыдущее не завершено.
         var firstOpen = null;
         for (var i = 0; i < list.length; i++) {
-            if (!isDone(list[i].status) && isWaitingStatus(list[i].status) && !cutStartedValue(list[i])) {
-                firstOpen = list[i];
-                break;
-            }
-        }
-        if (!firstOpen) {
-            for (var j = 0; j < list.length; j++) {
-                if (!isDone(list[j].status)) { firstOpen = list[j]; break; }
-            }
+            if (!isDone(list[i].status)) { firstOpen = list[i]; break; }
         }
         return { cuts: list, firstOpenCutId: firstOpen ? String(firstOpen.id) : null };
     }

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 41);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 42);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3579. Правка в `download/atex/js/slitter.js`.

## Проблема
В очереди станка можно было запустить следующее задание, пока предыдущее ещё «В работе» (не завершено) — на скриншоте резки 1 и 2 обе «В работе», а резка 3 («Ожидает») разблокирована.

Причина: «первой открытой» резкой (`firstOpenCutId`) считалась первая **ожидающая-незапущенная** — начатые (но не завершённые) резки пропускались, и блокировка «съезжала» на следующую ожидающую.

## Фикс
`firstOpenCutId` = первая **НЕ завершённая** резка в очереди. Пока активная резка не завершена (в работе/наладке/перерыве/ожидает), все следующие «Ожидает» заблокированы (`isCutLocked` блокирует все «Ожидает», кроме первой открытой; `startCut`/управление проверяют блокировку и показывают «ожидает предыдущую»).

Итог: нельзя запустить следующее задание, пока предыдущее не завершено. После завершения активной — следующая становится первой открытой и разблокируется.

Также удалён неиспользуемый `cutStartedValue` (после #3565 он больше нигде не нужен).

`VERSION` 41 → 42.

### Проверка
- `node -c download/atex/js/slitter.js` — синтаксис OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)