### PR TITLE
fix(atex): планирование — номер заказа в «Связанных позициях» при смене дат (#3624)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -901,6 +901,9 @@
                     positionId: row.supply_position_id ? String(row.supply_position_id) : null,
                     cutId: cutId,
                     finishedBatchId: finishedBatchId,
+                    // #3624: номер заказа позиции прямо из cut_planning — нужен подписи
+                    // «Связанные позиции», когда позиция выпала из активного positions_list.
+                    orderNo: str(row.order_no),
                     footage: rowNum(row, SUPPLY_FOOTAGE_COLUMNS),
                     rolls: rowNum(row, ['supply_rolls', 'supply_qty', 'supply_quantity', 'supply_roll_count'])
                 });
@@ -972,9 +975,18 @@
     // её «Количество» (qty шт. — сколько рулонов в позиции заказа) + рулоны/метраж
     // обеспечения. position — объект из rowsToPositions (может отсутствовать →
     // fallbackId для «позиция #N»). Чистая (DOM не трогает), проверяется модульно.
-    function formatLinkedPositionLabel(position, fallbackId, supplyRolls, footage) {
+    function formatLinkedPositionLabel(position, fallbackId, supplyRolls, footage, fallbackOrderNo) {
         var posId = position && position.id != null ? position.id : fallbackId;
-        var label = (position && position.label) || ('позиция #' + posId);
+        var label;
+        if (position && position.label) {
+            label = position.label;
+        } else {
+            // #3624: позиция выпала из активного positions_list (заказ закрыт/выполнен) —
+            // номер заказа берём из обеспечения (cut_planning.order_no), чтобы подпись
+            // осталась «<заказ>/<позиция>», а не «позиция #N». Нет order_no → прежний фолбэк.
+            var on = String(fallbackOrderNo == null ? '' : fallbackOrderNo).trim();
+            label = on !== '' ? (on + '/' + posId) : ('позиция #' + posId);
+        }
         var qty = stripNum(position && position.qty);
         if (qty > 0) label += ' · ' + round3(qty) + ' шт.';
         var rolls = stripNum(supplyRolls);
@@ -6838,7 +6850,10 @@
         (this.supplies || []).forEach(function(s) {
             var cid = String(s.cutId);
             if (!linkedLabelsByCut[cid]) linkedLabelsByCut[cid] = [];
-            linkedLabelsByCut[cid].push(posLabelById[String(s.positionId)] || ('позиция #' + s.positionId));
+            // #3624: позиция вне активного positions_list — в haystack кладём «<заказ>/<позиция>»
+            // из cut_planning.order_no, чтобы поиск по номеру заказа находил такие резки.
+            linkedLabelsByCut[cid].push(posLabelById[String(s.positionId)] ||
+                (s.orderNo ? (s.orderNo + '/' + s.positionId) : ('позиция #' + s.positionId)));
         });
         function cutMatchesSearch(c) {
             return cutMatchesQuery(c, query, linkedLabelsByCut[String(c.id)]);
@@ -7233,7 +7248,7 @@
             linked.forEach(function(s) {
                 // #3406 п.1: подпись + «Количество» позиции заказа + рулоны/метраж обеспечения.
                 var foot = supplyFootage(s, self.footageBySupply);
-                var label = formatLinkedPositionLabel(posById[s.positionId], s.positionId, s.rolls, foot);
+                var label = formatLinkedPositionLabel(posById[s.positionId], s.positionId, s.rolls, foot, s.orderNo);
                 var children = [el('span', { class: 'atex-pp-linked-label', text: label })];
                 var del = el('button', { class: 'atex-pp-linked-del', type: 'button', text: '×', title: 'Убрать из задания' });
                 del.addEventListener('click', function() { self.deleteSupply(s.id); });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -225,8 +225,8 @@ assertEqual(leadPlan.cuts.map(function(c){ return c.leaders; }),
     [['Софмикс'], ['Этикетка37','MONOCHROME'], []],
     'rowsToPlanning #3472: leaders[] — различные лидеры резки (легаси-смешение видно)');
 assertEqual(plan.supplies, [
-    { id: '900', positionId: '700', cutId: '10', finishedBatchId: '', footage: 0, rolls: 0 },
-    { id: '901', positionId: '701', cutId: '10', finishedBatchId: '', footage: 0, rolls: 0 }
+    { id: '900', positionId: '700', cutId: '10', finishedBatchId: '', orderNo: '', footage: 0, rolls: 0 },
+    { id: '901', positionId: '701', cutId: '10', finishedBatchId: '', orderNo: '', footage: 0, rolls: 0 }
 ], 'rowsToPlanning collects supplies from rows with supply_id, skips empty');
 assertEqual(planning.rowsToPlanning([]).cuts.length, 0, 'rowsToPlanning empty input → no cuts');
 // сценарий показа: группировка + счётчик связей поверх результата rowsToPlanning
@@ -241,13 +241,13 @@ var issue3209Rows = [
       cut_plan_date: '1780837651', cut_status: '', supply_id: '23352', supply_position_id: '21101',
       cut_sequence: '1', cut_material: 'MR194', cut_jumbo_remaining: '13260.00',
       cut_winding: 'OUT', cut_roller_width: '60.00', cut_material_id: '2086',
-      order_approval_date: '', order_id: '17990', supply_footage: '800', supply_rolls: '6',
+      order_approval_date: '', order_id: '17990', order_no: '3690', supply_footage: '800', supply_rolls: '6',
       cut_length: '1200' },
     { cut_id: '23316', cut_slitter: 'Станок 1', cut_slitter_id: '1277',
       cut_plan_date: '1780837651', cut_status: '', supply_id: '23353', supply_position_id: '21102',
       cut_sequence: '1', cut_material: 'MR194', cut_jumbo_remaining: '13260.00',
       cut_winding: 'OUT', cut_roller_width: '60.00', cut_material_id: '2086',
-      order_approval_date: '', order_id: '17990', supply_footage: '600', supply_rolls: '3',
+      order_approval_date: '', order_id: '17990', order_no: '3690', supply_footage: '600', supply_rolls: '3',
       cut_length: '1200' },
     { cut_id: '23370', cut_slitter: 'Станок 2', cut_slitter_id: '1279',
       cut_plan_date: '1780837653', cut_status: '', supply_id: '', supply_position_id: '',
@@ -262,9 +262,9 @@ assertEqual(issue3209Plan.cuts.map(function(cut) {
     { id: '23370', number: '1780837653', length: 700, visible: true }
 ], 'rowsToPlanning #3209/#3242: timestamp cut_plan_date, cut_length, and blank approval still produce visible cuts');
 assertEqual(issue3209Plan.supplies, [
-    { id: '23352', positionId: '21101', cutId: '23316', finishedBatchId: '', footage: 800, rolls: 6 },
-    { id: '23353', positionId: '21102', cutId: '23316', finishedBatchId: '', footage: 600, rolls: 3 }
-], 'rowsToPlanning #3209: carries supply footage and roll count from report rows');
+    { id: '23352', positionId: '21101', cutId: '23316', finishedBatchId: '', orderNo: '3690', footage: 800, rolls: 6 },
+    { id: '23353', positionId: '21102', cutId: '23316', finishedBatchId: '', orderNo: '3690', footage: 600, rolls: 3 }
+], 'rowsToPlanning #3209: carries supply footage/rolls + order_no (#3624) from report rows');
 assertEqual(planning.cutRunLength(issue3209Plan.cuts[0], issue3209Plan.supplies, {}), 1200,
     'cutRunLength #3209: cut_length is available as run-length fallback');
 assertEqual(planning.supplyFootage(issue3209Plan.supplies[0], { '23352': 0 }), 800,
@@ -315,6 +315,18 @@ assertEqual(planning.formatLinkedPositionLabel(
 assertEqual(planning.formatLinkedPositionLabel(undefined, '777', 3, 0),
     'позиция #777 · 3 рул.',
     'formatLinkedPositionLabel #3406: нет позиции в списке → fallback «позиция #N»');
+// #3624: позиция выпала из активного positions_list (другая дата) — номер заказа берём
+// из обеспечения (cut_planning.order_no), чтобы не терять «<заказ>/<позиция>».
+assertEqual(planning.formatLinkedPositionLabel(undefined, '73636', 0, 450, '3690'),
+    '3690/73636 · 450 м',
+    'formatLinkedPositionLabel #3624: позиции нет в списке, но order_no обеспечения даёт «3690/73636»');
+assertEqual(planning.formatLinkedPositionLabel(undefined, '73636', 0, 450, ''),
+    'позиция #73636 · 450 м',
+    'formatLinkedPositionLabel #3624: нет ни позиции, ни order_no → прежний фолбэк «позиция #N»');
+assertEqual(planning.formatLinkedPositionLabel(
+    { id: 'p1', label: 'АТХ-3002/1 · 25мм * 450м', qty: 70 }, 'p1', 12, 0, '9999'),
+    'АТХ-3002/1 · 25мм * 450м · 70 шт. · 12 рул.',
+    'formatLinkedPositionLabel #3624: позиция в списке есть → её подпись приоритетнее order_no обеспечения');
 
 // ── stripSupplyRolls (#3320): рулоны обеспечения полосы = min(рулоны полосы, 110% остатка) ──
 assertEqual(planning.stripSupplyRolls(8, 20), 8,

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 47);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 48);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3624.

## Симптом
В панели «Связанные позиции» подпись теряет номер заказа: вместо «3690/73636 · …» показывает «позиция #73636 · …». Проявляется при смене даты; на текущей дате — норм.

## Причина (подтверждена на живой базе ateh)
`renderLink` берёт подпись позиции только из `this.positions` = отчёт `report/positions_list`. Этот отчёт отдаёт лишь «активные» позиции — на ateh **46 штук, все с `order_no`**, а позиция **73636 в него не входит** (заказ выполнен/закрыт). Когда позиции нет в наборе, `formatLinkedPositionLabel` откатывается на `'позиция #' + posId` — без номера заказа.

Почему «от смены дат»: `this.positions` грузится один раз и на смене дат не перечитывается. На текущей дате видны резки с активными позициями (в наборе 46) → номер заказа резолвится; на другой дате всплывают резки, чьи позиции выпали из `positions_list` → фолбэк «позиция #N».

Отчёт `cut_planning` несёт `order_id`, но не нёс `order_no` — теперь **`order_no` в `cut_planning` добавлен** (серверная часть), и клиент берёт номер заказа прямо из обеспечения.

## Фикс (клиент, `production-planning.js`)
- `supply.orderNo = cut_planning.order_no` (в `rowsToPlanning`).
- `formatLinkedPositionLabel(position, fallbackId, rolls, footage, fallbackOrderNo)`: если позиции нет в `positions_list`, собирает «`<order_no>/<positionId>`» вместо «позиция #N». Подпись из `positions_list` (когда позиция есть) по-прежнему приоритетна.
- Haystack поиска по резкам тоже получает «`<order_no>/<positionId>`» — поиск по номеру заказа находит такие резки.

## Тесты
`experiments/atex-production-planning.test.js`: +3 кейса `formatLinkedPositionLabel` (#3624: позиции нет, но `order_no` даёт «3690/73636»; нет ни позиции, ни `order_no` → прежний фолбэк; позиция есть → её подпись приоритетнее) и `order_no` в `rowsToPlanning` (#3209). **534 проверки** проходят.

⚠️ 2 предсуществующих FAIL в наборе (`rowsToGenPositions #3340`, `isCutVisible #3249`) присутствуют и на чистом `origin/main` — к этой правке отношения не имеют.

`VERSION` 47→48.

## Зависимость
Требует колонку `order_no` в отчёте `cut_planning` (добавлена на ateh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)