### PR TITLE
fix(atex): планирование — генерация не утаскивает историю в выбранную дату (#3658)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2536,8 +2536,18 @@
         // До вставки обеда доступную ёмкость дня уменьшаем на длительность обеда (резерв):
         // если обед не получится поставить паузой между резками, день закончится раньше.
         function effCapacity(d) { return (lunch && !lunchDone[d]) ? (capacity - lunch.durationMin) : capacity; }
+        // #3658: якорь дня по «Дате план» — резка ложится на СВОЙ рабочий день, а не паком от
+        // дня «С». Иначе автозаполнение дней (#3619) при генерации с другой даты переписывало
+        // planStartTs истории (задания 30.05 уезжали в выбранную 4.06). Якорь может быть
+        // отрицательным (день раньше базы=дня «С»), поэтому стартовый день = минимальный якорь.
+        var anchorByCut = opts.dayAnchorByCut || {};
+        var minAnchor = null;
+        (orderedCuts || []).forEach(function(c){
+            var a = anchorByCut[String(c && c.id)];
+            if (a != null && (minAnchor == null || a < minAnchor)) minAnchor = a;
+        });
         var segments = [];
-        var day = 0, clock = 0;                      // clock — минут занято в текущем дне (от dayStart)
+        var day = (minAnchor != null ? minAnchor : 0), clock = 0;   // clock — минут занято в текущем дне (от dayStart)
         var prevPhysical = null;                     // предыдущая ФИЗИЧЕСКАЯ резка (для переналадки)
         // Обед как пауза перед НОВОЙ резкой: если в этот день он ещё не был и время дня
         // (dayStart+clock) дошло до LUNCH_START — вставляем паузу (clock += длительность).
@@ -2549,6 +2559,10 @@
         }
         (orderedCuts || []).forEach(function(c){
             var cid = c && c.id;
+            // #3658: если очередь не дотянула до рабочего дня этой резки — прыгаем вперёд к
+            // нему (08:00). Назад не двигаем (переполнение предыдущих дней сохраняется).
+            var anchorDay = anchorByCut[String(cid)];
+            if (anchorDay != null && anchorDay > day) { day = anchorDay; clock = 0; }
             var runs = Math.round(Number(runsByCut[String(cid)] != null ? runsByCut[String(cid)] : c && c.plannedRuns) || 0);
             var perPass = Number(perPassByCut[String(cid)] != null ? perPassByCut[String(cid)] : 0) || 0;
             var remaining = runs;
@@ -2844,7 +2858,8 @@
                 dayStartMin: opts.dayStartMin, dayEndMin: opts.dayEndMin,
                 leader: opts.leader, times: opts.times,
                 perPassByCut: perPass, runsByCut: runsByCut,
-                lunchStartMin: opts.lunchStartMin, lunchDurationMin: opts.lunchDurationMin
+                lunchStartMin: opts.lunchStartMin, lunchDurationMin: opts.lunchDurationMin,
+                dayAnchorByCut: opts.dayAnchorByCut   // #3658: привязка к дню «Даты план»
             });
             // headId → индекс продолжения в цепочке (0=голова, 1,2,… — продолжения по дням).
             var contIndexByHead = {};
@@ -7102,8 +7117,15 @@
         var planBaseMidnightMs = planBaseMidnightFrom(self.filter && self.filter.date, controllerNowMs(self));
         var windPoints = windingPointsFromTimes(self.opTimes || {});
         var perPassByCut = {};
+        // #3658: якорь дня по «Дате план» каждого задания (смещение от базы=дня «С»). Без него
+        // автозаполнение дней переписывало planStartTs истории: генерация с 4.06 утаскивала
+        // задания 30.05 в 4.06. Привязываем каждое задание к ЕГО рабочему дню (может быть и
+        // раньше базы → отрицательное смещение). Пустая «Дата план» — без якоря.
+        var dayAnchorByCut = {};
         self.cuts.forEach(function(c) {
             perPassByCut[String(c.id)] = windingMinutes(cutRunLength(c, self.supplies, self.footageBySupply), windPointsForCut(c.isFoil, windPoints)); // #3606
+            var off = dayOffsetFromBase(c.planDate, planBaseMidnightMs);
+            if (off != null) dayAnchorByCut[String(c.id)] = off;
         });
         var ops = planCutOperations(self.cuts, {
             weights: planOptions,
@@ -7114,7 +7136,8 @@
             planBaseMidnightMs: planBaseMidnightMs,
             lunchStartMin: dayWindow.lunchStartMin,
             lunchDurationMin: dayWindow.lunchDurationMin,
-            preserveOrder: preserveOrder   // #3619: только заполнить дни, не пересобирая порядок
+            preserveOrder: preserveOrder,   // #3619: только заполнить дни, не пересобирая порядок
+            dayAnchorByCut: dayAnchorByCut   // #3658: привязка к дню «Даты план»
         });
 
         // Родители разбиений нужны в updates всегда (для расчёта долей Обеспечения).

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -2382,6 +2382,32 @@ assertEqual(
     ['d1a', 'd1foil', 'd2a', 'd2b'],
     'planCutOperations #3635: preserveOrder день-первым — день1 (вкл. фольгу очередь 2) ПЕРЕД днём2, без перемешивания');
 
+// ── #3658: автозаполнение дней НЕ утаскивает историю в выбранную дату (якорь по «Дате план») ──
+// База = 4.06 (день фильтра «С»). Задание 30.05 (раньше базы) должно остаться на 30.05,
+// а не переехать в 4.06; новое задание 4.06 — на 4.06. Якорь может быть отрицательным.
+function cut3658(id, mat, ts) {
+    return { id: id, slitter: { id: 'm1' }, materialId: mat, winding: 'IN',
+        knifeWidths: [60], knifeCount: 1, plannedRuns: 1, planDate: ts };
+}
+var b3658 = Date.UTC(2026, 5, 4, 0, 0, 0); // 4.06.2026 00:00 UTC
+var ts3658May30 = String(Math.floor(Date.UTC(2026, 4, 30, 8, 0, 0) / 1000));
+var ts3658Jun4 = String(Math.floor(Date.UTC(2026, 5, 4, 8, 0, 0) / 1000));
+var anchor3658 = {
+    may30: planning.dayOffsetFromBase(ts3658May30, b3658),
+    jun4: planning.dayOffsetFromBase(ts3658Jun4, b3658)
+};
+assertEqual(anchor3658, { may30: -5, jun4: 0 }, 'dayOffsetFromBase #3658: 30.05 от базы 4.06 = −5 (раньше базы)');
+var ops3658 = planning.planCutOperations(
+    [ cut3658('may30', '1', ts3658May30), cut3658('jun4', '2', ts3658Jun4) ],
+    { preserveOrder: true, planBaseMidnightMs: b3658, dayAnchorByCut: anchor3658,
+      perPassByCut: { may30: 5, jun4: 5 }, dayStartMin: 480, dayEndMin: 990, times: { BETWEEN_CUTS: 0 } }
+);
+var u3658 = {}; ops3658.updates.forEach(function(u) { u3658[u.cutId] = u.planStartTs; });
+assertEqual(u3658.may30, Math.floor(Date.UTC(2026, 4, 30, 8, 0, 0) / 1000),
+    'planCutOperations #3658: задание 30.05 осталось на 30.05 08:00 (не уехало в 4.06)');
+assertEqual(u3658.jun4, Math.floor(Date.UTC(2026, 5, 4, 8, 0, 0) / 1000),
+    'planCutOperations #3658: задание 4.06 — на 4.06 08:00');
+
 // ── #3427: повторная раскладка УЖЕ разбитой цепочки идемпотентна ───────────────
 // Цепочка [A(день0, 10 проходов) → B(день1, 5 проходов)] уже разбита по дням.
 // Повторный planCutOperations должен ПЕРЕИСПОЛЬЗОВАТЬ запись B как update (а не

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 54);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 55);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3658.

> Отдельный PR (исправляю свою ошибку): фикс #3658 я по ошибке дописал в ветку уже смерженного #3656 — там оказался только #3652, а коммит #3658 осиротел и в `main` не попал. Здесь он отдельным PR от свежего `main`.

## Симптом
Удалил задание 30.05 → перешёл на 4.06 → «Сгенерировать» → автозаполнение дней (#3619) переписывало `planStartTs` ВСЕЙ истории, утаскивая задания 30.05 в 4.06 (а не только новое задание).

## Фикс
Тот же якорь по «Дате план», что и в `buildSchedule` для #3652 (уже в `main`), но в **пути генерации** — `splitMachineQueue.opts.dayAnchorByCut`. При генерации очередь включает историю **до** дня «С», поэтому якорь может быть **отрицательным**; стартовый день расчёта = минимальный якорь, внутри цикла прыжок вперёд (назад не двигаем — переполнение дней сохранено). `autoSequenceQueue` строит карту через `dayOffsetFromBase` (добавлен в #3652) по `self.cuts`. История остаётся на своих датах; пишутся только реально изменившиеся записи.

## Проверки
`dayOffsetFromBase` (−5 для истории) + `planCutOperations` с базой 4.06 (30.05 остаётся на 30.05, 4.06 на 4.06). **549** проверок; 2 предсуществующих FAIL (`#3340`, `#3249`) — не регрессия. VERSION 54→55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)