### PR TITLE
fix(atex): планирование — диапазон дат, уборка/окно, фольга в конец смены (#3599)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -162,12 +162,21 @@
 /* #3411: быстрый поиск занимает ту же ширину, что и остальные фильтры. */
 .atex-pp-search { width: 100%; }
 /* #3508 п.1: поле «Дата плана» со стрелками листания ‹/› по бокам (±1 день). */
-.atex-pp-date-field { display: flex; align-items: stretch; gap: 6px; }
-.atex-pp-date-field .atex-pp-input { flex: 1 1 auto; min-width: 0; }
+/* #3599 п.1/п.2: «С — По» со стрелками ‹/› — единый прилеплённый блок (без зазоров,
+   смежные границы схлопнуты, скруглены только внешние углы). */
+.atex-pp-date-field { display: flex; align-items: stretch; gap: 0; }
+.atex-pp-date-field .atex-pp-date-input { flex: 1 1 auto; min-width: 0; border-radius: 0; }
+.atex-pp-date-field > * + * { margin-left: -1px; }   /* схлопнуть смежные границы */
+.atex-pp-date-sep {
+    display: flex; align-items: center; justify-content: center;
+    flex: 0 0 auto; padding: 0 6px;
+    border: 1px solid var(--pp-border);
+    background: var(--pp-bg);
+}
 .atex-pp-date-nav {
     flex: 0 0 auto;
     border: 1px solid var(--pp-border);
-    border-radius: 6px;
+    border-radius: 0;
     background: var(--pp-bg);
     color: inherit;
     cursor: pointer;
@@ -176,6 +185,8 @@
     font-size: 18px;
     line-height: 1;
 }
+.atex-pp-date-field > .atex-pp-date-nav:first-child { border-top-left-radius: 6px; border-bottom-left-radius: 6px; }
+.atex-pp-date-field > .atex-pp-date-nav:last-child { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
 .atex-pp-date-nav:hover { background: var(--pp-surface); }
 
 .atex-pp-queue-group { margin-bottom: 16px; }

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -535,16 +535,22 @@
         return batchDateKey(s);
     }
 
-    function isCutVisible(cut, selectedDate) {
+    // #3599: видимость по ДИАПАЗОНУ дат [dateFrom; dateTo] (раньше — один день). Пустые
+    // оба → дата не фильтрует; задан один край → открытый интервал. Резка без «Дата план»
+    // (ещё не запланирована) видна всегда. Сравнение по календарному дню (planDateDayKey).
+    function isCutVisible(cut, dateFrom, dateTo) {
         if (!cut) return false;
         if (String(cut.status || '').trim() === 'Завершён') return false;
         var pd = String(cut.planDate || '').trim();
         if (pd === '') return true;
-        var sd = String(selectedDate == null ? '' : selectedDate).trim();
-        if (sd === '') return true;
-        // #3249: сравниваем по календарному дню (planDate — unix-штамп DATETIME,
-        // selectedDate — «ГГГГ-ММ-ДД»); раньше batchDateKey давал несравнимые шкалы.
-        return planDateDayKey(pd) === planDateDayKey(sd);
+        var fromStr = String(dateFrom == null ? '' : dateFrom).trim();
+        var toStr = String(dateTo == null ? '' : dateTo).trim();
+        if (fromStr === '' && toStr === '') return true;
+        var pk = planDateDayKey(pd);
+        var fromK = fromStr === '' ? -Infinity : planDateDayKey(fromStr);
+        var toK = toStr === '' ? Infinity : planDateDayKey(toStr);
+        if (fromK > toK) { var t = fromK; fromK = toK; toK = t; }  // «По» раньше «С» → меняем местами
+        return pk >= fromK && pk <= toK;
     }
 
     // #3475: задания и обеспечения выбранного дня — мишени кнопки «Удалить». Берём резки
@@ -1001,7 +1007,11 @@
                 // #3433: заказ позиции — для «ID заказа» создаваемой «Партии ГП». Если
                 // отчёт positions_list ещё не отдаёт order_id, остаётся пусто (в запас).
                 orderId: row.order_id == null ? '' : String(row.order_id).trim(),
-                approved: orderApproved || itemApproved
+                approved: orderApproved || itemApproved,
+                // #3599: тип сырья из отчёта (Вид сырья → «Тип сырья»). «Фольга» — грязное
+                // сырьё, его ставим в конец смены (после неё сложная уборка).
+                materialType: rowFirstValue(row, ['position_material_type']),
+                isFoil: /фольг/i.test(rowFirstValue(row, ['position_material_type']))
             };
         });
     }
@@ -1060,6 +1070,7 @@
                     materialId: p && p.materialId != null ? String(p.materialId) : '',
                     windDir: normWinding(p && p.windDir),
                     windLength: windLengthValue(p && p.windLength),
+                    isFoil: !!(p && p.isFoil),   // #3599: фольга (тип сырья) — в конец смены
                     positions: []
                 };
                 order.push(groupKey);
@@ -2093,7 +2104,12 @@
         if (end <= start) end = DAY_END_MIN > start ? DAY_END_MIN : start + 1;
         var cleanup = Number(cleanupMin != null ? cleanupMin : DEFAULT_OP_TIMES.CLEANUP_SHIFT);
         if (!isFinite(cleanup) || cleanup < 0) cleanup = DEFAULT_OP_TIMES.CLEANUP_SHIFT;
-        var cutEnd = end - cleanup;
+        // #3599: резку планируем вплотную до DAY_END_HOUR − TOTAL_INTERVALS (буфер из
+        // Настройки), а блок уборки идёт ПОСЛЕ DAY_END_HOUR (см. dayCleanups). Нет
+        // TOTAL_INTERVALS → прежнее поведение (буфер = длительность уборки).
+        var totalIntervals = parseDurationMinutes(cfg.TOTAL_INTERVALS);
+        if (!(totalIntervals > 0)) totalIntervals = cleanup;
+        var cutEnd = end - totalIntervals;
         if (cutEnd < start) cutEnd = start;
         // #3342: плавающий обед. LUNCH_START задан (HH:MM) → minutes, иначе null (обед выкл).
         var lunchDur = parseDurationMinutes(cfg.LUNCH_DURATION);
@@ -3378,7 +3394,9 @@
         this.preferredByMaterial = {};  // кеш ходовых ширин: materialId|windDir|windLength → [{width, popularity}]
         this.maxStockIndex = planning.buildMaxStockIndex([], null);  // #3391: индекс «Максимального запаса» (пуст до загрузки)
         this.draft = this.blankDraft();
-        this.filter = { slitter: '', status: '', date: todayISO(), query: '' };  // дата плана по умолчанию — сегодня; query — быстрый поиск (#3411)
+        // #3599: дата плана диапазоном [date; dateTo] — фильтр отображения очереди; date
+        // («С») остаётся базой генерации/планирования. По умолчанию оба = сегодня (один день).
+        this.filter = { slitter: '', status: '', date: todayISO(), dateTo: todayISO(), query: '' };  // query — быстрый поиск (#3411)
         this.selectedCutId = null; // выбранная резка для привязки обеспечения
         this.stripEditCutId = null; // резка с открытым инлайн-редактором полос (одна за раз)
         this.lastCutMainValue = 0;  // последний t{Задание в производство}, выданный клиентом
@@ -3474,7 +3492,8 @@
                 var key = String(r[0] == null ? '' : r[0]).replace(/^\uFEFF/, '').trim();
                 // #3342: \u043F\u043E\u043C\u0438\u043C\u043E \u0440\u0430\u0431\u043E\u0447\u0435\u0433\u043E \u043E\u043A\u043D\u0430 \u0447\u0438\u0442\u0430\u0435\u043C \u043D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438 \u043E\u0431\u0435\u0434\u0430 LUNCH_START/LUNCH_DURATION.
                 if (key !== 'DAY_START_HOUR' && key !== 'DAY_END_HOUR' &&
-                    key !== 'LUNCH_START' && key !== 'LUNCH_DURATION') return;
+                    key !== 'LUNCH_START' && key !== 'LUNCH_DURATION' &&
+                    key !== 'TOTAL_INTERVALS') return;   // #3599: буфер перед уборкой (мин)
                 var type = String(r[1] == null ? '' : r[1]).trim().toUpperCase();
                 var val = String(r[2] == null ? '' : r[2]).trim();
                 if (val === '') return;
@@ -5441,6 +5460,7 @@
                         lay.windDir = group.windDir;
                         lay.windLength = group.windLength;
                         lay.leader = group.leader;   // #3569: лидер профиля — копируется в задание
+                        lay.isFoil = !!group.isFoil; // #3599: фольга — раскладку в конец смены
                         allLayouts.push(lay);
                     });
                     (res.skipped || []).forEach(function(s) { skipped.push(s); });
@@ -6631,25 +6651,28 @@
         var statusFilter = this.selectText([''].concat(CUT_STATUSES), this.filter.status, function(v) { self.filter.status = v; self.renderQueue(); });
         // первый пункт статуса — «все»
         statusFilter.options[0].textContent = 'Все статусы';
-        var dateFilter = el('input', { class: 'atex-pp-input', type: 'date', value: this.filter.date || '' });
-        dateFilter.addEventListener('change', function() {
-            self.filter.date = dateFilter.value;
+        // #3599 п.2: дата плана ДИАПАЗОНОМ «С — По» (два поля, между ними дефис). Диапазон
+        // фильтрует отображение очереди; «С» (filter.date) остаётся базой генерации/планирования.
+        var dateFrom = el('input', { class: 'atex-pp-input atex-pp-date-input', type: 'date', value: this.filter.date || '', title: 'С (дата плана, от)' });
+        var dateTo = el('input', { class: 'atex-pp-input atex-pp-date-input', type: 'date', value: this.filter.dateTo || '', title: 'По (дата плана, до)' });
+        function applyDateRange() {
             self.selectedCutId = null;   // #3349: очищать панель «Связанные позиции»
             self.renderQueue();
             self.renderLink();
-        });
-        // #3508 п.1: стрелки ‹/› по бокам поля «Дата плана» — листание на ±1 день.
+        }
+        dateFrom.addEventListener('change', function() { self.filter.date = dateFrom.value; applyDateRange(); });
+        dateTo.addEventListener('change', function() { self.filter.dateTo = dateTo.value; applyDateRange(); });
+        // #3508 п.1 / #3599: стрелки ‹/› двигают ВЕСЬ диапазон на ±1 день (ширина окна сохраняется).
         function shiftFilterDate(delta) {
             self.filter.date = shiftPlanDate(self.filter.date || todayISO(), delta);
-            self.selectedCutId = null;   // как и при ручной смене даты
-            self.renderQueue();
-            self.renderLink();
+            self.filter.dateTo = shiftPlanDate(self.filter.dateTo || self.filter.date || todayISO(), delta);
+            applyDateRange();
         }
-        var datePrev = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '‹', title: 'Предыдущий день' });
-        var dateNext = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '›', title: 'Следующий день' });
+        var datePrev = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '‹', title: 'Сдвинуть диапазон на день назад' });
+        var dateNext = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '›', title: 'Сдвинуть диапазон на день вперёд' });
         datePrev.addEventListener('click', function() { if (!self.busy) shiftFilterDate(-1); });
         dateNext.addEventListener('click', function() { if (!self.busy) shiftFilterDate(1); });
-        var dateNav = el('div', { class: 'atex-pp-date-field' }, [datePrev, dateFilter, dateNext]);
+        var dateNav = el('div', { class: 'atex-pp-date-field' }, [datePrev, dateFrom, el('span', { class: 'atex-pp-date-sep', text: '–' }), dateTo, dateNext]);
         // #3411: быстрый поиск между «Дата плана» и «Статус». Фильтрует карточки очереди
         // и пересчитывает счётчики на закладках станков (видно, в каком станке сколько
         // совпавших позиций). Поиск идёт по сырью/намотке/статусу и подписям связанных
@@ -6701,7 +6724,7 @@
         }
 
         // Базовая видимость очереди: не «Завершён», дата плана = выбранной/пустая.
-        var visible = (this.cuts || []).filter(function(c) { return isCutVisible(c, self.filter.date); });
+        var visible = (this.cuts || []).filter(function(c) { return isCutVisible(c, self.filter.date, self.filter.dateTo); });
         var filtered = filterCuts(visible, this.filter);
         var groups = groupBySlitter(filtered);
 
@@ -6782,7 +6805,7 @@
         });
         // Уборка в конце рабочего дня (#3155): блок после последней резки каждого дня.
         var cleanupByDay = {};
-        dayCleanups(schedule, { cleanupMin: dayWindow.cleanupMin, shiftEndMin: dayWindow.cutEndMin })
+        dayCleanups(schedule, { cleanupMin: dayWindow.cleanupMin, shiftEndMin: dayWindow.endMin })   // #3599: уборка ПОСЛЕ DAY_END_HOUR
             .forEach(function(cl) { cleanupByDay[cl.day] = cl; });
         function schedDay(sc) { return sc ? Math.floor((Number(sc.startMin) || 0) / 1440) : null; }
 

--- a/index.php
+++ b/index.php
@@ -45,7 +45,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 42);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 43);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3599. Правки в `download/atex/js/production-planning.js` + `download/atex/css/production-planning.css`.

### 1. `.atex-pp-date-nav` — даты прилеплены к календарю
Стрелки ‹/› и поля даты теперь единый блок без зазоров (смежные границы схлопнуты, скруглены только внешние углы).

### 2. Дата плана диапазоном «С — По»
Два поля `<input type=date>` с дефисом между ними. Диапазон **фильтрует отображение очереди** (`isCutVisible` по `[date; dateTo]`); дата «С» (`filter.date`) **остаётся базой генерации/планирования** (как раньше единая дата). Стрелки ‹/› двигают **весь диапазон** на ±1 день. По умолчанию оба поля = сегодня (поведение как прежде).

### 3–4. Уборка после смены и окно планирования
- Резка планируется вплотную до **DAY_END_HOUR − TOTAL_INTERVALS** (`resolveWorkingWindow.cutEndMin`). `TOTAL_INTERVALS` (мин) читается из «Настройки» в `loadDaySettings`; если не задан — буфер = длительность уборки (прежнее поведение).
- Блок **«уборка»** (длительность `CLEANUP_SHIFT`, 30 мин) начинается **в DAY_END_HOUR** и идёт после смены (`dayCleanups` от `endMin`, а не `cutEndMin`).
- Пример (DAY_END_HOUR=16:40, TOTAL_INTERVALS=20): резки до 16:20 · буфер 16:20–16:40 · уборка 16:40→17:10.

### 5. Фольга в конец смены
Новое поле отчёта `positions_list.position_material_type` («Вид сырья» → «Тип сырья»). Если `Фольга` — позиция помечается `isFoil`, флаг проходит цепочку `position → group → layout → descriptor`, и существующий механизм `orderCuts` (не-фольга, затем фольга) ставит фольгу в конец очереди станка. Раньше `lay.isFoil` нигде не выставлялся — теперь источник появился.

`VERSION` 42 → 43.

### Проверка на БД ateh
- «Настройка»: `DAY_END_HOUR=16:30`, `TOTAL_INTERVALS=20`, обед `12:20/40` (DAY_END_HOUR=16:40 поставите в Настройке при необходимости).
- Отчёт `positions_list` (приложенный к issue) содержит `position_material_type` со значениями `''`/`Фольга` (4 строки фольги).
- `node -c download/atex/js/production-planning.js` — синтаксис OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)