### PR TITLE
fix(atex): заказы — qty сохраняется в «Заказанное количество» через _m_save (#3682)

### DIFF
--- a/download/atex/js/orders.js
+++ b/download/atex/js/orders.js
@@ -459,6 +459,16 @@
         return null;
     }
 
+    // #3682: команда записи поля позиции. Первую колонку (главное значение, t{id_типа})
+    // ставит ТОЛЬКО _m_save — _m_set к первой колонке неприменим (на live даёт 403, проверено
+    // в planning #775; см. docs/WORKSPACE_DEVELOPMENT_GUIDE.md §«_m_save» и docs/MCP.md §6–7;
+    // тот же паттерн в intake.js/production-planning.js). У «Заказанного количества» qty и есть
+    // первая колонка (writeKey == id таблицы), поэтому её правка раньше уходила в _m_set и
+    // молча не сохранялась. Реквизиты (writeKey == reqId) — по-прежнему _m_set.
+    function positionWriteCommand(writeKey, tableId) {
+        return String(writeKey) === String(tableId) ? '_m_save' : '_m_set';
+    }
+
     // Нормализация компактного формата JSON_DATA ([{i,u,o,r}]) в записи.
     function normalizeObjects(json, columns) {
         if (!Array.isArray(json)) return [];
@@ -575,6 +585,8 @@
 
     // Запрос правки позиции: POST _m_set/{positionId} + реквизиты редактируемых полей.
     // values — { qty, raw, width, length, sleeve, winding, status }; ключи без reqId пропускаются.
+    // ПРИМ.: в бою правка идёт по одной ячейке через savePositionCell (она и выбирает
+    // _m_set/_m_save по #3682). Этот батч-билдер используется только тестами.
     function buildSetPositionRequest(opts) {
         var fields = {};
         var cols = opts.columns || [];
@@ -1302,7 +1314,8 @@
         return pos && pos.values ? (pos.values.width || '') : '';
     }
 
-    // Сохранение одного поля позиции: _m_set/{posId} с единственным t{reqId}.
+    // Сохранение одного поля позиции: _m_set/{posId} с единственным t{reqId}
+    // (для первой колонки — qty у «Заказанного количества» — _m_save, см. #3682).
     // Если значение не изменилось — просто возврат отображения, без запроса.
     function savePositionCell(td, newValue) {
         if (!td) return;
@@ -1349,7 +1362,8 @@
         }
         var fields = {};
         fields[writeKey] = key === 'winding' ? normalizeWinding(nextCompare) : nextCompare;
-        var url = '/' + encodeURIComponent(getApiBase()) + '/_m_set/' + encodeURIComponent(posId) + '?JSON';
+        var cmd = positionWriteCommand(writeKey, state.positionTable);
+        var url = '/' + encodeURIComponent(getApiBase()) + '/' + cmd + '/' + encodeURIComponent(posId) + '?JSON';
         var body = buildFormBody(fields, getXsrf());
         setMessage('Сохранение…', 'info');
         var oldValue = pos.values[key] || '';
@@ -2048,6 +2062,9 @@
         buildCreateOrderRequest: buildCreateOrderRequest,
         buildCreatePositionRequest: buildCreatePositionRequest,
         buildSetPositionRequest: buildSetPositionRequest,
+        getColumn: getColumn,
+        positionWriteKey: positionWriteKey,
+        positionWriteCommand: positionWriteCommand,
         buildSetFieldRequest: buildSetFieldRequest,
         buildDeleteRequest: buildDeleteRequest,
         buildSetStatusRequest: buildSetStatusRequest,

--- a/experiments/test-issue-3682-atex-orders-qty.js
+++ b/experiments/test-issue-3682-atex-orders-qty.js
@@ -1,0 +1,80 @@
+/*
+ * Regression tests for issue #3682.
+ *
+ * На боевой схеме atex таблица позиций — «Заказанное количество», а её qty («Кол-во»)
+ * хранится в ПЕРВОЙ колонке записи (главное значение), отдельного реквизита нет.
+ * Первую колонку ставит только _m_save (t{id_типа}); _m_set к ней неприменим
+ * (docs/MCP.md §6–7). Раньше правка ячейки qty уходила в _m_set и молча не сохранялась —
+ * savePositionCell теперь выбирает команду через positionWriteCommand.
+ *
+ * Проверяем:
+ *   • новая схема: qty → writeKey == id таблицы → команда _m_save;
+ *   • реквизиты (dueDate, raw, …) → _m_set, и резолвятся в реальные id;
+ *   • старая схема («Позиция заказа», «Кол-во» = реквизит 1067) → _m_set (как раньше).
+ */
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const assert = require('assert');
+
+const root = path.join(__dirname, '..');
+const scriptPath = path.join(root, 'download', 'atex', 'js', 'orders.js');
+const source = fs.readFileSync(scriptPath, 'utf8');
+
+const sandbox = {
+    window: {},
+    document: { readyState: 'loading', addEventListener: function() {}, getElementById: function() { return null; } },
+    console, URLSearchParams, URL, setTimeout, clearTimeout,
+    fetch: function() { throw new Error('fetch should not be called by helper tests'); }
+};
+sandbox.window.window = sandbox.window;
+sandbox.window.document = sandbox.document;
+vm.runInNewContext(source, sandbox, { filename: scriptPath });
+
+const h = sandbox.window.AtexOrdersTesting;
+assert(h, 'AtexOrdersTesting helper API is exposed');
+
+function writeKey(cols, key, tableId) { return h.positionWriteKey(h.getColumn(cols, key), tableId); }
+function cmd(cols, key, tableId) { return h.positionWriteCommand(writeKey(cols, key, tableId), tableId); }
+
+// positionWriteCommand: первую колонку (writeKey == tableId) — только _m_save; иначе _m_set.
+assert.strictEqual(h.positionWriteCommand('1076', '1076'), '_m_save', 'первая колонка → _m_save');
+assert.strictEqual(h.positionWriteCommand('8627', '1076'), '_m_set', 'реквизит → _m_set');
+
+// ── Новая схема: «Заказанное количество» (id 1076), qty = первая колонка (реквизита нет) ──
+// Реквизиты — реальные id из metadata ateh (сверено с записью 82754).
+const NEW_TABLE = '1076';
+const newCols = h.buildColumns(h.POSITION_FIELDS, {
+    id: NEW_TABLE, val: 'Заказанное количество', type: '13',
+    reqs: [
+        { id: '1138', val: 'Вид сырья', type: '3', ref: '1069', ref_id: '1100' },
+        { id: '1141', val: 'Ширина, мм', type: '14' },
+        { id: '1143', val: 'Длина, м', type: '14' },
+        { id: '16325', val: 'Статус позиции', type: '3', ref: '16323', ref_id: '16324' },
+        { id: '8194', val: 'Диаметр втулки', type: '3', ref: '8188', ref_id: '8193' },
+        { id: '8463', val: 'Тип намотки', type: '3' },
+        { id: '8627', val: 'Срок изготовления', type: '9' }
+    ]
+});
+
+// qty не имеет собственного реквизита → writeKey == id таблицы → _m_save (это и есть фикс).
+assert.strictEqual(writeKey(newCols, 'qty', NEW_TABLE), NEW_TABLE, 'new: qty writeKey == tableId (первая колонка)');
+assert.strictEqual(cmd(newCols, 'qty', NEW_TABLE), '_m_save', 'new: правка qty идёт через _m_save');
+
+// Прочие поля позиции существуют в БД, резолвятся по смыслу и пишутся через _m_set.
+const reqMap = { raw: '1138', width: '1141', length: '1143', sleeve: '8194', winding: '8463', status: '16325', dueDate: '8627' };
+Object.keys(reqMap).forEach(function(k) {
+    assert.strictEqual(writeKey(newCols, k, NEW_TABLE), reqMap[k], 'new: ' + k + ' → реквизит ' + reqMap[k]);
+    assert.strictEqual(cmd(newCols, k, NEW_TABLE), '_m_set', 'new: ' + k + ' (реквизит) → _m_set');
+});
+
+// ── Старая схема: «Позиция заказа», «Кол-во» = реквизит 1067 → _m_set (поведение не меняется) ──
+const OLD_TABLE = '108';
+const oldCols = h.buildColumns(h.POSITION_FIELDS, {
+    id: OLD_TABLE, val: 'Позиция заказа', type: '13',
+    reqs: [ { id: '1067', val: 'Кол-во', type: '13' }, { id: '1159', val: 'Срок изготовления', type: '9' } ]
+});
+assert.strictEqual(writeKey(oldCols, 'qty', OLD_TABLE), '1067', 'old: qty → реквизит 1067');
+assert.strictEqual(cmd(oldCols, 'qty', OLD_TABLE), '_m_set', 'old: qty-реквизит → _m_set (как раньше)');
+
+console.log('issue-3682 atex orders qty save: ok');


### PR DESCRIPTION
Closes #3682.

## Проверка по боевой базе ateh
Запросил metadata и запись позиции 82754:
- таблица позиций — **«Заказанное количество»** (id **1076**, тип 13);
- qty («Кол-во») у неё **отдельного реквизита НЕ имеет** — это **первая колонка** записи (главное значение). Подтверждено сырой записью: `object/1076?...F_I=82754` → `r[0] = "210"`.

## Баг
Правка ячейки qty уходила в `POST _m_set/{posId}` с телом `t1076=210`. Но **`_m_set` не пишет первую колонку** — для неё нужен `_m_save` с `t{id_типа}`:
- `docs/WORKSPACE_DEVELOPMENT_GUIDE.md` §«_m_save — только для первой колонки»;
- `docs/MCP.md` §6–7 (`_m_set` нельзя применять к первой колонке);
- проверено на live в planning **#775**: `_m_set`→**403**, `_m_save{t{tableId}}` — работает;
- тот же паттерн уже используется в `intake.js` и `production-planning.js`.

Поэтому qty **молча не сохранялся**. На старой схеме («Позиция заказа», где «Кол-во» был реквизитом) `_m_set t{reqId}` работал — потому регресс-тесты и не ловили (фикстуры используют старую схему).

## Фикс
`savePositionCell` выбирает команду через новый чистый helper:
```js
positionWriteCommand(writeKey, tableId) // writeKey == tableId → '_m_save', иначе '_m_set'
```
- qty (первая колонка, `writeKey == 1076`) → `_m_save/{posId}` `t1076=210` ✅
- реквизиты (raw/width/length/sleeve/winding/status/срок) → `_m_set` без изменений.

## Сверка остальных полей с БД (по запросу из issue)
Все редактируемые поля позиции существуют в метаданных ateh и резолвятся по смыслу:

| поле | реквизит ateh | id |
|---|---|---|
| qty | **первая колонка «Заказанное количество»** | 1076 (main) |
| raw | Вид сырья | 1138 |
| width | Ширина, мм | 1141 |
| length | Длина, м | 1143 |
| sleeve | Диаметр втулки | 8194 |
| winding | Тип намотки | 8463 |
| status | Статус позиции | 16325 |
| dueDate | Срок изготовления | 8627 |

## Изменения
- `download/atex/js/orders.js` — helper `positionWriteCommand`; `savePositionCell` шлёт `_m_save` для первой колонки. `buildSetPositionRequest` (тест-онли батч-билдер) не трогаю — в бою правка идёт по одной ячейке.
- `experiments/test-issue-3682-atex-orders-qty.js` — новая схема (qty→_m_save, реквизиты→_m_set, маппинг полей) + старая схема (qty-реквизит→_m_set).

## Тесты
Новый тест + все существующие orders-тесты зелёные (2911, 3177, 3041, 3039, 3183, orders-enh).

⚠️ Рекомендую дымовой тест после мержа: на `/ateh` открыть заказ, изменить «Кол-во» позиции, обновить страницу — значение должно сохраниться.

🤖 Generated with [Claude Code](https://claude.com/claude-code)