### PR TITLE
fix(atex): слиттер — легенда и «Остаток, мм» в одном ряду (#3643)

### DIFF
--- a/download/atex/css/slitter.css
+++ b/download/atex/css/slitter.css
@@ -421,9 +421,20 @@
     border-right: none;
 }
 .atex-sl-cm-warn { margin-top: 8px; color: var(--sl-warn); font-weight: 600; }
-/* #3639: остаток (обрезь) в мм — справа внизу секции «Раскладка ножей». */
+/* #3643: легенда и «Остаток, мм» — в одном ряду (легенда слева, остаток справа,
+   по базовой линии). На узких экранах ряд переносит «Остаток» под легенду. */
+.atex-sl-cm-legend-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px 18px;
+    flex-wrap: wrap;
+    margin-top: 12px;
+}
+/* #3639: остаток (обрезь) в мм — справа в ряду «Раскладка ножей». */
 .atex-sl-cm-waste {
-    margin-top: 8px;
+    flex: 0 0 auto;
+    white-space: nowrap;
     text-align: right;
     font-size: 12px;
     color: var(--sl-muted);
@@ -433,7 +444,8 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px 18px;
-    margin-top: 12px;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 .atex-sl-cm-legend-item {
     display: flex;

--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -1752,15 +1752,16 @@
                     (s.purpose ? ' · ' + s.purpose : '') })
             ]));
         });
-        section.appendChild(legend);
 
-        // #3639: «Остаток, мм» справа внизу — сколько ширины входа уйдёт в отходы
-        // (обрезь). При переполнении (полосы шире входа) отхода нет → 0.
+        // #3639: «Остаток, мм» — сколько ширины входа уйдёт в отходы (обрезь). При
+        // переполнении (полосы шире входа) отхода нет → 0.
         var wasteMm = lay.remainder > 0 ? core.round3(lay.remainder) : 0;
-        section.appendChild(el('div', { class: 'atex-sl-cm-waste', title: 'Сколько ширины входа уйдёт в отходы (обрезь)' }, [
+        var waste = el('div', { class: 'atex-sl-cm-waste', title: 'Сколько ширины входа уйдёт в отходы (обрезь)' }, [
             el('span', { class: 'atex-sl-cm-waste-label', text: 'Остаток, мм: ' }),
             el('span', { class: 'atex-sl-cm-waste-value', text: String(wasteMm) })
-        ]));
+        ]);
+        // #3643: легенда и «Остаток, мм» — в ОДНОМ ряду (легенда слева, остаток справа).
+        section.appendChild(el('div', { class: 'atex-sl-cm-legend-row' }, [legend, waste]));
 
         return section;
     };

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 51);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 52);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3643.

В секции «Раскладка ножей» пульта слиттера легенда видов полос (`.atex-sl-cm-legend`) и «Остаток, мм» (`.atex-sl-cm-waste`, #3639) шли друг под другом (стопкой) — смотрелось криво.

## Фикс
Легенда и «Остаток, мм» обёрнуты в общий ряд `.atex-sl-cm-legend-row`:
- `display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap` — **легенда слева, «Остаток, мм» справа, на одной линии**;
- легенда `flex:1 1 auto; min-width:0` (переносит свои элементы внутри себя), «Остаток» `flex:0 0 auto; white-space:nowrap` (держится справа, не переносит текст);
- на узких экранах ряд переносит «Остаток» под легенду;
- у `.atex-sl-cm-legend` / `.atex-sl-cm-waste` убраны индивидуальные `margin-top` — отступ задаёт ряд.

## Проверки
DOM-смоук: `renderCutMap` → один `.atex-sl-cm-legend-row` с детьми `[legend, waste]`, «Остаток» больше не отдельный блок секции. `slitter.js` синтаксис ок, тест 159 проверок (2 предсуществующих FAIL `EVENT_TYPES` — не регрессия). VERSION 51→52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)