### PR TITLE
fix(atex): Гант — наладка первой резки от заправки станка (prev_cut_setup), как в планировщике (#3693)

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -611,6 +611,75 @@
         };
     }
 
+    // #3693: текущая заправка станка из отчёта prev_cut_setup → { materialId, winding,
+    // knifeWidths, knifeCount } по верхней (последней по task_start) задаче станка. Порт
+    // prevSetupFromRows планировщика (production-planning.js #3688). rows фильтруются по
+    // slitterId; нет задач → null. Нужна для переналадки ПЕРВОЙ резки станка (см. attachSetupMinutes).
+    function ganttPrevSetupFromRows(rows, slitterId) {
+        var sid = String(slitterId == null ? '' : slitterId);
+        var byTask = {};
+        (rows || []).forEach(function(r) {
+            if (sid !== '' && String(r.slitter_id) !== sid) return;
+            var tid = String(r.task_id == null ? '' : r.task_id);
+            if (tid === '') return;
+            var ts = Number(r.task_start) || 0;
+            if (!byTask[tid]) byTask[tid] = { start: ts, widths: [], material: '', winding: '' };
+            var rec = byTask[tid];
+            if (ts > rec.start) rec.start = ts;
+            var w = Number(r.width) || 0;
+            if (w > 0) rec.widths.push(w);
+            if (rec.material === '' && r.material_id != null && String(r.material_id) !== '') rec.material = String(r.material_id);
+            if (rec.winding === '' && r.wind_dir) rec.winding = ganttNormWinding(r.wind_dir);
+        });
+        var top = null;
+        Object.keys(byTask).forEach(function(tid) {
+            if (top === null || byTask[tid].start > byTask[top].start) top = tid;
+        });
+        if (top === null) return null;
+        var rec = byTask[top];
+        return { materialId: rec.material, winding: rec.winding, knifeWidths: rec.widths.slice(), knifeCount: rec.widths.length };
+    }
+
+    // #3693: строки отчёта prev_cut_setup → карта { slitterId: заправка }. Чистая — тест.
+    function ganttPrevSetupBySlitter(rows) {
+        var bySlitter = {};
+        (rows || []).forEach(function(r) {
+            var sid = String(r && r.slitter_id == null ? '' : r.slitter_id);
+            if (sid === '') return;
+            (bySlitter[sid] = bySlitter[sid] || []).push(r);
+        });
+        var map = {};
+        Object.keys(bySlitter).forEach(function(sid) {
+            var setup = ganttPrevSetupFromRows(bySlitter[sid], sid);
+            if (setup) map[sid] = setup;
+        });
+        return map;
+    }
+
+    // #3693: синтетическая «предыдущая резка» для первой резки станка от его текущей заправки
+    // (порт carryOverPrevCut #3688). cutChangeoverMinutes сравнивает материал/намотку/ножи —
+    // партию Гант не сравнивает (нет в cut_planning), поэтому её здесь не переносим. Нет заправки
+    // (null) → пустой станок: материал/намотка/ножи отличны → полный сетап.
+    function ganttCarryOverPrevCut(prevSetup) {
+        if (!prevSetup) {
+            return { materialId: ' none', winding: ' none', knifeWidths: [], knifeCount: 0, rollerWidth: 0 };
+        }
+        return { materialId: prevSetup.materialId, winding: prevSetup.winding,
+                 knifeWidths: (prevSetup.knifeWidths || []).slice(),
+                 knifeCount: (prevSetup.knifeWidths || []).length, rollerWidth: 0 };
+    }
+
+    // #3693: настройка ножей ПЕРВОЙ резки станка с нуля, когда заправка неизвестна (нет данных
+    // prev_cut_setup) — порт firstSetupParts/firstSetupCost (#3669 п.2). Только ножи (KNIFE),
+    // если у резки есть ножи; смена сырья при неизвестной заправке не бронируется. → минуты.
+    function ganttFirstSetupKnifeMin(next, times) {
+        var t = times || GANTT_OP_TIMES;
+        var knifeTime = Number(t.KNIFE != null ? t.KNIFE : GANTT_OP_TIMES.KNIFE) || 0;
+        if (!next || !(knifeTime > 0)) return 0;
+        var hasKnives = (Number(next.knifeCount) || 0) > 0 || ((next.knifeWidths || []).length > 0);
+        return hasKnives ? round3(knifeTime) : 0;
+    }
+
     // #3675 п.3: раскладка ножей из строк отчёта cut_strips (queryId 8656, JSON_KV:
     // { cut_id, strip_width, strip_qty }) → knifeWidths (ширины, развёрнутые по числу ножей) и
     // knifeCount (Σ strip_qty) на каждое задание. Мутирует cuts. Чистая — покрывается тестами.
@@ -634,9 +703,14 @@
     }
 
     // #3675 п.3: минуты наладки ПЕРЕД каждой резкой = переналадка с ПРЕДЫДУЩЕЙ резкой того же
-    // станка (порядок — по очерёдности/старту, как orderCutsInGroup). Первая резка станка → 0.
-    // Пишет cut.setupKnifeMin / cut.setupMaterialMin. Мутирует cuts. Чистая — покрывается тестами.
-    function attachSetupMinutes(cuts, times) {
+    // станка (порядок — по очерёдности/старту, как orderCutsInGroup). Пишет cut.setupKnifeMin /
+    // cut.setupMaterialMin. Мутирует cuts. Чистая — покрывается тестами.
+    // #3693: ПЕРВАЯ резка станка тоже получает наладку (как в планировщике, #3688): если известна
+    // текущая заправка станка (prevSetupBySlitter из отчёта prev_cut_setup) — переналадка от неё
+    // (та же конфигурация → 0, другое сырьё/ножи → смена сырья/ножей); заправка неизвестна →
+    // настройка ножей с нуля (firstSetup, #3669 п.2). Раньше первая резка ставила 0.
+    function attachSetupMinutes(cuts, times, prevSetupBySlitter) {
+        var prevMap = prevSetupBySlitter || {};
         var byMachine = {};
         (cuts || []).forEach(function(cut) {
             if (!cut) return;
@@ -647,7 +721,16 @@
             var arr = orderCutsInGroup(byMachine[sid]);   // тот же порядок, что в дорожке станка
             var prev = null;
             arr.forEach(function(cut) {
-                var ch = cutChangeoverMinutes(prev, cut, times);
+                var ch;
+                if (!prev) {
+                    // #3693: первая резка станка — от текущей заправки (prev_cut_setup), иначе ножи с нуля.
+                    var setup = prevMap[sid];
+                    ch = setup
+                        ? cutChangeoverMinutes(ganttCarryOverPrevCut(setup), cut, times)
+                        : { knife: ganttFirstSetupKnifeMin(cut, times), material: 0 };
+                } else {
+                    ch = cutChangeoverMinutes(prev, cut, times);
+                }
                 cut.setupKnifeMin = ch.knife;
                 cut.setupMaterialMin = ch.material;
                 prev = cut;
@@ -784,6 +867,10 @@
         cutSetupMin: cutSetupMin,
         cutBarSegments: cutBarSegments,
         cutChangeoverMinutes: cutChangeoverMinutes,
+        ganttPrevSetupFromRows: ganttPrevSetupFromRows,
+        ganttPrevSetupBySlitter: ganttPrevSetupBySlitter,
+        ganttCarryOverPrevCut: ganttCarryOverPrevCut,
+        ganttFirstSetupKnifeMin: ganttFirstSetupKnifeMin,
         attachStrips: attachStrips,
         attachSetupMinutes: attachSetupMinutes,
         rowsToCuts: rowsToCuts,
@@ -861,6 +948,12 @@
         return this.getJson('report/cut_strips?JSON_KV&LIMIT=0,20000').catch(function() { return []; });
     };
 
+    // #3693: текущая заправка станков из отчёта prev_cut_setup (как у планировщика, #3688) — для
+    // наладки ПЕРВОЙ резки станка. Ошибка/нет доступа → пусто (деградация к настройке ножей с нуля).
+    AtexCutGantt.prototype.loadPrevCutSetup = function() {
+        return this.getJson('report/prev_cut_setup?JSON_KV&LIMIT=0,5000').catch(function() { return []; });
+    };
+
     // #3675 п.3: op-времена наладки из таблицы «Время операции, мин» (как у планировщика). Код
     // операции ищем по виду UPPER_SNAKE среди колонок (без метаданных), минуты — главное значение.
     // Ошибка/нет таблицы → дефолты GANTT_OP_TIMES (смена сырья 15, ножи 30).
@@ -891,13 +984,16 @@
             this.getJson('report/cut_planning?JSON_KV&LIMIT=0,5000'),
             this.loadSlitters(),
             this.loadStrips(),
-            this.loadOpTimes()
+            this.loadOpTimes(),
+            this.loadPrevCutSetup()   // #3693: текущая заправка станков для наладки первой резки
         ]).then(function(res) {
             self.cuts = rowsToCuts(res[0] || []);
             // #3675 п.3: раскладка ножей + минуты наладки по переналадке с предыдущей резкой станка.
             attachStrips(self.cuts, res[2] || []);
             self.opTimes = res[3] || GANTT_OP_TIMES;
-            attachSetupMinutes(self.cuts, self.opTimes);
+            // #3693: первая резка станка — наладка от его текущей заправки (prev_cut_setup).
+            self.prevSetupBySlitter = ganttPrevSetupBySlitter(res[4] || []);
+            attachSetupMinutes(self.cuts, self.opTimes, self.prevSetupBySlitter);
             var merged = {};
             var ordered = [];
             (res[1] || []).concat(slittersFromCuts(self.cuts)).forEach(function(s) {

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -164,16 +164,50 @@ gantt.attachStrips(stripCuts, [
 assertEqual([stripCuts[0].knifeWidths, stripCuts[0].knifeCount], [[55, 55, 33], 3], 'attachStrips: ширины развёрнуты по qty');
 assertEqual([stripCuts[1].knifeWidths, stripCuts[1].knifeCount], [[110, 110, 110], 3], 'attachStrips: второе задание');
 
-// ── attachSetupMinutes (#3675 п.3): наладка по предыдущей резке станка ──
-var seqCuts = [
-    { id: 'a', sequence: 1, slitter: { id: '10' }, materialId: '5', winding: 'OUT', rollerWidth: 88, knifeWidths: [55], knifeCount: 1 },
-    { id: 'b', sequence: 2, slitter: { id: '10' }, materialId: '7', winding: 'OUT', rollerWidth: 88, knifeWidths: [55], knifeCount: 1 },
-    { id: 'c', sequence: 1, slitter: { id: '20' }, materialId: '5', winding: 'OUT', rollerWidth: 88, knifeWidths: [55], knifeCount: 1 }
+// ── attachSetupMinutes (#3675 п.3 / #3693): наладка по предыдущей резке + первая от заправки ──
+function freshSeq() {
+    return [
+        { id: 'a', sequence: 1, slitter: { id: '10' }, materialId: '5', winding: 'OUT', rollerWidth: 88, knifeWidths: [55], knifeCount: 1 },
+        { id: 'b', sequence: 2, slitter: { id: '10' }, materialId: '7', winding: 'OUT', rollerWidth: 88, knifeWidths: [55], knifeCount: 1 },
+        { id: 'c', sequence: 1, slitter: { id: '20' }, materialId: '5', winding: 'OUT', rollerWidth: 88, knifeWidths: [55], knifeCount: 1 }
+    ];
+}
+// #3693: нет данных prev_cut_setup → первая резка станка = настройка ножей с нуля (KNIFE 30), не 0.
+var seqNoSetup = freshSeq();
+gantt.attachSetupMinutes(seqNoSetup, TIMES);
+assertEqual([seqNoSetup[0].setupKnifeMin, seqNoSetup[0].setupMaterialMin], [30, 0], 'attachSetupMinutes #3693: первая (нет заправки) → ножи с нуля 30');
+assertEqual([seqNoSetup[1].setupKnifeMin, seqNoSetup[1].setupMaterialMin], [0, 15], 'attachSetupMinutes: смена сырья у второй');
+assertEqual([seqNoSetup[2].setupKnifeMin, seqNoSetup[2].setupMaterialMin], [30, 0], 'attachSetupMinutes #3693: первая на станке 20 (нет заправки) → ножи 30');
+
+// #3693: известна заправка станка 10 — тот же материал, ДРУГИЕ ножи → у первой только смена ножей 30.
+var seqSameMat = freshSeq();
+gantt.attachSetupMinutes(seqSameMat, TIMES, { '10': { materialId: '5', winding: 'OUT', knifeWidths: [99], knifeCount: 1 } });
+assertEqual([seqSameMat[0].setupKnifeMin, seqSameMat[0].setupMaterialMin], [30, 0], 'attachSetupMinutes #3693: заправка тем же сырьём, др. ножи → смена ножей 30');
+// Заправка ТОЧНО как первая резка (сырьё+намотка+ножи) → наладки нет (0).
+var seqIdentical = freshSeq();
+gantt.attachSetupMinutes(seqIdentical, TIMES, { '10': { materialId: '5', winding: 'OUT', knifeWidths: [55], knifeCount: 1 } });
+assertEqual([seqIdentical[0].setupKnifeMin, seqIdentical[0].setupMaterialMin], [0, 0], 'attachSetupMinutes #3693: та же заправка → первая без наладки');
+// Заправка другим сырьём, те же ножи → только смена сырья 15.
+var seqDiffMat = freshSeq();
+gantt.attachSetupMinutes(seqDiffMat, TIMES, { '10': { materialId: '999', winding: 'OUT', knifeWidths: [55], knifeCount: 1 } });
+assertEqual([seqDiffMat[0].setupKnifeMin, seqDiffMat[0].setupMaterialMin], [0, 15], 'attachSetupMinutes #3693: заправка др. сырьём, те же ножи → смена сырья 15');
+
+// ── #3693: разбор отчёта prev_cut_setup (порт prevSetupFromRows/carryOverPrevCut/firstSetup) ──
+var SETUP_ROWS = [
+    { task_start: '2000', slitter_id: '10', task_id: 'T2', wind_dir: 'IN', width: '55.00', material_id: '39014' },
+    { task_start: '2000', slitter_id: '10', task_id: 'T2', wind_dir: 'IN', width: '33.00', material_id: '39014' },
+    { task_start: '1000', slitter_id: '10', task_id: 'T1', wind_dir: 'OUT', width: '110.00', material_id: '2158' },
+    { task_start: '3000', slitter_id: '20', task_id: 'T3', wind_dir: 'IN', width: '90.00', material_id: '500' }
 ];
-gantt.attachSetupMinutes(seqCuts, TIMES);
-assertEqual([seqCuts[0].setupKnifeMin, seqCuts[0].setupMaterialMin], [0, 0], 'attachSetupMinutes: первая на станке 10 → 0');
-assertEqual([seqCuts[1].setupKnifeMin, seqCuts[1].setupMaterialMin], [0, 15], 'attachSetupMinutes: смена сырья у второй');
-assertEqual([seqCuts[2].setupKnifeMin, seqCuts[2].setupMaterialMin], [0, 0], 'attachSetupMinutes: первая на станке 20 → 0');
+assertEqual(gantt.ganttPrevSetupFromRows(SETUP_ROWS, '10'),
+    { materialId: '39014', winding: 'IN', knifeWidths: [55, 33], knifeCount: 2 }, 'ganttPrevSetupFromRows: верхняя задача станка 10 (T2)');
+assertEqual(gantt.ganttPrevSetupFromRows(SETUP_ROWS, '999'), null, 'ganttPrevSetupFromRows: нет задач станка → null');
+assertEqual(Object.keys(gantt.ganttPrevSetupBySlitter(SETUP_ROWS)).sort(), ['10', '20'], 'ganttPrevSetupBySlitter: карта по станкам');
+assertEqual(gantt.ganttCarryOverPrevCut({ materialId: '39014', winding: 'IN', knifeWidths: [55, 33] }),
+    { materialId: '39014', winding: 'IN', knifeWidths: [55, 33], knifeCount: 2, rollerWidth: 0 }, 'ganttCarryOverPrevCut: из заправки');
+assertEqual(gantt.ganttCarryOverPrevCut(null).knifeCount, 0, 'ganttCarryOverPrevCut: нет заправки → пустой станок');
+assertEqual(gantt.ganttFirstSetupKnifeMin({ knifeCount: 2 }, TIMES), 30, 'ganttFirstSetupKnifeMin: есть ножи → 30');
+assertEqual(gantt.ganttFirstSetupKnifeMin({ knifeCount: 0, knifeWidths: [] }, TIMES), 0, 'ganttFirstSetupKnifeMin: нет ножей → 0');
 
 // ── ganttWindow (#3668 п.1/п.7): окно = первое…последнее задание (снап до часа) ──
 assertEqual(


### PR DESCRIPTION
Closes #3693.

## Проблема
На диаграмме Ганта (`templates/atex/cut-gantt.html` → `download/atex/js/cut-gantt.js`) **первая резка станка не показывала сегменты наладки** (смена сырья/намотки + ножи), хотя должна. `attachSetupMinutes` для первой резки (`prev=null`) ставил `{knife:0, material:0}`.

Планировщик (`production-planning.js`, #3688) считает первую резку очереди от **текущей заправки станка** — отчёт `prev_cut_setup` (что сейчас стоит на станке). Портирую ту же логику в Гант.

## Что сделано
- `loadPrevCutSetup` → `report/prev_cut_setup?JSON_KV` (тот же отчёт, что у планировщика; проверен на боевой ateh — доступен, колонки `slitter_id/task_id/task_start/width/material_id/wind_dir`);
- `ganttPrevSetupFromRows` / `ganttPrevSetupBySlitter` — карта `slitterId → {materialId, winding, knifeWidths, knifeCount}` по верхней (последней по `task_start`) задаче станка (порт `prevSetupFromRows`);
- `attachSetupMinutes(cuts, times, prevSetupBySlitter)` — первая резка станка:
  - известна заправка → переналадка от неё (`ganttCarryOverPrevCut` → `cutChangeoverMinutes`): **та же конфигурация → 0**, другое сырьё → смена сырья, другие ножи → смена ножей;
  - заправка неизвестна (нет отчёта/доступа) → **настройка ножей с нуля** (`ganttFirstSetupKnifeMin`, порт `firstSetupCost` #3669). Деградация мягкая.

changeover-логика (сырьё/намотка + ножи) у Ганта уже совпадает с `changeoverParts` планировщика; партию Гант не сравнивает (нет в `cut_planning`) — мелкое расхождение, как и раньше.

## Поведение первой резки (как у планировщика)
| Заправка станка | Наладка первой резки |
|---|---|
| та же (сырьё+намотка+ножи) | 0 |
| другое сырьё, те же ножи | смена сырья 15 |
| то же сырьё, другие ножи | смена ножей 30 |
| нет данных prev_cut_setup | ножи с нуля 30 |

## Тесты
`experiments/atex-cut-gantt.test.js` — добавлены кейсы первой резки (все 4 варианта) + порт-функции. **70 assertions passed.**

> Примечание: логика `prev_cut_setup` в планировщике приходит из #3688 (PR #3690, ещё в ревью). Этот PR самодостаточен — у Ганта своя копия расчёта; конфликтов с #3690 нет (разные файлы).

🤖 Generated with [Claude Code](https://claude.com/claude-code)