### PR TITLE
feat(atex): диаграмма Ганта — часовые деления, пожирнее в 8/12/18 (#3654)

### DIFF
--- a/download/atex/css/cut-gantt.css
+++ b/download/atex/css/cut-gantt.css
@@ -146,6 +146,31 @@
     background: var(--cg-track);
 }
 
+/* #3654: верхняя шкала часов + часовые деления. Деления выровнены по px с упаковкой. */
+.atex-cg-scale-row { position: sticky; top: 0; z-index: 4; }
+.atex-cg-label--scale { font-weight: 600; font-size: 12px; color: var(--cg-muted); }
+.atex-cg-scale { min-height: 20px; background: var(--cg-surface); }
+.atex-cg-hour-label {
+    position: absolute;
+    top: 3px;
+    transform: translateX(3px);
+    font-size: 11px;
+    color: var(--cg-muted);
+    white-space: nowrap;
+    pointer-events: none;
+}
+.atex-cg-hour-label.is-bold { font-weight: 700; color: var(--cg-accent); }
+/* Часовые деления внутри дорожек заданий: пунктир каждый час, пожирнее в 8/12/18. */
+.atex-cg-hour {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 0;
+    border-left: 1px dashed var(--cg-grid);
+    pointer-events: none;
+}
+.atex-cg-hour.is-bold { border-left-width: 2px; border-left-color: var(--cg-muted); }
+
 /* Бар-ссылка (позиция/ширина в px задаются инлайн — упаковка встык). */
 .atex-cg-bar {
     position: absolute;

--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -309,6 +309,11 @@
     // по длительности в пределах станка (см. packGroups). Геометрия в px.
     var GANTT_PX_PER_MIN = 6;   // ширина бара = длительность(мин) × это; …
     var GANTT_MIN_BAR_PX = 26;  // …но не меньше минимума, чтобы крошечные задания было видно.
+    // #3654: часовая сетка. Упаковка идёт встык от начала смены, поэтому позиция в px
+    // соответствует «прошло от GANTT_DAY_START_HOUR»: x=0 → 08:00, далее каждый час.
+    // Деления каждый час пунктиром, пожирнее в GANTT_BOLD_HOURS (старт/обед/конец смены).
+    var GANTT_DAY_START_HOUR = 8;
+    var GANTT_BOLD_HOURS = { 8: true, 12: true, 18: true };
 
     // Текст внутри бара — номер заказа (полные детали — в title/подписи строки).
     function cutBarText(cut) {
@@ -698,6 +703,30 @@
         var trackPx = Math.max(data.trackPx, 1);
         body.style.minWidth = 'calc(var(--cg-label-w) + ' + trackPx + 'px)';
 
+        // #3654: часовые деления/подписи на дорожке шириной trackPx (x=0 → начало смены,
+        // далее каждый час). pxPerHour согласован с упаковкой (GANTT_PX_PER_MIN).
+        var pxPerHour = GANTT_PX_PER_MIN * 60;
+        function appendHours(track, withLabels) {
+            var hour = GANTT_DAY_START_HOUR;
+            for (var x = 0; x <= trackPx + 0.5; x += pxPerHour) {
+                var bold = !!GANTT_BOLD_HOURS[hour];
+                var node = el('span', { class: (withLabels ? 'atex-cg-hour-label' : 'atex-cg-hour') + (bold ? ' is-bold' : '') });
+                if (withLabels) node.textContent = String(hour);
+                node.style.left = x + 'px';
+                track.appendChild(node);
+                hour++;
+            }
+        }
+
+        // Верхняя шкала часов (подписи); деления выровнены с сеткой в дорожках заданий.
+        var scaleRow = el('div', { class: 'atex-cg-row atex-cg-scale-row' });
+        scaleRow.appendChild(el('div', { class: 'atex-cg-label atex-cg-label--scale', text: 'Время, ч' }));
+        var scaleTrack = el('div', { class: 'atex-cg-track atex-cg-scale' });
+        scaleTrack.style.minWidth = trackPx + 'px';
+        appendHours(scaleTrack, true);
+        scaleRow.appendChild(scaleTrack);
+        body.appendChild(scaleRow);
+
         data.groups.forEach(function(group) {
             // Заголовок станка (п.2) — отдельной строкой перед его заданиями.
             body.appendChild(el('div', { class: 'atex-cg-machine-head' }, [
@@ -712,6 +741,7 @@
                 ]);
                 var track = el('div', { class: 'atex-cg-track' });
                 track.style.minWidth = trackPx + 'px';
+                appendHours(track, false);   // #3654: часовая сетка под баром
                 var barLink = el('a', {
                     class: 'atex-cg-bar is-' + statusKey,
                     href: planningLink(t.cut, self.planningUrl),


### PR DESCRIPTION
Закрывает #3654.

## Что добавлено
Вертикальные **часовые деления** в диаграмме Ганта (cut-gantt) + верхняя шкала часов.

После #3648 ось Ганта — упаковка встык по длительности; позиция в px соответствует
«прошло от начала смены 08:00» (x=0 → 8:00, каждый час = 60 мин × `GANTT_PX_PER_MIN`).
Поэтому:
- деления **каждый час пунктиром** (`.atex-cg-hour`, dashed);
- **пожирнее** (толще + темнее) на **8, 12 и 18 ч** — старт/обед/конец смены
  (`GANTT_BOLD_HOURS`, `.is-bold`);
- верхняя строка «Время, ч» с подписями часов (жирные на 8/12/18); деления
  выровнены по px с упаковкой баров.

Константы: `GANTT_DAY_START_HOUR=8`, `GANTT_BOLD_HOURS={8,12,18}`.

## Проверка
- Юнит-тесты ядра — 23 ✅, `node --check` ✅ (правки только в рендере `_buildBody` + CSS).
- **Задеплоено на тест-базу ateh** и проверено в браузере (`/ateh/cut-gantt`): подписи
  часов 8–18, жирные на 8/12/18 (left 0/1440/3600px при 6px/мин), пунктирные деления
  каждый час в дорожках, бары и упаковка не сломаны.

🤖 Generated with [Claude Code](https://claude.com/claude-code)