### PR TITLE
fix(atex): диаграмма Ганта — часовая сетка на всю смену 08:00–18:00 (#3657)

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -313,7 +313,40 @@
     // соответствует «прошло от GANTT_DAY_START_HOUR»: x=0 → 08:00, далее каждый час.
     // Деления каждый час пунктиром, пожирнее в GANTT_BOLD_HOURS (старт/обед/конец смены).
     var GANTT_DAY_START_HOUR = 8;
+    var GANTT_DAY_END_HOUR = 18;   // #3657: конец смены. Сетка часов всегда покрывает
+                                   // 08:00–18:00, даже если упакованной работы меньше часа.
     var GANTT_BOLD_HOURS = { 8: true, 12: true, 18: true };
+
+    // #3657: ширина дорожки = max(упаковка, полная смена). При суммарной длительности
+    // заданий < 1 ч упаковка короче часа, и сетка рисует только деление 08:00 («нет
+    // вертикальных полос каждый час»), а бары не с чем соотнести по масштабу. Растягиваем
+    // дорожку минимум на всю смену, чтобы деления 8…18 были всегда и масштаб был читаем.
+    function ganttTrackPx(packedPx, opts) {
+        var o = opts || {};
+        var pxPerMin = o.pxPerMin > 0 ? o.pxPerMin : GANTT_PX_PER_MIN;
+        var startHour = o.startHour != null ? Number(o.startHour) : GANTT_DAY_START_HOUR;
+        var endHour = o.endHour != null ? Number(o.endHour) : GANTT_DAY_END_HOUR;
+        var shiftPx = Math.max(endHour - startHour, 0) * pxPerMin * 60;
+        return Math.max(Number(packedPx) || 0, shiftPx, 1);
+    }
+
+    // #3654/#3657: деления часовой сетки для дорожки шириной trackPx. x=0 → начало смены,
+    // каждый час = pxPerMin×60. Покрывает всю ширину (≥ полная смена). bold — для часов из
+    // GANTT_BOLD_HOURS (старт/обед/конец смены). Чистая функция — рендер и тесты общие.
+    function hourTicks(trackPx, opts) {
+        var o = opts || {};
+        var pxPerMin = o.pxPerMin > 0 ? o.pxPerMin : GANTT_PX_PER_MIN;
+        var startHour = o.startHour != null ? Number(o.startHour) : GANTT_DAY_START_HOUR;
+        var pxPerHour = pxPerMin * 60;
+        var width = Math.max(Number(trackPx) || 0, 0);
+        var ticks = [];
+        var hour = startHour;
+        for (var x = 0; x <= width + 0.5; x += pxPerHour) {
+            ticks.push({ hour: hour, leftPx: round3(x), bold: !!GANTT_BOLD_HOURS[hour], label: String(hour) });
+            hour++;
+        }
+        return ticks;
+    }
 
     // Текст внутри бара — номер заказа (полные детали — в title/подписи строки).
     function cutBarText(cut) {
@@ -527,6 +560,8 @@
         rowsToCuts: rowsToCuts,
         orderCutsInGroup: orderCutsInGroup,
         packGroups: packGroups,
+        ganttTrackPx: ganttTrackPx,
+        hourTicks: hourTicks,
         planningLink: planningLink,
         slittersFromCuts: slittersFromCuts,
         parseDeepLink: parseDeepLink,
@@ -700,22 +735,21 @@
             body.appendChild(el('div', { class: 'atex-cg-empty', text: 'На выбранном интервале заданий нет' }));
             return body;
         }
-        var trackPx = Math.max(data.trackPx, 1);
+        // #3657: дорожка покрывает всю смену (08:00–18:00), а не только упаковку, иначе
+        // при работе < 1 ч сетка рисует лишь деление 08:00 и масштаб не читается.
+        var trackPx = ganttTrackPx(data.trackPx);
         body.style.minWidth = 'calc(var(--cg-label-w) + ' + trackPx + 'px)';
 
-        // #3654: часовые деления/подписи на дорожке шириной trackPx (x=0 → начало смены,
-        // далее каждый час). pxPerHour согласован с упаковкой (GANTT_PX_PER_MIN).
-        var pxPerHour = GANTT_PX_PER_MIN * 60;
+        // #3654/#3657: часовые деления/подписи на дорожке шириной trackPx (x=0 → начало
+        // смены, далее каждый час, деления 8…18 всегда). Геометрия — в чистой hourTicks.
+        var ticks = hourTicks(trackPx);
         function appendHours(track, withLabels) {
-            var hour = GANTT_DAY_START_HOUR;
-            for (var x = 0; x <= trackPx + 0.5; x += pxPerHour) {
-                var bold = !!GANTT_BOLD_HOURS[hour];
-                var node = el('span', { class: (withLabels ? 'atex-cg-hour-label' : 'atex-cg-hour') + (bold ? ' is-bold' : '') });
-                if (withLabels) node.textContent = String(hour);
-                node.style.left = x + 'px';
+            ticks.forEach(function(t) {
+                var node = el('span', { class: (withLabels ? 'atex-cg-hour-label' : 'atex-cg-hour') + (t.bold ? ' is-bold' : '') });
+                if (withLabels) node.textContent = t.label;
+                node.style.left = t.leftPx + 'px';
                 track.appendChild(node);
-                hour++;
-            }
+            });
         }
 
         // Верхняя шкала часов (подписи); деления выровнены с сеткой в дорожках заданий.

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -97,6 +97,23 @@ assertEqual(packed.trackPx, 180, 'packGroups: trackPx = ширина самог�
 assertEqual(gantt.packGroups(packCuts, weekRange, NOW, { slitter: '2' }, {}).groups.map(function(g) { return g.slitter.label; }),
     ['Станок 2'], 'packGroups: фильтр по станку');
 
+// ── ganttTrackPx (#3657): дорожка не короче полной смены 08:00–18:00 ──
+// pxPerMin=6 → час=360px, смена 8…18 = 10 ч = 3600px.
+assertEqual(gantt.ganttTrackPx(355), 3600, 'ganttTrackPx: упаковка < смены → растягиваем до полной смены');
+assertEqual(gantt.ganttTrackPx(5000), 5000, 'ganttTrackPx: упаковка длиннее смены → оставляем упаковку');
+assertEqual(gantt.ganttTrackPx(0), 3600, 'ganttTrackPx: пустой день — всё равно полная смена');
+assertEqual(gantt.ganttTrackPx(100, { pxPerMin: 2, startHour: 8, endHour: 18 }), 1200,
+    'ganttTrackPx: масштаб/часы смены настраиваются (10 ч × 2px/мин × 60)');
+
+// ── hourTicks (#3654/#3657): деления 8…18 всегда, bold на 8/12/18 ──
+var ticks = gantt.hourTicks(gantt.ganttTrackPx(355));
+assertEqual(ticks.map(function(t) { return t.hour; }), [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18],
+    'hourTicks: при работе < 1 ч всё равно деления 8…18 (а не только 08:00)');
+assertEqual(ticks.filter(function(t) { return t.bold; }).map(function(t) { return t.hour; }), [8, 12, 18],
+    'hourTicks: пожирнее на 8/12/18');
+assertEqual([ticks[0].leftPx, ticks[1].leftPx, ticks[10].leftPx], [0, 360, 3600],
+    'hourTicks: x=0→08:00, шаг 360px (6px/мин×60), 18:00→3600px');
+
 // ── planningLink: ссылка на планировщик с датой/станком/заданием ──
 assertEqual(gantt.planningLink({ id: '85472', planDate: '06.05.2026', slitter: { id: '1285' } }),
     '/atex/production-planning?cut=85472&date=2026-05-06&slitter=1285',


### PR DESCRIPTION
Закрывает #3657.

## Проблема
«Как будто все бары в разном масштабе и нет вертикальных полос каждый час».

Обе жалобы — следствие одного. После #3648 ось Ганта — упаковка встык по длительности
(`GANTT_PX_PER_MIN=6`), а сетка часов из #3654/#3655 рисовалась по фактической ширине
упаковки. На реальных данных ateh длительности заданий **2–9 мин** (редко 32–35), и работа
станка за день упаковывается в **< 1 часа** (≈355px < 360px). Цикл
`for(x=0; x<=trackPx; x+=360)` давал **единственное** деление 08:00 → «полос каждый час»
нет, а без видимой сетки бары не с чем соотнести (масштаб на деле единый, 6px/мин).

План у заданий **дневной** (timestamp, много заданий на 08:00) — реальное календарное
позиционирование схлопнуло бы всё в одну точку, поэтому модель «упаковка встык от 08:00»
из #3648 верна; чинить нужно сетку.

## Решение
Дорожка всегда покрывает **всю смену 08:00–18:00**, а не только упаковку:
- `ganttTrackPx(packedPx)` = `max(упаковка, ширина смены)` — деления **8…18 есть всегда**,
  бары соотносятся с реальной часовой шкалой (читаемый масштаб);
- геометрия делений вынесена в чистую `hourTicks(trackPx)` (x=0→08:00, шаг 6px/мин×60,
  bold на 8/12/18) — общий код рендера и тестов;
- `GANTT_DAY_END_HOUR=18` (конец смены).

Правки только в рендере (`_buildBody`) и чистом ядре; **CSS не тронут**.

## Проверка
- Юнит-тесты ядра — **30 ✅** (было 23; +7 на `ganttTrackPx`/`hourTicks`), `node --check` ✅.
- **Задеплоено на тест-базу ateh** и проверено в браузере (`/ateh/cut-gantt`, реальные
  данные): верхняя шкала **8…18**, по **11 пунктирных делений** в каждой дорожке, жирные
  на 8/12/18, упаковка баров и ссылки на планировщик не сломаны.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
