### PR TITLE
fix(atex): планирование — дефекты раскладки/округления/прогресса (#3635 п.1–4)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2609,8 +2609,18 @@
             // очереди (сортировка по «Очередности»), а не пересобирая её по стратегии
             // (orderCuts). Нужно, чтобы автозаполнение дней после генерации не перетасовывало
             // ручной порядок оператора (#3449). Без флага — обычная пересборка по весам (#3421).
+            // #3635 п.1/п.2: сортируем СПЕРВА по дню «Даты план», затем по «Очередности» —
+            // как groupBySlitter (#3616) и planQueues. «Очередность» сбрасывается на каждый
+            // день, поэтому сортировка только по ней перемешивала дни: задание дня D+1 с
+            // очередью 1 вставало перед фольгой дня D с очередью 2 → splitMachineQueue
+            // переупаковывал перемешанную очередь, фольга всплывала в начало дня и ломала
+            // порядок ножей (#3130/#3568), а вид «сразу после планирования» расходился с
+            // видом после перезагрузки (groupBySlitter сортирует день-первым).
             var ordered = opts.preserveOrder
-                ? byMachine[key].slice().sort(function(a, b){ return (Number(a.sequence) || 0) - (Number(b.sequence) || 0); })
+                ? byMachine[key].slice().sort(function(a, b){
+                      return comparePlanDayKeys(cutPlanDayKey(a), cutPlanDayKey(b))
+                          || ((Number(a.sequence) || 0) - (Number(b.sequence) || 0));
+                  })
                 : orderCuts(byMachine[key], opts.weights);
             var runsByCut = {};
             ordered.forEach(function(c){ runsByCut[String(c.id)] = Number(c.plannedRuns) || 0; });
@@ -2750,7 +2760,9 @@
         // равно первому шагу тайминга окна, а не старту самой резки.
         var setup = stripNum(sc.setupMin);
         var windowStart = stripNum(sc.startMin) - setup;
-        return '⏱ ' + formatClock(windowStart) + ' – ' + formatClock(sc.finishMin) + ' · ' + round3(setup + dur) + ' мин';
+        // #3635 п.4: минуты окна показываем ЦЕЛЫМ числом, округляя ВВЕРХ (36.264 → 37) —
+        // совпадает с диапазоном по часам (09:03–09:40 ≈ 37 мин), без дробного «хвоста».
+        return '⏱ ' + formatClock(windowStart) + ' – ' + formatClock(sc.finishMin) + ' · ' + Math.ceil(setup + dur) + ' мин';
     }
 
     // Допуск остатка джамбо (мм): если задан (непустая строка) — берём его (терпимо
@@ -4330,7 +4342,7 @@
             slitter: d.slitterId,
             materialBatch: d.materialBatchId,
             plannedRuns: d.plannedRuns,
-            duration: duration > 0 ? duration : '',
+            duration: duration > 0 ? Math.ceil(duration) : '',   // #3635 п.4: «Длительность, минут» сохраняем целой (вверх)
             timing: timing,
             length: runLength > 0 ? runLength : '',
             planDate: d.planDate,
@@ -4533,7 +4545,7 @@
             var fields = buildFields(cutReqIds, {
                 slitter: d.slitterId,
                 plannedRuns: plan.plannedRuns,
-                duration: plan.duration > 0 ? plan.duration : '',
+                duration: plan.duration > 0 ? Math.ceil(plan.duration) : '',   // #3635 п.4: «Длительность, минут» — целой (вверх)
                 timing: plan.timing,
                 length: plan.runLength > 0 ? plan.runLength : '',
                 winding: normWinding(plan.layout && plan.layout.windDir),
@@ -6144,7 +6156,7 @@
                     slitter: slitterId,
                     materialBatch: batchId,
                     plannedRuns: plannedRuns,
-                    duration: duration > 0 ? duration : '',
+                    duration: duration > 0 ? Math.ceil(duration) : '',   // #3635 п.4: «Длительность, минут» сохраняем целой (вверх)
                     timing: timing,
                     length: runLength > 0 ? runLength : '',
                     winding: normWinding(lay && lay.windDir),
@@ -6507,7 +6519,13 @@
         var updateByCut = {};
         (ops.updates || []).forEach(function(u) { updateByCut[u.cutId] = u; });
 
+        // #3635 п.3: сохранение плана резок (день-заполнение) пишет десятки записей —
+        // показываем форму ожидания с прогрессом, а не «зависшую» заблокированную страницу.
+        var splitTotal = (ops.updates || []).length + Object.keys(createsByParent).length + (ops.deletes || []).length;
+        var splitDone = 0;
+        function splitBump() { self.updateProgress(++splitDone); }
         this.setBusy(true);
+        if (splitTotal > 0) this.showProgress('Сохранение плана резок…', splitTotal);
         var chain = Promise.resolve();
 
         // 1) Обновить существующие записи (первый сегмент каждой логической резки).
@@ -6529,7 +6547,7 @@
                     if (!Object.keys(fields).length) return;
                     return self.post('_m_set/' + u.cutId + '?JSON', fields);
                 });
-            });
+            }).then(splitBump);
         });
 
         // 2) Создать записи-продолжения с копией Полос и долей Обеспечения.
@@ -6638,18 +6656,18 @@
                     });
                 });
                 return cChain;
-            });
+            }).then(splitBump);
         });
 
         // 3) Удалить записи-продолжения прежних цепочек (их Полосы/дети каскадятся).
         (ops.deletes || []).forEach(function(id) {
-            chain = chain.then(function() { return self.post('_m_del/' + encodeURIComponent(id) + '?JSON', {}); });
+            chain = chain.then(function() { return self.post('_m_del/' + encodeURIComponent(id) + '?JSON', {}); }).then(splitBump);
         });
 
         return chain.then(function() { return self.reload(); }).then(function() {
-            self.setBusy(false); self.render(); return true;
+            self.hideProgress(); self.setBusy(false); self.render(); return true;
         }).catch(function(err) {
-            self.setBusy(false);
+            self.hideProgress(); self.setBusy(false);
             self.notify('Ошибка разбиения заданий: ' + err.message, 'error');
             return false;
         });

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -1326,11 +1326,11 @@ var segDays3401 = planning.splitMachineQueue([{ id:'A' }],
 assertEqual(segDays3401.map(function(s){ return { day:s.dayOffset, runs:s.runs }; }),
     [{ day:0, runs:3 }, { day:1, runs:2 }],
     'splitMachineQueue #3401: проход = 5+5=10 мин → в окно 30 мин влезает 3 прохода, остаток на след. день');
-// #3262: строка показывает ВСЁ окно (setup+резка): старт = startMin−setupMin (08:00),
-// длительность = setup(2)+12.5 = 14.5 (диапазон совпадает с числом минут).
+// #3262: строка показывает ВСЁ окно (setup+резка): старт = startMin−setupMin (08:00).
+// #3635 п.4: минуты окна округляем ВВЕРХ — setup(2)+12.5 = 14.5 → 15 (как диапазон по часам).
 assertEqual(planning.formatScheduleLine(schedStoredDuration[0], 0, true),
-    '⏱ 08:00 – 08:15 · 14.5 мин',
-    'formatScheduleLine #3262: окно от начала setup; длительность = setup + резка');
+    '⏱ 08:00 – 08:15 · 15 мин',
+    'formatScheduleLine #3262/#3635: окно от начала setup; минуты вверх (14.5 → 15)');
 assertEqual(planning.formatScheduleLine({ startMin:482, finishMin:482, durationMin:0 }, 0, true),
     '⏱ ошибка: нет метража прохода; длительность не рассчитана',
     'formatScheduleLine #3229: нулевая длительность без метража отображается как ошибка');
@@ -1753,8 +1753,8 @@ function runGenerateCutsDeferredGpTest() {
             'runGenerateCuts #3215: t16403 пишет Кол-во план');
         assertEqual(cutPost.fields.t24308, 1,
             'runGenerateCuts #3215: t24308 пишет Очередность при создании');
-        assertEqual(cutPost.fields.t26584, 5.9,
-            'runGenerateCuts #3223: t26584 пишет Длительность, минут при планировании');
+        assertEqual(cutPost.fields.t26584, 6,
+            'runGenerateCuts #3223/#3635: t26584 пишет Длительность, минут целой ВВЕРХ (5.9 → 6)');
         assertEqual(cutPost.fields.t26990, planning.cutTimingDetails(1200, 1, opT),
             'runGenerateCuts #3238: t26990 пишет Тайминг с деталями расчёта');
         assertEqual(cutPost.fields.t27172, 'OUT',
@@ -2129,6 +2129,10 @@ function runApplySplitPlanTest() {
     controller.reload = function() { return Promise.resolve(); };
     controller.render = function() {};
     controller.notify = function() {};
+    // #3635 п.3: applySplitPlan теперь показывает прогресс — мокаем заглушками (без DOM).
+    controller.showProgress = function() {};
+    controller.updateProgress = function() {};
+    controller.hideProgress = function() {};
     controller.post = function(path, fields) { posts.push({ path: path, fields: fields || {} }); return Promise.resolve({ obj: 'newB' }); };
     var ops = {
         updates: [{ cutId: 'A', sequence: 1, planStartTs: 1000, plannedRuns: 10 }],
@@ -2302,6 +2306,31 @@ assertEqual(ops3421.updates.slice().sort(function(a, b) { return a.sequence - b.
     ['B', 'C', 'A'], 'planCutOperations #3421: пересборка переставляет 6,16,16 → 16,16,6 (ножи убывают)');
 assertEqual(ops3421.creates, [], 'planCutOperations #3421: один день, без переноса');
 assertEqual(ops3421.deletes, [], 'planCutOperations #3421: без удалений');
+
+// ── #3635 п.1/п.2: preserveOrder сортирует ДЕНЬ-первым, затем по «Очередности» ──
+// «Очередность» сбрасывается на каждый день; сортировка ТОЛЬКО по ней перемешивала дни:
+// задание дня D+1 (очередь 1) вставало перед фольгой дня D (очередь 2), фольга всплывала
+// в начало дня и ломала порядок ножей (#1), а вид после генерации расходился с видом
+// после перезагрузки, где groupBySlitter сортирует день-первым (#2).
+function cut3635(id, dayTs, seq, isFoil) {
+    // materialId уникален у каждой резки — иначе mergeContinuationChains (#3280) сольёт их
+    // как сегменты одной логической резки (одинаковая «подпись продолжения»).
+    return { id: id, slitter: { id: 'm5' }, materialId: 'mat-' + id, winding: 'OUT',
+        knifeWidths: [100], knifeCount: 1, plannedRuns: 1, isFoil: !!isFoil,
+        sequence: seq, planDate: String(dayTs) };
+}
+var d1ts = 1780963200, d2ts = 1780963200 + 86400;
+var ops3635 = planning.planCutOperations(
+    // вход намеренно перемешан по дням (как могло прийти из groupBySlitter до фикса)
+    [ cut3635('d2a', d2ts, 1, false), cut3635('d1foil', d1ts, 2, true),
+      cut3635('d1a', d1ts, 1, false), cut3635('d2b', d2ts, 2, false) ],
+    { preserveOrder: true, perPassByCut: { d2a: 1, d1foil: 1, d1a: 1, d2b: 1 },
+      dayStartMin: 0, dayEndMin: 10000, times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: d1ts * 1000 }
+);
+assertEqual(
+    ops3635.updates.slice().sort(function(a, b) { return a.sequence - b.sequence; }).map(function(u) { return u.cutId; }),
+    ['d1a', 'd1foil', 'd2a', 'd2b'],
+    'planCutOperations #3635: preserveOrder день-первым — день1 (вкл. фольгу очередь 2) ПЕРЕД днём2, без перемешивания');
 
 // ── #3427: повторная раскладка УЖЕ разбитой цепочки идемпотентна ───────────────
 // Цепочка [A(день0, 10 проходов) → B(день1, 5 проходов)] уже разбита по дням.

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 49);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 50);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Частично закрывает #3635 (пункты 1–4; пункт 5 — см. ниже, нужно уточнение).

## п.1 + п.2 — фольга в начале дня · «после генерации» ≠ «после перезагрузки»
**Одна причина.** `autoSequenceQueue`/`planCutOperations` в режиме `preserveOrder` сортировал очередь станка **только по «Очередности»**. Но «Очередность» сбрасывается на каждый день (#3616), поэтому сортировка по ней перемешивала дни: задание дня D+1 (очередь 1) вставало перед фольгой дня D (очередь 2). Затем `splitMachineQueue` переупаковывал перемешанную очередь → фольга всплывала в начало дня и ломала порядок ножей (#3130/#3568). А вид «сразу после планирования» расходился с видом после `reload`, где `groupBySlitter` сортирует **день-первым**.

**Фикс** (`planCutOperations`, ветка `preserveOrder`): сортировать СПЕРВА по дню «Даты план» (`comparePlanDayKeys(cutPlanDayKey(...))`), затем по «Очередности» — ровно как `groupBySlitter` (#3616) и `planQueues`. Ручной порядок внутри дня (#3449) и идемпотентность (#3427) сохранены.

## п.3 — страница «зависает» при сохранении
`applySplitPlan` писал десятки записей под `setBusy(true)` без индикатора. Добавлена **форма ожидания с прогрессом** (`showProgress`/`updateProgress`/`hideProgress`) по числу операций update/create/delete.

## п.4 — дробные минуты `36.264`
- Строка расписания: минуты окна — целым числом **вверх** (`Math.ceil(setup+dur)` вместо `round3`): `36.264 → 37` (совпадает с диапазоном по часам 09:03–09:40).
- «Длительность, минут» сохраняется целой вверх (`Math.ceil` при записи `cut_duration`).

## п.5 — НЕ в этом PR (нужно уточнение)
> «Задание можно разрывать так: в один день попадает настройка ножей и сырья, а в другой — сама резка.»

Это запрос на изменение гранулярности дневного разрыва в `splitMachineQueue` (сейчас при нехватке места до конца дня вся резка вместе с настройкой уезжает на следующий день). Прежде чем менять ядро day-split, нужно подтвердить желаемое поведение — оставил вопрос в issue.

## Проверки
- `atex-production-planning.test.js`: добавлен `planCutOperations #3635` (день-первый порядок, проверяет, что фольга дня не всплывает за задание следующего дня), обновлены `formatScheduleLine` (14.5 → 15) и `t26584` (5.9 → 6). **535** проверок.
- 2 FAIL (`rowsToGenPositions #3340`, `isCutVisible #3249`) — предсуществующие на `origin/main`, не регрессия.

VERSION 49→50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)