### PR TITLE
fix(atex): диаграмма Ганта — компактный вид, группировка по станку, упаковка встык (#3648)

### DIFF
--- a/download/atex/css/cut-gantt.css
+++ b/download/atex/css/cut-gantt.css
@@ -107,69 +107,66 @@
     overflow: hidden;
 }
 
+/* #3648 п.2: заголовок станка — отдельной строкой перед его заданиями. */
+.atex-cg-machine-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 4px 10px;
+    font-weight: 700;
+    color: var(--cg-accent);
+    background: var(--cg-surface);
+    border-top: 2px solid var(--cg-accent);
+    position: sticky;
+    left: 0;
+}
+.atex-cg-body > .atex-cg-machine-head:first-child { border-top: 0; }
+.atex-cg-machine-count { font-weight: 400; font-size: 12px; color: var(--cg-muted); }
+
+/* #3648 п.3: компактные строки задания (метка | дорожка). */
 .atex-cg-row { display: grid; grid-template-columns: var(--cg-label-w) 1fr; border-top: 1px solid var(--cg-border-soft); }
-.atex-cg-row:first-child { border-top: 0; }
 
 .atex-cg-label {
-    padding: 8px 10px;
+    padding: 2px 10px;
     border-right: 1px solid var(--cg-border-soft);
     background: var(--cg-surface);
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: 2px;
+    align-items: center;
     min-width: 0;
+    position: sticky;
+    left: 0;
+    z-index: 1;
 }
-.atex-cg-label-main { font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.atex-cg-label-sub { color: var(--cg-muted); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-
-/* Шкала дат (sticky сверху) */
-.atex-cg-scale-row { position: sticky; top: 0; z-index: 3; background: var(--cg-surface); }
-.atex-cg-label--scale { font-weight: 600; color: var(--cg-muted); }
+.atex-cg-label-main { font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 .atex-cg-track {
     position: relative;
-    min-height: 40px;
+    min-height: 24px;
     background: var(--cg-track);
 }
-.atex-cg-scale { min-height: 28px; }
 
-/* Сетка дней */
-.atex-cg-tick { position: absolute; top: 0; bottom: 0; width: 0; border-left: 1px solid var(--cg-grid); }
-.atex-cg-tick.is-end { border-left: 0; }
-.atex-cg-tick.is-scale { border-left-color: var(--cg-border); }
-.atex-cg-tick-label {
-    position: absolute;
-    top: 5px;
-    left: 4px;
-    font-size: 12px;
-    color: var(--cg-muted);
-    white-space: nowrap;
-}
-.atex-cg-tick-label.is-minor { opacity: 0; }
-
-/* Бар-ссылка */
+/* Бар-ссылка (позиция/ширина в px задаются инлайн — упаковка встык). */
 .atex-cg-bar {
     position: absolute;
-    top: 5px;
-    bottom: 5px;
+    top: 2px;
+    bottom: 2px;
     min-width: 6px;
-    border-radius: 5px;
-    padding: 0 8px;
+    border-radius: 3px;
+    padding: 0 4px;
     display: flex;
-    flex-direction: column;
+    align-items: center;
     justify-content: center;
     overflow: hidden;
     text-decoration: none;
     color: #fff;
     background: var(--cg-unknown);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, .15);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .25);
     cursor: pointer;
 }
-.atex-cg-bar:hover { filter: brightness(1.06); box-shadow: 0 2px 6px rgba(0, 0, 0, .25); }
-.atex-cg-bar:focus-visible { outline: 2px solid var(--cg-accent); outline-offset: 1px; }
-.atex-cg-bar-main { font-weight: 600; font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.atex-cg-bar-status { font-size: 11px; opacity: .92; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.atex-cg-bar:hover { filter: brightness(1.08); z-index: 2; }
+.atex-cg-bar:focus-visible { outline: 2px solid var(--cg-accent); outline-offset: 1px; z-index: 2; }
+.atex-cg-bar-main { font-weight: 600; font-size: 11px; line-height: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 .atex-cg-bar.is-planned { background: var(--cg-planned); }
 .atex-cg-bar.is-running { background: var(--cg-running); }

--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -305,27 +305,23 @@
         };
     }
 
-    // Бар задания на шкале периода: позиция/ширина в %. null — если задание вне
-    // видимого интервала (тогда строка не показывается).
-    function cutBar(cut, range, nowMs) {
-        if (!cut || !range || !(range.endMs > range.startMs)) return null;
-        var tr = cutTimeRange(cut);
-        if (!tr) return null;
-        if (tr.endMs <= range.startMs || tr.startMs >= range.endMs) return null;
-        var clippedStartMs = Math.max(tr.startMs, range.startMs);
-        var clippedEndMs = Math.min(tr.endMs, range.endMs);
-        var spanMs = range.endMs - range.startMs;
-        var status = cutStatus(cut, nowMs);
-        return {
-            cut: cut,
-            cutId: String(cut.id == null ? '' : cut.id),
-            startMs: tr.startMs, endMs: tr.endMs,
-            leftPct: round3(((clippedStartMs - range.startMs) / spanMs) * 100),
-            widthPct: round3(Math.max(((clippedEndMs - clippedStartMs) / spanMs) * 100, 0.6)),
-            status: status,
-            barLabel: formatTime(tr.startMs) + '–' + formatTime(tr.endMs),
-            title: cutBarTitle(cut, tr, status)
-        };
+    // #3648: упаковка встык — позиция бара считается не по календарю, а кумулятивно
+    // по длительности в пределах станка (см. packGroups). Геометрия в px.
+    var GANTT_PX_PER_MIN = 6;   // ширина бара = длительность(мин) × это; …
+    var GANTT_MIN_BAR_PX = 26;  // …но не меньше минимума, чтобы крошечные задания было видно.
+
+    // Текст внутри бара — номер заказа (полные детали — в title/подписи строки).
+    function cutBarText(cut) {
+        return (cut && cut.orderNo) ? String(cut.orderNo) : ('#' + ((cut && cut.id) || ''));
+    }
+
+    // Задание попадает в видимый период (по плановой дате, иначе по фактическому старту)?
+    function cutInRange(cut, range) {
+        if (!range) return true;
+        var ms = parseDateTimeMs(cut && cut.planDate);
+        if (ms == null) ms = parseDateTimeMs(cut && cut.startDate);
+        if (ms == null) return false;
+        return ms >= range.startMs && ms < range.endMs;
     }
 
     function cutBarTitle(cut, tr, status) {
@@ -344,14 +340,14 @@
         return lines.join('\n');
     }
 
-    // Подпись строки-задания: главное + детали (заказ/сырьё/станок/лидер).
+    // #3648 п.1: подпись строки в ОДНУ строку без слова «Заказ»: «{заказ} / {сырьё} · {метраж}».
+    // Станок в подпись не входит — он выводится заголовком группы (п.2).
     function cutRowLabel(cut) {
-        var main = (cut && cut.orderNo) ? ('Заказ ' + cut.orderNo) : (formatCutNumber(cut && cut.number) || ('#' + ((cut && cut.id) || '')));
-        var parts = [];
-        if (cut && cut.materialName) parts.push(cut.materialName);
-        if (cut && cut.slitter && cut.slitter.label) parts.push(cut.slitter.label);
-        if (cut && cut.leader) parts.push(cut.leader);
-        return { main: main, sub: parts.join(' · ') };
+        var head = (cut && cut.orderNo) ? String(cut.orderNo) : (formatCutNumber(cut && cut.number) || ('#' + ((cut && cut.id) || '')));
+        var s = head;
+        if (cut && cut.materialName) s += ' / ' + cut.materialName;
+        if (cut && cut.length > 0) s += ' · ' + cut.length;
+        return s;
     }
 
     // Строки отчёта cut_planning → задания (dedup по cut_id). Несколько строк на
@@ -378,6 +374,7 @@
                 startDate: str(row.cut_start_date),
                 endDate: str(row.cut_end_date),
                 duration: durationOf(row),
+                length: stripNum(row.cut_length),
                 sequence: row.cut_sequence == null || row.cut_sequence === '' ? null : stripNum(row.cut_sequence),
                 leader: str(row.cut_leader),
                 orderNo: str(row.order_no),
@@ -390,22 +387,19 @@
         return order.map(function(id) { return byId[id]; });
     }
 
-    // Порядок строк task-Ганта: по станку (метка), затем по визуальному старту,
-    // затем по очередности, затем по id. Вход не мутирует.
-    function orderCutsForGantt(cuts) {
-        return (cuts || []).slice().sort(function(a, b) {
-            var sa = String((a.slitter && a.slitter.label) || '~');
-            var sb = String((b.slitter && b.slitter.label) || '~');
-            var bySlitter = sa.localeCompare(sb, 'ru');
-            if (bySlitter) return bySlitter;
-            var ta = cutTimeRange(a), tb = cutTimeRange(b);
-            var ma = ta ? ta.startMs : Infinity, mb = tb ? tb.startMs : Infinity;
-            if (ma !== mb) return ma - mb;
+    // Порядок заданий ВНУТРИ станка: по очередности (пусто — в конец), затем по
+    // визуальному старту, затем по id. Мутирует переданный массив (он локальный в packGroups).
+    function orderCutsInGroup(cuts) {
+        cuts.sort(function(a, b) {
             var qa = a.sequence == null ? Infinity : a.sequence;
             var qb = b.sequence == null ? Infinity : b.sequence;
             if (qa !== qb) return qa - qb;
+            var ta = cutTimeRange(a), tb = cutTimeRange(b);
+            var ma = ta ? ta.startMs : Infinity, mb = tb ? tb.startMs : Infinity;
+            if (ma !== mb) return ma - mb;
             return String(a.id).localeCompare(String(b.id));
         });
+        return cuts;
     }
 
     // Ссылка на «Планирование производства» с зашитыми заданием/датой/станком.
@@ -421,21 +415,61 @@
         return params.length ? base + '?' + params.join('&') : base;
     }
 
-    // Видимые в периоде задания (бар != null) после фильтров статуса/станка, в порядке Ганта.
-    function ganttRows(cuts, range, nowMs, filters) {
+    // #3648 п.2/п.3: группировка по станку + упаковка заданий встык по очерёдности.
+    // В каждом станке задания идут друг за другом: left = сумма ширин предыдущих,
+    // ширина = длительность×pxPerMin (но не меньше minPx) → бары стыкуются без зазоров.
+    // Геометрия в px; trackPx = ширина самого «длинного» станка (общий масштаб дорожек).
+    // Фильтры: дата (видимый период), станок, производный статус.
+    function packGroups(cuts, range, nowMs, filters, opts) {
         var f = filters || {};
+        var o = opts || {};
+        var pxPerMin = o.pxPerMin > 0 ? o.pxPerMin : GANTT_PX_PER_MIN;
+        var minPx = o.minPx > 0 ? o.minPx : GANTT_MIN_BAR_PX;
         var statusFilter = String(f.status == null ? '' : f.status).trim();
         var slitterFilter = String(f.slitter == null ? '' : f.slitter).trim();
-        var rows = [];
-        orderCutsForGantt(cuts).forEach(function(cut) {
+
+        var groupsMap = {};
+        var orderKeys = [];
+        (cuts || []).forEach(function(cut) {
             var s = cut && cut.slitter || { id: null, label: '' };
-            if (slitterFilter && String(s.id == null ? '' : s.id) !== slitterFilter) return;
-            var bar = cutBar(cut, range, nowMs);
-            if (!bar) return;
-            if (statusFilter && bar.status.key !== statusFilter) return;
-            rows.push({ cut: cut, bar: bar, label: cutRowLabel(cut) });
+            var sid = s.id == null ? '' : String(s.id);
+            if (slitterFilter && sid !== slitterFilter) return;
+            if (!cutInRange(cut, range)) return;
+            if (statusFilter && cutStatus(cut, nowMs).key !== statusFilter) return;
+            var key = sid === '' ? ' none' : sid;
+            if (!groupsMap[key]) {
+                groupsMap[key] = { slitter: { id: sid === '' ? null : sid, label: s.label || (sid === '' ? 'Без станка' : '#' + sid) }, cuts: [] };
+                orderKeys.push(key);
+            }
+            groupsMap[key].cuts.push(cut);
         });
-        return rows;
+
+        var groups = orderKeys.map(function(k) { return groupsMap[k]; }).sort(function(a, b) {
+            if (a.slitter.id == null) return 1;
+            if (b.slitter.id == null) return -1;
+            return String(a.slitter.label).localeCompare(String(b.slitter.label), 'ru');
+        });
+
+        var trackPx = 0;
+        groups.forEach(function(g) {
+            orderCutsInGroup(g.cuts);
+            var cum = 0;
+            g.tasks = g.cuts.map(function(cut) {
+                var w = Math.max(Math.round(stripNum(cut.duration) * pxPerMin), minPx);
+                var status = cutStatus(cut, nowMs);
+                var task = {
+                    cut: cut, status: status, leftPx: cum, widthPx: w,
+                    label: cutRowLabel(cut), barText: cutBarText(cut),
+                    title: cutBarTitle(cut, cutTimeRange(cut) || {}, status)
+                };
+                cum += w;
+                return task;
+            });
+            g.totalPx = cum;
+            if (cum > trackPx) trackPx = cum;
+            delete g.cuts;
+        });
+        return { groups: groups, trackPx: trackPx };
     }
 
     function slittersFromCuts(cuts) {
@@ -482,12 +516,13 @@
         shiftAnchor: shiftAnchor,
         cutStatus: cutStatus,
         cutTimeRange: cutTimeRange,
-        cutBar: cutBar,
+        cutInRange: cutInRange,
         cutRowLabel: cutRowLabel,
+        cutBarText: cutBarText,
         rowsToCuts: rowsToCuts,
-        orderCutsForGantt: orderCutsForGantt,
+        orderCutsInGroup: orderCutsInGroup,
+        packGroups: packGroups,
         planningLink: planningLink,
-        ganttRows: ganttRows,
         slittersFromCuts: slittersFromCuts,
         parseDeepLink: parseDeepLink,
         formatCutNumber: formatCutNumber,
@@ -652,65 +687,44 @@
     AtexCutGantt.prototype._buildBody = function(range, nowMs) {
         var self = this;
         var st = this.state;
-        var rows = ganttRows(this.cuts, range, nowMs, { status: st.status, slitter: st.slitter });
+        // #3648 п.2/п.3: группы по станку, задания упакованы встык по очерёдности.
+        var data = packGroups(this.cuts, range, nowMs, { status: st.status, slitter: st.slitter });
 
-        function appendTicks(track, scale) {
-            range.days.forEach(function(day, idx) {
-                var tick = el('span', { class: 'atex-cg-tick' + (scale ? ' is-scale' : '') });
-                tick.style.left = day.leftPct + '%';
-                if (scale) {
-                    var label = el('span', { class: 'atex-cg-tick-label', text: day.label });
-                    if (range.mode === 'month' && idx % 2 !== 0) label.className += ' is-minor';
-                    tick.appendChild(label);
-                }
-                track.appendChild(tick);
-            });
-            var endTick = el('span', { class: 'atex-cg-tick is-end' + (scale ? ' is-scale' : '') });
-            endTick.style.left = '100%';
-            track.appendChild(endTick);
-        }
-
-        var body = el('div', { class: 'atex-cg-body atex-cg-body--' + range.mode });
-
-        // Шапка-шкала: пустая ячейка под метки + шкала дат.
-        var scaleRow = el('div', { class: 'atex-cg-row atex-cg-scale-row' });
-        scaleRow.appendChild(el('div', { class: 'atex-cg-label atex-cg-label--scale', text: 'Задание' }));
-        var scaleTrack = el('div', { class: 'atex-cg-track atex-cg-scale' });
-        appendTicks(scaleTrack, true);
-        scaleRow.appendChild(scaleTrack);
-        body.appendChild(scaleRow);
-
-        if (!rows.length) {
+        var body = el('div', { class: 'atex-cg-body' });
+        if (!data.groups.length) {
             body.appendChild(el('div', { class: 'atex-cg-empty', text: 'На выбранном интервале заданий нет' }));
             return body;
         }
+        var trackPx = Math.max(data.trackPx, 1);
+        body.style.minWidth = 'calc(var(--cg-label-w) + ' + trackPx + 'px)';
 
-        rows.forEach(function(rowData) {
-            var bar = rowData.bar;
-            var statusKey = bar.status && bar.status.key || 'unknown';
+        data.groups.forEach(function(group) {
+            // Заголовок станка (п.2) — отдельной строкой перед его заданиями.
+            body.appendChild(el('div', { class: 'atex-cg-machine-head' }, [
+                el('span', { class: 'atex-cg-machine-name', text: group.slitter.label }),
+                el('span', { class: 'atex-cg-machine-count', text: group.tasks.length + ' зад.' })
+            ]));
 
-            var labelCell = el('div', { class: 'atex-cg-label', title: rowData.label.main + (rowData.label.sub ? ' · ' + rowData.label.sub : '') }, [
-                el('span', { class: 'atex-cg-label-main', text: rowData.label.main }),
-                rowData.label.sub ? el('span', { class: 'atex-cg-label-sub', text: rowData.label.sub }) : null
-            ]);
-
-            var track = el('div', { class: 'atex-cg-track' });
-            appendTicks(track, false);
-
-            var barLink = el('a', {
-                class: 'atex-cg-bar is-' + statusKey,
-                href: planningLink(rowData.cut, self.planningUrl),
-                title: bar.title,
-                dataset: { cutId: bar.cutId }
-            }, [
-                el('span', { class: 'atex-cg-bar-main', text: bar.barLabel }),
-                el('span', { class: 'atex-cg-bar-status', text: bar.status.label })
-            ]);
-            barLink.style.left = bar.leftPct + '%';
-            barLink.style.width = bar.widthPct + '%';
-            track.appendChild(barLink);
-
-            body.appendChild(el('div', { class: 'atex-cg-row' }, [labelCell, track]));
+            group.tasks.forEach(function(t) {
+                var statusKey = t.status && t.status.key || 'unknown';
+                var labelCell = el('div', { class: 'atex-cg-label', title: t.label }, [
+                    el('span', { class: 'atex-cg-label-main', text: t.label })
+                ]);
+                var track = el('div', { class: 'atex-cg-track' });
+                track.style.minWidth = trackPx + 'px';
+                var barLink = el('a', {
+                    class: 'atex-cg-bar is-' + statusKey,
+                    href: planningLink(t.cut, self.planningUrl),
+                    title: t.title,
+                    dataset: { cutId: String(t.cut.id == null ? '' : t.cut.id) }
+                }, [
+                    el('span', { class: 'atex-cg-bar-main', text: t.barText })
+                ]);
+                barLink.style.left = t.leftPx + 'px';
+                barLink.style.width = t.widthPx + 'px';
+                track.appendChild(barLink);
+                body.appendChild(el('div', { class: 'atex-cg-row' }, [labelCell, track]));
+            });
         });
 
         return body;

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -30,12 +30,12 @@ function assertEqual(actual, expected, name) {
     }
 }
 
-// ── rowsToCuts: dedup по cut_id; order/sequence/leader; длительность ──
+// ── rowsToCuts: dedup по cut_id; order/sequence/leader/метраж; длительность ──
 var cuts = gantt.rowsToCuts([
     { cut_id: '10', cut_slitter: 'Станок 1', cut_slitter_id: '101',
       cut_plan_date: '06.05.2026', cut_material: 'MR194', cut_material_id: '5',
       cut_start_date: '06.05.2026 08:10', cut_end_date: '06.05.2026 09:20',
-      cut_duration: '70', cut_status: 'В работе', cut_sequence: '2',
+      cut_duration: '70', cut_length: '600', cut_status: 'В работе', cut_sequence: '2',
       cut_leader: 'MONOCHROME', order_no: '3700', supply_id: '900' },
     // вторая строка той же резки (join с обеспечением) — схлопывается
     { cut_id: '10', cut_slitter: 'Станок 1', cut_slitter_id: '101', supply_id: '901' },
@@ -44,13 +44,18 @@ var cuts = gantt.rowsToCuts([
 ]);
 assertEqual(cuts, [
     { id: '10', number: '06.05.2026', planDate: '06.05.2026', status: 'В работе',
-      startDate: '06.05.2026 08:10', endDate: '06.05.2026 09:20', duration: 70,
+      startDate: '06.05.2026 08:10', endDate: '06.05.2026 09:20', duration: 70, length: 600,
       sequence: 2, leader: 'MONOCHROME', orderNo: '3700',
       materialId: '5', materialName: 'MR194', slitter: { id: '101', label: 'Станок 1' } },
     { id: '20', number: '27.05.2026', planDate: '27.05.2026', status: 'Ожидает',
-      startDate: '', endDate: '', duration: 0, sequence: null, leader: '', orderNo: '3701',
+      startDate: '', endDate: '', duration: 0, length: 0, sequence: null, leader: '', orderNo: '3701',
       materialId: '', materialName: '', slitter: { id: null, label: '' } }
-], 'rowsToCuts: dedup, поля order/sequence/leader, длительность');
+], 'rowsToCuts: dedup, поля order/sequence/leader/length, длительность');
+
+// ── cutRowLabel (#3648 п.1): одна строка «{заказ} / {сырьё} · {метраж}», без слова «Заказ» ──
+assertEqual(gantt.cutRowLabel({ orderNo: '3700', materialName: 'MWR116L', length: 600 }),
+    '3700 / MWR116L · 600', 'cutRowLabel: заказ / сырьё · метраж');
+assertEqual(gantt.cutRowLabel({ orderNo: '3701' }), '3701', 'cutRowLabel: только заказ');
 
 // ── ganttRange: неделя с понедельника, 7 дней ──
 var weekRange = gantt.ganttRange('2026-06-11', 'week');
@@ -70,31 +75,27 @@ assertEqual(gantt.cutStatus({ planDate: '2026-06-10 08:00', duration: 60, startD
 assertEqual(gantt.cutStatus({ planDate: '2026-06-10 08:00', duration: 60, endDate: '2026-06-10 10:00' }, NOW).key,
     'late', 'cutStatus: финиш позже дедлайна → с опозданием');
 
-// ── cutBar: позиция/ширина на недельной шкале ──
-var bar = gantt.cutBar({ id: '10', planDate: '2026-06-10' }, weekRange, NOW);
-assertEqual({ left: bar.leftPct, width: bar.widthPct, cutId: bar.cutId },
-    { left: 28.571, width: 0.6, cutId: '10' },
-    'cutBar: вторник недели → left 2/7, ширина минимальная');
-assertEqual(gantt.cutBar({ id: '99', planDate: '2026-07-01' }, weekRange, NOW), null,
-    'cutBar: вне периода → null');
+// ── cutInRange: задание в видимом периоде (по плановой дате, иначе по старту) ──
+assertEqual(gantt.cutInRange({ planDate: '2026-06-10' }, weekRange), true, 'cutInRange: дата внутри недели');
+assertEqual(gantt.cutInRange({ planDate: '2026-07-01' }, weekRange), false, 'cutInRange: дата вне недели');
+assertEqual(gantt.cutInRange({ planDate: '', startDate: '2026-06-11' }, weekRange), true, 'cutInRange: фолбэк на старт');
 
-// ── orderCutsForGantt: по станку, затем старту ──
-var ordered = gantt.orderCutsForGantt([
-    { id: 'A', planDate: '2026-06-10', slitter: { id: '2', label: 'Станок 2' } },
-    { id: 'B', planDate: '2026-06-11', slitter: { id: '1', label: 'Станок 1' } }
-]).map(function(c) { return c.id; });
-assertEqual(ordered, ['B', 'A'], 'orderCutsForGantt: Станок 1 раньше Станка 2');
-
-// ── ganttRows: фильтры станка/статуса + только видимые ──
-var rowCuts = [
-    { id: '10', planDate: '2026-06-10', slitter: { id: '1', label: 'Станок 1' } },
-    { id: '20', planDate: '2026-06-11', slitter: { id: '2', label: 'Станок 2' } },
-    { id: '30', planDate: '2026-07-01', slitter: { id: '1', label: 'Станок 1' } } // вне периода
+// ── packGroups (#3648 п.2/п.3): группы по станку + упаковка встык по очерёдности ──
+var packCuts = [
+    { id: '10', planDate: '2026-06-10', duration: 60, sequence: 2, orderNo: 'A', slitter: { id: '1', label: 'Станок 1' } },
+    { id: '11', planDate: '2026-06-09', duration: 30, sequence: 1, orderNo: 'B', slitter: { id: '1', label: 'Станок 1' } },
+    { id: '20', planDate: '2026-06-11', duration: 40, orderNo: 'C', slitter: { id: '2', label: 'Станок 2' } },
+    { id: '30', planDate: '2026-07-01', duration: 50, orderNo: 'D', slitter: { id: '1', label: 'Станок 1' } } // вне периода
 ];
-assertEqual(gantt.ganttRows(rowCuts, weekRange, NOW, {}).map(function(r) { return r.cut.id; }),
-    ['10', '20'], 'ganttRows: вне периода (30) отброшено');
-assertEqual(gantt.ganttRows(rowCuts, weekRange, NOW, { slitter: '2' }).map(function(r) { return r.cut.id; }),
-    ['20'], 'ganttRows: фильтр по станку');
+var packed = gantt.packGroups(packCuts, weekRange, NOW, {}, { pxPerMin: 2, minPx: 20 });
+assertEqual(packed.groups.map(function(g) { return g.slitter.label; }), ['Станок 1', 'Станок 2'],
+    'packGroups: группы по станку, сортировка по метке');
+assertEqual(packed.groups[0].tasks.map(function(t) { return [t.cut.id, t.leftPx, t.widthPx]; }),
+    [['11', 0, 60], ['10', 60, 120]],
+    'packGroups: внутри станка — по очерёдности, встык (left = сумма ширин), ширина = длит×px');
+assertEqual(packed.trackPx, 180, 'packGroups: trackPx = ширина самого длинного станка');
+assertEqual(gantt.packGroups(packCuts, weekRange, NOW, { slitter: '2' }, {}).groups.map(function(g) { return g.slitter.label; }),
+    ['Станок 2'], 'packGroups: фильтр по станку');
 
 // ── planningLink: ссылка на планировщик с датой/станком/заданием ──
 assertEqual(gantt.planningLink({ id: '85472', planDate: '06.05.2026', slitter: { id: '1285' } }),


### PR DESCRIPTION
Закрывает #3648 — правки к #3645 (cut-gantt) по отзыву.

## Изменения
1. **Подпись в одну строку, без слова «Заказ»**: `{заказ} / {сырьё} · {метраж}`
   (`cutRowLabel` теперь строка; в `rowsToCuts` добавлен `length` из `cut_length`).
2. **Станок — отдельным заголовком** перед его заданиями (группировка по станку,
   с счётчиком задач).
3. **Упаковка встык по очерёдности**: в пределах станка задания идут друг за другом
   (left = сумма ширин предыдущих, ширина = длительность×6px, минимум 26px) — без
   горизонтальных зазоров. Ось = очередь/длительность, а не календарь: у резок
   крошечные минутные длительности, и на календарной шкале все бары упирались в
   минимум и расходились «лесенкой» с зазорами переналадки. Строки стали компактнее.

Ядро переработано: `cutBar`/`ganttRows`/`orderCutsForGantt` → `cutInRange`/
`orderCutsInGroup`/`packGroups` (+ `cutBarText`).

## Проверка
- Юнит-тесты `experiments/atex-cut-gantt.test.js` — 23 ✅ (rowsToCuts+length,
  cutRowLabel, cutInRange, packGroups встык, planningLink, parseDeepLink). `node --check` ✅.
- **Задеплоено на тест-базу ateh** (dir_admin) и проверено в браузере (`/ateh/cut-gantt`):
  заголовки станков, однострочные подписи, бары стыкуются вплотную (right край =
  left следующего), ширина ∝ длительность, ссылки `/ateh/production-planning?cut=..&date=..&slitter=..`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)