### PR TITLE
fix(object): показывать самоссылающуюся подтаблицу в виде объекта (#3596)

### DIFF
--- a/experiments/test-issue-3587-self-subordinate.php
+++ b/experiments/test-issue-3587-self-subordinate.php
@@ -92,13 +92,18 @@ check("two rows have up==t (descriptor AND self-subordinate), got $bothUpT", $bo
 check("exactly one is the true descriptor (up==t AND ord=0)", $trueDesc === 1);
 check("the self-subordinate column is id 300 (ord>0)", (int)$selfSub === 300);
 
-echo "=== 3. requisite-LISTING guard: t!=up has the #3587 blind spot ===\n";
+echo "=== 3. requisite-LISTING guard (object view: index.php 6650 / GetObjectReqs 7941) ===\n";
+// #3596: the object view built its columns/record-reqs with the same `t!=up`
+// guard, so after #3589 metadata listed the self-subordinate column but the
+// object view did NOT — the column/data counts diverged and the sub-table
+// «открывается криво»/пустая. The fix switches those listing queries to
+// `NOT (t=up AND ord=0)`, the same discriminator as the metadata fix.
 // Columns of the table = children up=151. Three variants:
 $noGuard  = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T");                       // + descriptor = phantom
-$tNeUp    = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND t!=up");             // #2984 guard — drops self-subordinate too
-$correct  = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND NOT (t=up AND ord=0)"); // keeps self-subordinate
+$tNeUp    = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND t!=up");             // old object-view guard — drops self-subordinate too
+$correct  = (int)one($db, "SELECT COUNT(*) FROM z WHERE up=$T AND NOT (t=up AND ord=0)"); // #3596 fix — keeps self-subordinate
 check("no-guard listing includes the descriptor as a phantom column (got $noGuard, real is 4)", $noGuard === 5);
-check("t!=up guard WRONGLY drops the self-subordinate column (got $tNeUp, should be 4)", $tNeUp === 3);
+check("old t!=up guard WRONGLY dropped the self-subordinate column (got $tNeUp, should be 4)", $tNeUp === 3);
 check("correct guard keeps all 4 real columns, drops only the descriptor", $correct === 4);
 
 echo "=== 4. instance counting: t!=up is still correct here ===\n";

--- a/index.php
+++ b/index.php
@@ -6650,7 +6650,7 @@ function Get_block_data($block, $exe=TRUE, $noFilters=FALSE)
 						, CASE WHEN a.t=1 THEN 1 ELSE refs.id END ref_id, arrs.id arr_id, a.val attrs, a.id
 					FROM $z a LEFT JOIN $z typs ON typs.id=a.t AND a.t!=1 LEFT JOIN $z refs ON refs.id=typs.t AND refs.t!=refs.id
 							LEFT JOIN $z arrs ON refs.id IS NULL AND arrs.up=typs.id AND arrs.ord=1
-					WHERE a.up=$id AND a.t!=a.up ORDER BY a.ord";
+					WHERE a.up=$id AND NOT (a.t=a.up AND a.ord=0) ORDER BY a.ord"; // #3596: пропускаем только ord=0 self-descriptor; самоссылающуюся подтаблицу (ord>0) оставляем — иначе колонки вида объекта расходятся с metadata (#3589) и подтаблица «открывается криво»/пустая
 			$data_set = Exec_sql($sql, "Get all Names of Reqs of the Typ");
 			$GLOBALS["no_reqs"] = mysqli_num_rows($data_set) == 0; # Check if the Type has any Reqs
 			$ord = 0;
@@ -7941,7 +7941,7 @@ function GetObjectReqs($typ, $id)
 			FROM $z a LEFT JOIN $z typs ON typs.id=a.t AND a.t!=1
 				LEFT JOIN $z refs ON refs.id=typs.t AND refs.t!=refs.id
 				LEFT JOIN $z arrs ON refs.id IS NULL AND arrs.up=typs.id AND arrs.ord=1
-			WHERE a.up=$typ AND a.t!=a.up ORDER BY a.ord";
+			WHERE a.up=$typ AND NOT (a.t=a.up AND a.ord=0) ORDER BY a.ord"; // #3596: см. выше — самоссылающаяся подтаблица (up==t, ord>0) это реквизит записи, не self-descriptor; нужна для формы/реквизитов записи
 	$data_set = Exec_sql($sql, "Get the Reqs meta");
 	while($row = mysqli_fetch_array($data_set)){
 		if($row["ref_id"]){


### PR DESCRIPTION
Closes #3596

Follow-up к #3587/#3589 (тот PR уже смержен — поэтому отдельным PR).

## Симптом
После #3589 (`metadata` вернул самоссылающуюся подтаблицу «Меню») вид объекта стал расходиться с метаданными: подтаблица «открывается криво» / пустая.

## Причина
`metadata/151` отдаёт колонку-массив «Меню» (num 4, id 326, arr_id 151), а запросы вида объекта роняли её тем же `a.t != a.up`. Проверено на живом xcom:
- `object/151?JSON` → `req_order = [153,158,391]` (3 колонки, без самоссылки);
- `metadata/151` → 4 реквизита, включая `{num:4, id:326, val:«Меню», arr_id:151}`.

Рассинхрон «колонки vs данные» → пустая/кривая подтаблица.

## Изменение (`index.php`)
Тот же дискриминатор, что в #3589, в двух выборках вида объекта:
- `6650` — колонки списка таблицы (`&uni_obj`);
- `7941` (`GetObjectReqs`) — реквизиты записи / форма редактирования.

`a.t != a.up` → `NOT (a.t = a.up AND a.ord = 0)`: пропускаем только ord=0 self-descriptor, самоссылающуюся подтаблицу (ord>0) оставляем. Для таблиц без самоссылки поведение не меняется. Данные подменю достаются штатно (`object/151?F_U=<id>`).

## Проверка
- `php -l` ok 8.2/7.4.
- `experiments/test-issue-3587-self-subordinate.php` (секция 3 — гард списка) — 10/10.

NB: тот же `t!=up` остаётся в запросах списка реквизитов ДРУГИХ фич (CSV-экспорт, гранты, отчёты, импорт) — там самоссылка тоже теряется; вне симптома #3596, отдельной задачей при необходимости.
