### PR TITLE
feat(atex): пульт слиттера — карточки очереди и порядок завершённых (#3646)

### DIFF
--- a/download/atex/css/slitter.css
+++ b/download/atex/css/slitter.css
@@ -120,6 +120,12 @@
 .atex-sl-cut-main { display: flex; flex-direction: column; gap: 2px; overflow: hidden; }
 .atex-sl-cut-label { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .atex-sl-cut-sub { font-size: 12px; color: var(--sl-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* #3646: карточка списка — № (жирный) + «Вид сырья / Намотка / Метраж м * Резок»,
+   второй строкой — время начала–окончания. */
+.atex-sl-cut-line1 { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
+.atex-sl-cut-num { font-weight: 700; flex: none; }
+.atex-sl-cut-spec { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.atex-sl-cut-time { font-size: 12px; color: var(--sl-muted); font-variant-numeric: tabular-nums; }
 .atex-sl-empty { padding: 14px; color: var(--sl-muted); }
 
 /* Главная область */

--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -299,10 +299,10 @@
     }
 
     // #3565 #3: порядок резок — строго по «Очередности», без всплытия незапущенных
-    // над начатыми (раньше факт старта тасовал список «по времени»). Завершённые — в конце.
+    // над начатыми (раньше факт старта тасовал список «по времени»).
+    // #3646: завершённые БОЛЬШЕ НЕ уходят в конец — остаются на своих местах по очереди
+    // (видны в общем порядке вместе с активными).
     function compareCutsForQueue(a, b) {
-        var ad = isDone(a && a.status), bd = isDone(b && b.status);
-        if (ad !== bd) return ad ? 1 : -1;
         var as = sequenceKey(a), bs = sequenceKey(b);
         if (as !== bs) return as - bs;
         var ak = dateKey(a && a.planDate), bk = dateKey(b && b.planDate);
@@ -317,7 +317,8 @@
         var list = (cuts || []).filter(function(cut) {
             if (selectedSlitterId && cutSlitterId(cut) !== selectedSlitterId) return false;
             if (selectedDateKey !== Infinity && dateKey(cut && cut.planDate) !== selectedDateKey) return false;
-            if (!o.includeDone && isDone(cut && cut.status)) return false;
+            // #3646: завершённые НЕ скрываем — показываем всегда (галка «Отобразить
+            // завершённые» убрана, они видны в общем порядке очереди).
             return true;
         }).map(function(cut, i) { return { cut: cut, i: i }; }).sort(function(a, b) {
             return compareCutsForQueue(a.cut, b.cut) || a.i - b.i;
@@ -549,6 +550,19 @@
         return isTimestampSeconds(value) ? formatDate(value) : String(value == null ? '' : value);
     }
 
+    // #3646: вторая строка карточки списка — время начала–окончания резки. Фактические
+    // «Начато»–«Закончено» (завершённая → «8:08 – 8:55»); начата, но не завершена →
+    // «8:08 – …»; не начата → плановый старт (planDate) без конца. Пусто → ''.
+    function cutQueueTime(cut) {
+        if (!cut) return '';
+        var startStr = formatClock(cut.startedAt || cut.planDate || '');
+        if (!startStr) return '';
+        var endStr = cut.finishedAt ? formatClock(cut.finishedAt) : '';
+        if (endStr) return startStr + ' – ' + endStr;
+        if (cut.startedAt) return startStr + ' – …';
+        return startStr;
+    }
+
     // ── #3460: чистое ядро раскладки ножей (порт из cut-map.js) ──
     // Карта раскроя слиттера: каждая «полоса» даёт `qty` ножей шириной `width`.
 
@@ -766,6 +780,7 @@
         // #3460: формат времени резки и разбор партий из отчёта
         isTimestampSeconds: isTimestampSeconds,
         formatClock: formatClock,
+        cutQueueTime: cutQueueTime,   // #3646
         formatDate: formatDate,
         cutTitle: cutTitle,
         humanizeLabel: humanizeLabel,
@@ -857,7 +872,7 @@
         // #3460: восстанавливаем выбор станка из localStorage при открытии формы.
         this.selectedSlitterId = this.loadStoredSlitter();
         this.selectedDate = core.todayISO();
-        this.includeDone = false;
+        // #3646: this.includeDone убран — завершённые задания видны всегда.
         this.currentCutId = null; // выбранная резка
         this.currentCut = null;   // полная запись выбранной резки
         this.currentStrips = [];  // #3460: полосы выбранной резки (раскладка ножей)
@@ -1109,6 +1124,7 @@
             var startedIdx = colIndexAny(meta, CUT_STARTED_NAMES);
             var inWorkIdx = colIndex(meta, CUT_REQ.inWork);      // #3557
             var finishedIdx = colIndex(meta, CUT_REQ.finishedAt); // #3557
+            var windingIdx = colIndex(meta, CUT_REQ.winding);    // #3646: «Тип намотки» в карточке списка
             self.cuts = (rows || []).map(function(r) {
                 var row = r.r || [];
                 var slitterRef = slitterIdx >= 0 ? parseRef(row[slitterIdx]) : { id: null, label: '' };
@@ -1134,7 +1150,8 @@
                     sequence: sequenceIdx >= 0 ? row[sequenceIdx] : '',
                     plannedRuns: plannedRunsIdx >= 0 ? row[plannedRunsIdx] : '',
                     runLength: runLengthIdx >= 0 ? row[runLengthIdx] : '',
-                    startedAt: startedIdx >= 0 ? (row[startedIdx] || '') : ''
+                    startedAt: startedIdx >= 0 ? (row[startedIdx] || '') : '',
+                    winding: windingIdx >= 0 ? (row[windingIdx] || '') : '' // #3646
                 };
             });
         });
@@ -1406,8 +1423,8 @@
     AtexSlitter.prototype.currentQueue = function() {
         return core.prepareCutQueue(this.cuts, {
             slitterId: this.selectedSlitterId,
-            date: this.selectedDate,
-            includeDone: this.includeDone
+            date: this.selectedDate
+            // #3646: includeDone убран — завершённые показываем всегда.
         });
     };
 
@@ -1487,10 +1504,22 @@
             var active = String(self.currentCutId) === String(cut.id);
             var isFirstOpen = firstOpenId && String(firstOpenId) === String(cut.id);
             var locked = self.isCutLocked(cut);
-            // #3565 #2: подпись «N (время старта)», напр. «1 (08:30)»; у незапущенной — просто «N».
+            // #3646: карточка списка — № + «Вид сырья / Намотка / Метраж м * Резок» (стр. 1)
+            // и время начала–окончания (стр. 2). Вид сырья — из «Партии сырья» (Вид сырья).
+            var batch = self.findBatch(cut.batchId);
+            var material = (batch && batch.materialLabel) || cut.batch || '—';
+            var runLen = core.toNumber(cut.runLength);
+            var runsN = core.toNumber(cut.plannedRuns);
+            var dims = (runLen > 0 ? core.round3(runLen) + 'м' : '—') + (runsN > 0 ? ' * ' + runsN : '');
+            var spec = [material, cut.winding || '—', dims].join(' / ');
             var cutMain = [
-                el('span', { class: 'atex-sl-cut-label', text: (idx + 1) + (cut.startedAt ? ' (' + core.formatClock(cut.startedAt) + ')' : '') })
+                el('div', { class: 'atex-sl-cut-line1' }, [
+                    el('span', { class: 'atex-sl-cut-num', text: String(idx + 1) }),
+                    el('span', { class: 'atex-sl-cut-spec', text: spec })
+                ])
             ];
+            var timeTxt = core.cutQueueTime(cut);
+            if (timeTxt) cutMain.push(el('div', { class: 'atex-sl-cut-time', text: timeTxt }));
             if (locked) cutMain.push(el('span', { class: 'atex-sl-cut-sub', text: 'ожидает предыдущую' }));
             var item = el('button', {
                 class: 'atex-sl-cut-item' + (active ? ' is-active' : '') + (isFirstOpen && !active ? ' is-next' : '') + (locked ? ' is-disabled' : ''),
@@ -2447,13 +2476,9 @@
         var aside = el('aside', { class: 'atex-sl-sidebar' });
         // #3565 #1: счётчик резок в заголовке обновляется в renderCuts (updateSidebarTitle).
         this.sidebarTitleEl = el('h2', { text: 'Задание в производство' });
+        // #3646: галка «Отобразить завершённые» убрана — завершённые видны всегда,
+        // на своих местах по очереди.
         var head = el('div', { class: 'atex-sl-sidebar-head' }, [ this.sidebarTitleEl ]);
-        var filter = el('label', { class: 'atex-sl-filter' });
-        var cb = el('input', { type: 'checkbox' });
-        cb.addEventListener('change', function() { self.includeDone = cb.checked; self.renderCuts(); });
-        filter.appendChild(cb);
-        filter.appendChild(el('span', { text: 'Отобразить завершённые' }));
-        head.appendChild(filter);
         aside.appendChild(head);
         this.cutsEl = el('div', { class: 'atex-sl-cuts' });
         aside.appendChild(this.cutsEl);

--- a/experiments/atex-slitter.test.js
+++ b/experiments/atex-slitter.test.js
@@ -129,7 +129,8 @@ assertEqual(core.defectM2(-3, 910), 0, 'defectM2: отрицательные м�
 assertEqual(core.photoFieldKey('1118'), 't1118', 'photoFieldKey: t + reqId');
 assertEqual(core.photoFieldKey(null), '', 'photoFieldKey: нет reqId → пусто');
 
-// ── очередь слиттера: сначала выбор станка/даты, завершённые скрыты по умолчанию ──
+// ── #3646: очередь слиттера — фильтр по станку/дате; завершённые видны ВСЕГДА, на своих
+// местах по «Очередности» (не скрыты, не уходят в конец) ──
 var queueCuts = [
     { id: 'done-prev', slitterId: 's1', planDate: '2026-06-10', status: 'Завершена', sequence: 1, startedAt: '2026-06-10 08:00:00' },
     { id: 'wait-today', slitterId: 's1', planDate: '2026-06-11', status: 'Ожидает', sequence: 2, startedAt: '' },
@@ -137,13 +138,11 @@ var queueCuts = [
     { id: 'done-today', slitterId: 's1', planDate: '2026-06-11', status: 'Завершена', sequence: 1, startedAt: '2026-06-11 07:00:00' },
     { id: 'other-slitter', slitterId: 's2', planDate: '2026-06-11', status: 'Ожидает', sequence: 1, startedAt: '' }
 ];
-var hiddenDoneQueue = core.prepareCutQueue(queueCuts, { slitterId: 's1', date: '2026-06-11', includeDone: false });
-assertEqual(hiddenDoneQueue.cuts.map(function(c) { return c.id; }), ['wait-today', 'run-today'],
-    'prepareCutQueue filters by slitter/date and hides completed by default');
-assertEqual(hiddenDoneQueue.firstOpenCutId, 'wait-today',
-    'prepareCutQueue selects the first unstarted waiting cut');
-assertEqual(core.prepareCutQueue(queueCuts, { slitterId: 's1', date: '2026-06-11', includeDone: true }).cuts.map(function(c) { return c.id; }),
-    ['wait-today', 'run-today', 'done-today'], 'prepareCutQueue shows completed when requested');
+var q3646 = core.prepareCutQueue(queueCuts, { slitterId: 's1', date: '2026-06-11' });
+assertEqual(q3646.cuts.map(function(c) { return c.id; }), ['done-today', 'wait-today', 'run-today'],
+    'prepareCutQueue #3646: фильтр по станку/дате; завершённая (Очередность 1) остаётся на своём месте, не в конце и не скрыта');
+assertEqual(q3646.firstOpenCutId, 'wait-today',
+    'prepareCutQueue: первая открытая = первая НЕ завершённая по очереди (завершённую пропускаем)');
 
 // ── открытая смена: последняя отметка пользователя за день должна быть началом, не концом ──
 assertEqual(core.hasOpenShift([
@@ -214,9 +213,25 @@ var blockedCuts = [
     { id: 'c2', slitterId: 's1', planDate: '2026-06-11', status: 'Ожидает', sequence: 2, startedAt: '' },
     { id: 'c3', slitterId: 's1', planDate: '2026-06-11', status: 'Ожидает', sequence: 3, startedAt: '' }
 ];
-var blockedQueue = core.prepareCutQueue(blockedCuts, { slitterId: 's1', date: '2026-06-11', includeDone: false });
+var blockedQueue = core.prepareCutQueue(blockedCuts, { slitterId: 's1', date: '2026-06-11' });
 assertEqual(blockedQueue.firstOpenCutId, 'c1', '#3459 only first waiting cut is firstOpenCutId');
 assertEqual(blockedQueue.cuts.length, 3, '#3459 all three waiting cuts are in the queue (UI disables c2, c3)');
+
+// ── #3646: cutQueueTime — вторая строка карточки (начало–окончание). Время форматирует
+// formatClock (штамп → ЧЧ:ММ); сверяем композицию диапазона TZ-независимо. ──
+var t808 = String(Math.floor(Date.UTC(2026, 5, 11, 8, 8, 0) / 1000));
+var t855 = String(Math.floor(Date.UTC(2026, 5, 11, 8, 55, 0) / 1000));
+assertEqual(core.cutQueueTime({ startedAt: t808, finishedAt: t855 }),
+    core.formatClock(t808) + ' – ' + core.formatClock(t855),
+    'cutQueueTime #3646: завершённая → «начало – окончание»');
+assertEqual(core.cutQueueTime({ startedAt: t808, finishedAt: '' }),
+    core.formatClock(t808) + ' – …',
+    'cutQueueTime #3646: начата, не завершена → «начало – …»');
+assertEqual(core.cutQueueTime({ startedAt: '', planDate: t808 }),
+    core.formatClock(t808),
+    'cutQueueTime #3646: не начата → плановый старт (planDate)');
+assertEqual(core.cutQueueTime({ startedAt: '', planDate: '' }),
+    '', 'cutQueueTime #3646: нет времён → пусто');
 
 // ── #3459: verify new EVENT_TYPES include Пропуск and Отмена ──
 assertEqual(core.EVENT_TYPES.indexOf('Пропуск') >= 0, true, '#3459 EVENT_TYPES includes Пропуск');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 52);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 53);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3646.

## п.1 — содержимое карточек «Задание в производство (N)»
Помимо номера в карточке списка теперь выводится:
- **строка 1:** `№ Вид сырья / Намотка / Метраж, м * Резок`
- **строка 2:** время начала–окончания

Пример:
```
1  MWR116L / IN / 600м * 2
08:08 – 08:55
```
- «Вид сырья» — из «Партии сырья» (реквизит «Вид сырья») через `findBatch`; в `loadCuts` добавлено чтение «Тип намотки».
- Время — фактические «Начато»–«Закончено»: завершённая → `08:08 – 08:55`; начата, не завершена → `08:08 – …`; не начата → плановый старт (`planDate`). Чистый помощник `core.cutQueueTime` + тест.

## п.2 — завершённые в общем порядке, без галки
- `compareCutsForQueue` больше **не** уводит завершённые в конец — они остаются на своих местах по «Очередности».
- `prepareCutQueue` больше **не** скрывает завершённые (фильтр `includeDone` убран) — видны всегда.
- Галка **«Отобразить завершённые»** убрана из сайдбара.

## Проверки
DOM-смоук: карточка даёт `№=1`, `spec=MWR116L / IN / 600м * 2`, `time=08:08 – 08:55`. Тест слиттера обновлён (порядок очереди: завершённая «Очередность 1» остаётся первой; `cutQueueTime` 4 кейса) — **162** проверки (2 предсуществующих FAIL `EVENT_TYPES #3459` — не регрессия). VERSION 52→53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)