### PR TITLE
feat(atex): пульт слиттера — убрать «Начать», всегда показывать Наладка/Перерыв/Прекратить (#3640)

### DIFF
--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -1636,31 +1636,17 @@
         // Текущий (выведенный из событий) статус: 'Ожидает'|'В работе'|'Наладка'|'Перерыв'|'Завершена'.
         var s = String(cut.status == null ? '' : cut.status).trim();
         var defs;
+        // #3640: «Начать» убрана — старт резки идёт через «Наладку» (setupCut ставит «Начато»
+        // + «В работе»). Для активной резки в ЛЮБОМ статусе показываем все три кнопки
+        // «Наладка / Перерыв / Прекратить» (каждая пишет событие смены). «Возобновить»
+        // оставлена только для завершённой резки — переоткрыть (снять «Закончено»).
         if (core.isDone(s)) {
             defs = [['Возобновить', 'secondary', function() { self.resumeCut(); }]];
-        } else if (s === 'Наладка') {
-            defs = [
-                ['Возобновить', 'primary', function() { self.resumeCut(); }],
-                ['Перерыв', 'secondary', function() { self.breakCut(); }],
-                ['Прекратить', 'secondary', function() { self.abortCut(); }]
-            ];
-        } else if (s === 'Перерыв') {
-            defs = [
-                ['Возобновить', 'primary', function() { self.resumeCut(); }],
-                ['Наладка', 'secondary', function() { self.setupCut(); }],
-                ['Прекратить', 'secondary', function() { self.abortCut(); }]
-            ];
-        } else if (s === 'В работе') {
-            defs = [
-                ['Наладка', 'secondary', function() { self.setupCut(); }],
-                ['Перерыв', 'secondary', function() { self.breakCut(); }],
-                ['Прекратить', 'secondary', function() { self.abortCut(); }]
-            ];
         } else {
-            // Ожидает
             defs = [
-                ['Начать', 'primary', function() { self.startCut(); }],
-                ['Наладка', 'secondary', function() { self.setupCut(); }]
+                ['Наладка', 'primary', function() { self.setupCut(); }],
+                ['Перерыв', 'secondary', function() { self.breakCut(); }],
+                ['Прекратить', 'secondary', function() { self.abortCut(); }]
             ];
         }
         var actions = el('div', { class: 'atex-sl-section-actions atex-sl-life-actions' });

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 50);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 51);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3640.

Путь оператора (событие на каждое действие): **Наладка** → **Готово/Перерыв/Прекратить** → **Готовы все** (последний проход — сохраняет показания/выработку, снимает «В работе», ставит «Закончено») → **Сохранить показания**.

## Изменение
В блоке статус-кнопок резки (`renderCutControls`):
- **«Начать» убрана** — старт резки идёт через **«Наладку»** (`setupCut` уже ставит «Начато» + «В работе»).
- Для активной резки в **любом** статусе (Ожидает / Наладка / Перерыв / В работе) показываем все три: **Наладка / Перерыв / Прекратить** (раньше набор зависел от статуса). Каждая пишет своё событие смены.
- **«Возобновить»** оставлена только для **завершённой** резки (переоткрыть — снять «Закончено»); из активных статусов убрана — продолжение после перерыва идёт через зелёную «Готово».

Кнопки «Готово / Готовы все» (проходы) и «Сохранить показания» — без изменений (отдельные секции).

Метод `startCut`/событие `EV.startCut` оставлены (нужны для статуса по легаси-событиям), просто больше не привязаны к кнопке.

## Проверки
`slitter.js` — синтаксис ок, тест 159 проверок (2 предсуществующих FAIL `EVENT_TYPES #3459` — не регрессия). VERSION 50→51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)