### PR TITLE
fix(atex): планирование — при смене «По» подтягивать «С» к «По», если «С» позже (#3664)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -7490,7 +7490,17 @@
             self.renderLink();
         }
         dateFrom.addEventListener('change', function() { self.filter.date = dateFrom.value; applyDateRange(); });
-        dateTo.addEventListener('change', function() { self.filter.dateTo = dateTo.value; applyDateRange(); });
+        dateTo.addEventListener('change', function() {
+            self.filter.dateTo = dateTo.value;
+            // При смене «По»: если «С» оказалась ПОЗЖЕ «По» — подтягиваем «С» к «По» (не
+            // оставляем перевёрнутый диапазон). renderQueue перерисует поле «С» новым значением.
+            var to = String(self.filter.dateTo || '').trim();
+            var from = String(self.filter.date || '').trim();
+            if (to !== '' && from !== '' && planDateDayKey(from) > planDateDayKey(to)) {
+                self.filter.date = self.filter.dateTo;
+            }
+            applyDateRange();
+        });
         // #3508 п.1 / #3599: стрелки ‹/› двигают ВЕСЬ диапазон на ±1 день (ширина окна сохраняется).
         function shiftFilterDate(delta) {
             self.filter.date = shiftPlanDate(self.filter.date || todayISO(), delta);

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 55);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 56);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3664.

В фильтре «Дата плана» при изменении поля **«По (дата плана, до)»**: если «С (дата плана, от)» оказывается **позже** новой «По» — автоматически делаем «С» = «По» (не оставляем перевёрнутый диапазон). Обработчик `dateTo.change` сравнивает дни через `planDateDayKey`; `renderQueue` перерисует поле «С» новым значением.

## Проверки
Симуляция обработчика: «С»=10.06, «По»→04.06 ⇒ «С»=04.06; «С»=01.06, «По»→04.06 ⇒ «С» без изменений; равные даты ⇒ без клампа. Синтаксис ок, основной набор планирования 549 проверок (2 предсуществующих FAIL `#3340`/`#3249` — не регрессия). VERSION 55→56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)