### PR TITLE
feat(atex): слиттер — «Остаток, мм» в раскладке ножей (#3639)

### DIFF
--- a/download/atex/css/slitter.css
+++ b/download/atex/css/slitter.css
@@ -421,6 +421,14 @@
     border-right: none;
 }
 .atex-sl-cm-warn { margin-top: 8px; color: var(--sl-warn); font-weight: 600; }
+/* #3639: остаток (обрезь) в мм — справа внизу секции «Раскладка ножей». */
+.atex-sl-cm-waste {
+    margin-top: 8px;
+    text-align: right;
+    font-size: 12px;
+    color: var(--sl-muted);
+}
+.atex-sl-cm-waste-value { font-weight: 600; color: var(--text-secondary, #475569); }
 .atex-sl-cm-legend {
     display: flex;
     flex-wrap: wrap;

--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -1753,6 +1753,15 @@
             ]));
         });
         section.appendChild(legend);
+
+        // #3639: «Остаток, мм» справа внизу — сколько ширины входа уйдёт в отходы
+        // (обрезь). При переполнении (полосы шире входа) отхода нет → 0.
+        var wasteMm = lay.remainder > 0 ? core.round3(lay.remainder) : 0;
+        section.appendChild(el('div', { class: 'atex-sl-cm-waste', title: 'Сколько ширины входа уйдёт в отходы (обрезь)' }, [
+            el('span', { class: 'atex-sl-cm-waste-label', text: 'Остаток, мм: ' }),
+            el('span', { class: 'atex-sl-cm-waste-value', text: String(wasteMm) })
+        ]));
+
         return section;
     };
 


### PR DESCRIPTION
Closes #3639.

В секцию **«Раскладка ножей (K полос)»** на странице слиттера (`download/atex/js/slitter.js`) справа внизу добавлен показатель **«Остаток, мм»** — сколько ширины входа уйдёт в отходы (обрезь).

## Что сделано
- `renderCutMap`: после легенды добавлен блок `atex-sl-cm-waste` со значением `Остаток, мм: N`, где `N = lay.remainder` (ширина входа − занято полосами). При переполнении (полосы шире входа) отхода нет → `0`.
- `download/atex/css/slitter.css`: стиль `.atex-sl-cm-waste` — выравнивание вправо, в тон подписи «Занято».

Значение уже вычисляется ядром `computeLayout` (`lay.remainder`); добавлен только его вывод и стиль. Ядро не менялось.

## Проверка
- `node experiments/atex-slitter.test.js` — все «зелёные» как были; новых провалов нет (2 пред­существующих провала про `EVENT_TYPES` не связаны с этой правкой).
- Визуально на стенде `experiments/atex-slitter.fixture.html`: для полос 25 мм × 35 при ширине входа 910 мм секция показывает «Раскладка ножей (35 полос)», «Занято: 875 мм» и справа внизу **«Остаток, мм: 35»** (910 − 875).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
