### PR TITLE
fix(atex): планирование — одинаковый набор ножей на один станок (#3666)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1384,6 +1384,17 @@
         return keys;
     }
 
+    // #3666: подпись НАБОРА ШИРИН ножей резки (уникальные ширины ↑, через запятую) — «та же
+    // конфигурация ножей» в терминах оператора. Нужна для выбора станка: резки с одинаковым
+    // набором ширин кладём на ОДИН станок (оператор работает тем же набором ножей, а не
+    // настраивает их с нуля на другом станке), даже если число ножей/намотка отличаются.
+    // Ширин нет (неизвестны) → '' (без группировки по ножам).
+    function knifeWidthSig(cut){
+        var set = {};
+        ((cut && cut.knifeWidths) || []).forEach(function(x){ var n = Number(x); if (isFinite(n) && n > 0) set[String(n)] = 1; });
+        return Object.keys(set).map(Number).sort(function(a, b){ return a - b; }).join(',');
+    }
+
     // Неудобный остаток джамбо: 0 < m < REMAINDER_OK_M (не дорезан до ≈0 и не оставлен крупным).
     function awkwardRemainder(m){ var x = Number(m); return !isNaN(x) && x > 1e-6 && x < REMAINDER_OK_M; }
 
@@ -3426,9 +3437,12 @@
     }
 
     // Выбрать станок для новой резки по приросту минут переналадки (#3268).
-    // Пустой станок выигрывает у несовместимого занятого (delta меньше), но при
-    // равном delta предпочитаем уже занятый setup-совместимый станок, а не
-    // разбрасываем одинаковые профили только ради баланса.
+    // #3666: ГЛАВНЫЙ критерий — станок, который уже режет ТОТ ЖЕ набор ширин ножей
+    // (knifeWidthSig). Одинаковую конфигурацию ножей не разносим по разным станкам: на
+    // пустом станке прирост переналадки = 0 (у одиночной резки нет переходов), и прежде он
+    // обыгрывал занятый совместимый (delta которого = переналадка), хотя физически пустой
+    // станок тоже требует настройки ножей с нуля. Поэтому совпавший набор ножей — первым,
+    // дальше прежний порядок: delta ↑, affinity ↑, загрузка ↑, id.
     function chooseSlitterBySetup(cut, slitters, groupsBySlitterId, loadBySlitterId, weights) {
         var groups = groupsBySlitterId || {};
         var load = loadBySlitterId || {};
@@ -3440,20 +3454,25 @@
             if (b === Infinity) return -1;
             return a - b;
         }
+        var cutSig = knifeWidthSig(cut);
         var candidates = allowed.map(function(s) {
             var id = String(s.id);
             var group = groups[id] || [];
             var before = orderedChangeoverCost(group, weights);
             var after = orderedChangeoverCost(group.concat([cut]), weights);
+            // #3666: 0 — станок уже режет тот же набор ширин ножей (приоритет), иначе 1.
+            var sameKnives = (cutSig !== '' && group.some(function(g){ return knifeWidthSig(g) === cutSig; })) ? 0 : 1;
             return {
                 id: id,
+                sameKnives: sameKnives,
                 delta: round3(after - before),
                 affinity: bestExistingTransitionCost(group, cut, weights),
                 load: Number(load[id]) || 0
             };
         });
         candidates.sort(function(a, b) {
-            return cmpNumber(a.delta, b.delta)
+            return cmpNumber(a.sameKnives, b.sameKnives)   // #3666: тот же набор ножей — на тот же станок
+                || cmpNumber(a.delta, b.delta)
                 || cmpNumber(a.affinity, b.affinity)
                 || cmpNumber(a.load, b.load)
                 || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0);
@@ -3700,6 +3719,7 @@
         orderedChangeoverCost: orderedChangeoverCost,
         bestExistingTransitionCost: bestExistingTransitionCost,
         chooseSlitterBySetup: chooseSlitterBySetup,
+        knifeWidthSig: knifeWidthSig,   // #3666
         byKnifeCountDesc: byKnifeCountDesc,
         planQueues: planQueues,
         moveInQueue: moveInQueue,

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -572,6 +572,22 @@ assertEqual(planning.orderedChangeoverCost(cuts3412), planning.orderedChangeover
     'orderCuts #3412: стоимость переналадки не зависит от исходного порядка (детерминированный минимум)');
 assertEqual(planning.orderedChangeoverCost(cuts3412), 45, 'orderCuts #3412: суммарная переналадка минимальна (#3600: 15 сырьё + 30 ножи фикс = 45)');
 
+// ── #3666: одинаковый набор ширин ножей → на ТОТ ЖЕ станок, не разносим по разным ──
+assertEqual(planning.knifeWidthSig({ knifeWidths: [55, 33] }), '33,55', 'knifeWidthSig #3666: уникальные ширины ↑');
+assertEqual(planning.knifeWidthSig({ knifeWidths: [55, 55, 33, 33] }), '33,55', 'knifeWidthSig #3666: дубликаты схлопываются (тот же набор)');
+assertEqual(planning.knifeWidthSig({ knifeWidths: [] }), '', 'knifeWidthSig #3666: ширин нет → пусто');
+var s3666 = [{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }];
+// Станок 4 уже режет 55+33 (OUT). Новая резка 55+33 (IN, другое число ножей) — на станок 4.
+var g3666 = { '4': [{ id: 'A', materialId: 'MWR116L', winding: 'OUT', batchId: 'b1', knifeCount: 2, knifeWidths: [55, 33], rollerWidth: 600 }] };
+var l3666 = { '1': 0, '2': 0, '3': 0, '4': 1 };
+assertEqual(
+    planning.chooseSlitterBySetup({ id: 'B', materialId: 'MWR116L', winding: 'IN', batchId: 'b1', knifeCount: 4, knifeWidths: [55, 55, 33, 33], rollerWidth: 600 }, s3666, g3666, l3666, null),
+    '4', 'chooseSlitterBySetup #3666: тот же набор ширин (55+33) — на занятый станок 4, а не на пустой');
+// Контроль: другой набор ширин → на пустой станок (без регресса разнесения чужих конфигов).
+assertEqual(
+    planning.chooseSlitterBySetup({ id: 'C', materialId: 'MWR116L', winding: 'IN', batchId: 'b1', knifeCount: 2, knifeWidths: [40, 40], rollerWidth: 600 }, s3666, g3666, l3666, null),
+    '1', 'chooseSlitterBySetup #3666: другой набор ширин — на пустой станок (не пихаем к чужому набору)');
+
 // #3421: генерация хардкодила стратегию FATIGUE («сложные раньше»), которая по
 // route-score выдаёт ножи по ВОЗРАСТАНИЮ (6,16,16) на данных скриншота — вопреки
 // #3130. Фиксы #3412/#3415 правили SETUP-путь, до генерации не доходили. Поэтому
@@ -1887,8 +1903,12 @@ function runGenerateCutsSlitterAffinityTest() {
     ], []).then(function() {
         var slitters = posts.filter(function(p) { return p.path.indexOf('_m_new/1078') === 0; })
             .map(function(p) { return p.fields.t1156; });
-        assertEqual(slitters, ['10', '10', '20', '10'],
-            'runGenerateCuts #3268: одинаковое сырьё+намотка остаётся на setup-совместимом станке, даже если метраж другой');
+        // #3666: все 4 резки режут ОДИН набор ширин ножей (25) → один станок, даже если
+        // намотка (IN у p3) и метраж (450 у p4) отличаются. Намотка — не часть конфигурации
+        // ножей, поэтому не разносим одинаковый набор ножей по станкам (раньше p3 IN уезжала
+        // на станок 20 ради меньшей переналадки, хотя там пришлось бы ставить те же ножи с нуля).
+        assertEqual(slitters, ['10', '10', '10', '10'],
+            'runGenerateCuts #3268/#3666: один набор ширин ножей — один станок (намотка/метраж не разносят)');
     });
 }
 


### PR DESCRIPTION
Closes #3666.

## Симптом
Генерация разносила резки с **одинаковым набором ширин ножей** по разным станкам: на скринах станок 3 = MWR116L IN (ножи 55+33) и станок 4 = MWR116L OUT (ножи 55+33). Конфигурация ножей одна — а станки разные, оператору пришлось бы ставить те же ножи дважды.

## Причина
`chooseSlitterBySetup` сортировал станки по приросту минут переналадки. У **пустого** станка прирост = 0 (у одиночной резки нет переходов между резками), и он обыгрывал занятый совместимый станок, чья `delta` = переналадка (смена намотки/числа ножей). Но физически пустой станок тоже требует настройки тех же ножей с нуля — этот расход модель не учитывала.

## Фикс
Главный критерий выбора станка — **тот же набор ширин ножей** (`knifeWidthSig` = уникальные ширины). Резку кладём на станок, который уже режет этот набор; намотка / метраж / число ножей больше не разносят одинаковую конфигурацию ножей по станкам. Новый набор ширин по-прежнему уходит на пустой станок (без регресса). Далее — прежний порядок (delta → affinity → загрузка → id).

## Проверки
`chooseSlitterBySetup` #3666 (55+33 IN → к занятому 55+33 OUT; другой набор → пустой), `knifeWidthSig`. Обновлён тест #3268 (резка IN с тем же набором ножей теперь остаётся на том же станке, а не уезжает на соседний ради меньшей переналадки). **557** проверок; 2 предсуществующих FAIL (`#3340`, `#3249`) — не регрессия. VERSION 55→56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)