### PR TITLE
feat(atex): планирование — заполнять день до конца, расщепляя задания по дням (#3619)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2571,7 +2571,13 @@
         // headId → число использованных записей цепочки (голова + переиспользованные продолжения).
         var usedByHead = {};
         mOrder.forEach(function(key){
-            var ordered = orderCuts(byMachine[key], opts.weights);
+            // #3619: preserveOrder — расщеплять задания по дням, СОХРАНЯЯ текущий порядок
+            // очереди (сортировка по «Очередности»), а не пересобирая её по стратегии
+            // (orderCuts). Нужно, чтобы автозаполнение дней после генерации не перетасовывало
+            // ручной порядок оператора (#3449). Без флага — обычная пересборка по весам (#3421).
+            var ordered = opts.preserveOrder
+                ? byMachine[key].slice().sort(function(a, b){ return (Number(a.sequence) || 0) - (Number(b.sequence) || 0); })
+                : orderCuts(byMachine[key], opts.weights);
             var runsByCut = {};
             ordered.forEach(function(c){ runsByCut[String(c.id)] = Number(c.plannedRuns) || 0; });
             var segs = splitMachineQueue(ordered, {
@@ -5498,11 +5504,15 @@
         var unsup = uncoveredPositions(this.genPositions, this.supplies).filter(function(p) { return p.approved; });
         console.log('[pp] ⚙️ generateCuts: всего позиций:', this.genPositions.length, ', необеспеченных согласованных:', unsup.length);
         if (!unsup.length) {
-            // #3449: «Сгенерировать резки» только вытаскивает незапланированные позиции.
-            // Если таких нет — ничего не делаем: уже запланированные резки не трогаем и
-            // очередь не пересобираем (это оператор сделает сам, удалив резки и Партии ГП).
-            console.log('[pp] ⚙️ generateCuts: незапланированных позиций нет — очередь не трогаем');
-            self.notify('Нет незапланированных позиций для генерации заданий', 'info');
+            // #3449: очередь по стратегии НЕ пересобираем (порядок оператора неприкосновенен).
+            // #3619: но всё равно заполняем дни до конца — расщепляем уже стоящие задания,
+            // переходящие границу рабочего дня, на по-дневные сегменты (preserveOrder=true
+            // сохраняет порядок). Идемпотентно (#3427): если расщеплять нечего — ничего не пишем.
+            console.log('[pp] ⚙️ generateCuts: незапланированных позиций нет — заполняю дни существующих заданий');
+            this.autoSequenceQueue(PLANNING_STRATEGY_SETUP, true).then(function(changed) {
+                self.notify(changed ? 'Дни заполнены: задания, переходящие границу дня, расщеплены по дням'
+                                    : 'Нет незапланированных позиций; дни уже заполнены', 'info');
+            });
             return;
         }
         var profiles = groupPositionsByPlanningProfile(unsup);
@@ -6049,9 +6059,13 @@
                 ', заданий на втулки ' + nSleeveTasks +
                 (sleeveMin > 0 ? ' (' + sleeveMin + ' мин)' : '') +
                 ', пропущено ' + skipped.length + ' позиций' + (reasons ? ' (' + reasons + ')' : ''), 'success');
-            // #3449: уже запланированные резки не трогаем и очередь не пересобираем.
-            // Новые резки получают «Очередность»/плановое время при создании (дописываются
-            // после существующих в своей группе слиттер/день), reload+render уже сделаны выше.
+            // #3449: очередь по стратегии НЕ пересобираем — порядок оператора неприкосновенен.
+            // #3619: но заполняем дни до конца — расщепляем задания, переходящие границу
+            // рабочего дня, на по-дневные сегменты: под каждый день своё «Задание в
+            // производство» + «Партия ГП» + «Обеспечение», рекурсивно. preserveOrder=true
+            // сохраняет текущий порядок очереди; идемпотентно (#3427) — повторный прогон без
+            // изменений ничего не пишет. applySplitPlan сам делает reload+render.
+            return self.autoSequenceQueue(PLANNING_STRATEGY_SETUP, true);
         }).catch(function(err) {
             self.hideProgress();
             self.setBusy(false);
@@ -6413,7 +6427,10 @@
     // и без уведомления — их даёт вызывающая генерация). Ручную перестановку (↑↓)
     // оператор делает ПОСЛЕ генерации. Ничего не изменилось → Promise<false> без записи.
     // → Promise<boolean> (true, если что-то применилось).
-    AtexProductionPlanning.prototype.autoSequenceQueue = function(strategy) {
+    // #3619: preserveOrder=true — НЕ пересобирать очередь по стратегии, а только расщепить
+    // задания, переходящие границу рабочего дня, на по-дневные сегменты, СОХРАНЯЯ текущий
+    // порядок очереди. Без флага (legacy #3421) — полная пересборка «Очередности» по SETUP/FATIGUE.
+    AtexProductionPlanning.prototype.autoSequenceQueue = function(strategy, preserveOrder) {
         var self = this;
         if (!(self.cuts && self.cuts.length)) return Promise.resolve(false);
         var planOptions = makePlanningOptions(strategy || PLANNING_STRATEGY_SETUP, self.changeTimes);
@@ -6435,7 +6452,8 @@
             perPassByCut: perPassByCut,
             planBaseMidnightMs: planBaseMidnightMs,
             lunchStartMin: dayWindow.lunchStartMin,
-            lunchDurationMin: dayWindow.lunchDurationMin
+            lunchDurationMin: dayWindow.lunchDurationMin,
+            preserveOrder: preserveOrder   // #3619: только заполнить дни, не пересобирая порядок
         });
 
         // Родители разбиений нужны в updates всегда (для расчёта долей Обеспечения).

--- a/experiments/atex-production-planning-3619.test.js
+++ b/experiments/atex-production-planning-3619.test.js
@@ -1,0 +1,104 @@
+// Unit tests for #3619 — «Заполнять день до конца».
+// После генерации очередь заполняет дни до конца: задания, переходящие границу
+// рабочего дня, расщепляются на по-дневные сегменты (своё «Задание в производство»
+// + «Партия ГП» + «Обеспечение» под каждый день, рекурсивно). При этом порядок
+// очереди оператора СОХРАНЯЕТСЯ (#3449): planCutOperations с preserveOrder:true
+// раскладывает резки в текущем порядке «Очередности», не пересобирая её по стратегии.
+//
+// Покрываем флаг preserveOrder в planCutOperations:
+//   • без флага  — пересборка по SETUP (ножи по убыванию), как было (#3421);
+//   • с флагом   — порядок «Очередности» неприкосновенен, режем только по дням;
+//   • с флагом   — перелив дня всё равно расщепляется, продолжение встаёт сразу
+//                  за родителем (последующие сдвигаются), идемпотентно (#3427).
+//
+// Run with: node experiments/atex-production-planning-3619.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) {
+        passed++;
+    } else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// Три резки одного станко-дня с РАЗНЫМИ сигнатурами (не сливаются в цепочку) и явной
+// «Очередностью». Оператор поставил их A(1) → C(2) → B(3). Пересборка по SETUP
+// (ножи по убыванию: 6,16,16 → 16,16,6) дала бы B,C,A.
+function cut(id, material, knifeWidths, runs, sequence, planDate) {
+    return { id: id, slitter: { id: 'm3' }, materialId: material,
+        winding: 'OUT', knifeWidths: knifeWidths, knifeCount: knifeWidths.length,
+        plannedRuns: runs, planDate: planDate || '1780963200', sequence: sequence };
+}
+function widths(pairs) { var o = []; pairs.forEach(function(pr) { for (var i = 0; i < pr[1]; i++) o.push(pr[0]); }); return o; }
+
+var queue = [
+    cut('A', 'MW308', widths([[152, 5], [110, 1]]), 1, 1),   // 6 ножей
+    cut('C', 'MW308', widths([[59, 14], [30, 2]]), 1, 2),    // 16 ножей
+    cut('B', 'MR194', widths([[59, 14], [30, 2]]), 1, 3)     // 16 ножей
+];
+var oneDay = { perPassByCut: { A: 10, B: 10, C: 10 }, dayStartMin: 0, dayEndMin: 10000,
+    times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000 };
+
+function orderOf(ops) {
+    return ops.updates.slice().sort(function(a, b) { return a.sequence - b.sequence; })
+        .map(function(u) { return u.cutId; });
+}
+
+// 1) Без preserveOrder — пересборка по SETUP переставляет очередь (как #3421).
+var reseq = planning.planCutOperations(queue, oneDay);
+assertEqual(orderOf(reseq), ['B', 'C', 'A'],
+    '#3619: без preserveOrder очередь пересобирается по SETUP (16,16,6 → B,C,A)');
+
+// 2) С preserveOrder — порядок «Очередности» оператора СОХРАНЯЁТСЯ (A,C,B), не SETUP.
+var preserveOpts = {};
+for (var k in oneDay) preserveOpts[k] = oneDay[k];
+preserveOpts.preserveOrder = true;
+var kept = planning.planCutOperations(queue, preserveOpts);
+assertEqual(orderOf(kept), ['A', 'C', 'B'],
+    '#3619: preserveOrder сохраняет порядок оператора (A,C,B), очередь не пересобирается');
+assertEqual(kept.creates, [], '#3619: всё влезает в день → переносов нет');
+assertEqual(kept.deletes, [], '#3619: нет прежних продолжений → нет удалений');
+
+// 3) preserveOrder + перелив дня: задание, не влезающее до конца дня, расщепляется;
+//    продолжение встаёт СРАЗУ за родителем, следующее задание сдвигается на позицию ниже.
+//    A(seq1): 15 проходов × 10 мин = 150 > день 100 → 10 проходов сегодня, 5 на след. день.
+//    B(seq2): 5 проходов × 10 мин = 50 → встаёт после продолжения A (день уже занят A).
+var split = planning.planCutOperations(
+    [ cut('A', 'MW308', widths([[152, 6]]), 15, 1),
+      cut('B', 'MR194', widths([[59, 16]]), 5, 2) ],
+    { perPassByCut: { A: 10, B: 10 }, dayStartMin: 0, dayEndMin: 100,
+      times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000, preserveOrder: true }
+);
+assertEqual(split.updates.map(function(u) { return { id: u.cutId, seq: u.sequence, runs: u.plannedRuns }; }),
+    [ { id: 'A', seq: 1, runs: 10 }, { id: 'B', seq: 3, runs: 5 } ],
+    '#3619: A — голова (seq1, 10 проходов сегодня); B сдвинут на seq3 (за продолжением A), порядок сохранён');
+assertEqual(split.creates.map(function(c) { return { parent: c.parentCutId, seq: c.sequence, runs: c.plannedRuns }; }),
+    [ { parent: 'A', seq: 2, runs: 5 } ],
+    '#3619: остаток A → продолжение на след. день (seq2, 5 проходов) — заполняем день до конца');
+assertEqual(split.deletes, [], '#3619: продолжений ещё не было → без удалений');
+
+// 4) Идемпотентность (#3427): повторный прогон уже разбитой цепочки переиспользует
+//    запись продолжения как update — ни одной новой записи, порядок тот же.
+var again = planning.planCutOperations(
+    [ cut('A', 'MW308', widths([[152, 6]]), 10, 1, '1780963200'),
+      cut('Acont', 'MW308', widths([[152, 6]]), 5, 2, '1781049600'),   // продолжение A: СМЕЖНЫЙ день, та же сигнатура
+      cut('B', 'MR194', widths([[59, 16]]), 5, 3, '1781049600') ],
+    { perPassByCut: { A: 10, Acont: 10, B: 10 }, dayStartMin: 0, dayEndMin: 100,
+      times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000, preserveOrder: true }
+);
+// A и Acont — смежные дни одной сигнатуры → сливаются в одну логическую резку (15 проходов),
+// раскладываются обратно в A(seq1,10)+Acont(seq2,5); B остаётся seq3. Создавать нечего.
+assertEqual(again.creates, [], '#3619/#3427: повторная раскладка не создаёт продолжений (переиспользует запись)');
+assertEqual(again.deletes, [], '#3619/#3427: и не удаляет (нет лишних записей)');
+
+console.log('\n' + passed + ' passed');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 46);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 47);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3619.

## Что просил тикет
«Заполнять день до конца»: задание, переходящее границу рабочего дня, расщеплять по дням — под каждый день своё «Задание в производство» + «Партия ГП» + «Обеспечение», рекурсивно («если и в следующий день не влезло — ещё расщеплять»).

## Что оказалось
Движок расщепления уже есть и делает ровно это (`splitMachineQueue` → `planCutOperations` → `applySplitPlan`: по-дневные сегменты, копия «Полос», «Партия ГП» и доли «Обеспечения» через `splitSupplyShares`, идемпотентно #3427). Но его единственный вход — `autoSequenceQueue` — после #3449 нигде не вызывался: генерация перестала трогать уже стоящие задания. Поэтому существующие задания, пересекающие границу дня, не заполняли день до конца.

## Что сделано
Вернул заполнение дней в генерацию — но **без** пересборки порядка очереди, которую #3449 намеренно убрал (оператор расставляет ↑↓ вручную). Полный `autoSequenceQueue` помимо резки по дням ещё и пересортировывал очередь по SETUP — это и есть регрессия #3449, которую #3427 (идемпотентность продолжений) НЕ закрывает. Поэтому добавлен флаг `preserveOrder`:

- **`planCutOperations(opts.preserveOrder)`** — станко-очередь сортируется по текущей «Очередности», а не пересобирается `orderCuts(weights)`; режем только по дням.
- **`autoSequenceQueue(strategy, preserveOrder)`** — проброс флага.
- **`runGenerateCuts`** (после создания новых резок) — `autoSequenceQueue(SETUP, true)`: заполнить дни, сохранив порядок.
- **`generateCuts`** (нет незапланированных позиций) — теперь тоже заполняет дни уже стоящих заданий, а не «ничего не делаем». Иначе сценарий #3619 (только существующие данные, новых позиций нет) нечем запустить, т.к. отдельной кнопки нет.

Триггер — нажатие «Сгенерировать» (как и просили: автоматически в рамках генерации). Идемпотентно: повторный прогон при неизменной раскладке не пишет ни одной записи (#3427).

## Тесты
`experiments/atex-production-planning-3619.test.js` — 9 проверок:
- без `preserveOrder` очередь пересобирается по SETUP (B,C,A);
- с `preserveOrder` порядок оператора сохраняется (A,C,B);
- с `preserveOrder` перелив дня всё равно расщепляется, продолжение встаёт сразу за родителем (следующее задание сдвигается на позицию ниже);
- идемпотентность #3427 сохранена.

Основной набор `atex-production-planning.test.js` — 531/531 без регрессий.

`VERSION` 46→47 — клиенты подтянут обновлённый `production-planning.js`.

## На что обратить внимание ревьюеру
1. Полный re-sequence (старое поведение #3421/#3449) намеренно **не** возвращён — только заполнение дней с сохранением порядка. Если нужна и авто-пересборка очереди — это `preserveOrder=false`, отдельным решением.
2. Заполнение дней привязано к кнопке «Сгенерировать» (в обеих ветках — с новыми позициями и без). Отдельной кнопки «Заполнить дни» не добавлял.

🤖 Generated with [Claude Code](https://claude.com/claude-code)