### PR TITLE
fix(atex): планирование — полная подпись «Связанные позиции» вместо id записи (#3633)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -926,6 +926,13 @@
                     // #3624: номер заказа позиции прямо из cut_planning — нужен подписи
                     // «Связанные позиции», когда позиция выпала из активного positions_list.
                     orderNo: str(row.order_no),
+                    // #3633: габариты позиции обеспечения прямо из cut_planning — чтобы
+                    // подпись «Связанные позиции» для позиции вне активного positions_list
+                    // была полной («<заказ> · <ширина>мм * <длина>м»), а не id записи + метраж.
+                    // Ширина = cut_roller_width (Заказанное количество → Ширина, мм), длина —
+                    // добавленная колонка position_length (Заказанное количество → Длина, м).
+                    positionWidth: (row.cut_roller_width == null || row.cut_roller_width === '') ? 0 : Number(row.cut_roller_width),
+                    positionLength: (row.position_length == null || row.position_length === '') ? 0 : Number(row.position_length),
                     footage: rowNum(row, SUPPLY_FOOTAGE_COLUMNS),
                     rolls: rowNum(row, ['supply_rolls', 'supply_qty', 'supply_quantity', 'supply_roll_count'])
                 });
@@ -961,7 +968,12 @@
             var width = stripNum(row.position_width);
             var length = stripNum(rowFirstValue(row, ['position_length', 'position_length_m', 'position_wind_length', 'wind_length']));
             var qty = stripNum(row.position_qty);
-            var head = orderNo !== '' ? orderNo + '/' + no : '№' + no;
+            // #3633: positions_list не отдаёт номер позиции (no обычно пусто) — тогда не
+            // оставляем «висячий» слэш «<заказ>/», а показываем просто «<заказ>». Если номер
+            // когда-нибудь появится — подпись снова «<заказ>/<номер>».
+            var head = orderNo !== ''
+                ? (no !== '' ? orderNo + '/' + no : orderNo)
+                : (no !== '' ? '№' + no : '');
             var dims = positionDimensionsLabel(width, length);
             var label = head + (dims !== '' ? ' · ' + dims : '');
             return { id: id, label: label, width: width, length: length, qty: qty };
@@ -997,17 +1009,21 @@
     // её «Количество» (qty шт. — сколько рулонов в позиции заказа) + рулоны/метраж
     // обеспечения. position — объект из rowsToPositions (может отсутствовать →
     // fallbackId для «позиция #N»). Чистая (DOM не трогает), проверяется модульно.
-    function formatLinkedPositionLabel(position, fallbackId, supplyRolls, footage, fallbackOrderNo) {
+    function formatLinkedPositionLabel(position, fallbackId, supplyRolls, footage, fallbackOrderNo, fallbackWidth, fallbackLength) {
         var posId = position && position.id != null ? position.id : fallbackId;
         var label;
         if (position && position.label) {
             label = position.label;
         } else {
-            // #3624: позиция выпала из активного positions_list (заказ закрыт/выполнен) —
-            // номер заказа берём из обеспечения (cut_planning.order_no), чтобы подпись
-            // осталась «<заказ>/<позиция>», а не «позиция #N». Нет order_no → прежний фолбэк.
+            // #3633: позиция выпала из активного positions_list (заказ закрыт/выполнен) —
+            // собираем полную подпись из данных обеспечения (cut_planning): номер заказа
+            // (order_no) + габариты позиции (cut_roller_width × position_length), т.е.
+            // «<заказ> · <ширина>мм * <длина>м», а НЕ id записи позиции. Нет order_no —
+            // прежний фолбэк «позиция #N»; нет габаритов — просто «<заказ>».
             var on = String(fallbackOrderNo == null ? '' : fallbackOrderNo).trim();
-            label = on !== '' ? (on + '/' + posId) : ('позиция #' + posId);
+            var dims = positionDimensionsLabel(fallbackWidth, fallbackLength);
+            var base = on !== '' ? on : ('позиция #' + posId);
+            label = base + (dims !== '' ? ' · ' + dims : '');
         }
         var qty = stripNum(position && position.qty);
         if (qty > 0) label += ' · ' + round3(qty) + ' шт.';
@@ -7492,7 +7508,7 @@
             linked.forEach(function(s) {
                 // #3406 п.1: подпись + «Количество» позиции заказа + рулоны/метраж обеспечения.
                 var foot = supplyFootage(s, self.footageBySupply);
-                var label = formatLinkedPositionLabel(posById[s.positionId], s.positionId, s.rolls, foot, s.orderNo);
+                var label = formatLinkedPositionLabel(posById[s.positionId], s.positionId, s.rolls, foot, s.orderNo, s.positionWidth, s.positionLength);
                 var children = [el('span', { class: 'atex-pp-linked-label', text: label })];
                 var del = el('button', { class: 'atex-pp-linked-del', type: 'button', text: '×', title: 'Убрать из задания' });
                 del.addEventListener('click', function() { self.deleteSupply(s.id); });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -225,8 +225,8 @@ assertEqual(leadPlan.cuts.map(function(c){ return c.leaders; }),
     [['Софмикс'], ['Этикетка37','MONOCHROME'], []],
     'rowsToPlanning #3472: leaders[] — различные лидеры резки (легаси-смешение видно)');
 assertEqual(plan.supplies, [
-    { id: '900', positionId: '700', cutId: '10', finishedBatchId: '', orderNo: '', footage: 0, rolls: 0 },
-    { id: '901', positionId: '701', cutId: '10', finishedBatchId: '', orderNo: '', footage: 0, rolls: 0 }
+    { id: '900', positionId: '700', cutId: '10', finishedBatchId: '', orderNo: '', positionWidth: 0, positionLength: 0, footage: 0, rolls: 0 },
+    { id: '901', positionId: '701', cutId: '10', finishedBatchId: '', orderNo: '', positionWidth: 0, positionLength: 0, footage: 0, rolls: 0 }
 ], 'rowsToPlanning collects supplies from rows with supply_id, skips empty');
 assertEqual(planning.rowsToPlanning([]).cuts.length, 0, 'rowsToPlanning empty input → no cuts');
 // сценарий показа: группировка + счётчик связей поверх результата rowsToPlanning
@@ -262,9 +262,9 @@ assertEqual(issue3209Plan.cuts.map(function(cut) {
     { id: '23370', number: '1780837653', length: 700, visible: true }
 ], 'rowsToPlanning #3209/#3242: timestamp cut_plan_date, cut_length, and blank approval still produce visible cuts');
 assertEqual(issue3209Plan.supplies, [
-    { id: '23352', positionId: '21101', cutId: '23316', finishedBatchId: '', orderNo: '3690', footage: 800, rolls: 6 },
-    { id: '23353', positionId: '21102', cutId: '23316', finishedBatchId: '', orderNo: '3690', footage: 600, rolls: 3 }
-], 'rowsToPlanning #3209: carries supply footage/rolls + order_no (#3624) from report rows');
+    { id: '23352', positionId: '21101', cutId: '23316', finishedBatchId: '', orderNo: '3690', positionWidth: 60, positionLength: 0, footage: 800, rolls: 6 },
+    { id: '23353', positionId: '21102', cutId: '23316', finishedBatchId: '', orderNo: '3690', positionWidth: 60, positionLength: 0, footage: 600, rolls: 3 }
+], 'rowsToPlanning #3209: carries supply footage/rolls + order_no (#3624) + position dims (#3633) from report rows');
 assertEqual(planning.cutRunLength(issue3209Plan.cuts[0], issue3209Plan.supplies, {}), 1200,
     'cutRunLength #3209: cut_length is available as run-length fallback');
 assertEqual(planning.supplyFootage(issue3209Plan.supplies[0], { '23352': 0 }), 800,
@@ -315,14 +315,17 @@ assertEqual(planning.formatLinkedPositionLabel(
 assertEqual(planning.formatLinkedPositionLabel(undefined, '777', 3, 0),
     'позиция #777 · 3 рул.',
     'formatLinkedPositionLabel #3406: нет позиции в списке → fallback «позиция #N»');
-// #3624: позиция выпала из активного positions_list (другая дата) — номер заказа берём
-// из обеспечения (cut_planning.order_no), чтобы не терять «<заказ>/<позиция>».
+// #3633: позиция выпала из активного positions_list (другая дата/закрытый заказ) — подпись
+// собираем из данных обеспечения: номер заказа + габариты позиции, а НЕ id записи позиции.
+assertEqual(planning.formatLinkedPositionLabel(undefined, '84667', 0, 900, '3335', 25, 900),
+    '3335 · 25мм * 900м',
+    'formatLinkedPositionLabel #3633: позиции нет в списке → «<заказ> · <ширина>мм * <длина>м» (без id записи), метраж не дублируется');
 assertEqual(planning.formatLinkedPositionLabel(undefined, '73636', 0, 450, '3690'),
-    '3690/73636 · 450 м',
-    'formatLinkedPositionLabel #3624: позиции нет в списке, но order_no обеспечения даёт «3690/73636»');
+    '3690 · 450 м',
+    'formatLinkedPositionLabel #3633: есть order_no, но нет габаритов → «<заказ>» + метраж (без висячего id)');
 assertEqual(planning.formatLinkedPositionLabel(undefined, '73636', 0, 450, ''),
     'позиция #73636 · 450 м',
-    'formatLinkedPositionLabel #3624: нет ни позиции, ни order_no → прежний фолбэк «позиция #N»');
+    'formatLinkedPositionLabel #3633: нет ни позиции, ни order_no → прежний фолбэк «позиция #N»');
 assertEqual(planning.formatLinkedPositionLabel(
     { id: 'p1', label: 'АТХ-3002/1 · 25мм * 450м', qty: 70 }, 'p1', 12, 0, '9999'),
     'АТХ-3002/1 · 25мм * 450м · 70 шт. · 12 рул.',

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 49);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 50);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3633.

Плашка «Связанные позиции» для позиции вне активного `positions_list` показывала **`3335/84667 · 900 м`** (`84667` — id записи позиции, без габаритов). Стало: **`3335 · 25мм * 900м`**.

## Корень
- Номера позиции в схеме **нет**: у «Заказанного количества» (1076) главное значение — количество; в `positions_list` колонка номера (`Вычисляемое`) — служебный флаг `COALESCE(...) IS NOT NULL`, не номер.
- Фолбэк после #3624 был половинчатым: подставлял id записи позиции и только метраж.

## Серверная часть (БД ateh, отчёт `cut_planning`, queryId 8384)
Добавлена колонка (рецепт из `docs/integram-reports.md`):

| t100 | t28 (источник) | colId |
|---|---|---|
| `position_length` | `1143` (Заказанное количество → Длина, м) | **88026** |

Ширина уже была в отчёте как `cut_roller_width` (реквизит `1141`). Отчёты — записи типа 22/28, в git-репозитории их нет; колонка добавлена напрямую в БД и проверена (`report/cut_planning?JSON_KV` отдаёт `position_length`, для позиции 84667 = `900.00`).

> ⚠️ Серверная колонка уже добавлена на рабочей базе atex (ateh). Без неё клиент деградирует мягко: показывает «<заказ> · <ширина>мм» (длина 0 опускается).

## Клиент (`production-planning.js`)
- `rowsToPlanning`: `supply` несёт `positionWidth` (`cut_roller_width`) и `positionLength` (`position_length`).
- `formatLinkedPositionLabel`: в фолбэке собирает «<заказ> · <ширина>мм * <длина>м» через `positionDimensionsLabel`, без id записи. Нет габаритов → «<заказ>»; нет `order_no` → прежний «позиция #N».
- `rowsToPositions`: убран «висячий слэш» у активных подписей (`positions_list` не отдаёт номер позиции → `3700/` стало `3700`).

## Проверки
- Основной набор `atex-production-planning.test.js` — **535** проверок (обновлены ассерты подписи и габаритов в `supply`; добавлен кейс полной подписи `3335 · 25мм * 900м`).
- Два FAIL (`rowsToGenPositions #3340`, `isCutVisible #3249`) **предсуществующие на `origin/main`** (534) — не регрессия (проверено).

VERSION 49→50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)