### PR TITLE
feat(atex): слиттер — «Резка N» из событий, зелёные кнопки готовности, «Намотка» (#3621)

### DIFF
--- a/download/atex/css/slitter.css
+++ b/download/atex/css/slitter.css
@@ -139,9 +139,10 @@
 
 /* #3583: кнопки отметки проходов правее .atex-sl-head-title. */
 .atex-sl-head-pass { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.atex-sl-btn-pass { font-weight: 600; }
-.atex-sl-btn-pass-all { background: var(--sl-success-bg); border-color: var(--sl-success-border); color: var(--sl-ok); }
-.atex-sl-btn-pass-all:hover:not(:disabled) { background: var(--sl-success-hover-bg, var(--sl-success-bg)); }
+/* #3621: «Готово» и «Готовы все» — зелёные (вместо убранной кнопки «Завершить»).
+   Обе кнопки несут класс .atex-sl-btn-pass, поэтому одного правила достаточно. */
+.atex-sl-btn-pass { font-weight: 600; background: var(--sl-success-bg); border-color: var(--sl-success-border); color: var(--sl-ok); }
+.atex-sl-btn-pass:hover:not(:disabled) { background: var(--sl-success-hover-bg, var(--sl-success-bg)); }
 
 /* #3583: модалка подтверждения «Готовы все» (без confirm()). */
 .atex-sl-confirm-overlay {
@@ -326,8 +327,6 @@
 .atex-sl-btn:hover { background: var(--sl-surface); }
 .atex-sl-btn-primary { background: var(--sl-accent); border-color: var(--sl-accent); color: #fff; }
 .atex-sl-btn-primary:hover { background: var(--sl-accent-d); }
-.atex-sl-btn-advance { background: var(--sl-success-bg); border-color: var(--sl-success-border); color: var(--sl-ok); font-weight: 600; }
-.atex-sl-btn-advance:hover { background: var(--sl-success-hover-bg); }
 .atex-sl-btn-secondary { background: var(--sl-surface); }
 .atex-sl-photo { display: flex; align-items: center; gap: 8px; }
 

--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -423,24 +423,6 @@
         return runs > 0 ? Math.ceil(runs) : 1;
     }
 
-    // #3566 #1: текущий проход задания (1..M) для заголовка «Резка N из M».
-    // Отрезано проходов = погонаж факт (или счётчик кон. − нач.) ÷ метраж прохода;
-    // текущий = отрезано + 1, в пределах [1, M]. До старта = 1, по завершении = M.
-    function currentPassForCut(cut) {
-        var total = plannedRunsForCut(cut);
-        var runLength = runLengthForCut(cut);
-        if (!(runLength > 0)) return 1;
-        var done = coreToNumber(cut && cut.meterage);
-        if (!(done > 0)) {
-            var cs = coreToNumber(cut && cut.counterStart), ce = coreToNumber(cut && cut.counterEnd);
-            if (ce > cs) done = ce - cs;
-        }
-        var pass = Math.floor(done / runLength) + 1;
-        if (pass < 1) pass = 1;
-        if (pass > total) pass = total;
-        return pass;
-    }
-
     // Internal alias to avoid function-hoisting surprises in minifiers and keep
     // these helpers readable before `core` is assembled.
     function coreToNumber(value) {
@@ -767,7 +749,6 @@
         shiftEventSlitterLabel: shiftEventSlitterLabel,
         runLengthForCut: runLengthForCut,
         plannedRunsForCut: plannedRunsForCut,
-        currentPassForCut: currentPassForCut,
         batchPasses: batchPasses,
         batchMatchesCut: batchMatchesCut,
         availableBatchesForCut: availableBatchesForCut,
@@ -1580,9 +1561,13 @@
     AtexSlitter.prototype.renderHead = function() {
         var cut = this.currentCut;
         // #3566 #1: «Резка N из M» — проход N из M проходов ТЕКУЩЕГО задания (а не
-        // позиция задания в очереди). M = «Кол-во резок план»; N = текущий проход.
+        // позиция задания в очереди). M = «Кол-во резок план».
+        // #3621: N (текущий проход) выводим из числа отметок «Готово» — событий
+        // «Резка» этой резки + 1, в пределах [1, M] (раньше — из метража, #3566).
         var total = core.plannedRunsForCut(cut);
-        var title = 'Резка ' + core.currentPassForCut(cut) + ' из ' + total;
+        var pass = Math.min(this.donePassCount(cut) + 1, total);
+        if (pass < 1) pass = 1;
+        var title = 'Резка ' + pass + ' из ' + total;
         // #3557 #5: строку .atex-sl-head-meta убрали (Слиттер/Партия/План видно в тулбаре/метриках).
         var head = el('div', { class: 'atex-sl-head' }, [
             el('div', { class: 'atex-sl-head-main' }, [
@@ -1596,6 +1581,17 @@
         wrap.appendChild(head);
         wrap.appendChild(this.renderCutMetrics());
         return wrap;
+    };
+
+    // #3621: число выполненных проходов текущей резки = число событий «Резка»
+    // (EV.pass) среди событий смены этой резки. Источник номера прохода в шапке —
+    // надёжнее метража: каждое «Готово» пишет одно событие «Резка».
+    AtexSlitter.prototype.donePassCount = function(cut) {
+        var cutId = cut ? String(cut.id) : '';
+        if (!cutId) return 0;
+        return (this.shiftEvents || []).filter(function(ev) {
+            return ev.type === EV.pass && String(ev.cutId || '') === cutId;
+        }).length;
     };
 
     // #3583: кнопки отметки проходов правее .atex-sl-head-title. «Готово» — один
@@ -1618,6 +1614,8 @@
     // #3557 #4: кнопки управления статусом — в шапке (вместо секции «Статус резки»).
     // Доступные кнопки зависят от текущего (выведенного из событий) статуса. Для
     // заблокированной очередью резки (#8) кнопки показаны, но деактивированы.
+    // #3621: кнопка «Завершить» убрана — завершение теперь через зелёные кнопки
+    // «Готово»/«Готовы все» (markPassDone → finishCut на последнем проходе).
     AtexSlitter.prototype.renderCutControls = function(cut) {
         var self = this;
         var locked = this.isCutLocked(cut);
@@ -1630,22 +1628,19 @@
             defs = [
                 ['Возобновить', 'primary', function() { self.resumeCut(); }],
                 ['Перерыв', 'secondary', function() { self.breakCut(); }],
-                ['Прекратить', 'secondary', function() { self.abortCut(); }],
-                ['Завершить', 'advance', function() { self.finishCut(); }]
+                ['Прекратить', 'secondary', function() { self.abortCut(); }]
             ];
         } else if (s === 'Перерыв') {
             defs = [
                 ['Возобновить', 'primary', function() { self.resumeCut(); }],
                 ['Наладка', 'secondary', function() { self.setupCut(); }],
-                ['Прекратить', 'secondary', function() { self.abortCut(); }],
-                ['Завершить', 'advance', function() { self.finishCut(); }]
+                ['Прекратить', 'secondary', function() { self.abortCut(); }]
             ];
         } else if (s === 'В работе') {
             defs = [
                 ['Наладка', 'secondary', function() { self.setupCut(); }],
                 ['Перерыв', 'secondary', function() { self.breakCut(); }],
-                ['Прекратить', 'secondary', function() { self.abortCut(); }],
-                ['Завершить', 'advance', function() { self.finishCut(); }]
+                ['Прекратить', 'secondary', function() { self.abortCut(); }]
             ];
         } else {
             // Ожидает
@@ -1680,7 +1675,7 @@
             ['Вид сырья', material || '—'],
             ['Метраж, м', runLength > 0 ? String(core.round3(runLength)) : '—'],
             ['Резок', String(runs)],
-            ['Направление намотки', cut.winding || '—'],
+            ['Намотка', cut.winding || '—'],
             ['Лидер', cut.leader || '—']
         ];
         var grid = el('div', { class: 'atex-sl-metrics' });

--- a/experiments/atex-slitter.test.js
+++ b/experiments/atex-slitter.test.js
@@ -356,6 +356,32 @@ assertEqual(core.formatDuration(NaN), '', 'formatDuration: NaN → пусто');
         '#3560 createEvent: цель — таблица «Событие смены» (1082)');
 })();
 
+// ── #3621: donePassCount — число выполненных проходов = число событий «Резка» этой резки ──
+// Заголовок «Резка N из M»: N = donePassCount + 1 (текущий проход), в пределах [1, M].
+(function() {
+    var Controller = require('../download/atex/js/slitter.js').Controller;
+    var inst = Object.create(Controller.prototype);
+    inst.shiftEvents = [
+        { type: 'Начало смены', cutId: null },
+        { type: 'Начало резки', cutId: '81663' },
+        { type: 'Резка', cutId: '81663', value: '1' },
+        { type: 'Резка', cutId: '81663', value: '2' },
+        { type: 'Резка', cutId: '99999', value: '1' }, // другая резка — не считаем
+        { type: 'Наладка', cutId: '81663' }
+    ];
+    assertEqual(inst.donePassCount({ id: '81663' }), 2,
+        '#3621 donePassCount: считает только события «Резка» этой резки');
+    assertEqual(inst.donePassCount({ id: '99999' }), 1,
+        '#3621 donePassCount: фильтр по cutId');
+    assertEqual(inst.donePassCount({ id: '00000' }), 0,
+        '#3621 donePassCount: нет событий «Резка» → 0');
+    assertEqual(inst.donePassCount(null), 0,
+        '#3621 donePassCount: без резки → 0');
+    var empty = Object.create(Controller.prototype);
+    assertEqual(empty.donePassCount({ id: '81663' }), 0,
+        '#3621 donePassCount: shiftEvents не загружены → 0');
+})();
+
 // ── #3609: бесшовное продолжение смены ──
 assertEqual(core.knifeLayoutKey([{width:55,qty:10},{width:32.5,qty:10}]),
             core.knifeLayoutKey([{width:32.5,qty:10},{width:55,qty:10}]),


### PR DESCRIPTION
Закрывает #3621 (+ правка подписи метрики «Намотка»).

## Изменения
1. **Номер резки из событий смены.** Заголовок «Резка N из M»: N теперь =
   число событий «Резка» текущей резки (отметок «Готово») + 1, в пределах
   `[1, M]`, а не выводится из метража (#3566). Новый метод `donePassCount(cut)`
   считает события `EV.pass` этой резки в `shiftEvents`. Удалён ставший мёртвым
   `core.currentPassForCut` и его экспорт.
2. **Убрана кнопка «Завершить»**, окрашены зелёным «Готово»/«Готовы все».
   Из `renderCutControls` удалены кнопки `Завершить` (состояния Наладка/Перерыв/
   В работе) — завершение задания идёт через зелёные `Готово`/`Готовы все`
   (`markPassDone → finishCut` на последнем проходе). `.atex-sl-btn-pass` (обе
   кнопки) окрашен зелёным; удалён осиротевший стиль `.atex-sl-btn-advance`.
3. **Подпись метрики** «Направление намотки» → «Намотка».

## Проверка
- `node --check` ✅; остаточных ссылок на удалённый код нет.
- `experiments/atex-slitter.test.js`: +5 проверок `donePassCount`, всего 155 ✅.
  (2 FAIL `#3459 … Пропуск/Отмена` — предсуществующие на `main`, к этим правкам
  не относятся.)

## Замечание
После удаления «Завершить» завершить задание можно зелёными кнопками
(`markPassDone` требует заполненный «Метраж, м»). Если метраж не задан —
остаётся «Прекратить» (тоже уводит резку в «Завершена»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)