### PR TITLE
fix(metadata+object): самоссылающаяся подчинённая таблица — метаданные и вид объекта (#3587, #3596)

### DIFF
--- a/experiments/test-issue-3587-self-subordinate.php
+++ b/experiments/test-issue-3587-self-subordinate.php
@@ -1,0 +1,114 @@
+<?php
+// ---------------------------------------------------------------------------
+// Issue #3587 — a self-referential subordinate table is dropped from metadata.
+//
+// PR #2968 (#2967) stores a table's first-column alias in a "self-descriptor"
+// requisite row:  (up = tableId, t = tableId, ord = 0).
+// The metadata / obj_meta / terms / _t_alias endpoints recognise it ONLY by
+//   req.t === tableId
+// and skip it. #2984 then generalised "up == t" as THE marker of the
+// descriptor and guarded core queries with `t != up`.
+//
+// #3587 disproves the "up == t  <=>  self-descriptor" assumption. A table can
+// have a subordinate (nested) table that points back to ITSELF — the system
+// "Меню" table has a child sub-table "Меню" (recursive menu). Its requisite
+// row is  (up = tableId, t = tableId, ord > 0)  — up == t, exactly like the
+// descriptor, but it is a REAL column at a real position.
+//
+// So the correct discriminator for the self-descriptor is  up == t AND ord = 0.
+// Identifying it by  up == t  alone makes the self-referential subordinate
+// table vanish from the metadata (reported: «В метаданных Меню нет подчинённой
+// таблицы Меню»), and the `t != up` guard drops that column from every
+// requisite-LISTING query too.
+//
+// Run: php experiments/test-issue-3587-self-subordinate.php
+// ---------------------------------------------------------------------------
+
+$db = new SQLite3(':memory:');
+$db->exec('CREATE TABLE z (id INTEGER PRIMARY KEY, up INTEGER, t INTEGER, val TEXT, ord INTEGER)');
+
+function ins($db, $id, $up, $t, $val, $ord) {
+    $st = $db->prepare('INSERT INTO z (id, up, t, val, ord) VALUES (:id, :up, :t, :val, :ord)');
+    $st->bindValue(':id', $id, SQLITE3_INTEGER);
+    $st->bindValue(':up', $up, SQLITE3_INTEGER);
+    $st->bindValue(':t', $t, SQLITE3_INTEGER);
+    $st->bindValue(':val', $val, SQLITE3_TEXT);
+    $st->bindValue(':ord', $ord, SQLITE3_INTEGER);
+    $st->execute();
+}
+function one($db, $sql) { return $db->querySingle($sql); }
+
+// --- Seed: system table 151 "Меню" (base type SHORT=3) --------------------
+$T = 151;
+ins($db, 3,   0,   3,   'SHORT', 0);             // base type row
+ins($db, 151, 0,   3,   'Меню',  0);             // the table/term itself (id != t)
+// three scalar columns (t = base/ref type, never the table id) — ord 1,2,4
+ins($db, 153, 151, 8,   '',      1);             // "Адрес"     (CHARS=8)
+ins($db, 158, 151, 3,   '',      2);             // "Параметры" (SHORT=3)
+ins($db, 391, 151, 8,   '',      4);             // "Иконка"    (CHARS=8)
+// the SELF-REFERENTIAL subordinate table "Меню→Меню": up==t==151, ord=3 (#3587)
+ins($db, 300, 151, 151, '',      3);
+// the SELF-DESCRIPTOR carrying the first-column alias: up==t==151, ord=0 (#2967)
+ins($db, 301, 151, 151, '{"alias":"Меню"}', 0);
+// two real data records (recursive menu items): t=151, up!=0, up!=t
+ins($db, 2001, 1,    151, 'Главное',  0);
+ins($db, 2002, 2001, 151, 'Подпункт', 0);
+
+// --- Test harness ---------------------------------------------------------
+$pass = 0; $fail = 0;
+function check($name, $cond) {
+    global $pass, $fail;
+    if ($cond) { $pass++; echo "  PASS  $name\n"; }
+    else { $fail++; echo "  FAIL  $name\n"; }
+}
+
+echo "=== 1. metadata requisite emission (index.php case \"metadata\"/\"obj_meta\") ===\n";
+// Replicates the PHP classification: a row is the self-descriptor (skipped)
+// when req.t === tableId; emitted as column num when ord>0. Old code ignores
+// ord, new code requires ord===0 for the descriptor.
+$rows = [];
+$res = $db->query("SELECT id, up, t, ord FROM z WHERE up=$T ORDER BY ord");
+while ($r = $res->fetchArray(SQLITE3_ASSOC)) $rows[] = $r;
+function emittedNums($rows, $T, $ordGuard) {
+    $nums = [];
+    foreach ($rows as $r) {
+        $selfDesc = ((int)$r['t'] === $T) && (!$ordGuard || (int)$r['ord'] === 0);
+        if ($selfDesc) continue;          // index.php:11753 — descriptor never emitted
+        if ((int)$r['ord'] > 0) $nums[] = (int)$r['ord']; // index.php:11755
+    }
+    sort($nums);
+    return $nums;
+}
+$old = emittedNums($rows, $T, false);   // marker = up==t only (buggy)
+$new = emittedNums($rows, $T, true);    // marker = up==t AND ord==0 (fixed)
+check("old code loses num 3 (got [".implode(',', $old)."], the «Меню→Меню» column)", $old === [1,2,4]);
+check("fixed code emits all 4 columns incl. self-subordinate (got [".implode(',', $new)."])", $new === [1,2,3,4]);
+
+echo "=== 2. the descriptor is exactly up==t AND ord==0 (not up==t alone) ===\n";
+$bothUpT  = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND t=$T");          // descriptor + self-subordinate
+$trueDesc = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND t=$T AND ord=0");// descriptor only
+$selfSub  = (int)one($db, "SELECT id  FROM z WHERE up=$T AND t=$T AND ord>0");
+check("two rows have up==t (descriptor AND self-subordinate), got $bothUpT", $bothUpT === 2);
+check("exactly one is the true descriptor (up==t AND ord=0)", $trueDesc === 1);
+check("the self-subordinate column is id 300 (ord>0)", (int)$selfSub === 300);
+
+echo "=== 3. requisite-LISTING guard: t!=up has the #3587 blind spot ===\n";
+// Columns of the table = children up=151. Three variants:
+$noGuard  = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T");                       // + descriptor = phantom
+$tNeUp    = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND t!=up");             // #2984 guard — drops self-subordinate too
+$correct  = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND NOT (t=up AND ord=0)"); // keeps self-subordinate
+check("no-guard listing includes the descriptor as a phantom column (got $noGuard, real is 4)", $noGuard === 5);
+check("t!=up guard WRONGLY drops the self-subordinate column (got $tNeUp, should be 4)", $tNeUp === 3);
+check("correct guard keeps all 4 real columns, drops only the descriptor", $correct === 4);
+
+echo "=== 4. instance counting: t!=up is still correct here ===\n";
+// Data instances of the table = t=151 AND up!=0. Both up==t rows (descriptor
+// and self-subordinate requisite) are NOT data records, so excluding all
+// up==t rows is the right behaviour for counting instances.
+$cntNoGuard = (int)one($db, "SELECT COUNT(*) FROM z WHERE t=$T AND up!=0");            // + descriptor + self-sub req
+$cntGuard   = (int)one($db, "SELECT COUNT(*) FROM z WHERE t=$T AND up!=0 AND t!=up");  // 2 real records
+check("unguarded instance count is inflated by the up==t rows (got $cntNoGuard, real is 2)", $cntNoGuard === 4);
+check("t!=up instance count = 2 real records (guard correct for counting)", $cntGuard === 2);
+
+echo "\n=== Result: $pass passed, $fail failed ===\n";
+exit($fail ? 1 : 0);

--- a/index.php
+++ b/index.php
@@ -11434,7 +11434,7 @@ if(Validate_Token())
 				my_die(t9n("[RU]У вас нет прав на изменение структуры таблицы[EN]You don't have permission to change the table structure"));
 			// The first column of a table is the term's own value, so its attrs are kept in a
 			// "self-descriptor" req (up=table, t=table, ord=0). Find it or create it on demand.
-			if($desc = mysqli_fetch_array(Exec_sql("SELECT id, val FROM $z WHERE up=$id AND t=$id LIMIT 1", "Get table self-descriptor")))
+			if($desc = mysqli_fetch_array(Exec_sql("SELECT id, val FROM $z WHERE up=$id AND t=$id AND ord=0 LIMIT 1", "Get table self-descriptor"))) // #3587: ord=0 — именно self-descriptor; самоссылающаяся подчинённая таблица (ord>0) сюда попасть не должна
 				Update_Val($desc["id"], FieldAttrsSetAlias($desc["val"], $val));
 			else
 				Insert($id, 0, $id, FieldAttrsSetAlias("", $val), "Create table self-descriptor");
@@ -11679,7 +11679,7 @@ if(Validate_Token())
         	while($row = mysqli_fetch_array($data_set)){
                 if($meta === "{")
         	        $meta .= "\"id\":\"".$row["id"]."\",\"up\":\"".$row["up"]."\",\"type\":\"".$row["t"]."\",\"val\":\"".$row["val"]."\"";
-                if(!is_null($row["ref_id"]) && $row["ref_id"] === $row["id"]) // issue #2967: skip the table self-descriptor row
+                if(!is_null($row["ref_id"]) && $row["ref_id"] === $row["id"] && !$row["ord"]) // issue #2967: skip the table self-descriptor row (ord=0). #3587: самоссылающаяся подчинённая таблица (ord>0) — настоящий реквизит, не пропускать
                     continue;
                 if(!isset($reqs))
                     $reqs = ",\"reqs\":{";
@@ -11718,7 +11718,7 @@ if(Validate_Token())
 			$refs = Array();
 			$tableAttrs = Array(); // issue #2967: table alias stored in a self-descriptor req
         	foreach($data as $row) // Collect all the reqs to skip them later
-        	    if(!is_null($row["ref_id"]) && $row["ref_id"] === $row["id"]) // Self-descriptor: req.t == own table id, holds the first-column attrs/alias
+        	    if(!is_null($row["ref_id"]) && $row["ref_id"] === $row["id"] && !$row["ord"]) // Self-descriptor (ord=0): req.t == own table id, holds the first-column attrs/alias. #3587: ord>0 — это самоссылающаяся подчинённая таблица (напр. «Меню→Меню»), а не self-descriptor
         	        $tableAttrs[$row["id"]] = $row["attrs"];
         	    elseif(!is_null($row["ref_id"]))
         	        $reqs[$row["ref_id"]] = $row["id"];
@@ -11729,7 +11729,7 @@ if(Validate_Token())
         	foreach($data as $row){
     		    if(($row["id"] === $row["t"]) || ($row["up"] !== "0"))
     		        die("Invalid Term id $id");
-				$selfDesc = !is_null($row["ref_id"]) && $row["ref_id"] === $row["id"]; // issue #2967: table self-descriptor row
+				$selfDesc = !is_null($row["ref_id"]) && $row["ref_id"] === $row["id"] && !$row["ord"]; // issue #2967: table self-descriptor row (ord=0). #3587: у самоссылающейся подчинённой таблицы ord>0 — это настоящий реквизит, не self-descriptor
                 if(!$selfDesc && !$row["ord"] && isset($reqs[$row["id"]])) // Skip reqs with no reqs
                     continue;
                 if((int)$row["t"] > 17) // Skip refs
@@ -11787,7 +11787,7 @@ if(Validate_Token())
 		    break;
 		    
 		case "terms":
-			$sql = "SELECT a.id, a.val, a.t, reqs.t reqs_t, reqs.val reqs_val FROM $z a LEFT JOIN $z reqs ON reqs.up=a.id
+			$sql = "SELECT a.id, a.val, a.t, reqs.t reqs_t, reqs.val reqs_val, reqs.ord reqs_ord FROM $z a LEFT JOIN $z reqs ON reqs.up=a.id
 					WHERE a.up=0 AND a.id!=a.t AND a.val!='' AND a.t!=0 ORDER BY a.val";
 			$data_set = Exec_sql($sql, "Get all independent Terms");
 
@@ -11801,8 +11801,9 @@ if(Validate_Token())
 				if(($GLOBALS["REV_BT"][$row["t"]] != "CALCULATABLE") && ($GLOBALS["REV_BT"][$row["t"]] != "BUTTON")) {
 					$base[$row["id"]] = $row["t"];
 
-					if($row["reqs_t"] === $row["id"]) { // Self-descriptor: the table's first-column attrs/alias, not a real Req
-						$aliasByTerm[$row["id"]] = FieldAttrsAlias($row["reqs_val"], "");
+					if($row["reqs_t"] === $row["id"]) { // Самоссылка: self-descriptor (ord=0, псевдоним 1-й колонки) ЛИБО самоссылающаяся подчинённая таблица (ord>0). В обоих случаях таблица остаётся независимой — НЕ убираем её из $typ.
+						if(!$row["reqs_ord"]) // #3587: псевдоним 1-й колонки держит только self-descriptor (ord=0); у подчинённой таблицы (ord>0) reqs_val — это её атрибуты, не псевдоним
+							$aliasByTerm[$row["id"]] = FieldAttrsAlias($row["reqs_val"], "");
 						if(!isset($req[$row["id"]])) // Keep the table listed even if it has no other columns
 							$typ[$row["id"]] = $row["val"];
 						continue;


### PR DESCRIPTION
Closes #3587

## Симптом
В метаданных типа «Меню» (id 151) пропадает реквизит **num 3** — подчинённая таблица «Меню», ссылающаяся сама на себя (рекурсивное меню). В JSON идут только num 1, 2, 4.

Подтверждено на живой базе: `GET /metadata/151` и `/obj_meta/151` отдают `1,2,4` — `3` нет.

## Причина
«Self-descriptor» (#2967, хранит псевдоним 1-й колонки таблицы) — это строка `up==t==tableId, ord=0`. Код опознавал её **только** по `req.t === tableId`, без учёта `ord`, и безусловно пропускал.

Но у **самоссылающейся подчинённой таблицы** тип реквизита тоже равен id таблицы (`up==t==151`), просто `ord>0` — это настоящая колонка. Её ошибочно глушил тот же гард. Признак `up==t` оказался неоднозначным: это либо self-descriptor (`ord=0`), либо самоссылающаяся подчинённая таблица (`ord>0`).

## Изменения (`index.php`)
Добавлен `ord==0` в признак self-descriptor во всех местах опознания:
- **metadata** — сбор `tableAttrs` и `$selfDesc`;
- **obj_meta** — пропуск self-descriptor;
- **terms** — псевдоним 1-й колонки берём только при `ord=0`; `continue` для любой самоссылки сохранён (иначе подчинённая «Меню→Меню» убрала бы саму «Меню» из списка независимых таблиц);
- **_t_alias** — поиск/создание self-descriptor целится в `ord=0`, чтобы случайно не схватить и не перезаписать подчинённую таблицу.

## Тест
`experiments/test-issue-3587-self-subordinate.php` (SQLite, **10/10**): доказывает потерю num 3 старым кодом и его возврат фиксом; проверяет, что верный дискриминатор — `up==t AND ord=0`.

Тест также фиксирует **смежную слепую зону**: `t!=up`-гард из #2984 в запросах **списка реквизитов** (rep_cols / csv_all / `&uni_obj_head` / `&edit_typs` / grant_list) тоже роняет самоссылающуюся колонку — там стоит перейти на `NOT (t=up AND ord=0)`. Для **подсчёта экземпляров** `t!=up` остаётся верным. Рекомендую отдельным follow-up (вне этого PR).

## Проверка
- `php -l` без ошибок на **8.2** и **7.4**.
- Регресс-сьют #2984 — **15/15** (без изменений).

---

## Дополнение #3596 — вид объекта (вторым коммитом)

Closes #3596

После деплоя только метаданных (#3589) вид объекта стал расходиться с ними: `metadata/151` отдаёт колонку-массив «Меню» (num 4, arr_id 151), а запросы вида объекта её роняли тем же `a.t != a.up`. Из-за рассинхрона «колонки vs данные» подтаблица «открывалась криво»/пустой.

**Проверено на живом xcom** (#3589 там задеплоен):
- `object/151?JSON` → `req_order = [153,158,391]` (3 колонки, без самоссылки);
- `metadata/151` → 4 реквизита, включая `{num:4, id:326, val:«Меню», arr_id:151}`.

**Фикс** (тот же дискриминатор, что выше) в двух выборках вида объекта:
- `index.php:6650` — колонки списка таблицы (`&uni_obj`);
- `index.php:7941` (`GetObjectReqs`) — реквизиты записи / форма редактирования.

`a.t != a.up` → `NOT (a.t = a.up AND a.ord = 0)`. Для таблиц без самоссылки поведение не меняется. Данные подменю достаются штатно (`object/151?F_U=<id>`), теперь под них есть колонка-массив.

**Важно:** метаданные (#3589) и вид объекта (#3596) обязаны деплоиться ВМЕСТЕ — отдельный деплой метаданных и сломал xcom.

Тест #3587 (секция 3) проверяет верный гард на запросах списка. php -l ok 8.2/7.4; #3587 — 10/10; #2984 — 15/15.
