### PR TITLE
fix(atex): Гант — период по умолчанию «День» (#3683)

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -146,7 +146,7 @@
         for (var i = 0; i < GANTT_MODES.length; i++) {
             if (GANTT_MODES[i].id === s) return s;
         }
-        return 'week';
+        return 'day';   // #3683: период по умолчанию — «День»
     }
 
     function localDateMs(year, month, day, hour, minute, second) {
@@ -827,7 +827,7 @@
         this.busy = false;
         this.cuts = [];
         this.slitters = [];
-        this.state = { mode: 'week', anchor: todayISO(), slitter: '', status: '' };
+        this.state = { mode: 'day', anchor: todayISO(), slitter: '', status: '' };   // #3683: дефолт — «День»
     }
 
     AtexCutGantt.prototype.url = function(path) {

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -83,6 +83,13 @@ assertEqual({ mode: weekRange.mode, startIso: weekRange.startIso, endIso: weekRa
 assertEqual(gantt.shiftAnchor('2026-06-11', 'week', 1), '2026-06-15', 'shiftAnchor: +1 неделя');
 assertEqual(gantt.shiftAnchor('2026-06-11', 'week', -1), '2026-06-01', 'shiftAnchor: −1 неделя');
 
+// ── #3683: период по умолчанию — «День» (пустой/неизвестный режим → 'day', один день) ──
+var defRange = gantt.ganttRange('2026-06-11', '');
+assertEqual({ mode: defRange.mode, startIso: defRange.startIso, endIso: defRange.endIso, days: defRange.days.length },
+    { mode: 'day', startIso: '2026-06-11', endIso: '2026-06-12', days: 1 },
+    'ganttRange: дефолтный режим — День (1 день)');
+assertEqual(gantt.ganttRange('2026-06-11', 'неизвестно').mode, 'day', 'ganttRange: неизвестный режим → День');
+
 // ── cutStatus ──
 var NOW = gantt.parseDateTimeMs('2026-06-10 12:00');
 assertEqual(gantt.cutStatus({ planDate: '2026-06-20' }, NOW).key, 'planned', 'cutStatus: будущее → запланировано');


### PR DESCRIPTION
Closes #3683.

## Что было
Диаграмма Ганта (`templates/atex/cut-gantt.html` → `download/atex/js/cut-gantt.js`) открывалась в режиме **«Неделя»**: `this.state = { mode: 'week', … }` в конструкторе `AtexCutGantt`, и `normalizeMode` тоже падал в `'week'` по умолчанию. Режим из URL не приходит (`parseDeepLink` читает только `cut/date/slitter`), поэтому начальный период = именно эта константа.

## Фикс
Дефолтный период — **«День»**:
- конструктор: `mode: 'week'` → `mode: 'day'`;
- `normalizeMode` fallback: `return 'week'` → `return 'day'` (для пустого/неизвестного режима — тоже День).

Масштаб по умолчанию (`MODE_PX_PER_MIN.day`) уже соответствует Дню — отдельной правки не требует. Кнопки переключения период (День / 3 дня / Неделя / Месяц) работают как прежде.

## Тесты
`experiments/atex-cut-gantt.test.js`: добавлены проверки `ganttRange('2026-06-11', '')` → режим `'day'` (1 день) и неизвестный режим → `'day'`. Все **60 assertions passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)