### PR TITLE
fix(atex): cut-optimizer — «Допуск» только выводится, без поля ввода (#3597)

### DIFF
--- a/download/atex/css/cut-optimizer.css
+++ b/download/atex/css/cut-optimizer.css
@@ -88,6 +88,8 @@
     border-color: var(--co-accent);
     box-shadow: 0 0 0 2px rgba(19, 65, 116, .15);
 }
+/* #3597: «Допуск, мм» — только вывод значения, без поля ввода. */
+.atex-co-readonly { padding: 8px 10px; font: inherit; font-weight: 600; }
 
 /* Комбобокс «Длина рулона» (#3482): свой ввод + полный нефильтруемый список */
 .atex-co-combo { position: relative; }

--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -721,13 +721,11 @@
         ]));
         form.appendChild(dims);
 
-        // Допуск на отход, мм — автоподстановка из Вида сырья («Допуск, мм»),
-        // редактируемый. По нему красится отход каждой карты раскроя.
-        this.tolInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
-            placeholder: 'напр. 20', value: this.tolValue || '' });
-        this.tolInput.addEventListener('input', function() { self.tolValue = self.tolInput.value; self.maybeRecalc(); });
+        // #3597: «Допуск, мм» — только вывод значения (не редактируется). Берётся из
+        // Вида сырья («Допуск, мм»); если не задан — 21 мм (#3573). По нему красится отход.
+        this.tolDisplay = el('div', { class: 'atex-co-readonly', text: this.tolValue || String(DEFAULT_TOLERANCE) });
         form.appendChild(el('div', { class: 'atex-co-field' }, [
-            el('label', { class: 'atex-co-label', text: 'Допуск, мм' }), this.tolInput
+            el('label', { class: 'atex-co-label', text: 'Допуск, мм' }), this.tolDisplay
         ]));
 
         // Желаемые полосы (ширина + количество), редактируемый список.
@@ -873,11 +871,10 @@
             // (по умолчанию 450, выбор из списка стандартных длин), материал её не диктует.
             if (this.widthInput) this.widthInput.value = String(m.width || '');
             this.widthValue = String(m.width || '');
-            // Допуск на отход — из выбранного материала («Допуск, мм»); если не задан,
-            // действует значение по умолчанию 21 мм (#3573). Поле редактируемое.
+            // Допуск на отход — из выбранного материала («Допуск, мм»); если не задан, 21 мм (#3573).
             var matTol = toNumber(m.tolerance) > 0 ? String(m.tolerance) : String(DEFAULT_TOLERANCE);
-            if (this.tolInput) this.tolInput.value = matTol;
             this.tolValue = matTol;
+            if (this.tolDisplay) this.tolDisplay.textContent = matTol;  // #3597: только вывод
         }
         this.renderBatches();
         this.maybeRecalc();
@@ -948,8 +945,8 @@
     // Несколько карт раскроя (по одной на ширину, объединённые ради отхода).
     AtexCutOptimizer.prototype.renderMaps = function(p) {
         var wrap = el('div', { class: 'atex-co-maps' });
-        // Допуск на отход (Вид сырья → «Допуск, мм»), редактируемый. Пусто/0 → 21 мм (#3573).
-        var tol = this.tolInput ? toNumber(this.tolInput.value) : 0;
+        // #3597: допуск только из Вида сырья (this.tolValue), не редактируется. Пусто/0 → 21 мм.
+        var tol = toNumber(this.tolValue);
         if (!(tol > 0)) tol = DEFAULT_TOLERANCE;
         p.maps.forEach(function(m) {
             var card = el('div', { class: 'atex-co-map' });

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 42);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 43);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3597. Правки в `download/atex/js/cut-optimizer.js` + `download/atex/css/cut-optimizer.css`.

Поле **«Допуск, мм»** больше не редактируется — вместо `<input>` выводится готовое значение (`.atex-co-readonly`). Значение берётся из «Вида сырья» («Допуск, мм»), по умолчанию **21 мм** (#3573); по нему по-прежнему красится отход карт раскроя (≤ допуска — зелёный, больше — красный).

- Убран редактируемый input и его обработчик; `tolInput` → `tolDisplay` (вывод).
- При смене материала обновляется выводимое значение (`tolDisplay.textContent`).
- Расцветка отхода читает допуск из состояния `this.tolValue` (а не из поля ввода).

`VERSION` 42 → 43.

### Проверка
- `node -c download/atex/js/cut-optimizer.js` — синтаксис OK; ссылок на `tolInput` не осталось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)