### PR TITLE
fix(atex): планирование — «Удалить»/«Зафиксировать» по диапазону дат, а не одному дню (#3622)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -553,21 +553,24 @@
         return pk >= fromK && pk <= toK;
     }
 
-    // #3475: задания и обеспечения выбранного дня — мишени кнопки «Удалить». Берём резки
-    // с непустой плановой датой именно этого дня (незавершённые); недатированные резки к
-    // дню не относим. Обеспечения — все, чьё cutId входит в набор резок дня. Чистая
-    // функция (без контроллера/сети), чтобы покрыть отбор тестами.
-    function dayDeletionTargets(cuts, supplies, selectedDate) {
-        var sd = String(selectedDate == null ? '' : selectedDate).trim();
-        if (sd === '') return { cuts: [], supplies: [] };
-        var dayKey = planDateDayKey(sd);
+    // #3475/#3622: задания и обеспечения для кнопки «Удалить». Берём резки с непустой
+    // плановой датой В ДИАПАЗОНЕ фильтра [dateFrom; dateTo] — тот же набор, что показан в
+    // очереди (isCutVisible, #3599). До #3622 отбирали только один день (dateFrom), из-за
+    // чего при выбранном диапазоне «Удалить» не находило видимых заданий, чья «Дата план»
+    // приходилась на другой день диапазона («нет заданий для удаления, хотя вот они»).
+    // Незавершённые, незафиксированные (#3508 п.3), датированные. Обеспечения — все, чьё
+    // cutId входит в набор. Чистая функция — покрывается тестами. dateTo пуст → один день
+    // dateFrom (без перелива в соседние).
+    function dayDeletionTargets(cuts, supplies, dateFrom, dateTo) {
+        var fromStr = String(dateFrom == null ? '' : dateFrom).trim();
+        var toStr = String(dateTo == null ? '' : dateTo).trim();
+        if (fromStr === '') return { cuts: [], supplies: [] };
+        if (toStr === '') toStr = fromStr;
         var dayCuts = (cuts || []).filter(function(c) {
             if (!c) return false;
-            if (String(c.status || '').trim() === 'Завершён') return false;
-            if (c.fixed) return false;   // #3508 п.3: зафиксированные задания при удалении дня пропускаем
-            var pd = String(c.planDate || '').trim();
-            if (pd === '') return false;
-            return planDateDayKey(pd) === dayKey;
+            if (c.fixed) return false;   // #3508 п.3: зафиксированные при удалении пропускаем
+            if (String(c.planDate || '').trim() === '') return false;   // недатированные к диапазону не относим
+            return isCutVisible(c, fromStr, toStr);   // #3599: тот же диапазон, что и видимость очереди (отсеивает «Завершён»)
         });
         var cutIds = {};
         dayCuts.forEach(function(c) { cutIds[String(c.id)] = true; });
@@ -639,6 +642,16 @@
         var s = String(dateStr == null ? '' : dateStr).trim();
         var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
         return m ? (m[3] + '.' + m[2] + '.' + m[1]) : s;
+    }
+
+    // #3622: подпись диапазона дат плана для тостов/подтверждений: «ДД.ММ.ГГГГ» для
+    // одного дня (или пустого «По»), «ДД.ММ.ГГГГ – ДД.ММ.ГГГГ» для диапазона.
+    function formatPlanDayRangeLabel(dateFrom, dateTo) {
+        var from = formatPlanDayLabel(dateFrom);
+        var to = formatPlanDayLabel(dateTo);
+        if (from === '') return to;
+        if (to === '' || to === from) return from;
+        return from + ' – ' + to;
     }
 
     // #3616: дата-заголовок рабочего дня очереди. baseMidnightMs — полночь дня 0 расписания
@@ -3288,6 +3301,8 @@
         cutMatchesQuery: cutMatchesQuery,
         isCutVisible: isCutVisible,
         dayDeletionTargets: dayDeletionTargets,
+        formatPlanDayLabel: formatPlanDayLabel,
+        formatPlanDayRangeLabel: formatPlanDayRangeLabel,   // #3622
         fulfillmentIdsFromRows: fulfillmentIdsFromRows,   // #3486
         extractApiError: extractApiError,
         planDateDayKey: planDateDayKey,
@@ -4658,15 +4673,20 @@
     AtexProductionPlanning.prototype.fixDayTasks = function() {
         var self = this;
         if (this.busy) return;
-        var dateStr = String(this.filter && this.filter.date || '').trim();
-        if (dateStr === '') {
+        var fromStr = String(this.filter && this.filter.date || '').trim();
+        if (fromStr === '') {
             this.notify('Выберите «Дату плана», чтобы зафиксировать задания дня', 'error');
             return;
         }
-        var dayKey = planDateDayKey(dateStr);
-        var dayCuts = (this.cuts || []).filter(function(c) { return planDateDayKey(c.planDate) === dayKey; });
+        var toStr = String(this.filter && this.filter.dateTo || '').trim();
+        if (toStr === '') toStr = fromStr;
+        // #3622: фиксируем задания всего ВИДИМОГО диапазона [С; По], а не одного дня (как и
+        // удаление). Незавершённые/датированные — тот же набор, что в очереди (isCutVisible).
+        var dayCuts = (this.cuts || []).filter(function(c) {
+            return c && String(c.planDate || '').trim() !== '' && isCutVisible(c, fromStr, toStr);
+        });
         var toFix = dayCuts.filter(function(c) { return !c.fixed; });
-        var dateLabel = formatPlanDayLabel(dateStr);
+        var dateLabel = formatPlanDayRangeLabel(fromStr, toStr);
         if (!dayCuts.length) { this.notify('Нет заданий за ' + dateLabel + ' для фиксации', 'info'); return; }
         if (!toFix.length) { this.notify('Все задания за ' + dateLabel + ' уже зафиксированы', 'info'); return; }
         self.setCutsFixed(toFix.map(function(c) { return c.id; }), true, {
@@ -4693,8 +4713,8 @@
             this.notify('Выберите «Дату плана», чтобы удалить задания дня', 'error');
             return;
         }
-        var targets = dayDeletionTargets(this.cuts, this.supplies, dateStr);
-        var dateLabel = formatPlanDayLabel(dateStr);
+        var targets = dayDeletionTargets(this.cuts, this.supplies, this.filter.date, this.filter.dateTo);
+        var dateLabel = formatPlanDayRangeLabel(this.filter.date, this.filter.dateTo);
         if (!targets.cuts.length) {
             this.notify('Нет заданий за ' + dateLabel + ' для удаления', 'info');
             return;

--- a/experiments/atex-production-planning-3622.test.js
+++ b/experiments/atex-production-planning-3622.test.js
@@ -1,0 +1,88 @@
+// Unit tests for #3622 — «Удалить»/«Зафиксировать» ищут задания по ДИАПАЗОНУ дат.
+// До #3622 кнопка «Удалить» отбирала задания только за один день (filter.date = «С»),
+// а очередь после #3599 показывает диапазон [С; По] и группирует по дню РАСПИСАНИЯ.
+// Из-за этого при выбранном диапазоне «Удалить» сообщало «нет заданий для удаления»,
+// хотя задания видны (их «Дата план» приходилась на другой день диапазона).
+// Здесь покрываем чистый отбор dayDeletionTargets(cuts, supplies, dateFrom, dateTo)
+// и подпись диапазона formatPlanDayRangeLabel.
+//
+// Run with: node experiments/atex-production-planning-3622.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) {
+        passed++;
+    } else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+var ts20 = Math.floor(Date.UTC(2026, 5, 20, 8, 30) / 1000);   // 2026-06-20 08:30 UTC (unix-штамп)
+
+// Задания по дням 19/20/21 + краевые (завершён, без даты, зафиксирован, вне диапазона).
+var cuts = [
+    { id: '1', planDate: '2026-06-19', status: 'В очереди' },   // день 19 (строка)
+    { id: '2', planDate: String(ts20), status: 'Начато' },      // день 20 (unix) — середина диапазона
+    { id: '3', planDate: '2026-06-21', status: 'В очереди' },   // день 21
+    { id: '4', planDate: String(ts20), status: 'Завершён' },    // день 20, но завершён — не трогаем
+    { id: '5', planDate: '', status: 'В очереди' },             // без даты — к диапазону не относим
+    { id: '6', planDate: '2026-06-20', status: 'В очереди', fixed: true }, // зафиксирован — пропускаем
+    { id: '7', planDate: '2026-06-25', status: 'В очереди' }    // вне диапазона
+];
+var supplies = [
+    { id: 's1', cutId: '1' }, { id: 's2', cutId: '2' }, { id: 's3', cutId: '3' },
+    { id: 's4', cutId: '4' }, { id: 's5', cutId: '5' }, { id: 's6', cutId: '6' }, { id: 's7', cutId: '7' }
+];
+
+// 1) Диапазон [19; 21] — все датированные незавершённые незафиксированные задания.
+var range = planning.dayDeletionTargets(cuts, supplies, '2026-06-19', '2026-06-21');
+assertEqual(range.cuts.map(function(c) { return c.id; }), ['1', '2', '3'],
+    '#3622: диапазон [19;21] берёт задания всех дней диапазона (без завершённых/недатированных/зафиксированных/вне диапазона)');
+assertEqual(range.supplies.map(function(s) { return s.id; }), ['s1', 's2', 's3'],
+    '#3622: обеспечения только по заданиям диапазона');
+
+// 2) РЕПРО бага: задание видно на дне 20, но «С» = 19. Старый однодневный отбор по «С»
+//    нашёл бы только день 19 (id 1) и упустил бы id 2/3 → «нет заданий для удаления».
+//    Диапазон их находит.
+var single19 = planning.dayDeletionTargets(cuts, supplies, '2026-06-19', '2026-06-19');
+assertEqual(single19.cuts.map(function(c) { return c.id; }), ['1'],
+    '#3622: один день 19 берёт только задания дня 19 (как было до диапазона)');
+assertEqual(range.cuts.length > single19.cuts.length, true,
+    '#3622: диапазон находит задания, которые однодневный отбор упускал (суть бага)');
+
+// 3) «По» пусто → один день «С» (без перелива в соседние дни).
+assertEqual(planning.dayDeletionTargets(cuts, supplies, '2026-06-20', '').cuts.map(function(c) { return c.id; }), ['2'],
+    '#3622: пустое «По» → один день «С» (id 2; id 4 завершён, id 6 зафиксирован — мимо)');
+
+// 4) Обратная совместимость: вызов с 3 аргументами (без dateTo) = один день.
+assertEqual(planning.dayDeletionTargets(cuts, supplies, '2026-06-19').cuts.map(function(c) { return c.id; }), ['1'],
+    '#3622: вызов без dateTo по-прежнему = один день «С»');
+
+// 5) Зафиксированное задание (id 6, день 20) в диапазон удаления НЕ попадает.
+assertEqual(range.cuts.map(function(c) { return c.id; }).indexOf('6'), -1,
+    '#3622: зафиксированное задание исключено из удаления (#3508 п.3)');
+
+// 6) Пустое «С» → удалять нечего.
+assertEqual(planning.dayDeletionTargets(cuts, supplies, '', '2026-06-21'), { cuts: [], supplies: [] },
+    '#3622: пустое «С» → пустой набор');
+
+// 7) Подпись диапазона.
+assertEqual(planning.formatPlanDayRangeLabel('2026-05-29', '2026-05-31'), '29.05.2026 – 31.05.2026',
+    '#3622: подпись диапазона «29.05.2026 – 31.05.2026»');
+assertEqual(planning.formatPlanDayRangeLabel('2026-05-29', '2026-05-29'), '29.05.2026',
+    '#3622: одинаковые края → один день');
+assertEqual(planning.formatPlanDayRangeLabel('2026-05-29', ''), '29.05.2026',
+    '#3622: пустое «По» → один день');
+assertEqual(planning.formatPlanDayRangeLabel('2026-05-29', null), '29.05.2026',
+    '#3622: null «По» → один день');
+
+console.log('\n' + passed + ' assertions passed');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 47);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 48);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3622.

## Симптом
Выбран диапазон «Дата плана» (на скрине 29.05–31.05), задания видны в очереди, но «Удалить» отвечает «Нет заданий за 29.05.2026 для удаления».

## Причина
#3599 сделал «Дату плана» **диапазоном** `[С; По]` и переключил видимость очереди (`isCutVisible`) на диапазон, а группировку/заголовки дней — на день РАСПИСАНИЯ (`schedDay`, #3616). Но кнопки «Удалить» (`dayDeletionTargets`/`deleteDayTasks`, #3475) и «Зафиксировать» (`fixDayTasks`, #3508) **остались на одном дне** = `filter.date` (только «С»). Они отбирали задания, чья хранимая «Дата план» day-key == «С». Когда у видимых заданий «Дата план» приходится на другой день диапазона (например 30–31.05), отбор по одному дню «С» (29.05) даёт пусто — отсюда «нет заданий», хотя вот они. Заголовок дня (день расписания) показывал 29.05 и маскировал расхождение.

## Фикс
Действия теперь работают по тому же ВИДИМОМУ диапазону, что и очередь:
- **`dayDeletionTargets(cuts, supplies, dateFrom, dateTo)`** — отбор через `isCutVisible(c, from, to)` (тот же предикат, что и видимость очереди). `dateTo` пуст → один день «С» (без перелива). Незавершённые, незафиксированные (#3508 п.3), датированные.
- **`fixDayTasks`** — тоже по диапазону `[С; По]`; заодно перестал фиксировать завершённые (через `isCutVisible`).
- **`formatPlanDayRangeLabel`** — подпись `ДД.ММ.ГГГГ` / `ДД.ММ.ГГГГ – ДД.ММ.ГГГГ` в подтверждении и тостах. Подтверждение по-прежнему показывает точное число заданий/обеспечений и «необратимо».

## Тесты
`experiments/atex-production-planning-3622.test.js` — 12 проверок (диапазон берёт задания всех дней; репро бага «однодневный отбор упускает»; пустое «По» = один день; обратная совместимость 3-арг вызова; зафиксированные/завершённые/недатированные исключены; подпись диапазона). Существующий `atex-production-planning-3475.test.js` — 7/7 без правок. Основной набор — 531/531.

`VERSION` 47→48.

## На что обратить внимание ревьюеру
Семантика кнопок «Удалить»/«Зафиксировать» теперь — **весь выбранный диапазон**, а не один день (следствие диапазонной «Даты плана» из #3599). Подтверждение удаления показывает счётчик, так что массового удаления «вслепую» нет. Если нужно удаление строго по одному дню — сузьте диапазон («С» = «По»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)