### PR TITLE
feat(atex): слиттер — чтения через защищённый слой report/ (#3674)

### DIFF
--- a/docs/scripts/create_slitter_reports.py
+++ b/docs/scripts/create_slitter_reports.py
@@ -157,12 +157,24 @@ def existing_reports():
             out[str(name).strip()] = str(rec.get('i'))
     return out
 
-# ── Создание одного отчёта ─────────────────────────────────────────────────────
+def report_col_names(qid):
+    # Имена уже существующих колонок отчёта (t100) — для идемпотентного дозаведения.
+    meta = _req('GET', f'report/{qid}?JSON')
+    cols = meta.get('columns') or meta.get('cols') or []
+    return set((c.get('name') or c.get('val')) for c in cols if (c.get('name') or c.get('val')))
+
+def add_column(qid, t100, t28, fn, fmt):
+    c = post(f'_m_new/28?JSON&up={qid}', {'t28': t28, 't100': t100})
+    cid = str(c.get('id') or c.get('obj'))
+    if fn:
+        post(f'_m_set/{cid}?JSON', {'t104': str(fn)})
+    if fmt:
+        post(f'_m_set/{cid}?JSON', {'t84': fmt})
+    return cid
+
+# ── Создание/доводка одного отчёта (идемпотентно на уровне колонок) ─────────────
 def build_report(name, spec, existing):
     master = spec['master']
-    if name in existing:
-        print(f'  ∙ {name}: уже существует (queryId={existing[name]}) — пропускаю')
-        return existing[name]
     plan = []  # (t100, t28, t104, t84)
     for t100, src, fn, fmt in spec['cols']:
         if 'table' in src:
@@ -174,6 +186,21 @@ def build_report(name, spec, existing):
                 print(f'      ~ колонка {t100}: реквизит «{src["req"]}» не найден (optional) — пропущена')
                 continue
         plan.append((t100, t28, fn, fmt))
+
+    if name in existing:
+        qid = existing[name]
+        have = set() if DRY else report_col_names(qid)
+        missing = [p for p in plan if p[0] not in have]
+        print(f'  ∙ {name}: уже существует (queryId={qid}); колонок в спецификации={len(plan)}, недостающих={len(missing)}')
+        for t100, t28, fn, fmt in missing:
+            extra = (f' t104={fn}' if fn else '') + (f' t84={fmt}' if fmt else '')
+            print(f'      + {t100:20} t28={t28}{extra}')
+            if not DRY:
+                add_column(qid, t100, t28, fn, fmt)
+        if missing and not DRY:
+            print(f'      ✓ {name}: добавлено колонок {len(missing)}')
+        return qid
+
     print(f'  ∙ {name}: мастер={find_table(master).get("val")} ({table_id(master)}), колонок={len(plan)}')
     for t100, t28, fn, fmt in plan:
         extra = (f' t104={fn}' if fn else '') + (f' t84={fmt}' if fmt else '')
@@ -184,12 +211,7 @@ def build_report(name, spec, existing):
     qid = str(q.get('id') or q.get('obj'))
     print(f'      → queryId={qid}')
     for t100, t28, fn, fmt in plan:
-        c = post(f'_m_new/28?JSON&up={qid}', {'t28': t28, 't100': t100})
-        cid = str(c.get('id') or c.get('obj'))
-        if fn:
-            post(f'_m_set/{cid}?JSON', {'t104': str(fn)})
-        if fmt:
-            post(f'_m_set/{cid}?JSON', {'t84': fmt})
+        add_column(qid, t100, t28, fn, fmt)
     print(f'      ✓ {name} создан')
     return qid
 

--- a/docs/scripts/create_slitter_reports.py
+++ b/docs/scripts/create_slitter_reports.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Создание защищённых отчётов (report/) для РМ «Пульт слиттера» (download/atex/js/slitter.js).
+#
+# Зачем: слиттер сейчас читает данные сырыми `object/{table}/?JSON_OBJ` и джойнит на
+# клиенте (loadCuts / loadShiftEvents / loadSlitters / loadMaterialWidths). Эти отчёты
+# дают защищённый слой report/ — изоляция данных по ролям и серверные джойны.
+#
+# Что создаёт (если отчёта с таким именем ещё нет — идемпотентно):
+#   slitter_cuts          — очередь заданий станка (взамен loadCuts + loadMaterialWidths)
+#   slitter_shift_events  — лог событий смены (взамен loadShiftEvents)
+#   slitters_list         — справочник станков (взамен loadSlitters)
+#
+# ID реквизитов НЕ хардкодятся: резолвятся по именам из живого GET metadata?JSON
+# (ID зависят от сборки базы — поэтому slitter.js и резолвит их по имени в рантайме).
+#
+# Запуск (curl в окружении нет — берём python3 stdlib):
+#   TOKEN=<актуальный сессионный X-Authorization>  DB=https://ideav.ru/ateh \
+#   python3 docs/scripts/create_slitter_reports.py
+#   (по умолчанию DB=https://ideav.ru/ateh; --dry-run — только показать план, без записи)
+#
+# Соглашения конструктора (docs/integram-reports.md §5, docs/integram-app-workflow.md):
+#   POST _m_new/22?JSON&up=1          t22=<имя>            → { id: queryId }
+#   POST _m_new/28?JSON&up=queryId    t28=<tableId|reqId>  t100=<имя колонки>  → { id: colId }
+#   POST _m_set/<colId>?JSON          t104=85 (abn_ID)  |  t84=DATETIME (формат)
+#   t28 = ID таблицы            → главное значение (label)
+#   t28 = ID таблицы + t104=85  → ID записи
+#   t28 = ID реквизита          → значение реквизита (для ref — имя цели)
+#   t28 = ID реквизита + t104=85→ ID цели ссылки (abn_ID)
+#   Колонки с t100 — фильтруемы снаружи через FR_/TO_.
+
+import os, sys, json, urllib.request, urllib.parse, urllib.error
+
+DB = os.environ.get('DB', 'https://ideav.ru/ateh').rstrip('/')
+TOKEN = os.environ.get('TOKEN', '')
+DRY = '--dry-run' in sys.argv
+
+# ── Спецификация отчётов ──────────────────────────────────────────────────────
+# col = (имя_в_отчёте t100, источник, функция t104|None, формат t84|None)
+#   источник: {'table': '<имя таблицы>'}                 → главное значение / id записи
+#             {'req': '<имя реквизита>', 'in': '<табл>'}  → реквизит таблицы (по умолч. in=мастер)
+ABN_ID = 85          # функция abn_ID (id записи / id цели ссылки)
+DT = 'DATETIME'
+
+REPORTS = {
+    # Очередь заданий станка. Мастер — «Задание в производство» (старое имя «Производственная резка»).
+    'slitter_cuts': {
+        'master': ['Задание в производство', 'Производственная резка'],
+        'cols': [
+            ('cut_id',           {'table': 'Задание в производство'}, ABN_ID, None),
+            ('cut_plan_date',    {'table': 'Задание в производство'}, None,   DT),   # гл. значение = «Дата план» (штамп)
+            ('cut_slitter_id',   {'req': 'Слиттер'},                  ABN_ID, None), # FR_ фильтр очереди по станку
+            ('cut_slitter',      {'req': 'Слиттер'},                  None,   None),
+            ('cut_batch_id',     {'req': 'Партия сырья'},             ABN_ID, None),
+            ('cut_batch',        {'req': 'Партия сырья'},             None,   None),
+            ('cut_sequence',     {'req': 'Очередность'},              None,   None),
+            ('cut_planned_runs', {'req': 'Кол-во резок план'},        None,   None), # фолбэк «Кол-во план» (см. RESOLVE_ALT)
+            ('cut_run_length',   {'req': 'Метраж, м'},                None,   None),
+            ('cut_started',      {'req': 'Начато'},                   None,   DT),
+            ('cut_in_work',      {'req': 'В работе'},                 None,   None), # булев — занимает станок
+            ('cut_finished',     {'req': 'Закончено'},                None,   DT),
+            ('cut_winding',      {'req': 'Тип намотки'},              None,   None),
+            ('cut_leader',       {'req': 'Лидер'},                    None,   None), # #3623/#3629: был пустой
+            # Авто-джойн через «Партия сырья» → «Вид сырья» (как cut_planning). Снимает loadMaterialWidths/resolveCutWidth:
+            ('cut_material_id',  {'req': 'Вид сырья', 'in': 'Партия сырья'}, ABN_ID, None),
+            ('cut_material',     {'req': 'Вид сырья', 'in': 'Партия сырья'}, None,   None),
+            ('cut_material_width',{'req': 'Ширина, мм', 'in': 'Вид сырья'},  None,   None), # 3 хопа — проверить живьём
+        ],
+    },
+    # Лог событий смены. Мастер — «Событие смены» (подчинён резке: up=cutId).
+    'slitter_shift_events': {
+        'master': ['Событие смены'],
+        'cols': [
+            ('event_id',      {'table': 'Событие смены'}, ABN_ID, None),
+            ('event_when',    {'table': 'Событие смены'}, None,   DT),   # гл. значение = дата/время события
+            ('event_type',    {'req': 'Тип события'},     None,   None),
+            ('event_type_id', {'req': 'Тип события'},     ABN_ID, None),
+            ('event_user_id', {'req': 'Пользователь'},    ABN_ID, None), # FR_ фильтр по оператору
+            ('event_user',    {'req': 'Пользователь'},    None,   None),
+            ('event_value',   {'req': 'Значение'},        None,   None),
+            ('event_notes',   {'req': 'Примечания'},      None,   None),
+            # Ссылка на задание. Если реквизит-ref «Задание в производство» есть в сборке — abn_ID;
+            # иначе связь только через подчинение (up) — резолвится при проверке живьём.
+            ('event_cut_id',  {'req': 'Задание в производство', 'optional': True}, ABN_ID, None),
+        ],
+    },
+    # Справочник станков.
+    'slitters_list': {
+        'master': ['Слиттер'],
+        'cols': [
+            ('slitter_id',   {'table': 'Слиттер'}, ABN_ID, None),
+            ('slitter_name', {'table': 'Слиттер'}, None,   None),
+        ],
+    },
+}
+# Если основного имени реквизита нет — пробуем альтернативу (разные сборки/issue).
+RESOLVE_ALT = {'Кол-во резок план': ['Кол-во план']}
+
+# ── HTTP ──────────────────────────────────────────────────────────────────────
+def _req(method, path, fields=None):
+    url = f'{DB}/{path}'
+    data = None
+    if fields is not None:
+        data = urllib.parse.urlencode(fields).encode()
+    headers = {'X-Authorization': TOKEN, 'Cookie': f'idb_ateh={TOKEN}', 'Accept': 'application/json'}
+    r = urllib.request.Request(url, data=data, headers=headers, method=method)
+    with urllib.request.urlopen(r, timeout=30) as resp:
+        body = resp.read().decode('utf-8', 'replace')
+    try:
+        return json.loads(body)
+    except Exception:
+        raise SystemExit(f'НЕ JSON от {method} {path} (нужен валидный токен?):\n{body[:300]}')
+
+def get_xsrf():
+    return _req('GET', 'xsrf?JSON=1').get('_xsrf', '')
+
+XSRF = ''
+def post(path, fields):
+    f = dict(fields); f['token'] = TOKEN; f['_xsrf'] = XSRF
+    return _req('POST', path, f)
+
+# ── Метаданные: резолв ID таблиц и реквизитов по именам ────────────────────────
+META = []
+def load_meta():
+    global META
+    m = _req('GET', 'metadata?JSON')
+    META = m if isinstance(m, list) else (m.get('items') or m.get('types') or [m])
+
+def find_table(names):
+    names = names if isinstance(names, list) else [names]
+    for nm in names:
+        for t in META:
+            if str(t.get('val', '')).strip().lower() == nm.strip().lower():
+                return t
+    raise SystemExit(f'В metadata не найдена таблица: {names}')
+
+def table_id(names):
+    return str(find_table(names).get('id'))
+
+def req_id(table_names, req_name, optional=False):
+    t = find_table(table_names)
+    cand = [req_name] + RESOLVE_ALT.get(req_name, [])
+    for nm in cand:
+        for r in (t.get('reqs') or []):
+            if str(r.get('val', '')).strip().lower() == nm.strip().lower():
+                return str(r.get('id'))
+    if optional:
+        return None
+    raise SystemExit(f'В таблице «{find_table(table_names).get("val")}» нет реквизита: {cand}')
+
+def existing_reports():
+    # object/22 — список всех отчётов (записи таблицы «Запрос»). Имя = главное значение.
+    rows = _req('GET', 'object/22/?JSON_OBJ&LIMIT=0,5000')
+    out = {}
+    for rec in (rows or []):
+        name = (rec.get('r') or [''])[0]
+        if name:
+            out[str(name).strip()] = str(rec.get('i'))
+    return out
+
+# ── Создание одного отчёта ─────────────────────────────────────────────────────
+def build_report(name, spec, existing):
+    master = spec['master']
+    if name in existing:
+        print(f'  ∙ {name}: уже существует (queryId={existing[name]}) — пропускаю')
+        return existing[name]
+    plan = []  # (t100, t28, t104, t84)
+    for t100, src, fn, fmt in spec['cols']:
+        if 'table' in src:
+            t28 = table_id(src['table'])
+        else:
+            in_tbl = src.get('in', master)
+            t28 = req_id(in_tbl, src['req'], optional=src.get('optional'))
+            if t28 is None:
+                print(f'      ~ колонка {t100}: реквизит «{src["req"]}» не найден (optional) — пропущена')
+                continue
+        plan.append((t100, t28, fn, fmt))
+    print(f'  ∙ {name}: мастер={find_table(master).get("val")} ({table_id(master)}), колонок={len(plan)}')
+    for t100, t28, fn, fmt in plan:
+        extra = (f' t104={fn}' if fn else '') + (f' t84={fmt}' if fmt else '')
+        print(f'      - {t100:20} t28={t28}{extra}')
+    if DRY:
+        return None
+    q = post('_m_new/22?JSON&up=1', {'t22': name})
+    qid = str(q.get('id') or q.get('obj'))
+    print(f'      → queryId={qid}')
+    for t100, t28, fn, fmt in plan:
+        c = post(f'_m_new/28?JSON&up={qid}', {'t28': t28, 't100': t100})
+        cid = str(c.get('id') or c.get('obj'))
+        if fn:
+            post(f'_m_set/{cid}?JSON', {'t104': str(fn)})
+        if fmt:
+            post(f'_m_set/{cid}?JSON', {'t84': fmt})
+    print(f'      ✓ {name} создан')
+    return qid
+
+def main():
+    if not TOKEN:
+        raise SystemExit('Нужен TOKEN=<сессионный X-Authorization> в окружении.')
+    global XSRF
+    load_meta()
+    print(f'DB={DB}  таблиц в metadata={len(META)}  dry_run={DRY}')
+    existing = {} if DRY else existing_reports()
+    if not DRY:
+        XSRF = get_xsrf()
+    result = {}
+    for name, spec in REPORTS.items():
+        result[name] = build_report(name, spec, existing)
+    print('\nИтог (queryId по отчётам):')
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+if __name__ == '__main__':
+    main()

--- a/download/atex/js/slitter.js
+++ b/download/atex/js/slitter.js
@@ -7,13 +7,16 @@
 // Решение задачи ideav/crm#2915 (часть #2903). Правила разработки рабочих мест —
 // docs/WORKSPACE_DEVELOPMENT_GUIDE.md, карта рабочих мест — docs/atex_workplaces.md §3.5.
 //
-// На этом этапе рабочее место обращается к данным напрямую командами `_m_*`
-// (#2903): статус/счётчики/погонаж/брак — `_m_set/{резкаId}`; событие —
-// `_m_new/{Событие смены}`; список резок строится из `object/{Задание в производство}/`
-// с фильтром по выбранным слиттеру/дате. ID таблиц и реквизитов не хардкодятся: они
-// берутся по именам из `GET /{db}/metadata` (WORKSPACE_DEVELOPMENT_GUIDE.md,
-// разделы 3 и 6). Перевод чтений на защищённый слой `report/` — следующий этап и
-// в объём этой задачи не входит.
+// Запись данных идёт напрямую командами `_m_*` (#2903): статус/счётчики/погонаж/брак
+// — `_m_set/{резкаId}`; событие — `_m_new/{Событие смены}`. ID таблиц и реквизитов не
+// хардкодятся: берутся по именам из `GET /{db}/metadata` (WORKSPACE_DEVELOPMENT_GUIDE.md,
+// разделы 3 и 6).
+// #3674: чтения переведены на защищённый слой `report/` — slitter_cuts (очередь
+// станка, FR_cut_slitter_id), slitter_shift_events (события), slitters_list (станки);
+// партии — material_batches (#3460). Разбор строк отчётов — чистые core.rowsTo*. На
+// случай отсутствия отчёта в сборке у каждого чтения тихий фолбэк на `object/`
+// (loadCutsFromTable / loadShiftEventsFromTable / loadSlittersFromTable). Отчёты
+// заводит docs/scripts/create_slitter_reports.py.
 //
 // Чистое ядро (цепочка статусов, FIFO-подбор партий, списание остатка, погонаж
 // из счётчиков, формат даты события) вынесено в объект `core` и экспортируется
@@ -693,6 +696,74 @@
         });
     }
 
+    // #3674: разбор защищённых отчётов слиттера (взамен сырых object/ + клиентских
+    // джойнов). Имена колонок — из report/slitter_cuts (80981), slitter_shift_events
+    // (91520), slitters_list (81051). DATETIME-поля приходят unix-штампом (секунды) —
+    // их понимают cutTitle/humanizeLabel/cutQueueTime/dateKey/eventWhenSeconds.
+
+    // Станки: report/slitters_list → { id, label } (как старый object/Слиттер).
+    // Дедуп по id: отчёт джойнит стоп-лист сырья (N:M) и размножает строки станка.
+    function rowsToSlitters(rows) {
+        var seen = {};
+        var out = [];
+        (rows || []).forEach(function(row) {
+            var id = firstField(row, ['slitter_id', 'id', 'i']);
+            if (!id || seen[id]) return;
+            seen[id] = true;
+            out.push({ id: id, label: firstField(row, ['slitter_name', 'name']) || ('Слиттер #' + id) });
+        });
+        return out;
+    }
+
+    // Резки: report/slitter_cuts → дескриптор резки той же формы, что давал
+    // object/-разбор loadCuts. Дополнительно из отчёта берём материал и ширину
+    // (cut_material*/cut_material_width) — раньше резолвились через findBatch/materialWidths.
+    function rowsToCuts(rows) {
+        return (rows || []).map(function(row) {
+            var id = firstField(row, ['cut_id', 'id']);
+            var planDate = firstField(row, ['cut_plan_date']);
+            return {
+                id: id,
+                label: cutTitle(planDate || id),
+                status: STATUSES[0], // фактический статус доберётся из событий (applyEventStatuses)
+                inWork: firstField(row, ['cut_in_work']),
+                finishedAt: firstField(row, ['cut_finished']),
+                slitterId: firstField(row, ['cut_slitter_id']) || null,
+                slitter: firstField(row, ['cut_slitter']),
+                batchId: firstField(row, ['cut_batch_id']) || null,
+                batch: firstField(row, ['cut_batch']),
+                planDate: planDate,
+                sequence: firstField(row, ['cut_sequence']),
+                plannedRuns: firstField(row, ['cut_planned_runs']),
+                runLength: firstField(row, ['cut_run_length']),
+                startedAt: firstField(row, ['cut_started']),
+                winding: firstField(row, ['cut_winding']),
+                materialId: firstField(row, ['cut_material_id']) || null,
+                material: firstField(row, ['cut_material']),
+                materialWidthMm: toNumber(firstField(row, ['cut_material_width']))
+            };
+        }).filter(function(c) { return c.id; });
+    }
+
+    // События смены: report/slitter_shift_events → та же форма, что parseEventRows
+    // (новые сверху). cutId — из event_cut_id (ref на задание, 16415).
+    function rowsToShiftEvents(rows) {
+        return (rows || []).map(function(row) {
+            return {
+                id: firstField(row, ['event_id', 'id']),
+                when: firstField(row, ['event_when', 'when']),
+                type: firstField(row, ['event_type']),
+                cutId: firstField(row, ['event_cut_id']) || null,
+                userId: firstField(row, ['event_user_id']) || null,
+                user: firstField(row, ['event_user']),
+                value: firstField(row, ['event_value']),
+                notes: firstField(row, ['event_notes'])
+            };
+        }).sort(function(a, b) {
+            return String(b.when).localeCompare(String(a.when)); // новые сверху
+        });
+    }
+
     // #3557: статус резки выводится из последнего её события смены (приоритет) и
     // подкрепляется атрибутами «Начато»/«В работе»(bool)/«Закончено». Возвращает
     // один из: Ожидает | В работе | Наладка | Перерыв | Завершена.
@@ -787,6 +858,9 @@
         cutTitle: cutTitle,
         humanizeLabel: humanizeLabel,
         rowsToActiveBatches: rowsToActiveBatches,
+        rowsToSlitters: rowsToSlitters,     // #3674
+        rowsToCuts: rowsToCuts,             // #3674
+        rowsToShiftEvents: rowsToShiftEvents, // #3674
         isForeignWarehouse: isForeignWarehouse,
         // #3460: раскладка ножей (визуализация)
         totalKnives: totalKnives,
@@ -1011,7 +1085,16 @@
         });
     };
 
+    // #3674: станки из защищённого отчёта report/slitters_list (81051) вместо
+    // сырого object/Слиттер. Тихий фолбэк на прямое чтение, если отчёта нет в сборке.
     AtexSlitter.prototype.loadSlitters = function() {
+        var self = this;
+        return this.getJson('report/slitters_list?JSON_KV&LIMIT=0,1000').then(function(rows) {
+            self.slitters = core.rowsToSlitters(Array.isArray(rows) ? rows : (rows && rows.rows) || []);
+        }).catch(function() { return self.loadSlittersFromTable(); });
+    };
+
+    AtexSlitter.prototype.loadSlittersFromTable = function() {
         var self = this;
         var meta = this.meta.slitter;
         if (!meta) { this.slitters = []; return Promise.resolve(); }
@@ -1113,7 +1196,24 @@
         cut.materialWidthMm = cut.materialId ? (this.materialWidths[String(cut.materialId)] || 0) : 0;
     };
 
+    // #3674: очередь станка из защищённого отчёта report/slitter_cuts (80981) вместо
+    // сырого object/. Отчёт фильтруем по станку (FR_cut_slitter_id) — он рассчитан на
+    // этот фильтр (без него тяжёлый), а список и так станко-зависим (visibleCuts). Без
+    // выбранного станка резки не нужны (renderCuts просит выбрать станок). Материал и
+    // ширину отдаёт сам отчёт (cut_material*/cut_material_width). На отсутствие отчёта
+    // — тихий фолбэк на прямое чтение таблицы (loadCutsFromTable).
     AtexSlitter.prototype.loadCuts = function() {
+        var self = this;
+        var sid = this.selectedSlitterId;
+        if (!sid) { this.cuts = []; return Promise.resolve(); }
+        return this.getJson('report/slitter_cuts?JSON_KV&FR_cut_slitter_id=' + encodeURIComponent(sid) + '&LIMIT=0,2000')
+            .then(function(rows) {
+                self.cuts = core.rowsToCuts(Array.isArray(rows) ? rows : (rows && rows.rows) || []);
+            })
+            .catch(function() { return self.loadCutsFromTable(); });
+    };
+
+    AtexSlitter.prototype.loadCutsFromTable = function() {
         var self = this;
         var meta = this.meta.cut;
         return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,1000').then(function(rows) {
@@ -1323,18 +1423,34 @@
         });
     };
 
+    // #3674: события смены из защищённого отчёта report/slitter_shift_events (91520)
+    // вместо сырого object/. Разобранные события раскладываем общим хвостом
+    // applyLoadedEvents. Тихий фолбэк на прямое чтение (loadShiftEventsFromTable).
     AtexSlitter.prototype.loadShiftEvents = function() {
         var self = this;
+        return this.getJson('report/slitter_shift_events?JSON_KV&LIMIT=0,5000').then(function(rows) {
+            self.applyLoadedEvents(core.rowsToShiftEvents(Array.isArray(rows) ? rows : (rows && rows.rows) || []));
+        }).catch(function() { return self.loadShiftEventsFromTable(); });
+    };
+
+    // Общий хвост: разложить разобранные события (всё/за смену/текущей резки) и
+    // пересчитать статусы резок.
+    AtexSlitter.prototype.applyLoadedEvents = function(all) {
+        var self = this;
+        self.allEvents = all; // #3557: все события (для вывода статуса резок)
+        self.shiftEvents = self.filterShiftEvents(all);
+        self.events = self.currentCutId
+            ? self.shiftEvents.filter(function(ev) { return String(ev.cutId || '') === String(self.currentCutId); })
+            : [];
+        self.applyEventStatuses();
+    };
+
+    AtexSlitter.prototype.loadShiftEventsFromTable = function() {
+        var self = this;
         var meta = this.meta.event;
-        if (!meta) { this.shiftEvents = []; this.events = []; return Promise.resolve(); }
+        if (!meta) { this.shiftEvents = []; this.events = []; this.allEvents = []; return Promise.resolve(); }
         return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,2000').then(function(rows) {
-            var all = self.parseEventRows(rows);
-            self.allEvents = all; // #3557: все события (для вывода статуса резок)
-            self.shiftEvents = self.filterShiftEvents(all);
-            self.events = self.currentCutId
-                ? self.shiftEvents.filter(function(ev) { return String(ev.cutId || '') === String(self.currentCutId); })
-                : [];
-            self.applyEventStatuses();
+            self.applyLoadedEvents(self.parseEventRows(rows));
         });
     };
 
@@ -1463,7 +1579,9 @@
             self.currentCutId = null;
             self.currentCut = null;
             self.selectedBatchIds = [];
-            self.loadShiftEvents().then(function() { self.render(); });
+            // #3674: report/slitter_cuts фильтруется по станку → при смене станка
+            // перезагружаем резки (раньше грузились один раз, фильтровал visibleCuts).
+            self.loadCuts().then(function() { return self.loadShiftEvents(); }).then(function() { self.render(); });
         });
 
         box.appendChild(field('Дата', dateInp));
@@ -1509,7 +1627,7 @@
             // #3646: карточка списка — № + «Вид сырья / Намотка / Метраж м * Резок» (стр. 1)
             // и время начала–окончания (стр. 2). Вид сырья — из «Партии сырья» (Вид сырья).
             var batch = self.findBatch(cut.batchId);
-            var material = (batch && batch.materialLabel) || cut.batch || '—';
+            var material = (batch && batch.materialLabel) || cut.material || cut.batch || '—'; // #3674: cut.material из отчёта
             var runLen = core.toNumber(cut.runLength);
             var runsN = core.toNumber(cut.plannedRuns);
             var dims = (runLen > 0 ? core.round3(runLen) + 'м' : '—') + (runsN > 0 ? ' * ' + runsN : '');

--- a/experiments/atex-slitter.test.js
+++ b/experiments/atex-slitter.test.js
@@ -429,4 +429,51 @@ var scD = core.shiftContinuation(scCuts, scCuts[3]);
 assertEqual(scD.isLast, true, 'shiftContinuation: D — последняя 30-го');
 assertEqual(scD.nextCut, null, 'shiftContinuation: нет следующего дня → nextCut null');
 
+// ── #3674: парсеры защищённых отчётов слиттера (report/ → те же формы, что object/) ──
+// rowsToSlitters: report/slitters_list → { id, label }
+var sl = core.rowsToSlitters([
+    { slitter_id: '1277', slitter_name: 'Станок 1' },
+    { slitter_id: '1277', slitter_name: 'Станок 1' },   // дубль (N:M стоп-лист) → схлопнуть
+    { slitter_id: '1279', slitter_name: '' },           // без имени → «Слиттер #id»
+    { slitter_id: '', slitter_name: 'мусор' }            // без id → отброшен
+]);
+assertEqual(sl, [
+    { id: '1277', label: 'Станок 1' },
+    { id: '1279', label: 'Слиттер #1279' }
+], 'rowsToSlitters: дедуп по id / фолбэк имени / без id отброшен');
+assertEqual(core.rowsToSlitters([]), [], 'rowsToSlitters: пусто → []');
+
+// rowsToCuts: report/slitter_cuts → дескриптор резки (DATETIME — unix-штамп секунд)
+var cuts3674 = core.rowsToCuts([{
+    cut_id: '90158', cut_plan_date: '1780203600', cut_slitter_id: '1282', cut_slitter: 'Станок 3',
+    cut_batch_id: '777', cut_batch: '1781038800', cut_sequence: '1', cut_planned_runs: '1',
+    cut_run_length: '600.00', cut_started: '1780253146', cut_in_work: 'X', cut_finished: '',
+    cut_winding: 'OUT', cut_material_id: '55', cut_material: 'MWR116L', cut_material_width: '891.00'
+}]);
+assertEqual(cuts3674.length, 1, 'rowsToCuts: одна строка → одна резка');
+assertEqual(cuts3674[0].id, '90158', 'rowsToCuts: id ← cut_id');
+assertEqual(cuts3674[0].label, core.cutTitle('1780203600'), 'rowsToCuts: label = cutTitle(plan_date)');
+assertEqual(cuts3674[0].status, 'Ожидает', 'rowsToCuts: статус по умолчанию = Ожидает (доберётся из событий)');
+assertEqual(cuts3674[0].slitterId, '1282', 'rowsToCuts: slitterId ← cut_slitter_id');
+assertEqual(cuts3674[0].batchId, '777', 'rowsToCuts: batchId ← cut_batch_id');
+assertEqual(cuts3674[0].planDate, '1780203600', 'rowsToCuts: planDate ← cut_plan_date (штамп)');
+assertEqual(cuts3674[0].runLength, '600.00', 'rowsToCuts: runLength ← cut_run_length');
+assertEqual(cuts3674[0].winding, 'OUT', 'rowsToCuts: winding ← cut_winding');
+assertEqual(cuts3674[0].materialId, '55', 'rowsToCuts: materialId ← cut_material_id');
+assertEqual(cuts3674[0].material, 'MWR116L', 'rowsToCuts: material ← cut_material');
+assertEqual(cuts3674[0].materialWidthMm, 891, 'rowsToCuts: materialWidthMm ← cut_material_width (число)');
+assertEqual(core.rowsToCuts([{ cut_plan_date: '1', cut_slitter_id: '1' }]), [], 'rowsToCuts: без cut_id → отброшено');
+
+// rowsToShiftEvents: report/slitter_shift_events → события (новые сверху), cutId ← event_cut_id
+var ev3674 = core.rowsToShiftEvents([
+    { event_id: '1', event_when: '1780057598', event_type: 'Начало смены', event_cut_id: '', event_user_id: '456', event_user: 'ateh', event_value: '', event_notes: 'Станок 1' },
+    { event_id: '2', event_when: '1780058141', event_type: 'Начало резки', event_cut_id: '89694', event_user_id: '456', event_user: 'ateh', event_value: '', event_notes: '' }
+]);
+assertEqual(ev3674.map(function(e){ return e.id; }), ['2', '1'], 'rowsToShiftEvents: сортировка по when убыв. (новые сверху)');
+assertEqual(ev3674[0].cutId, '89694', 'rowsToShiftEvents: cutId ← event_cut_id');
+assertEqual(ev3674[1].cutId, null, 'rowsToShiftEvents: пустой event_cut_id → null');
+assertEqual(ev3674[0].type, 'Начало резки', 'rowsToShiftEvents: type ← event_type');
+assertEqual(ev3674[0].userId, '456', 'rowsToShiftEvents: userId ← event_user_id');
+assertEqual(core.deriveCutStatus(ev3674[0].type, {}), 'В работе', 'rowsToShiftEvents+deriveCutStatus: «Начало резки» → В работе');
+
 console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Closes #3674.

Реальная миграция чтений РМ «Пульт слиттера» (`download/atex/js/slitter.js`) с сырого `object/{table}/?JSON_OBJ` на защищённый слой `report/` — доводка #3623 (тот PR #3629 чинил лишь поле «Лидер», саму миграцию не делал).

## Отчёты (создание)

`docs/scripts/create_slitter_reports.py` — идемпотентный `python3` (curl в окружении нет): читает `metadata?JSON`, **резолвит ID реквизитов по именам** (офлайн-схема в репо устарела), создаёт `_m_new/22` → колонки `_m_new/28` → функции/формат `_m_set`; для существующего отчёта дозаводит только недостающие колонки.

Создано и проверено на `https://ideav.ru/ateh`:

| Отчёт | queryId | Прим. |
|---|---|---|
| `slitter_cuts` | 80981 | существовал (следы #3462); дозаведены `cut_batch`, `cut_material`, `cut_leader` |
| `slitter_shift_events` | 91520 | создан с нуля |
| `slitters_list` | 81051 | существовал |

## Изменения в `slitter.js`

- **`loadSlitters` → `report/slitters_list`**, `loadCuts` → **`report/slitter_cuts`** (фильтр `FR_cut_slitter_id`), `loadShiftEvents` → **`report/slitter_shift_events`**.
- Разбор строк — чистые `core.rowsToSlitters` / `rowsToCuts` / `rowsToShiftEvents` (те же формы объектов, что давал `object/`-путь; тестируемы).
- У каждого чтения **тихий фолбэк** `*FromTable` на `object/` (паттерн `loadBatches → loadBatchesFromTable`), если отчёта нет в сборке.
- `slitter_cuts` фильтруется **по станку**: безфильтровый отчёт тяжёлый (LEFT JOIN-ы), а список и так станко-зависим (`visibleCuts`). Поэтому при смене станка теперь перезагружаем резки (раньше грузились один раз на init).
- Материал/ширину резки отдаёт сам отчёт (`cut_material*`/`cut_material_width`) — `renderCuts` использует `cut.material` как фолбэк.
- `rowsToSlitters` **дедупит по id**: отчёт джойнит стоп-лист сырья (N:M) и размножает строки станка (поймано на живых данных).
- Шапка файла обновлена (убрано «перевод на report/ — следующий этап»).

`loadCut` (одиночная редактируемая запись под `_m_set`) пока оставлен на `object/` — отдельный follow-up (хотя `slitter_cuts` уже содержит `cut_counter_*`/`cut_footage_fact`/`cut_defect_m`/`cut_notes` для будущего перевода).

## Проверка

- `node experiments/atex-slitter.test.js` — **187 ассертов зелёные** (+21 на новые парсеры).
- Живьём на `ateh`: паритет числа событий (13=13) и станков (4=4); per-station резки полные и быстрые (0.3–0.5s); реальные строки отчётов прогнаны через `core.rowsTo*` → статусы из событий (`deriveCutStatus`), очередь (`prepareCutQueue`), материал/ширина, дедуп станков — корректно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
