### PR TITLE
fix(atex): пульт слиттера — заголовок партии сырья датой/временем, а не таймштампом

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -1689,7 +1689,9 @@
                 (selected[String(batch.id)] ? ' is-selected' : '') +
                 (foreign ? ' is-disabled' : '');
             var cells = [
-                el('span', { class: 'atex-sl-batch-title', text: batch.label }),
+                // Заголовок партии = «Дата прихода» (DATETIME-штамп) → «ДД.ММ.ГГГГ ЧЧ:ММ»,
+                // а не сырой таймштамп. Не-штамп (штрих-код/имя) остаётся как есть.
+                el('span', { class: 'atex-sl-batch-title', text: core.formatEventWhen(batch.label) }),
                 el('span', { class: 'atex-sl-batch-meta', text: 'Приход: ' + (batch.date || '—') }),
                 el('span', { class: 'atex-sl-batch-metric', text: 'Остаток, м: ' + core.round3(batch.remainderM || 0) }),
                 el('span', { class: 'atex-sl-batch-meta', text: 'Штрих-код: ' + (batch.barcode || '—') }),

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 41);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 42);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Правка в `download/atex/js/slitter.js`.

`.atex-sl-batch-title` (заголовок карточки партии сырья = «Дата прихода», DATETIME) выводился **сырым unix-таймштампом** (напр. `1781038800`). Теперь штамп форматируется как **«ДД.ММ.ГГГГ ЧЧ:ММ»** через существующий `core.formatEventWhen`. Не-штамп (штрих-код/имя/«Партия N») остаётся как есть — `isTimestampSeconds` форматирует только реальные unix-секунды (год 2001–2100).

`VERSION` 41 → 42.

### Проверка
- `node -c download/atex/js/slitter.js` — синтаксис OK.
- Подтверждено по БД ateh: отчёт `material_batches` отдаёт `batch_no` штампом (напр. `1781038800` → 2026 г.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)