### PR TITLE
fix(atex): обеспечения удаляемой резки из this.supplies, не из 81463 (#3691)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -627,6 +627,26 @@
         return out;
     }
 
+    // #3691: id «Обеспечений» резки из УЖЕ ЗАГРУЖЕННЫХ supplies (this.supplies из cut_planning,
+    // у каждого есть cutId). Отчёт 81463 (cut→fulfillment) оказался ненадёжным (зависел от
+    // совпадения дат резки/Партии ГП/Обеспечения и возвращал пусто) → удаление резки слало
+    // _m_del, не сняв ссылки Обеспечений на Партии ГП → 409. Берём связи из состояния очереди,
+    // дедупликация по id, пустые/чужие пропускаем. Чистая функция — покрывается тестами.
+    function cutFulfillmentIds(supplies, cutId) {
+        var want = (cutId == null || cutId === '') ? null : String(cutId);
+        var seen = {};
+        var out = [];
+        (supplies || []).forEach(function(s) {
+            if (!s) return;
+            if (want != null && String(s.cutId == null ? '' : s.cutId) !== want) return;
+            var fid = (s.id == null) ? '' : String(s.id).trim();
+            if (fid === '' || fid === 'null' || seen[fid]) return;
+            seen[fid] = true;
+            out.push(fid);
+        });
+        return out;
+    }
+
     // Сообщение об ошибке из ответа API. Команды `_m_*` и отчёты при отказе отдают
     // `[{"error":"…"}]` (массив; см. my_die/api_dump в index.php) с HTTP-кодом 4xx,
     // успех — данные без ключа `error`. Разворачиваем обе формы (массив-обёртку и
@@ -3682,6 +3702,7 @@
         formatPlanDayLabel: formatPlanDayLabel,
         formatPlanDayRangeLabel: formatPlanDayRangeLabel,   // #3622
         fulfillmentIdsFromRows: fulfillmentIdsFromRows,   // #3486
+        cutFulfillmentIds: cutFulfillmentIds,             // #3691
         extractApiError: extractApiError,
         planDateDayKey: planDateDayKey,
         dayOffsetFromBase: dayOffsetFromBase,   // #3652
@@ -5462,17 +5483,18 @@
         return name || day || ('#' + cut.id);
     }
 
-    // #3486: id всех «Обеспечений» резки отчётом 81463 (cut → fulfillment). Они
-    // ссылаются на «Партии ГП» резки; пока ссылки живы, _m_del резки вернёт 409
-    // (DeleteTreeRefsCount в index.php), поэтому удалять их нужно ДО самой резки.
-    // Возвращает Promise<массив id>. LIMIT с запасом — резок с тысячами связей нет.
+    // #3691: id всех «Обеспечений» резки — из УЖЕ ЗАГРУЖЕННЫХ this.supplies (cut_planning),
+    // НЕ из отчёта 81463 (cut→fulfillment). Они ссылаются на «Партии ГП» резки; пока ссылки
+    // живы, _m_del резки вернёт 409 (DeleteTreeRefsCount в index.php), поэтому удалять их нужно
+    // ДО самой резки. Отчёт 81463 оказался ненадёжным (зависел от совпадения дат резки/Партии
+    // ГП/Обеспечения и возвращал пусто) → резка падала на 409. Promise — для совместимости с
+    // вызовом deleteCutTask (асинхронный контракт сохраняем).
     AtexProductionPlanning.prototype.loadCutFulfillments = function(cutId) {
-        return this.getJson('report/81463?JSON_KV&LIMIT=0,1000&FR_cutID=' + encodeURIComponent(cutId))
-            .then(function(rows) { return fulfillmentIdsFromRows(rows, cutId); });
+        return Promise.resolve(cutFulfillmentIds(this.supplies || [], cutId));
     };
 
-    // #3486: кнопка «🗑» в карточке резки. Сначала тянем id «Обеспечений» резки
-    // (report/81463), показываем подтверждение с их числом, по согласию — удаляем.
+    // #3486: кнопка «🗑» в карточке резки. Сначала собираем id «Обеспечений» резки
+    // (#3691: из this.supplies), показываем подтверждение с их числом, по согласию — удаляем.
     AtexProductionPlanning.prototype.deleteCutTask = function(cut, cardEl) {
         var self = this;
         if (this.busy || !cut) return;

--- a/experiments/test-issue-3691-cut-fulfillments-from-supplies.js
+++ b/experiments/test-issue-3691-cut-fulfillments-from-supplies.js
@@ -1,0 +1,51 @@
+// Unit-тесты ideav/crm#3691: id «Обеспечений» удаляемой резки берутся из УЖЕ ЗАГРУЖЕННЫХ
+// this.supplies (cut_planning), а НЕ из отчёта 81463 (cut→fulfillment) — тот зависел от
+// совпадения дат резки/Партии ГП/Обеспечения и возвращал пусто, из-за чего _m_del резки
+// падал на 409 (живая ссылка Обеспечения на Партию ГП).
+//
+// Run with: node experiments/test-issue-3691-cut-fulfillments-from-supplies.js
+
+process.env.TZ = 'UTC';
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else { console.log('  expected:', JSON.stringify(expected)); console.log('  actual:  ', JSON.stringify(actual)); process.exitCode = 1; }
+}
+
+// Форма this.supplies как из rowsToPlanning: { id, positionId, cutId, finishedBatchId, ... }
+var SUP = [
+    { id:'93151', cutId:'94345', positionId:'91750', finishedBatchId:'93123' },
+    { id:'93156', cutId:'94345', positionId:'91747', finishedBatchId:'93131' },
+    { id:'93161', cutId:'999',   positionId:'91748', finishedBatchId:'93131' }
+];
+assertEqual(planning.cutFulfillmentIds(SUP, '94345'), ['93151', '93156'],
+    'cutFulfillmentIds: обеспечения резки 94345 из this.supplies');
+assertEqual(planning.cutFulfillmentIds(SUP, 94345), ['93151', '93156'],
+    'cutFulfillmentIds: числовой cutId приводится к строке');
+assertEqual(planning.cutFulfillmentIds(SUP, '999'), ['93161'], 'cutFulfillmentIds: другая резка');
+assertEqual(planning.cutFulfillmentIds(SUP, '7777'), [], 'cutFulfillmentIds: нет связей → []');
+assertEqual(planning.cutFulfillmentIds(SUP, null), ['93151', '93156', '93161'],
+    'cutFulfillmentIds: без cutId → все обеспечения');
+// дедуп и пропуск пустых/null id
+assertEqual(planning.cutFulfillmentIds([
+    { id:'s1', cutId:'A' }, { id:'s1', cutId:'A' }, { id:'', cutId:'A' }, { id:null, cutId:'A' }, null
+], 'A'), ['s1'], 'cutFulfillmentIds: дедуп + пропуск пустых/null');
+assertEqual(planning.cutFulfillmentIds(null, 'A'), [], 'cutFulfillmentIds: null supplies → []');
+
+// loadCutFulfillments читает из this.supplies (без сети/отчёта 81463) и возвращает Promise.
+var controller = Object.create(api.Controller.prototype);
+controller.supplies = SUP;
+var reportCalled = false;
+controller.getJson = function() { reportCalled = true; return Promise.reject(new Error('отчёт 81463 не должен дёргаться')); };
+controller.loadCutFulfillments('94345').then(function(ids) {
+    assertEqual(ids, ['93151', '93156'], 'loadCutFulfillments #3691: id из this.supplies');
+    assertEqual(reportCalled, false, 'loadCutFulfillments #3691: отчёт 81463 НЕ запрашивается');
+    console.log('\n' + passed + ' проверок прошло.');
+    if (process.exitCode === 1) console.log('ЕСТЬ ПАДЕНИЯ — см. выше.');
+    else console.log('Все проверки #3691 зелёные.');
+}).catch(function(err) { console.error(err && err.stack || err); process.exitCode = 1; });


### PR DESCRIPTION
## Что и зачем

Closes #3691. Удаление задания падало на **409** («Нельзя удалить объект, на который существует ссылки (всего: 1)»): живое «Обеспечение» ссылается на «Партию ГП» под резкой, и каскад `_m_del` резки не снимал эту ссылку.

## Причина

`deleteCutTask` → `loadCutFulfillments(cutId)` брал id «Обеспечений» из отчёта **`report/81463` (`cut_n_fullfill`, cut→fulfillment)**. Этот отчёт возвращал **пусто** — проверено на ateh: даже когда в `cut_planning` были резки с `supply_id`, `report/81463` отдавал **0 строк вообще**. Похоже, его JOIN зависит от совпадения дат резки / Партии ГП / Обеспечения (гипотеза из тикета подтверждается). Раз обеспечения не находились — они не удалялись перед резкой → `_m_del/<резка>` → 409.

## Фикс (клиентский, `production-planning.js`)

- Новый чистый помощник `cutFulfillmentIds(supplies, cutId)` берёт id «Обеспечений» из **уже загруженных `this.supplies`** (`cut_planning` через `rowsToPlanning`, у каждого supply есть `cutId`) — дедуп, пропуск пустых/чужих.
- `loadCutFulfillments` больше **не дёргает 81463**, а резолвит из состояния очереди (`Promise.resolve(...)` — асинхронный контракт `deleteCutTask` сохранён).
- Порядок удаления прежний (#3486/#3475): сначала все «Обеспечения» (снимаем ссылки на Партии ГП), затем сама резка — backend каскадом сносит Партии ГП/Полосы/Расход.
- `fulfillmentIdsFromRows` (старый report-парсер) оставлен (его тест #3486 зелёный), но в проде не используется.

## Тесты

- Новый `experiments/test-issue-3691-cut-fulfillments-from-supplies.js` (9): фильтр по `cutId`, числовой `cutId`, дедуп, пустые/`null`, `loadCutFulfillments` читает из `this.supplies` и **не** делает сетевой запрос к 81463.
- Регрессия: `atex-production-planning-3486.test.js` (10), `atex-production-planning.test.js` (568; 2 провала — `rowsToGenPositions`/`isCutVisible` — **предсуществуют на main**).

> Замечание: тест-база ateh на момент работы была очищена (cut_planning/1078 пусты), живой 94345 воспроизвести не удалось. Фикс проверен по фактической форме `cut_planning` (ранний снимок: `supply_id`+`cut_id` по каждой резке) и юнит-тестами. Если разница дат выбрасывает supply и из самого `cut_planning` — это уже серверная сторона (отчёт), отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
