### PR TITLE
fix(atex): планирование — генерация не перепланирует чужие даты (#3660)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2823,10 +2823,27 @@
         var merged = mergeContinuationChains(cuts);
         var chainByLogical = merged.chainByLogical || {};
         var perPass = opts.perPassByCut || {};
+        // #3660: НЕ перепланировать чужие даты — обрабатываем только цепочки, чья ГОЛОВА в
+        // выбранном диапазоне «Дата плана» [scopeFromKey; scopeToKey] (ключи YYYYMMDD). Иначе
+        // генерация на 31.05 переписывала очередь/время ВСЕХ будущих заданий. Переполнение дня
+        // (продолжение цепочки на следующий день) сохраняется — это сегменты той же головы.
+        // Без scope (оба ключа null) — обрабатываем все (обратная совместимость/тесты).
+        var scopeFrom = opts.scopeFromKey, scopeTo = opts.scopeToKey;
+        var hasScope = scopeFrom != null || scopeTo != null;
+        function headInScope(c){
+            if (!hasScope) return true;
+            var k = planDateDayKey(c && c.planDate);
+            if (k === Infinity) return true;   // без «Дата план» (новая, ещё не датирована) — в scope
+            var fromK = scopeFrom == null ? -Infinity : scopeFrom;
+            var toK = scopeTo == null ? Infinity : scopeTo;
+            if (fromK > toK) { var t = fromK; fromK = toK; toK = t; }
+            return k >= fromK && k <= toK;
+        }
         var byMachine = {}, mOrder = [];
         merged.cuts.forEach(function(c){
             var sid = c && c.slitter && c.slitter.id;
             if (sid == null) return;
+            if (!headInScope(c)) return;   // #3660: чужая дата — не трогаем
             var key = String(sid);
             if (!byMachine[key]) { byMachine[key] = []; mOrder.push(key); }
             byMachine[key].push(c);
@@ -7127,6 +7144,10 @@
             var off = dayOffsetFromBase(c.planDate, planBaseMidnightMs);
             if (off != null) dayAnchorByCut[String(c.id)] = off;
         });
+        // #3660: перепланируем ТОЛЬКО выбранный диапазон дат [С; По] — не лезем в другие даты.
+        // Пустой край → null (без ограничения с этой стороны).
+        var fromStr = String(self.filter && self.filter.date || '').trim();
+        var toStr = String(self.filter && self.filter.dateTo || '').trim();
         var ops = planCutOperations(self.cuts, {
             weights: planOptions,
             times: self.changeTimes,
@@ -7137,7 +7158,9 @@
             lunchStartMin: dayWindow.lunchStartMin,
             lunchDurationMin: dayWindow.lunchDurationMin,
             preserveOrder: preserveOrder,   // #3619: только заполнить дни, не пересобирая порядок
-            dayAnchorByCut: dayAnchorByCut   // #3658: привязка к дню «Даты план»
+            dayAnchorByCut: dayAnchorByCut,   // #3658: привязка к дню «Даты план»
+            scopeFromKey: fromStr === '' ? null : planDateDayKey(fromStr),   // #3660: scope = диапазон фильтра
+            scopeToKey: toStr === '' ? null : planDateDayKey(toStr)
         });
 
         // Родители разбиений нужны в updates всегда (для расчёта долей Обеспечения).

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -2408,6 +2408,32 @@ assertEqual(u3658.may30, Math.floor(Date.UTC(2026, 4, 30, 8, 0, 0) / 1000),
 assertEqual(u3658.jun4, Math.floor(Date.UTC(2026, 5, 4, 8, 0, 0) / 1000),
     'planCutOperations #3658: задание 4.06 — на 4.06 08:00');
 
+// ── #3660: scope — перепланируем ТОЛЬКО выбранный диапазон дат, не лезем в чужие даты ──
+// Генерация на 31.05 (scope [31.05;31.05]) не должна трогать задание 5.06.
+var ts3660May31 = String(Math.floor(Date.UTC(2026, 4, 31, 8, 0, 0) / 1000));
+var ts3660Jun5 = String(Math.floor(Date.UTC(2026, 5, 5, 8, 0, 0) / 1000));
+var b3660 = Date.UTC(2026, 4, 31, 0, 0, 0);
+var ops3660 = planning.planCutOperations(
+    [ cut3658('m31', '1', ts3660May31), cut3658('j5', '2', ts3660Jun5) ],
+    { preserveOrder: true, planBaseMidnightMs: b3660,
+      dayAnchorByCut: { m31: planning.dayOffsetFromBase(ts3660May31, b3660), j5: planning.dayOffsetFromBase(ts3660Jun5, b3660) },
+      perPassByCut: { m31: 5, j5: 5 }, dayStartMin: 480, dayEndMin: 990, times: { BETWEEN_CUTS: 0 },
+      scopeFromKey: planning.planDateDayKey('2026-05-31'), scopeToKey: planning.planDateDayKey('2026-05-31') }
+);
+assertEqual(ops3660.updates.map(function(u) { return u.cutId; }), ['m31'],
+    'planCutOperations #3660: scope 31.05 — в ops только 31.05, задание 5.06 НЕ трогаем');
+assertEqual(ops3660.creates.length === 0 && ops3660.deletes.length === 0, true,
+    'planCutOperations #3660: вне scope — без creates/deletes (будущее не перепланируется)');
+// Без scope (оба null) — обрабатываем оба (обратная совместимость).
+var ops3660all = planning.planCutOperations(
+    [ cut3658('m31', '1', ts3660May31), cut3658('j5', '2', ts3660Jun5) ],
+    { preserveOrder: true, planBaseMidnightMs: b3660,
+      dayAnchorByCut: { m31: 0, j5: 5 }, perPassByCut: { m31: 5, j5: 5 },
+      dayStartMin: 480, dayEndMin: 990, times: { BETWEEN_CUTS: 0 } }
+);
+assertEqual(ops3660all.updates.map(function(u) { return u.cutId; }).sort(), ['j5', 'm31'],
+    'planCutOperations #3660: без scope — обрабатываем оба (совместимость)');
+
 // ── #3427: повторная раскладка УЖЕ разбитой цепочки идемпотентна ───────────────
 // Цепочка [A(день0, 10 проходов) → B(день1, 5 проходов)] уже разбита по дням.
 // Повторный planCutOperations должен ПЕРЕИСПОЛЬЗОВАТЬ запись B как update (а не

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 55);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 56);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3660.

## Симптом
Удалил задание 4.06, пересоздал на 31.05 → генерация переписывала очередь/время **всех** будущих заданий. На скрине: фильтр «Дата плана» = 31.05–31.05, очередь пуста, создано 1 задание — а модалка «Сохранение плана резок… **5 из 10**» сохраняет 10 записей (будущее).

После #3658 (привязка к «Дате план») задания не **уезжают** в другую дату, но автозаполнение дней всё равно **пересчитывало и переписывало** будущие задания (менялась «Очередность» при вставке нового, и записи перезаписывались).

## Правило оператора
> Никогда не лезь в другие даты, если только задание не вылезает из этого дня в следующий.

## Фикс
`planCutOperations` получил `scopeFromKey`/`scopeToKey` — обрабатываем **только** цепочки, чья голова в выбранном диапазоне «Дата плана» `[С; По]` (ключи YYYYMMDD). Будущие/прошлые даты не трогаем вовсе. **Переполнение дня** (продолжение цепочки на следующий день) сохраняется — это сегменты той же головы, она в scope. `autoSequenceQueue` передаёт диапазон фильтра. Без scope (тесты/прочие вызовы) — обрабатываем все (обратная совместимость).

## Проверки
`planCutOperations` со scope 31.05 → в ops только 31.05, задание 5.06 не тронуто (0 creates/deletes); без scope → оба. **552** проверки; 2 предсуществующих FAIL (`#3340`, `#3249`) — не регрессия. VERSION 55→56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)