### PR TITLE
fix(atex): минимизировать отход при подборе — seed «1 заказ = 1 резка» (#3706)

### DIFF
--- a/download/atex/js/cut-layout.js
+++ b/download/atex/js/cut-layout.js
@@ -209,11 +209,13 @@
     return String(materialId == null ? '' : materialId) + '|' + parts.join('+');
   }
 
-  // ───────────────────── #3472: цель раскроя ─────────────────────
-  // Менеджер минимизирует РАСХОД джамбо (число прогонов ≡ метраж сырья), затем СКРАП
-  // (перепроизводство НЕзапасных ширин — рулоны сверх заказа, которые некуда деть).
-  // Эти две величины — лексикографическая цель оптимизатора (отход первичен, #3472):
-  // 110×8 + 89×10 раздельно = 18 прогонов выгоднее, чем 4+4 слитно = 20.
+  // ───────────────────── #3472/#3706: цель раскроя ─────────────────────
+  // Лексикографическая цель оптимизатора (по убыванию приоритета):
+  //   1) ПРОГОНЫ — расход джамбо ≡ метраж сырья (110×8 + 89×10 раздельно = 18 прогонов
+  //      выгоднее, чем 4+4 слитно = 20);
+  //   2) СКРАП — перепроизводство НЕзапасных ширин (рулоны сверх заказа, которые некуда деть);
+  //   3) ОТХОД — незанятая ширина джамбо × прогоны (#3706: при равных прогонах и скрапе
+  //      берём раскладку с меньшим реальным отходом — «не должно быть отходов вне допуска»).
 
   // orderStripQty: полос назначения «Заказ» данной ширины (миррор
   // nonStockStripQtyForWidth в production-planning — добор «Склад» не считаем).
@@ -249,12 +251,13 @@
     return scrap;
   }
 
-  // planLayouts: оркестратор раскладки (#3472). input = {jumboWidth, positions,
-  // preferred, options:{windowDays=3, tolerance}}. Группирует позиции по окну срока;
-  // ВНУТРИ окна — менеджерская модель: каждый заказ (различная ширина) сначала идёт
-  // ОТДЕЛЬНОЙ раскладкой (seed «1 заказ = 1 резка», макс. заполнение джамбо). Затем
-  // ограниченный перебор слияний: две раскладки сливаются в комбо ТОЛЬКО если это
-  // лексикографически снижает цель (прогоны, затем скрап) — заказ не дробится,
+  // planLayouts: оркестратор раскладки (#3472/#3706). input = {jumboWidth, positions
+  // (каждая {id, orderId, width, qty, dueKey, stockable}), preferred, options:{windowDays=3,
+  // tolerance}}. Группирует позиции по окну срока; ВНУТРИ окна — менеджерская модель:
+  // seed «1 заказ = 1 резка» по ключу (заказ, ширина) — одинаковая ширина одного заказа
+  // консолидируется, разных заказов — нет (иначе #3684). Затем ограниченный перебор
+  // слияний (B&B по парам): две раскладки сливаются в комбо ТОЛЬКО если это
+  // лексикографически снижает цель (прогоны → скрап → отход) — заказ не дробится,
   // объединение лишь по выгоде. Комбо ограничено (#3472 п.3): не более
   // options.maxWidthsPerCut (3) ширин и options.maxPositionsPerCut (3) заказов.
   // Позиции шире джамбо → skipped. Вход не мутирует.
@@ -271,7 +274,7 @@
     var maxWidths = (opts.maxWidthsPerCut == null) ? 3 : toNumber(opts.maxWidthsPerCut);
     var maxPositions = (opts.maxPositionsPerCut == null) ? 3 : toNumber(opts.maxPositionsPerCut);
     var positions = (input.positions || []).map(function(p){
-      return { id: p.id, width: toNumber(p.width), qty: toNumber(p.qty),
+      return { id: p.id, orderId: p.orderId, width: toNumber(p.width), qty: toNumber(p.qty),
                dueKey: isFinite(p.dueKey) ? p.dueKey : Infinity, stockable: !!p.stockable };
     });
 
@@ -302,6 +305,9 @@
         demands: demands, result: result, demandByWidth: demandByWidth,
         stockableByWidth: stockableByWidth, positionsCovered: covered,
         runs: runs, scrap: layoutScrap(result.strips, runs, demandByWidth, stockableByWidth),
+        // #3706: реальный отход раскладки — незанятая ширина джамбо × прогоны
+        // (третичный критерий цели: при равных прогонах и скрапе берём меньший отход).
+        waste: round3(toNumber(result.remainder) * runs),
         overflow: result.overflow
       };
     }
@@ -314,15 +320,21 @@
       var clusterDueKey = Infinity;
       cluster.forEach(function(p){ if (p.dueKey < clusterDueKey) clusterDueKey = p.dueKey; });
 
-      // seed: одна раскладка на каждую РАЗЛИЧНУЮ ширину (одинаковая ширина — один продукт,
-      // склейка бесплатна; разные ширины — отдельные резки по умолчанию, без дробления заказа).
-      var widthOrder = [], byWidth = {};
+      // seed «1 заказ = 1 резка» (#3472/#3684): группируем по ключу (ЗАКАЗ, ширина).
+      // Одинаковая ширина ОДНОГО заказа — один продукт, консолидируем; одинаковая ширина
+      // РАЗНЫХ заказов — раздельные seed-группы (не склеиваем принудительно — иначе #3684:
+      // перебор по ширине джамбо → лишний прогон + почти пустая резка-сирота). Позиции без
+      // orderId — каждая своей группой (= «1 позиция = 1 резка»). Ключ всегда одноширинный,
+      // поэтому composeLayout агрегирует без риска сбросить «не влезшие» ширины в overflow;
+      // разные ширины заказа собираются обратно в одну резку ниже в refine — по выгоде.
+      var seedOrder = [], bySeed = {};
       cluster.forEach(function(p){
-        var k = String(round3(p.width));
-        if (!byWidth[k]) { byWidth[k] = []; widthOrder.push(k); }
-        byWidth[k].push({ width: p.width, qty: p.qty, positionId: p.id, stockable: p.stockable });
+        var owner = (p.orderId != null && String(p.orderId) !== '') ? ('o' + p.orderId) : ('p' + p.id);
+        var k = owner + '|w' + round3(p.width);
+        if (!bySeed[k]) { bySeed[k] = []; seedOrder.push(k); }
+        bySeed[k].push({ width: p.width, qty: p.qty, positionId: p.id, stockable: p.stockable });
       });
-      var groups = widthOrder.map(function(k){ return buildGroup(byWidth[k]); });
+      var groups = seedOrder.map(function(k){ return buildGroup(bySeed[k]); });
 
       // refine: пока есть лексикографически улучшающее слияние пары — сливаем (B&B по парам).
       var guard = 0;
@@ -340,10 +352,13 @@
             if (maxPositions > 0 && merged.positionsCovered.length > maxPositions) continue;
             var dr = merged.runs - (gi.runs + gj.runs);
             var ds = round3(merged.scrap - (gi.scrap + gj.scrap));
-            var improves = dr < 0 || (dr === 0 && ds < 0);        // строго лучше по (прогоны, скрап)
+            var dw = round3(merged.waste - (gi.waste + gj.waste));   // #3706: отход (трим)
+            // строго лучше по лексикографической цели (прогоны → скрап → отход)
+            var improves = dr < 0 || (dr === 0 && ds < 0) || (dr === 0 && ds === 0 && dw < 0);
             if (!improves) continue;
-            if (!best || dr < best.dr || (dr === best.dr && ds < best.ds)) {
-              best = { i: i, j: j, group: merged, dr: dr, ds: ds };
+            if (!best || dr < best.dr || (dr === best.dr && ds < best.ds) ||
+                (dr === best.dr && ds === best.ds && dw < best.dw)) {
+              best = { i: i, j: j, group: merged, dr: dr, ds: ds, dw: dw };
             }
           }
         }

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -6517,7 +6517,10 @@
                         positions: positionGroup.map(function(p) {
                             // #3423: запасные комбинации (есть в «Максимальном запасе») можно
                             // перепроизводить в запас; незапасные — резать ровно под заказ.
-                            return { id: p.id, width: p.width, qty: p.qty, dueKey: p.dueKey,
+                            // #3684/#3706: orderId — для seed «1 заказ = 1 резка» (позиции
+                            // одного заказа собираются в одну резку; одинаковая ширина РАЗНЫХ
+                            // заказов не склеивается принудительно).
+                            return { id: p.id, orderId: p.orderId, width: p.width, qty: p.qty, dueKey: p.dueKey,
                                 stockable: planning.isStockableNomenclature(self.maxStockIndex, {
                                     material: mat, width: p.width,
                                     length: group.windLength, winding: group.windDir }) };

--- a/experiments/atex-cut-layout-3706.test.js
+++ b/experiments/atex-cut-layout-3706.test.js
@@ -1,0 +1,108 @@
+// Unit-тесты #3706/#3684 — минимизация отхода при подборе: seed «1 заказ = 1 резка»
+// по ключу (ЗАКАЗ, ширина). Одинаковая ширина РАЗНЫХ заказов больше не склеивается
+// принудительно на seed (иначе перебор по ширине джамбо → лишний прогон + почти пустая
+// резка-сирота с отходом вне допуска). Цель оптимизатора: прогоны → скрап → ОТХОД.
+//
+// Run with: node experiments/atex-cut-layout-3706.test.js
+
+var layout = require('../download/atex/js/cut-layout.js').layout;
+var passed = 0;
+function assertEqual(actual, expected, name){
+  var ok = JSON.stringify(actual) === JSON.stringify(expected);
+  console.log((ok?'PASS':'FAIL')+' — '+name);
+  if(ok) passed++; else { console.log('  exp:',JSON.stringify(expected)); console.log('  got:',JSON.stringify(actual)); process.exitCode=1; }
+}
+function sortedCover(l){ return l.positionsCovered.slice().sort(); }
+function coverKey(l){ return sortedCover(l).join(','); }
+
+// ── РЕПРО #3684: MWR116L, джамбо 891, допуск 20. Заказы 3346 (33×27) и 3347
+//    (33×7 + 34×3 + 55×10). Менеджер: 2 резки, 2 прогона, отход 0 и 8 (в допуске).
+//    Регресс до фикса: seed по ширине склеивал 33 двух заказов → 3 прогона + резка
+//    34×3 на 102/891 (отход 789, ВНЕ допуска). ──
+var r3684 = layout.planLayouts({
+  jumboWidth: 891,
+  positions: [
+    { id: '91747', orderId: '3346', width: 33, qty: 27, dueKey: 20260601 },
+    { id: '91748', orderId: '3347', width: 33, qty: 7,  dueKey: 20260601 },
+    { id: '91749', orderId: '3347', width: 34, qty: 3,  dueKey: 20260601 },
+    { id: '91750', orderId: '3347', width: 55, qty: 10, dueKey: 20260601 }
+  ],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 20 }
+});
+
+assertEqual(r3684.layouts.length, 2, '#3684: ровно 2 резки (как у менеджера, не 3)');
+assertEqual(r3684.layouts.map(coverKey).sort(), ['91747', '91748,91749,91750'],
+  '#3684: заказ 3346 — отдельная резка; все позиции заказа 3347 — в одной резке');
+
+// КЛЮЧЕВАЯ цель #3706: ни одной резки с отходом ВНЕ допуска.
+var anyOutOfTol = r3684.layouts.some(function(l){ return !l.withinTolerance; });
+assertEqual(anyOutOfTol, false, '#3706: нет резок с отходом вне допуска (остатки 0 и 8 ≤ 20)');
+// Нет осиротевшей резки 34×3 (одна позиция 91749 в своей резке).
+var orphan = r3684.layouts.some(function(l){ return coverKey(l) === '91749'; });
+assertEqual(orphan, false, '#3684: нет резки-сироты 34×3 (789 мм отхода)');
+// Заказ не дроблён: каждая позиция ровно в одной резке.
+var seen = {}, split = false;
+r3684.layouts.forEach(function(l){ l.positionsCovered.forEach(function(p){ if (seen[p]) split = true; seen[p] = 1; }); });
+assertEqual(split, false, '#3684: ни одна позиция не дроблена на две резки');
+// Суммарный отход (Σ остатков) минимален = 8 (0 + 8), как у менеджера.
+var totalRem = r3684.layouts.reduce(function(a, l){ return a + l.remainder; }, 0);
+assertEqual(layout.round3(totalRem), 8, '#3684: суммарный отход 8 мм (менеджерский оптимум)');
+
+// ── Одинаковая ширина ОДНОГО заказа — консолидируется в одну резку (один продукт). ──
+var sameOrder = layout.planLayouts({
+  jumboWidth: 200,
+  positions: [
+    { id: 'x1', orderId: 'A', width: 50, qty: 5, dueKey: 20260601 },
+    { id: 'x2', orderId: 'A', width: 50, qty: 5, dueKey: 20260601 }
+  ],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 0 }
+});
+assertEqual(sameOrder.layouts.length, 1, 'один заказ, одинаковая ширина → одна резка (консолидация)');
+assertEqual(sortedCover(sameOrder.layouts[0]), ['x1', 'x2'], 'обе позиции заказа в одной резке');
+
+// ── Одинаковая ширина РАЗНЫХ заказов: НЕ склеиваем, если это не экономит прогоны.
+//    Заказ A 50×4 (ровно заполняет джамбо 200, 1 прогон, отход 0); заказ B 50×4 — своя
+//    резка. Склейка дала бы {50:8} → 2 прогона (как 1+1), без выгоды → раздельно. ──
+var diffOrderNoGain = layout.planLayouts({
+  jumboWidth: 200,
+  positions: [
+    { id: 'a', orderId: 'A', width: 50, qty: 4, dueKey: 20260601 },
+    { id: 'b', orderId: 'B', width: 50, qty: 4, dueKey: 20260601 }
+  ],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 0 }
+});
+assertEqual(diffOrderNoGain.layouts.length, 2, 'разные заказы, одинаковая ширина без выгоды → 2 резки (не склеены)');
+assertEqual(diffOrderNoGain.layouts.every(function(l){ return l.remainder === 0; }), true,
+  'разные заказы: каждая резка заполнена (отход 0)');
+
+// ── Одинаковая ширина РАЗНЫХ заказов: склеиваем, ЕСЛИ это экономит прогоны.
+//    A 50×5 + B 50×5: раздельно 2+2=4 прогона; слитно {50:10}=3 прогона → склеить. ──
+var diffOrderGain = layout.planLayouts({
+  jumboWidth: 200,
+  positions: [
+    { id: 'a', orderId: 'A', width: 50, qty: 5, dueKey: 20260601 },
+    { id: 'b', orderId: 'B', width: 50, qty: 5, dueKey: 20260601 }
+  ],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 0 }
+});
+assertEqual(diffOrderGain.layouts.length, 1, 'разные заказы, склейка экономит прогон → 1 резка (по выгоде)');
+
+// ── Обратная совместимость: позиции БЕЗ orderId → seed по позиции (как было).
+//    Эталон #3472: 110×80 + 89×80, джамбо 910 → 2 раздельные резки (18 прогонов). ──
+var noOrderId = layout.planLayouts({
+  jumboWidth: 910,
+  positions: [
+    { id: '3673', width: 110, qty: 80, dueKey: 20260601 },
+    { id: '3672', width: 89,  qty: 80, dueKey: 20260601 }
+  ],
+  preferred: [],
+  options: { windowDays: 3, tolerance: 0 }
+});
+assertEqual(noOrderId.layouts.length, 2, 'без orderId: seed по позиции — 110 и 89 раздельно (#3472)');
+assertEqual(noOrderId.layouts.map(coverKey).sort(), ['3672', '3673'], 'без orderId: каждая позиция — своя резка');
+
+console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Часть 2 для #3706 (часть 1 — сигнал на кнопке «Полосы» — уже в main, PR #3710). Здесь — **реальная минимизация отхода при подборе** (заголовок issue + корень #3684).

## Проблема
Планировщик группировал позиции в seed **по ширине** → одинаковая ширина РАЗНЫХ заказов склеивалась принудительно → перебор по ширине джамбо (лишний прогон) + почти пустые резки-сироты с отходом ВНЕ допуска. Кейс #3684: резка `34×3` на 102/891 мм, отход 789 мм; 3 прогона вместо 2.

## Решение
**Seed «1 заказ = 1 резка» по ключу (заказ, ширина):**
- одинаковая ширина одного заказа — консолидируется; разных заказов — нет;
- разные ширины заказа собираются обратно в одну резку в `refine` (B&B по парам) — только по выгоде;
- ключ одноширинный → `composeLayout` не сбрасывает «не влезшие» ширины в overflow;
- позиции без `orderId` → seed по позиции (обратная совместимость, #3472).

Цель оптимизатора расширена третичным критерием: **прогоны → скрап → отход** (незанятая ширина × прогоны). При равных прогонах и скрапе берём раскладку с меньшим реальным отходом.

## Результат на кейсе #3684
2 резки, 2 прогона, отход **0 и 8 мм (в допуске)** — менеджерский оптимум вместо 3 прогонов и отхода 789 мм.

## Файлы
- `download/atex/js/cut-layout.js` — seed (заказ, ширина); `waste` в `buildGroup`; отход третичным критерием в `refine`.
- `download/atex/js/production-planning.js` — проброс `orderId` в позиции `planLayouts`.
- `experiments/atex-cut-layout-3706.test.js` — 13 проверок (репро #3684, консолидация/раздельность одинаковых ширин по выгоде, обратная совместимость без orderId).

## Проверки
- `node --check` обоих модулей — ок.
- Новый тест 13/13; связанные (`atex-cut-layout` 27, `atex-cut-layout-3472` 20, `atex-production-planning-3706` 12, `atex-production-planning-3391` 32, `atex-cut-map` 21) — зелёные.
- Регрессий нет: единичные FAIL в наборе доуже-существуют на чистом `main` (дрейф полей/TZ, jsdom-харнесс спиннера) — не от этой ветки.

🤖 Generated with [Claude Code](https://claude.com/claude-code)