### PR TITLE
feat(atex): диаграмма Ганта по заданиям в производство + deep-link в планирование (#3638)

### DIFF
--- a/docs/atex_menu.json
+++ b/docs/atex_menu.json
@@ -7,6 +7,7 @@
         { "name": "Приём и ведение заказов", "href": "orders", "icon": "<i class=\"pi pi-shopping-cart\"></i>" },
         { "name": "Планирование производства", "href": "production-planning", "icon": "<i class=\"pi pi-calendar\"></i>" },
         { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" },
+        { "name": "Диаграмма Ганта (задания)", "href": "cut-gantt", "icon": "<i class=\"pi pi-bars\"></i>" },
         { "name": "Приёмка сырья", "href": "intake", "icon": "<i class=\"pi pi-inbox\"></i>" },
         { "name": "Пульт слиттера", "href": "slitter", "icon": "<i class=\"pi pi-sliders-h\"></i>" },
         { "name": "Пульт втулкореза", "href": "sleeve-cutter", "icon": "<i class=\"pi pi-cog\"></i>" },
@@ -28,6 +29,7 @@
       "menus": [
         { "name": "Планирование производства", "href": "production-planning", "icon": "<i class=\"pi pi-calendar\"></i>" },
         { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" },
+        { "name": "Диаграмма Ганта (задания)", "href": "cut-gantt", "icon": "<i class=\"pi pi-bars\"></i>" },
         { "name": "Расчёт оптимальной резки", "href": "cut-optimizer", "icon": "<i class=\"pi pi-calculator\"></i>" }
       ]
     },
@@ -45,7 +47,8 @@
       "role": "Руководитель",
       "menus": [
         { "name": "Дашборды и отчёты", "href": "dashboards", "icon": "<i class=\"pi pi-chart-bar\"></i>" },
-        { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" }
+        { "name": "Календарь занятости станков", "href": "machine-calendar", "icon": "<i class=\"pi pi-calendar-clock\"></i>" },
+        { "name": "Диаграмма Ганта (задания)", "href": "cut-gantt", "icon": "<i class=\"pi pi-bars\"></i>" }
       ]
     },
     {

--- a/download/atex/css/cut-gantt.css
+++ b/download/atex/css/cut-gantt.css
@@ -1,0 +1,183 @@
+/* Рабочее место atex «Диаграмма Ганта (задания)» (ideav/crm#3638).
+   Task-Гант: одна строка = одно «Задание в производство», бар-ссылка на «Планирование
+   производства». Стили скоупятся под #atex-cut-gantt / .atex-cg, чтобы не пересекаться
+   с другими РМ в main.html. Палитра статусов и тёмная тема — как в machine-calendar. */
+
+.atex-cg {
+    --cg-border: var(--input-border, #d9dee5);
+    --cg-border-soft: var(--border-color, #eef1f5);
+    --cg-bg: var(--input-bg, #ffffff);
+    --cg-surface: var(--bg-secondary, #f8fafc);
+    --cg-muted: var(--text-secondary, #6b7280);
+    --cg-accent: var(--atex-navy, #134174);
+    --cg-warn: var(--color-error, #b91c1c);
+    --cg-track: #f8fafc;
+    --cg-grid: #e5e7eb;
+    --cg-planned: #2563eb;
+    --cg-running: #0891b2;
+    --cg-unfinished: #d97706;
+    --cg-ok: #15803d;
+    --cg-late: #b91c1c;
+    --cg-unknown: #64748b;
+    --cg-label-w: 240px;
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 64px);
+    padding: 16px;
+    gap: 12px;
+    color: var(--text-primary, #1f2933);
+    font-size: 14px;
+    box-sizing: border-box;
+}
+
+[data-theme="dark"] .atex-cg {
+    --cg-track: rgba(15, 23, 42, .45);
+    --cg-grid: rgba(148, 163, 184, .28);
+    --cg-planned: #60a5fa;
+    --cg-running: #22d3ee;
+    --cg-unfinished: #f59e0b;
+    --cg-ok: #22c55e;
+    --cg-late: #f87171;
+    --cg-unknown: #94a3b8;
+}
+
+.atex-cg *,
+.atex-cg *::before,
+.atex-cg *::after { box-sizing: border-box; }
+
+.atex-cg.is-busy { opacity: .65; pointer-events: none; }
+
+.atex-cg-loading,
+.atex-cg-fatal { padding: 24px; color: var(--cg-muted); }
+.atex-cg-fatal { color: var(--cg-warn); }
+
+/* ── Тулбар ── */
+.atex-cg-input,
+.atex-cg-btn,
+.atex-cg-arrow,
+.atex-cg-mode {
+    height: 32px;
+    border: 1px solid var(--cg-border);
+    border-radius: 6px;
+    background: var(--cg-bg);
+    color: inherit;
+    font: inherit;
+    padding: 0 10px;
+    cursor: pointer;
+}
+.atex-cg-input { cursor: auto; }
+.atex-cg-btn:hover,
+.atex-cg-arrow:hover,
+.atex-cg-mode:hover { background: var(--cg-surface); }
+
+.atex-cg-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px 16px;
+}
+.atex-cg-title { font-weight: 600; font-size: 16px; color: var(--cg-accent); margin-right: auto; }
+.atex-cg-period { display: flex; align-items: center; gap: 8px; }
+.atex-cg-range { min-width: 150px; text-align: center; font-weight: 600; }
+.atex-cg-arrow { width: 32px; padding: 0; font-size: 18px; line-height: 1; }
+.atex-cg-modes { display: inline-flex; }
+.atex-cg-mode { border-radius: 0; border-left-width: 0; }
+.atex-cg-mode:first-child { border-top-left-radius: 6px; border-bottom-left-radius: 6px; border-left-width: 1px; }
+.atex-cg-mode:last-child { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
+.atex-cg-mode.is-active { background: var(--cg-accent); color: #fff; border-color: var(--cg-accent); }
+.atex-cg-tools { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+
+/* ── Легенда ── */
+.atex-cg-legend { display: flex; flex-wrap: wrap; gap: 14px; color: var(--cg-muted); }
+.atex-cg-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+.atex-cg-legend-item::before { content: ""; width: 14px; height: 14px; border-radius: 3px; background: var(--cg-unknown); }
+.atex-cg-legend-item.is-planned::before { background: var(--cg-planned); }
+.atex-cg-legend-item.is-running::before { background: var(--cg-running); }
+.atex-cg-legend-item.is-unfinished::before { background: var(--cg-unfinished); }
+.atex-cg-legend-item.is-on-time::before { background: var(--cg-ok); }
+.atex-cg-legend-item.is-late::before { background: var(--cg-late); }
+
+/* ── Тело ── */
+.atex-cg-scroll { overflow-x: auto; flex: 1; }
+.atex-cg-body {
+    min-width: 720px;
+    border: 1px solid var(--cg-border-soft);
+    border-radius: 8px;
+    background: var(--cg-bg);
+    overflow: hidden;
+}
+
+.atex-cg-row { display: grid; grid-template-columns: var(--cg-label-w) 1fr; border-top: 1px solid var(--cg-border-soft); }
+.atex-cg-row:first-child { border-top: 0; }
+
+.atex-cg-label {
+    padding: 8px 10px;
+    border-right: 1px solid var(--cg-border-soft);
+    background: var(--cg-surface);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2px;
+    min-width: 0;
+}
+.atex-cg-label-main { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.atex-cg-label-sub { color: var(--cg-muted); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* Шкала дат (sticky сверху) */
+.atex-cg-scale-row { position: sticky; top: 0; z-index: 3; background: var(--cg-surface); }
+.atex-cg-label--scale { font-weight: 600; color: var(--cg-muted); }
+
+.atex-cg-track {
+    position: relative;
+    min-height: 40px;
+    background: var(--cg-track);
+}
+.atex-cg-scale { min-height: 28px; }
+
+/* Сетка дней */
+.atex-cg-tick { position: absolute; top: 0; bottom: 0; width: 0; border-left: 1px solid var(--cg-grid); }
+.atex-cg-tick.is-end { border-left: 0; }
+.atex-cg-tick.is-scale { border-left-color: var(--cg-border); }
+.atex-cg-tick-label {
+    position: absolute;
+    top: 5px;
+    left: 4px;
+    font-size: 12px;
+    color: var(--cg-muted);
+    white-space: nowrap;
+}
+.atex-cg-tick-label.is-minor { opacity: 0; }
+
+/* Бар-ссылка */
+.atex-cg-bar {
+    position: absolute;
+    top: 5px;
+    bottom: 5px;
+    min-width: 6px;
+    border-radius: 5px;
+    padding: 0 8px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    overflow: hidden;
+    text-decoration: none;
+    color: #fff;
+    background: var(--cg-unknown);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, .15);
+    cursor: pointer;
+}
+.atex-cg-bar:hover { filter: brightness(1.06); box-shadow: 0 2px 6px rgba(0, 0, 0, .25); }
+.atex-cg-bar:focus-visible { outline: 2px solid var(--cg-accent); outline-offset: 1px; }
+.atex-cg-bar-main { font-weight: 600; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.atex-cg-bar-status { font-size: 11px; opacity: .92; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.atex-cg-bar.is-planned { background: var(--cg-planned); }
+.atex-cg-bar.is-running { background: var(--cg-running); }
+.atex-cg-bar.is-unfinished { background: var(--cg-unfinished); }
+.atex-cg-bar.is-on-time,
+.atex-cg-bar.is-done { background: var(--cg-ok); }
+.atex-cg-bar.is-late,
+.atex-cg-bar.is-late-start { background: var(--cg-late); }
+.atex-cg-bar.is-unknown { background: var(--cg-unknown); }
+
+.atex-cg-empty { padding: 24px; text-align: center; color: var(--cg-muted); }

--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -207,6 +207,12 @@
 .atex-pp-cut.is-fixed { border-color: #9ca3af; background: rgba(107, 114, 128, .06); box-shadow: inset 0 0 0 1px #cbd1d9; }
 .atex-pp-cut.is-fixed:hover { background: rgba(107, 114, 128, .1); }
 .atex-pp-cut.is-active { border-color: var(--pp-accent); box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
+/* #3638: задание, открытое по ссылке из диаграммы Ганта — кратковременная подсветка. */
+.atex-pp-cut.is-deeplink { animation: atex-pp-deeplink 2.4s ease-out 1; }
+@keyframes atex-pp-deeplink {
+    0%, 30% { box-shadow: 0 0 0 3px rgba(19, 65, 116, .5); }
+    100% { box-shadow: 0 0 0 2px rgba(19, 65, 116, .15); }
+}
 /* Нет подходящей партии сырья — резку нельзя обеспечить (#3120 п.4, Фаза 1a). */
 .atex-pp-cut.is-unreserved { background: rgba(185, 28, 28, .07); }
 /* #3545: красный бордюр «нет обеспечения» — только у НЕзафиксированного задания.

--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -1,0 +1,760 @@
+// Рабочее место atex «Диаграмма Ганта (задания)» (роли Руководитель, Диспетчер).
+//
+// Полноэкранная диаграмма Ганта по «Заданиям в производство»: ОДНА строка на
+// задание, бар на горизонтальной шкале времени (день / 3 дня / неделя / месяц),
+// цвет бара кодирует статус (запланировано / в работе / не завершено / в срок /
+// с опозданием). Только чтение.
+//
+// Отличие от «Календаря занятости станков» (machine-calendar, #3339): там дорожка =
+// станок, здесь строка = отдельное задание (классический task-Гант). Каждый бар —
+// ссылка на рабочее место «Планирование производства» с зашитыми в URL датой,
+// станком и заданием, чтобы открыть планировщик на нужном задании. Решение #3638.
+//
+// Данные — одним отчётом (минимум серверных запросов):
+//   • GET /{db}/report/cut_planning?JSON_KV — задания с плановой датой, фактическими
+//     стартом/финишем, станком, статусом, длительностью, очередностью, лидером,
+//     заказом и материалом (ссылки резолвятся сервером — доступ к справочникам
+//     ролям не нужен, в т.ч. к «Лидер», ср. #3623).
+//   • GET /{db}/object/{slitter}/?JSON_OBJ — справочник станков для фильтра (при
+//     отсутствии прав станки берутся из самих заданий).
+//
+// Чистое ядро (разбор дат, интервалы, статусы, раскладка баров, сортировка строк,
+// сборка ссылки на планировщик) вынесено в объект `gantt` и экспортируется через
+// module.exports для модульных тестов (experiments/atex-cut-gantt.test.js).
+
+(function(root, factory) {
+    'use strict';
+    var api = factory();
+    if (typeof module === 'object' && module.exports) {
+        module.exports = api;
+    }
+    if (typeof window !== 'undefined') {
+        window.AtexCutGantt = api;
+        if (typeof document !== 'undefined') {
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', api.init);
+            } else {
+                api.init();
+            }
+        }
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+    'use strict';
+
+    // ───────────────────────── Чистое ядро ─────────────────────────
+
+    function stripNum(value) {
+        if (typeof value === 'number') return isFinite(value) ? value : 0;
+        var text = String(value == null ? '' : value).replace(/\s+/g, '').replace(',', '.');
+        var n = parseFloat(text);
+        return isFinite(n) ? n : 0;
+    }
+
+    function round3(n) { return Math.round(n * 1000) / 1000; }
+
+    function truthyFlag(value) {
+        if (value === true) return true;
+        if (value === false || value == null) return false;
+        if (typeof value === 'number') return isFinite(value) && value !== 0;
+        var s = String(value).trim().toLowerCase();
+        if (s === '') return false;
+        if (s === '0' || s === 'false' || s === 'нет' || s === 'no' || s === 'off') return false;
+        return true;
+    }
+
+    function refSearchHelper() {
+        if (typeof window !== 'undefined' && window.AtexRefSearch) return window.AtexRefSearch;
+        if (typeof globalThis !== 'undefined' && globalThis.AtexRefSearch) return globalThis.AtexRefSearch;
+        return null;
+    }
+
+    // Номер задания = плановая дата-штамп (DATETIME). Юникс-штамп → человекочитаемо.
+    function isTimestampCutNumber(value) {
+        var s = String(value == null ? '' : value).trim();
+        if (!/^\d+$/.test(s)) return false;
+        var n = Number(s);
+        if (!isFinite(n) || n < 1000000000) return false;
+        var d = new Date(n * 1000);
+        return !isNaN(d.getTime());
+    }
+
+    function formatCutNumber(value) {
+        if (value == null || value === '') return '';
+        var s = String(value).trim();
+        if (s === '' || !isTimestampCutNumber(s)) return s;
+        var helper = refSearchHelper();
+        if (helper && typeof helper.formatDateTime === 'function') {
+            var formatted = helper.formatDateTime(s);
+            return formatted == null || formatted === '' ? s : String(formatted);
+        }
+        return s;
+    }
+
+    function formatDateTimeMinute(date) {
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(date.getDate()) + '.' + pad(date.getMonth() + 1) + '.' + date.getFullYear() +
+            ' ' + pad(date.getHours()) + ':' + pad(date.getMinutes());
+    }
+
+    var GANTT_DAY_MS = 86400000;
+    var GANTT_MODES = [
+        { id: 'day', label: 'День', days: 1 },
+        { id: 'three', label: '3 дня', days: 3 },
+        { id: 'week', label: 'Неделя', days: 7 },
+        { id: 'month', label: 'Месяц', days: 0 }
+    ];
+
+    var CUT_DURATION_COLUMNS = ['cut_duration', 'cut_duration_min', 'cut_duration_minutes'];
+
+    // URL рабочего места «Планирование производства». Префикс пути = имя БД и
+    // отличается между базами (на тест-базе /ateh/, в проде может быть иным), поэтому
+    // по умолчанию вычисляем ссылку ОТНОСИТЕЛЬНО текущего РМ (соседний маршрут), а не
+    // хардкодим. Может быть переопределён data-атрибутом корня (data-planning-url).
+    var DEFAULT_PLANNING_URL = '/atex/production-planning';
+
+    // База ссылки на планировщик из текущего пути: последний сегмент пути заменяем на
+    // production-planning. /ateh/cut-gantt → /ateh/production-planning. Вне браузера —
+    // DEFAULT_PLANNING_URL (для тестов; pure-функция planningLink принимает base явно).
+    function planningBaseFromLocation() {
+        if (typeof window === 'undefined' || !window.location || !window.location.pathname) return DEFAULT_PLANNING_URL;
+        var path = String(window.location.pathname).replace(/\/+$/, '');
+        var idx = path.lastIndexOf('/');
+        return (idx >= 0 ? path.slice(0, idx) : '') + '/production-planning';
+    }
+
+    // Производные статусы задания — ключ → подпись (для фильтра и легенды).
+    var STATUS_LABELS = {
+        planned: 'Запланировано',
+        running: 'В работе',
+        unfinished: 'Не завершено',
+        'on-time': 'В срок',
+        done: 'Завершено',
+        late: 'С опозданием',
+        'late-start': 'Старт просрочен',
+        unknown: 'Без даты'
+    };
+
+    function todayISO() {
+        var d = new Date();
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+    }
+
+    function normalizeMode(mode) {
+        var s = String(mode == null ? '' : mode).trim().toLowerCase();
+        if (s === '3' || s === '3d' || s === '3days' || s === 'three-days') return 'three';
+        for (var i = 0; i < GANTT_MODES.length; i++) {
+            if (GANTT_MODES[i].id === s) return s;
+        }
+        return 'week';
+    }
+
+    function localDateMs(year, month, day, hour, minute, second) {
+        var d = new Date(Number(year), Number(month) - 1, Number(day),
+            Number(hour) || 0, Number(minute) || 0, Number(second) || 0, 0);
+        if (isNaN(d.getTime())) return null;
+        if (d.getFullYear() !== Number(year) || d.getMonth() !== Number(month) - 1 || d.getDate() !== Number(day)) return null;
+        return d.getTime();
+    }
+
+    function parseDateTimeMs(value) {
+        var s = String(value == null ? '' : value).trim();
+        if (s === '') return null;
+        if (/^\d{9,13}$/.test(s)) {
+            var num = Number(s);
+            var ms = num >= 1e12 ? num : num * 1000;
+            var stamp = new Date(ms);
+            var year = stamp.getFullYear();
+            if (!isNaN(stamp.getTime()) && year >= 2001 && year <= 2100) return ms;
+        }
+        var iso = s.match(/^(\d{4})-(\d{1,2})-(\d{1,2})(?:[T\s]+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
+        if (iso) return localDateMs(iso[1], iso[2], iso[3], iso[4], iso[5], iso[6]);
+        var dmy = s.match(/^(\d{1,2})[.\/](\d{1,2})[.\/](\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?)?/);
+        if (dmy) return localDateMs(dmy[3], dmy[2], dmy[1], dmy[4], dmy[5], dmy[6]);
+        var parsed = Date.parse(s);
+        return isNaN(parsed) ? null : parsed;
+    }
+
+    function localIsoDateFromMs(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate());
+    }
+
+    function startOfLocalDayMs(ms) {
+        var d = new Date(ms);
+        return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 0, 0, 0, 0).getTime();
+    }
+
+    function shiftIsoDate(iso, days) {
+        var ms = parseDateTimeMs(iso);
+        if (ms == null) ms = Date.now();
+        var d = new Date(ms);
+        return localIsoDateFromMs(new Date(d.getFullYear(), d.getMonth(), d.getDate() + Number(days || 0), 0, 0, 0, 0).getTime());
+    }
+
+    function formatDateShort(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(d.getDate()) + '.' + pad(d.getMonth() + 1);
+    }
+
+    function formatDateFull(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(d.getDate()) + '.' + pad(d.getMonth() + 1) + '.' + d.getFullYear();
+    }
+
+    function formatTime(ms) {
+        var d = new Date(ms);
+        function pad(n) { return (n < 10 ? '0' : '') + n; }
+        return pad(d.getHours()) + ':' + pad(d.getMinutes());
+    }
+
+    function rangeLabel(startMs, endMs) {
+        var lastMs = endMs - 1;
+        if (localIsoDateFromMs(startMs) === localIsoDateFromMs(lastMs)) return formatDateFull(startMs);
+        return formatDateFull(startMs) + ' - ' + formatDateFull(lastMs);
+    }
+
+    function ganttRange(anchorIso, mode) {
+        var normalized = normalizeMode(mode);
+        var anchorMs = parseDateTimeMs(anchorIso);
+        if (anchorMs == null) anchorMs = startOfLocalDayMs(Date.now());
+        var anchorDay = startOfLocalDayMs(anchorMs);
+        var startMs, endMs;
+        if (normalized === 'week') {
+            var wd = new Date(anchorDay).getDay();
+            var mondayOffset = (wd + 6) % 7;
+            startMs = anchorDay - mondayOffset * GANTT_DAY_MS;
+            endMs = startMs + 7 * GANTT_DAY_MS;
+        } else if (normalized === 'month') {
+            var m = new Date(anchorDay);
+            startMs = new Date(m.getFullYear(), m.getMonth(), 1, 0, 0, 0, 0).getTime();
+            endMs = new Date(m.getFullYear(), m.getMonth() + 1, 1, 0, 0, 0, 0).getTime();
+        } else {
+            var days = normalized === 'three' ? 3 : 1;
+            startMs = anchorDay;
+            endMs = startMs + days * GANTT_DAY_MS;
+        }
+        var outDays = [];
+        for (var t = startMs; t < endMs; t += GANTT_DAY_MS) {
+            outDays.push({
+                iso: localIsoDateFromMs(t),
+                label: formatDateShort(t),
+                leftPct: round3(((t - startMs) / (endMs - startMs)) * 100)
+            });
+        }
+        return {
+            mode: normalized, startMs: startMs, endMs: endMs,
+            startIso: localIsoDateFromMs(startMs), endIso: localIsoDateFromMs(endMs),
+            label: rangeLabel(startMs, endMs), days: outDays
+        };
+    }
+
+    function shiftAnchor(anchorIso, mode, direction) {
+        var range = ganttRange(anchorIso, mode);
+        var dir = Number(direction) || 0;
+        if (range.mode === 'month') {
+            var d = new Date(range.startMs);
+            return localIsoDateFromMs(new Date(d.getFullYear(), d.getMonth() + dir, 1, 0, 0, 0, 0).getTime());
+        }
+        var step = range.mode === 'week' ? 7 : (range.mode === 'three' ? 3 : 1);
+        return shiftIsoDate(range.startIso, dir * step);
+    }
+
+    function cutDeadlineMs(cut) {
+        var planMs = parseDateTimeMs(cut && cut.planDate);
+        var duration = stripNum(cut && cut.duration);
+        if (planMs == null || !(duration > 0)) return null;
+        return planMs + duration * 60000;
+    }
+
+    function cutStatus(cut, nowMs) {
+        var now = Number(nowMs);
+        if (!isFinite(now)) now = Date.now();
+        var planMs = parseDateTimeMs(cut && cut.planDate);
+        var startMs = parseDateTimeMs(cut && cut.startDate);
+        var endMs = parseDateTimeMs(cut && cut.endDate);
+        var deadlineMs = cutDeadlineMs(cut);
+        var unfinished = truthyFlag(cut && cut.status);
+        if (endMs != null) {
+            if (deadlineMs != null && endMs > deadlineMs) return { key: 'late', label: STATUS_LABELS.late };
+            return deadlineMs != null ? { key: 'on-time', label: STATUS_LABELS['on-time'] } : { key: 'done', label: STATUS_LABELS.done };
+        }
+        if (deadlineMs != null && now > deadlineMs) return { key: 'late', label: STATUS_LABELS.late };
+        if (unfinished) return { key: 'unfinished', label: STATUS_LABELS.unfinished };
+        if (startMs != null) return { key: 'running', label: STATUS_LABELS.running };
+        if (planMs != null && now > planMs) return { key: 'late-start', label: STATUS_LABELS['late-start'] };
+        if (planMs != null) return { key: 'planned', label: STATUS_LABELS.planned };
+        return { key: 'unknown', label: STATUS_LABELS.unknown };
+    }
+
+    function cutTimeRange(cut) {
+        var planMs = parseDateTimeMs(cut && cut.planDate);
+        var startMs = parseDateTimeMs(cut && cut.startDate);
+        var endMs = parseDateTimeMs(cut && cut.endDate);
+        var visualStartMs = startMs != null ? startMs : planMs;
+        if (visualStartMs == null) return null;
+        var deadlineMs = cutDeadlineMs(cut);
+        var visualEndMs = endMs != null ? endMs : (deadlineMs != null ? deadlineMs : visualStartMs + 30 * 60000);
+        if (!(visualEndMs > visualStartMs)) visualEndMs = visualStartMs + 30 * 60000;
+        return {
+            startMs: visualStartMs, endMs: visualEndMs, planMs: planMs,
+            actualStartMs: startMs, actualEndMs: endMs, deadlineMs: deadlineMs
+        };
+    }
+
+    // Бар задания на шкале периода: позиция/ширина в %. null — если задание вне
+    // видимого интервала (тогда строка не показывается).
+    function cutBar(cut, range, nowMs) {
+        if (!cut || !range || !(range.endMs > range.startMs)) return null;
+        var tr = cutTimeRange(cut);
+        if (!tr) return null;
+        if (tr.endMs <= range.startMs || tr.startMs >= range.endMs) return null;
+        var clippedStartMs = Math.max(tr.startMs, range.startMs);
+        var clippedEndMs = Math.min(tr.endMs, range.endMs);
+        var spanMs = range.endMs - range.startMs;
+        var status = cutStatus(cut, nowMs);
+        return {
+            cut: cut,
+            cutId: String(cut.id == null ? '' : cut.id),
+            startMs: tr.startMs, endMs: tr.endMs,
+            leftPct: round3(((clippedStartMs - range.startMs) / spanMs) * 100),
+            widthPct: round3(Math.max(((clippedEndMs - clippedStartMs) / spanMs) * 100, 0.6)),
+            status: status,
+            barLabel: formatTime(tr.startMs) + '–' + formatTime(tr.endMs),
+            title: cutBarTitle(cut, tr, status)
+        };
+    }
+
+    function cutBarTitle(cut, tr, status) {
+        var lines = [];
+        lines.push('Задание ' + (formatCutNumber(cut && cut.number) || ('#' + ((cut && cut.id) || ''))));
+        if (cut && cut.orderNo) lines.push('Заказ: ' + cut.orderNo);
+        if (cut && cut.slitter && cut.slitter.label) lines.push('Станок: ' + cut.slitter.label);
+        if (cut && cut.materialName) lines.push('Сырьё: ' + cut.materialName);
+        if (cut && cut.leader) lines.push('Лидер: ' + cut.leader);
+        if (tr.planMs != null) lines.push('План: ' + formatDateTimeMinute(new Date(tr.planMs)));
+        if (tr.actualStartMs != null) lines.push('Старт факт: ' + formatDateTimeMinute(new Date(tr.actualStartMs)));
+        if (tr.actualEndMs != null) lines.push('Финиш факт: ' + formatDateTimeMinute(new Date(tr.actualEndMs)));
+        if (tr.deadlineMs != null) lines.push('Дедлайн: ' + formatDateTimeMinute(new Date(tr.deadlineMs)));
+        lines.push('Статус: ' + status.label);
+        lines.push('→ открыть в планировании');
+        return lines.join('\n');
+    }
+
+    // Подпись строки-задания: главное + детали (заказ/сырьё/станок/лидер).
+    function cutRowLabel(cut) {
+        var main = (cut && cut.orderNo) ? ('Заказ ' + cut.orderNo) : (formatCutNumber(cut && cut.number) || ('#' + ((cut && cut.id) || '')));
+        var parts = [];
+        if (cut && cut.materialName) parts.push(cut.materialName);
+        if (cut && cut.slitter && cut.slitter.label) parts.push(cut.slitter.label);
+        if (cut && cut.leader) parts.push(cut.leader);
+        return { main: main, sub: parts.join(' · ') };
+    }
+
+    // Строки отчёта cut_planning → задания (dedup по cut_id). Несколько строк на
+    // одно задание (join с обеспечением) схлопываются в одну.
+    function rowsToCuts(rows) {
+        var byId = {};
+        var order = [];
+        function str(v) { return v == null ? '' : String(v); }
+        function durationOf(row) {
+            for (var i = 0; i < CUT_DURATION_COLUMNS.length; i++) {
+                var v = row && row[CUT_DURATION_COLUMNS[i]];
+                if (v != null && v !== '') return stripNum(v);
+            }
+            return 0;
+        }
+        (rows || []).forEach(function(row) {
+            var id = str(row && row.cut_id);
+            if (!id || byId[id]) return;
+            byId[id] = {
+                id: id,
+                number: str(row.cut_plan_date),
+                planDate: str(row.cut_plan_date),
+                status: str(row.cut_status),
+                startDate: str(row.cut_start_date),
+                endDate: str(row.cut_end_date),
+                duration: durationOf(row),
+                sequence: row.cut_sequence == null || row.cut_sequence === '' ? null : stripNum(row.cut_sequence),
+                leader: str(row.cut_leader),
+                orderNo: str(row.order_no),
+                materialId: str(row.cut_material_id),
+                materialName: str(row.cut_material),
+                slitter: { id: row.cut_slitter_id ? String(row.cut_slitter_id) : null, label: str(row.cut_slitter) }
+            };
+            order.push(id);
+        });
+        return order.map(function(id) { return byId[id]; });
+    }
+
+    // Порядок строк task-Ганта: по станку (метка), затем по визуальному старту,
+    // затем по очередности, затем по id. Вход не мутирует.
+    function orderCutsForGantt(cuts) {
+        return (cuts || []).slice().sort(function(a, b) {
+            var sa = String((a.slitter && a.slitter.label) || '~');
+            var sb = String((b.slitter && b.slitter.label) || '~');
+            var bySlitter = sa.localeCompare(sb, 'ru');
+            if (bySlitter) return bySlitter;
+            var ta = cutTimeRange(a), tb = cutTimeRange(b);
+            var ma = ta ? ta.startMs : Infinity, mb = tb ? tb.startMs : Infinity;
+            if (ma !== mb) return ma - mb;
+            var qa = a.sequence == null ? Infinity : a.sequence;
+            var qb = b.sequence == null ? Infinity : b.sequence;
+            if (qa !== qb) return qa - qb;
+            return String(a.id).localeCompare(String(b.id));
+        });
+    }
+
+    // Ссылка на «Планирование производства» с зашитыми заданием/датой/станком.
+    // date — плановый день (YYYY-MM-DD) для фильтра очереди планировщика.
+    function planningLink(cut, baseUrl) {
+        var base = baseUrl || DEFAULT_PLANNING_URL;
+        var params = [];
+        if (cut && cut.id != null && cut.id !== '') params.push('cut=' + encodeURIComponent(String(cut.id)));
+        var planMs = parseDateTimeMs(cut && cut.planDate);
+        if (planMs != null) params.push('date=' + encodeURIComponent(localIsoDateFromMs(planMs)));
+        var sid = cut && cut.slitter && cut.slitter.id;
+        if (sid != null && String(sid) !== '') params.push('slitter=' + encodeURIComponent(String(sid)));
+        return params.length ? base + '?' + params.join('&') : base;
+    }
+
+    // Видимые в периоде задания (бар != null) после фильтров статуса/станка, в порядке Ганта.
+    function ganttRows(cuts, range, nowMs, filters) {
+        var f = filters || {};
+        var statusFilter = String(f.status == null ? '' : f.status).trim();
+        var slitterFilter = String(f.slitter == null ? '' : f.slitter).trim();
+        var rows = [];
+        orderCutsForGantt(cuts).forEach(function(cut) {
+            var s = cut && cut.slitter || { id: null, label: '' };
+            if (slitterFilter && String(s.id == null ? '' : s.id) !== slitterFilter) return;
+            var bar = cutBar(cut, range, nowMs);
+            if (!bar) return;
+            if (statusFilter && bar.status.key !== statusFilter) return;
+            rows.push({ cut: cut, bar: bar, label: cutRowLabel(cut) });
+        });
+        return rows;
+    }
+
+    function slittersFromCuts(cuts) {
+        var seen = {};
+        var out = [];
+        (cuts || []).forEach(function(cut) {
+            var s = cut && cut.slitter;
+            if (!s || s.id == null || String(s.id) === '') return;
+            var key = String(s.id);
+            if (seen[key]) return;
+            seen[key] = true;
+            out.push({ id: key, label: s.label || ('#' + key) });
+        });
+        return out;
+    }
+
+    // Разбор deep-link параметров (?cut=..&date=..&slitter=..) из строки запроса.
+    // Используется и планировщиком (приём фокуса), и тестами. Вход — location.search
+    // или полный URL.
+    function parseDeepLink(search) {
+        var s = String(search == null ? '' : search);
+        var qm = s.indexOf('?');
+        if (qm >= 0) s = s.slice(qm + 1);
+        var out = { cut: '', date: '', slitter: '' };
+        s.split('&').forEach(function(pair) {
+            if (!pair) return;
+            var eq = pair.indexOf('=');
+            var key = eq >= 0 ? pair.slice(0, eq) : pair;
+            var val = eq >= 0 ? pair.slice(eq + 1) : '';
+            try { val = decodeURIComponent(val.replace(/\+/g, ' ')); } catch (e) {}
+            if (key === 'cut' || key === 'date' || key === 'slitter') out[key] = val;
+        });
+        return out;
+    }
+
+    var gantt = {
+        GANTT_MODES: GANTT_MODES,
+        STATUS_LABELS: STATUS_LABELS,
+        normalizeMode: normalizeMode,
+        parseDateTimeMs: parseDateTimeMs,
+        localIsoDateFromMs: localIsoDateFromMs,
+        shiftIsoDate: shiftIsoDate,
+        ganttRange: ganttRange,
+        shiftAnchor: shiftAnchor,
+        cutStatus: cutStatus,
+        cutTimeRange: cutTimeRange,
+        cutBar: cutBar,
+        cutRowLabel: cutRowLabel,
+        rowsToCuts: rowsToCuts,
+        orderCutsForGantt: orderCutsForGantt,
+        planningLink: planningLink,
+        ganttRows: ganttRows,
+        slittersFromCuts: slittersFromCuts,
+        parseDeepLink: parseDeepLink,
+        formatCutNumber: formatCutNumber,
+        todayISO: todayISO
+    };
+
+    // ───────────────────────── DOM-хелпер ─────────────────────────
+
+    function el(tag, attrs, children) {
+        var node = document.createElement(tag);
+        if (attrs) Object.keys(attrs).forEach(function(k) {
+            if (k === 'class') node.className = attrs[k];
+            else if (k === 'text') node.textContent = attrs[k];
+            else if (k === 'html') node.innerHTML = attrs[k];
+            else if (k === 'dataset') Object.keys(attrs[k]).forEach(function(d) { node.dataset[d] = attrs[k][d]; });
+            else node.setAttribute(k, attrs[k]);
+        });
+        (children || []).forEach(function(c) {
+            if (c == null) return;
+            node.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+        });
+        return node;
+    }
+
+    // ───────────────────────── Контроллер ─────────────────────────
+
+    function AtexCutGantt(root) {
+        this.root = root;
+        this.db = (typeof window !== 'undefined' && window.db) || root.getAttribute('data-db') || '';
+        this.slitterTable = root.getAttribute('data-slitter-table') || '1070';
+        this.planningUrl = root.getAttribute('data-planning-url') || planningBaseFromLocation();
+        this.busy = false;
+        this.cuts = [];
+        this.slitters = [];
+        this.state = { mode: 'week', anchor: todayISO(), slitter: '', status: '' };
+    }
+
+    AtexCutGantt.prototype.url = function(path) {
+        return '/' + encodeURIComponent(this.db) + '/' + path;
+    };
+
+    AtexCutGantt.prototype.getJson = function(path) {
+        return fetch(this.url(path), { credentials: 'same-origin' }).then(function(resp) {
+            return resp.text().then(function(text) {
+                try { return JSON.parse(text); }
+                catch (e) { throw new Error('Некорректный JSON: ' + text.slice(0, 200)); }
+            });
+        });
+    };
+
+    AtexCutGantt.prototype.nowMs = function() { return Date.now(); };
+
+    AtexCutGantt.prototype.loadSlitters = function() {
+        return this.getJson('object/' + encodeURIComponent(this.slitterTable) + '/?JSON_OBJ&LIMIT=0,1000').then(function(rows) {
+            return (rows || []).map(function(r) {
+                return { id: String(r.i), label: (r.r && r.r[0]) || ('#' + r.i) };
+            });
+        }).catch(function() { return []; });
+    };
+
+    AtexCutGantt.prototype.collect = function() {
+        var self = this;
+        return Promise.all([
+            this.getJson('report/cut_planning?JSON_KV&LIMIT=0,5000'),
+            this.loadSlitters()
+        ]).then(function(res) {
+            self.cuts = rowsToCuts(res[0] || []);
+            var merged = {};
+            var ordered = [];
+            (res[1] || []).concat(slittersFromCuts(self.cuts)).forEach(function(s) {
+                if (!s || s.id == null) return;
+                var key = String(s.id);
+                if (merged[key]) return;
+                merged[key] = { id: key, label: s.label || ('#' + key) };
+                ordered.push(merged[key]);
+            });
+            self.slitters = ordered;
+        });
+    };
+
+    // ── Рендеринг ──
+
+    AtexCutGantt.prototype.render = function() {
+        var self = this;
+        var st = this.state;
+        st.mode = normalizeMode(st.mode);
+        var range = ganttRange(st.anchor || todayISO(), st.mode);
+        if (!st.anchor) st.anchor = range.startIso;
+        var nowMs = this.nowMs();
+
+        this.root.innerHTML = '';
+        this.root.appendChild(this._buildToolbar(range));
+        this.root.appendChild(this._buildLegend());
+
+        var scroll = el('div', { class: 'atex-cg-scroll' });
+        scroll.appendChild(this._buildBody(range, nowMs));
+        this.root.appendChild(scroll);
+    };
+
+    AtexCutGantt.prototype._buildToolbar = function(range) {
+        var self = this;
+        var st = this.state;
+
+        var prevBtn = el('button', { class: 'atex-cg-arrow', type: 'button', text: '‹', title: 'Предыдущий период' });
+        var nextBtn = el('button', { class: 'atex-cg-arrow', type: 'button', text: '›', title: 'Следующий период' });
+        prevBtn.addEventListener('click', function() { st.anchor = shiftAnchor(st.anchor || range.startIso, st.mode, -1); self.render(); });
+        nextBtn.addEventListener('click', function() { st.anchor = shiftAnchor(st.anchor || range.startIso, st.mode, 1); self.render(); });
+
+        var modeWrap = el('div', { class: 'atex-cg-modes', role: 'group', 'aria-label': 'Период' });
+        GANTT_MODES.forEach(function(m) {
+            var btn = el('button', { class: 'atex-cg-mode' + (m.id === st.mode ? ' is-active' : ''), type: 'button', text: m.label, title: m.label });
+            btn.addEventListener('click', function() { st.mode = m.id; self.render(); });
+            modeWrap.appendChild(btn);
+        });
+
+        var dateInput = el('input', { class: 'atex-cg-input atex-cg-date', type: 'date', value: st.anchor || range.startIso, title: 'Дата периода' });
+        dateInput.addEventListener('change', function() { if (dateInput.value) { st.anchor = dateInput.value; self.render(); } });
+
+        var slitterSelect = el('select', { class: 'atex-cg-input atex-cg-slitter', title: 'Станок' });
+        slitterSelect.appendChild(el('option', { value: '', text: 'Все станки' }));
+        this.slitters.forEach(function(s) {
+            var opt = el('option', { value: s.id, text: s.label });
+            if (String(st.slitter) === String(s.id)) opt.setAttribute('selected', 'selected');
+            slitterSelect.appendChild(opt);
+        });
+        slitterSelect.value = st.slitter || '';
+        slitterSelect.addEventListener('change', function() { st.slitter = slitterSelect.value || ''; self.render(); });
+
+        var statusSelect = el('select', { class: 'atex-cg-input atex-cg-status', title: 'Статус' });
+        statusSelect.appendChild(el('option', { value: '', text: 'Все статусы' }));
+        ['planned', 'running', 'unfinished', 'on-time', 'late', 'late-start', 'done'].forEach(function(key) {
+            var opt = el('option', { value: key, text: STATUS_LABELS[key] });
+            if (st.status === key) opt.setAttribute('selected', 'selected');
+            statusSelect.appendChild(opt);
+        });
+        statusSelect.value = st.status || '';
+        statusSelect.addEventListener('change', function() { st.status = statusSelect.value || ''; self.render(); });
+
+        var todayBtn = el('button', { class: 'atex-cg-btn', type: 'button', text: 'Сегодня', title: 'Перейти к текущей дате' });
+        todayBtn.addEventListener('click', function() { st.anchor = todayISO(); self.render(); });
+        var refreshBtn = el('button', { class: 'atex-cg-btn', type: 'button', text: 'Обновить', title: 'Перечитать данные' });
+        refreshBtn.addEventListener('click', function() { self.refresh(); });
+
+        return el('div', { class: 'atex-cg-toolbar' }, [
+            el('div', { class: 'atex-cg-title', text: 'Диаграмма Ганта — задания в производство' }),
+            el('div', { class: 'atex-cg-period' }, [prevBtn, el('span', { class: 'atex-cg-range', text: range.label }), nextBtn]),
+            modeWrap,
+            el('div', { class: 'atex-cg-tools' }, [dateInput, slitterSelect, statusSelect, todayBtn, refreshBtn])
+        ]);
+    };
+
+    AtexCutGantt.prototype._buildLegend = function() {
+        return el('div', { class: 'atex-cg-legend' }, [
+            el('span', { class: 'atex-cg-legend-item is-planned', text: STATUS_LABELS.planned }),
+            el('span', { class: 'atex-cg-legend-item is-running', text: STATUS_LABELS.running }),
+            el('span', { class: 'atex-cg-legend-item is-unfinished', text: STATUS_LABELS.unfinished }),
+            el('span', { class: 'atex-cg-legend-item is-on-time', text: STATUS_LABELS['on-time'] }),
+            el('span', { class: 'atex-cg-legend-item is-late', text: STATUS_LABELS.late })
+        ]);
+    };
+
+    AtexCutGantt.prototype._buildBody = function(range, nowMs) {
+        var self = this;
+        var st = this.state;
+        var rows = ganttRows(this.cuts, range, nowMs, { status: st.status, slitter: st.slitter });
+
+        function appendTicks(track, scale) {
+            range.days.forEach(function(day, idx) {
+                var tick = el('span', { class: 'atex-cg-tick' + (scale ? ' is-scale' : '') });
+                tick.style.left = day.leftPct + '%';
+                if (scale) {
+                    var label = el('span', { class: 'atex-cg-tick-label', text: day.label });
+                    if (range.mode === 'month' && idx % 2 !== 0) label.className += ' is-minor';
+                    tick.appendChild(label);
+                }
+                track.appendChild(tick);
+            });
+            var endTick = el('span', { class: 'atex-cg-tick is-end' + (scale ? ' is-scale' : '') });
+            endTick.style.left = '100%';
+            track.appendChild(endTick);
+        }
+
+        var body = el('div', { class: 'atex-cg-body atex-cg-body--' + range.mode });
+
+        // Шапка-шкала: пустая ячейка под метки + шкала дат.
+        var scaleRow = el('div', { class: 'atex-cg-row atex-cg-scale-row' });
+        scaleRow.appendChild(el('div', { class: 'atex-cg-label atex-cg-label--scale', text: 'Задание' }));
+        var scaleTrack = el('div', { class: 'atex-cg-track atex-cg-scale' });
+        appendTicks(scaleTrack, true);
+        scaleRow.appendChild(scaleTrack);
+        body.appendChild(scaleRow);
+
+        if (!rows.length) {
+            body.appendChild(el('div', { class: 'atex-cg-empty', text: 'На выбранном интервале заданий нет' }));
+            return body;
+        }
+
+        rows.forEach(function(rowData) {
+            var bar = rowData.bar;
+            var statusKey = bar.status && bar.status.key || 'unknown';
+
+            var labelCell = el('div', { class: 'atex-cg-label', title: rowData.label.main + (rowData.label.sub ? ' · ' + rowData.label.sub : '') }, [
+                el('span', { class: 'atex-cg-label-main', text: rowData.label.main }),
+                rowData.label.sub ? el('span', { class: 'atex-cg-label-sub', text: rowData.label.sub }) : null
+            ]);
+
+            var track = el('div', { class: 'atex-cg-track' });
+            appendTicks(track, false);
+
+            var barLink = el('a', {
+                class: 'atex-cg-bar is-' + statusKey,
+                href: planningLink(rowData.cut, self.planningUrl),
+                title: bar.title,
+                dataset: { cutId: bar.cutId }
+            }, [
+                el('span', { class: 'atex-cg-bar-main', text: bar.barLabel }),
+                el('span', { class: 'atex-cg-bar-status', text: bar.status.label })
+            ]);
+            barLink.style.left = bar.leftPct + '%';
+            barLink.style.width = bar.widthPct + '%';
+            track.appendChild(barLink);
+
+            body.appendChild(el('div', { class: 'atex-cg-row' }, [labelCell, track]));
+        });
+
+        return body;
+    };
+
+    AtexCutGantt.prototype.setBusy = function(on) {
+        this.busy = on;
+        if (this.root) this.root.classList.toggle('is-busy', !!on);
+    };
+
+    AtexCutGantt.prototype.fatal = function(message) {
+        this.root.innerHTML = '';
+        this.root.appendChild(el('div', { class: 'atex-cg-fatal', text: message }));
+    };
+
+    AtexCutGantt.prototype.refresh = function() {
+        var self = this;
+        if (this.busy) return Promise.resolve();
+        this.setBusy(true);
+        return this.collect().then(function() {
+            self.render();
+            self.setBusy(false);
+        }).catch(function(err) {
+            self.setBusy(false);
+            self.fatal('Ошибка загрузки данных: ' + err.message);
+        });
+    };
+
+    AtexCutGantt.prototype.start = function() {
+        var self = this;
+        this.root.innerHTML = '';
+        this.root.appendChild(el('div', { class: 'atex-cg-loading', text: 'Загрузка диаграммы Ганта…' }));
+        return this.refresh().catch(function(err) { self.fatal('Ошибка инициализации: ' + err.message); });
+    };
+
+    function init() {
+        if (typeof document === 'undefined') return;
+        var root = document.getElementById('atex-cut-gantt');
+        if (!root || root.dataset.initialized === '1') return;
+        root.dataset.initialized = '1';
+        var controller = new AtexCutGantt(root);
+        root._atexCutGantt = controller;
+        controller.start();
+    }
+
+    return { gantt: gantt, Controller: AtexCutGantt, init: init };
+});

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3326,7 +3326,27 @@
         return !target.closest('.atex-pp-strip-panel');
     }
 
+    // #3638: разбор deep-link из строки запроса (?cut=..&date=..&slitter=..). Ганта
+    // (cut-gantt) шлёт сюда дату/станок/задание, чтобы открыть очередь на нужной
+    // резке. Чистая → проверяется тестом. Возвращает {cut,date,slitter} (строки).
+    function parseDeepLink(search) {
+        var s = String(search == null ? '' : search);
+        var qm = s.indexOf('?');
+        if (qm >= 0) s = s.slice(qm + 1);
+        var out = { cut: '', date: '', slitter: '' };
+        s.split('&').forEach(function(pair) {
+            if (!pair) return;
+            var eq = pair.indexOf('=');
+            var key = eq >= 0 ? pair.slice(0, eq) : pair;
+            var val = eq >= 0 ? pair.slice(eq + 1) : '';
+            try { val = decodeURIComponent(val.replace(/\+/g, ' ')); } catch (e) {}
+            if (key === 'cut' || key === 'date' || key === 'slitter') out[key] = val;
+        });
+        return out;
+    }
+
     var planning = {
+        parseDeepLink: parseDeepLink,
         cutClickSelectsCut: cutClickSelectsCut,
         parseRef: parseRef,
         parseMultiRefIds: parseMultiRefIds,
@@ -6759,6 +6779,26 @@
         this.renderLink();
     };
 
+    // #3638: применить deep-link из cut-gantt: выставить день (фильтр дат), активный
+    // станок и сфокусировать задание (подсветка + прокрутка к карточке). Вызывается
+    // после первичного рендера. Параметры — { cut, date, slitter } (строки, любой пуст).
+    AtexProductionPlanning.prototype.applyDeepLink = function(params) {
+        var p = params || {};
+        if (!p.cut && !p.date && !p.slitter) return;
+        if (p.date) { this.filter.date = p.date; this.filter.dateTo = p.date; }
+        if (p.slitter) this.activeSlitter = String(p.slitter);
+        this.renderQueue();   // пересобрать вкладки/очередь под новый день/станок
+        if (p.cut) {
+            this.selectCut(p.cut);
+            var card = this.queueEl && this.queueEl.querySelector('.atex-pp-cut[data-cut-id="' + String(p.cut).replace(/"/g, '\\"') + '"]');
+            if (card) {
+                card.classList.add('is-deeplink');
+                if (typeof card.scrollIntoView === 'function') card.scrollIntoView({ block: 'center' });
+            }
+        }
+        this.renderLink();
+    };
+
     // Открыть модалку формы новой резки (#3116 п.1). Содержимое уже отрисовано
     // renderForm; здесь только показываем оверлей.
     AtexProductionPlanning.prototype.openForm = function() {
@@ -7710,7 +7750,14 @@
         console.log('[pp] 🟢 init: запуск production-planning, db=', (root.getAttribute('data-db') || '?'));
         var controller = new AtexProductionPlanning(root);
         root._atexProductionPlanning = controller;
-        controller.start();
+        // #3638: deep-link из cut-gantt (?cut=..&date=..&slitter=..) — после загрузки
+        // данных открыть очередь на нужном дне/станке и подсветить задание.
+        var deepLink = (typeof window !== 'undefined' && window.location)
+            ? parseDeepLink(window.location.search) : null;
+        var started = controller.start();
+        if (deepLink && (deepLink.cut || deepLink.date || deepLink.slitter) && started && typeof started.then === 'function') {
+            started.then(function() { controller.applyDeepLink(deepLink); });
+        }
     }
 
     return { planning: planning, Controller: AtexProductionPlanning, init: init };

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -1,0 +1,116 @@
+// Unit tests for the «Диаграмма Ганта (задания)» core (ideav/crm#3638).
+// Проверяет чистое ядро автономного рабочего места cut-gantt:
+//   • rowsToCuts        — строки отчёта cut_planning → задания (с order/sequence/leader);
+//   • ganttRange        — интервал по режиму (день/3 дня/неделя/месяц);
+//   • shiftAnchor       — сдвиг периода назад/вперёд;
+//   • cutStatus         — статус задания (в срок / с опозданием / запланировано …);
+//   • cutBar            — позиция/ширина бара на шкале;
+//   • orderCutsForGantt — порядок строк (станок → старт → очередность → id);
+//   • ganttRows         — видимые строки с фильтрами станка/статуса;
+//   • planningLink      — ссылка на «Планирование производства» (дата/станок/задание);
+//   • parseDeepLink     — разбор ?cut=..&date=..&slitter=.. (и в cut-gantt, и в planning).
+//
+// Run with: node experiments/atex-cut-gantt.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/cut-gantt.js');
+var gantt = api.gantt;
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// ── rowsToCuts: dedup по cut_id; order/sequence/leader; длительность ──
+var cuts = gantt.rowsToCuts([
+    { cut_id: '10', cut_slitter: 'Станок 1', cut_slitter_id: '101',
+      cut_plan_date: '06.05.2026', cut_material: 'MR194', cut_material_id: '5',
+      cut_start_date: '06.05.2026 08:10', cut_end_date: '06.05.2026 09:20',
+      cut_duration: '70', cut_status: 'В работе', cut_sequence: '2',
+      cut_leader: 'MONOCHROME', order_no: '3700', supply_id: '900' },
+    // вторая строка той же резки (join с обеспечением) — схлопывается
+    { cut_id: '10', cut_slitter: 'Станок 1', cut_slitter_id: '101', supply_id: '901' },
+    { cut_id: '20', cut_slitter: '', cut_slitter_id: '',
+      cut_plan_date: '27.05.2026', cut_status: 'Ожидает', order_no: '3701' }
+]);
+assertEqual(cuts, [
+    { id: '10', number: '06.05.2026', planDate: '06.05.2026', status: 'В работе',
+      startDate: '06.05.2026 08:10', endDate: '06.05.2026 09:20', duration: 70,
+      sequence: 2, leader: 'MONOCHROME', orderNo: '3700',
+      materialId: '5', materialName: 'MR194', slitter: { id: '101', label: 'Станок 1' } },
+    { id: '20', number: '27.05.2026', planDate: '27.05.2026', status: 'Ожидает',
+      startDate: '', endDate: '', duration: 0, sequence: null, leader: '', orderNo: '3701',
+      materialId: '', materialName: '', slitter: { id: null, label: '' } }
+], 'rowsToCuts: dedup, поля order/sequence/leader, длительность');
+
+// ── ganttRange: неделя с понедельника, 7 дней ──
+var weekRange = gantt.ganttRange('2026-06-11', 'week');
+assertEqual({ mode: weekRange.mode, startIso: weekRange.startIso, endIso: weekRange.endIso, days: weekRange.days.length },
+    { mode: 'week', startIso: '2026-06-08', endIso: '2026-06-15', days: 7 },
+    'ganttRange: неделя 08–14 июня (7 дней)');
+
+// ── shiftAnchor: неделя назад/вперёд ──
+assertEqual(gantt.shiftAnchor('2026-06-11', 'week', 1), '2026-06-15', 'shiftAnchor: +1 неделя');
+assertEqual(gantt.shiftAnchor('2026-06-11', 'week', -1), '2026-06-01', 'shiftAnchor: −1 неделя');
+
+// ── cutStatus ──
+var NOW = gantt.parseDateTimeMs('2026-06-10 12:00');
+assertEqual(gantt.cutStatus({ planDate: '2026-06-20' }, NOW).key, 'planned', 'cutStatus: будущее → запланировано');
+assertEqual(gantt.cutStatus({ planDate: '2026-06-10 08:00', duration: 60, startDate: '2026-06-10 08:00', endDate: '2026-06-10 08:40' }, NOW).key,
+    'on-time', 'cutStatus: финиш до дедлайна → в срок');
+assertEqual(gantt.cutStatus({ planDate: '2026-06-10 08:00', duration: 60, endDate: '2026-06-10 10:00' }, NOW).key,
+    'late', 'cutStatus: финиш позже дедлайна → с опозданием');
+
+// ── cutBar: позиция/ширина на недельной шкале ──
+var bar = gantt.cutBar({ id: '10', planDate: '2026-06-10' }, weekRange, NOW);
+assertEqual({ left: bar.leftPct, width: bar.widthPct, cutId: bar.cutId },
+    { left: 28.571, width: 0.6, cutId: '10' },
+    'cutBar: вторник недели → left 2/7, ширина минимальная');
+assertEqual(gantt.cutBar({ id: '99', planDate: '2026-07-01' }, weekRange, NOW), null,
+    'cutBar: вне периода → null');
+
+// ── orderCutsForGantt: по станку, затем старту ──
+var ordered = gantt.orderCutsForGantt([
+    { id: 'A', planDate: '2026-06-10', slitter: { id: '2', label: 'Станок 2' } },
+    { id: 'B', planDate: '2026-06-11', slitter: { id: '1', label: 'Станок 1' } }
+]).map(function(c) { return c.id; });
+assertEqual(ordered, ['B', 'A'], 'orderCutsForGantt: Станок 1 раньше Станка 2');
+
+// ── ganttRows: фильтры станка/статуса + только видимые ──
+var rowCuts = [
+    { id: '10', planDate: '2026-06-10', slitter: { id: '1', label: 'Станок 1' } },
+    { id: '20', planDate: '2026-06-11', slitter: { id: '2', label: 'Станок 2' } },
+    { id: '30', planDate: '2026-07-01', slitter: { id: '1', label: 'Станок 1' } } // вне периода
+];
+assertEqual(gantt.ganttRows(rowCuts, weekRange, NOW, {}).map(function(r) { return r.cut.id; }),
+    ['10', '20'], 'ganttRows: вне периода (30) отброшено');
+assertEqual(gantt.ganttRows(rowCuts, weekRange, NOW, { slitter: '2' }).map(function(r) { return r.cut.id; }),
+    ['20'], 'ganttRows: фильтр по станку');
+
+// ── planningLink: ссылка на планировщик с датой/станком/заданием ──
+assertEqual(gantt.planningLink({ id: '85472', planDate: '06.05.2026', slitter: { id: '1285' } }),
+    '/atex/production-planning?cut=85472&date=2026-05-06&slitter=1285',
+    'planningLink: cut+date+slitter');
+assertEqual(gantt.planningLink({ id: '7', planDate: '', slitter: { id: null } }),
+    '/atex/production-planning?cut=7',
+    'planningLink: без даты/станка — только cut');
+assertEqual(gantt.planningLink({ id: '7' }, '/x/pp'),
+    '/x/pp?cut=7', 'planningLink: базовый URL переопределяется');
+
+// ── parseDeepLink: cut-gantt и planning разбирают одинаково ──
+var expectDL = { cut: '85472', date: '2026-05-06', slitter: '1285' };
+assertEqual(gantt.parseDeepLink('?cut=85472&date=2026-05-06&slitter=1285'), expectDL, 'parseDeepLink (gantt): полный');
+assertEqual(planning.parseDeepLink('?cut=85472&date=2026-05-06&slitter=1285'), expectDL, 'parseDeepLink (planning): полный');
+assertEqual(gantt.parseDeepLink(''), { cut: '', date: '', slitter: '' }, 'parseDeepLink: пусто');
+assertEqual(gantt.parseDeepLink('?foo=1&cut=9'), { cut: '9', date: '', slitter: '' }, 'parseDeepLink: лишние параметры игнорируются');
+
+console.log('\n' + passed + ' assertions passed');

--- a/templates/atex/cut-gantt.html
+++ b/templates/atex/cut-gantt.html
@@ -1,0 +1,14 @@
+<!-- Рабочее место atex «Диаграмма Ганта (задания)» (роли Руководитель, Диспетчер). -->
+<!-- Решение ideav/crm#3638. Строка = «Задание в производство», бар — ссылка на -->
+<!-- «Планирование производства» (дата/станок/задание в URL). URL: /atex/cut-gantt -->
+<link rel="stylesheet" href="/download/{_global_.z}/css/atex-brand.css?0{_global_.version}">
+<link rel="stylesheet" href="/download/{_global_.z}/css/cut-gantt.css?0{_global_.version}">
+<div id="atex-cut-gantt"
+     class="atex-cg atex-brand"
+     data-db="{_global_.z}"
+     data-xsrf="{_global_.xsrf}"
+     data-user="{_global_.user}">
+    <div class="atex-cg-loading">Загрузка диаграммы Ганта…</div>
+</div>
+<script src="/download/{_global_.z}/js/ref-search.js?0{_global_.version}" defer></script>
+<script src="/download/{_global_.z}/js/cut-gantt.js?0{_global_.version}" defer></script>


### PR DESCRIPTION
Закрывает #3638.

## Что это
Новое read-only рабочее место **«Диаграмма Ганта (задания)»** (`cut-gantt`) для
ролей **Руководитель, Диспетчер, Администратор**. В отличие от «Календаря занятости
станков» (machine-calendar, дорожка=станок) здесь **строка = одно «Задание в
производство»** (task-Гант): бары на шкале времени (день/3 дня/неделя/месяц), цвет =
статус (запланировано / в работе / не завершено / в срок / с опозданием).

**Каждый бар — ссылка** на «Планирование производства» с зашитыми в URL **датой,
станком и заданием** (`?cut=&date=&slitter=`), чтобы открыть планировщик на нужном
задании. Планировщик ловит deep-link, открывает нужный день/станок и подсвечивает
задание (анимация `.is-deeplink`).

## Файлы
- `download/atex/js/cut-gantt.js` — ядро `gantt` (шкала, бар, статус, `rowsToCuts`,
  `orderCutsForGantt`, `planningLink`, `ganttRows`, `parseDeepLink`) + контроллер + init.
  Данные — `report/cut_planning?JSON_KV` (ссылки, включая «Лидер», резолвятся серверно,
  как в machine-calendar; прав на справочники роли не нужно).
- `download/atex/css/cut-gantt.css`, `templates/atex/cut-gantt.html` — стили и шаблон.
- `download/atex/js/production-planning.js` — `parseDeepLink` + `applyDeepLink`: приём
  `?cut=&date=&slitter=` из `window.location.search`, открытие дня/станка, `selectCut`
  + прокрутка/подсветка. `download/atex/css/production-planning.css` — стиль `.is-deeplink`.
- `docs/atex_menu.json` — пункт «Диаграмма Ганта (задания)» для 3 ролей.
- `experiments/atex-cut-gantt.test.js` — 19 проверок ядра.

## Ссылка на планировщик — относительная
Префикс пути РМ = имя БД (на тест-базе `/ateh/...`, в проде может отличаться), поэтому
ссылка строится **относительно текущего пути** (соседний маршрут `production-planning`),
а не хардкодом. Проверено вживую: бары дают `/ateh/production-planning?cut=..&date=..&slitter=..`.

## Проверка
- Юнит-тесты: `atex-cut-gantt.test.js` — 19 ✅; `atex-production-planning.test.js` — 534 ✅
  (включая `parseDeepLink`). `node --check` ✅.
- **Живой деплой на тест-базу ateh** (dir_admin) + регистрация меню под 3 роли. РМ
  открывается (`/ateh/cut-gantt`), рендерит тулбар/легенду/бары/ссылки корректно —
  скриншот ниже. Сквозной клик в планировщик не дожат: отчёт `cut_planning` на тест-базе
  очень медленный (>85 с), это узкое место отчёта (общее с machine-calendar), не кода.

🤖 Generated with [Claude Code](https://claude.com/claude-code)