### PR TITLE
fix(atex): Гант — задания не налезают на следующие (округление длительностей) (#3708)

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -443,7 +443,7 @@
     // #3680: подпись охватывает ВСЁ задание (наладка + резка), а не только резку.
     // Начало = левый край бара (tr.startMs, та же точка, что у строки .atex-cg-label-main);
     // setupMin раздвигает только правый край — добавляет к окну минуты наладки перед резкой.
-    function cutBarTime(cut, setupMin) {
+    function cutBarTime(cut, setupMin, maxEndMs) {
         var tr = cutTimeRange(cut);
         if (!tr) return '';
         // #3705: правый край = старт + (резка+лидер) + наладка — ровно та же сумма минут, что у
@@ -451,6 +451,11 @@
         // лидера) + наладка → конец задания получался на лидер «между резками» короче плана.
         var startMs = tr.startMs;
         var endMs = startMs + (cutBarMinutes(cut) + (Number(setupMin) || 0)) * 60000;
+        // #3708: не заходить за старт следующего задания того же станка. Длительности хранятся
+        // округлёнными вверх (#3635 п.4), а cut_plan_date — по дробному времени, поэтому бар бывает
+        // на доли минуты длиннее реального окна и налезал на следующий бар.
+        var maxMs = Number(maxEndMs);
+        if (maxEndMs != null && isFinite(maxMs) && maxMs > startMs && endMs > maxMs) endMs = maxMs;
         var mins = Math.max(1, Math.round((endMs - startMs) / 60000));
         return formatTime(startMs) + '-' + formatTime(endMs) + ' (' + mins + ' мин)';
     }
@@ -885,18 +890,34 @@
 
         groups.forEach(function(g) {
             orderCutsInGroup(g.cuts);
-            g.tasks = g.cuts.map(function(cut) {
+            var ordered = g.cuts;
+            g.tasks = ordered.map(function(cut, i) {
                 var tr = cutTimeRange(cut) || { startMs: win.startMs, endMs: win.startMs };
                 var status = cutStatus(cut, nowMs);
                 // #3675 п.3 / #3680: ширина бара = наладка + резка; подпись времени — ВСЁ окно задания
                 // (от начала наладки до конца резки), а не только резка.
                 var seg = cutBarSegments(cut, pxPerMin, minPx);
+                var leftPx = round3((tr.startMs - win.startMs) / 60000 * pxPerMin);
+                var widthPx = seg.totalPx;
+                // #3708: бар не должен заходить за старт следующего задания того же станка —
+                // длительности хранятся вверх (#3635 п.4), а старты по дробному времени, поэтому бар
+                // бывал длиннее реального окна. Завершённые (есть факт. финиш) не режем — реальную
+                // длительность показываем как есть (конфликт виден).
+                var nextStartMs = null;
+                if (tr.actualEndMs == null && i + 1 < ordered.length) {
+                    var ntr = cutTimeRange(ordered[i + 1]);
+                    if (ntr && ntr.startMs > tr.startMs) nextStartMs = ntr.startMs;
+                }
+                if (nextStartMs != null) {
+                    var maxWidthPx = round3((nextStartMs - tr.startMs) / 60000 * pxPerMin);
+                    if (maxWidthPx > 0 && widthPx > maxWidthPx) widthPx = maxWidthPx;
+                }
                 return {
                     cut: cut, status: status,
-                    leftPx: round3((tr.startMs - win.startMs) / 60000 * pxPerMin),
-                    widthPx: seg.totalPx,
+                    leftPx: leftPx,
+                    widthPx: widthPx,
                     segments: seg,
-                    label: cutRowLabel(cut), barText: cutBarTime(cut, seg.setupMin),
+                    label: cutRowLabel(cut), barText: cutBarTime(cut, seg.setupMin, nextStartMs),
                     title: cutBarTitle(cut, tr, status)
                 };
             });

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -7209,6 +7209,9 @@
         //    отсюда ложная «смена сырья».
         var times = this.changeTimes || DEFAULT_OP_TIMES;
         var betweenCuts = Number(times.BETWEEN_CUTS != null ? times.BETWEEN_CUTS : DEFAULT_OP_TIMES.BETWEEN_CUTS) || 0;
+        // #3708: точная намотка (как в расписании) для дробного «Резка и Лидер» — НЕ из ceil'нутой
+        // «Длительность, минут» (c.duration), иначе сохранённая длительность длиннее реального окна.
+        var windPoints = windingPointsFromTimes(this.opTimes || {});
         var prevBySlitter = this.prevSetupBySlitter || {};
         var updates = [];
         groupBySlitter(this.cuts || []).forEach(function(group) {
@@ -7219,14 +7222,18 @@
             var cols = setupActivityColumns(arr, times, carryPrevCut);
             arr.forEach(function(c) {
                 var want = cols[String(c.id)] || { knifeMin: 0, materialWindingMin: 0 };
-                var wantK = Math.round(want.knifeMin), wantM = Math.round(want.materialWindingMin);
-                // #3700: «Резка и Лидер» = намотка («Длительность, минут») + лидер
-                // (BETWEEN_CUTS × число резок цуга, cutLeaderRuns). Зависит только от самой резки.
-                var wantT = Math.round(stripNum(c.duration) + betweenCuts * cutLeaderRuns(c));
+                // #3708: поля наладок/лидера дробные (type 14) — храним ТОЧНЫЕ минуты (round3), без
+                // округления, иначе бар в Ганте (наладка + «Резка и Лидер») длиннее реального окна
+                // расписания (старт следующего задания) и налезает на него.
+                var wantK = round3(want.knifeMin), wantM = round3(want.materialWindingMin);
+                // #3700/#3708: «Резка и Лидер» = ТОЧНАЯ намотка (пересчёт из метража и норм, как
+                // расписание) + лидер (BETWEEN_CUTS × число резок цуга, cutLeaderRuns). НЕ из c.duration —
+                // она сохранена округлённой вверх (#3635 п.4), что и давало налезание баров.
+                var wantT = round3(scheduleDurationMinutes(c, c.length, windPoints) + betweenCuts * cutLeaderRuns(c));
                 // Колонку учитываем в diff только если она есть в метаданных (иначе её не пишем
                 // и не считаем «изменившейся» — иначе были бы лишние записи на каждом сохранении).
                 function changed(req, cur, val) {
-                    return req && (!(cur != null && cur !== '') || Math.round(stripNum(cur)) !== val);
+                    return req && (!(cur != null && cur !== '') || round3(stripNum(cur)) !== round3(val));
                 }
                 if (changed(knifeReq, c.storedKnifeSetupMin, wantK)
                     || changed(matReq, c.storedMaterialWindingMin, wantM)

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -316,4 +316,35 @@ assertEqual(laidFitSmall.pxPerMin, 1, 'layoutGroups #3704: fitTrackPx меньш
 var laidZoomFit = gantt.layoutGroups(layoutCuts, weekRange, NOW, {}, { pxPerMin: 1, zoom: 0.25, fitTrackPx: 3120 });
 assertEqual(laidZoomFit.pxPerMin, 2, 'layoutGroups #3704: «−» ниже экрана упирается в «вписать в экран»');
 
+// ── #3708: бар не заходит за старт следующего задания (округление длительностей вверх) ──
+// cutBarTime с maxEndMs обрезает конец до старта следующего.
+var cutOvershoot = { planDate: '2026-06-10 08:00', duration: 21, leaderMin: 16 };   // намотка 21 + лидер 16 = 37
+assertEqual(gantt.cutBarTime(cutOvershoot, 30), '08:00-09:07 (67 мин)',
+    'cutBarTime: без обрезки — наладка 30 + резка+лидер 37 = 67 мин (конец 09:07)');
+assertEqual(gantt.cutBarTime(cutOvershoot, 30, gantt.parseDateTimeMs('2026-06-10 09:06')), '08:00-09:06 (66 мин)',
+    'cutBarTime #3708: конец обрезан до старта следующего (09:06)');
+assertEqual(gantt.cutBarTime(cutOvershoot, 30, gantt.parseDateTimeMs('2026-06-10 10:00')), '08:00-09:07 (67 мин)',
+    'cutBarTime #3708: clamp позже конца — без изменений');
+// layoutGroups: два задания подряд на станке, бар первого «перелезал» бы на 1 мин — режется встык.
+var overlapCuts = [
+    { id: 'A', planDate: '2026-06-10 08:00', duration: 21, plannedRuns: 8, leaderMin: 16, setupKnifeMin: 30, sequence: 1, slitter: { id: '1', label: 'Станок 1' } },
+    { id: 'B', planDate: '2026-06-10 09:06', duration: 44, plannedRuns: 10, leaderMin: 20, sequence: 2, slitter: { id: '1', label: 'Станок 1' } }
+];
+var laidClamp = gantt.layoutGroups(overlapCuts, gantt.ganttRange('2026-06-10', 'day'),
+    gantt.parseDateTimeMs('2026-06-10 07:00'), {}, { pxPerMin: 1 });
+var ct = laidClamp.groups[0].tasks;
+assertEqual([ct[0].cut.id, ct[0].leftPx, ct[0].widthPx], ['A', 0, 66],
+    'layoutGroups #3708: бар A обрезан с 67 до 66 мин (старт B)');
+assertEqual(ct[0].barText, '08:00-09:06 (66 мин)', 'layoutGroups #3708: подпись A совпадает с планом (до 09:06)');
+assertEqual(ct[0].leftPx + ct[0].widthPx, ct[1].leftPx, 'layoutGroups #3708: A встык к B — налезания нет');
+// Завершённое задание (есть факт. финиш) не режем — показываем реальную длительность.
+var doneThenNext = [
+    { id: 'D', planDate: '2026-06-10 08:00', startDate: '2026-06-10 08:00', endDate: '2026-06-10 09:10', sequence: 1, slitter: { id: '1', label: 'Станок 1' } },
+    { id: 'E', planDate: '2026-06-10 09:06', duration: 30, sequence: 2, slitter: { id: '1', label: 'Станок 1' } }
+];
+var laidDone = gantt.layoutGroups(doneThenNext, gantt.ganttRange('2026-06-10', 'day'),
+    gantt.parseDateTimeMs('2026-06-10 07:00'), {}, { pxPerMin: 1 });
+assertEqual(laidDone.groups[0].tasks[0].widthPx, 70,
+    'layoutGroups #3708: завершённое задание не обрезается (факт 70 мин, конфликт виден)');
+
 console.log('\n' + passed + ' assertions passed');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 59);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 60);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3708. Регрессия после #3705 (#3707): добавление лидера в бар сделало многие бары на доли минуты длиннее реального окна — конец задания заходил за старт следующего.

## Причина — округление вверх
Планировщик ставит задания на шкале по **точному дробному** времени (`cut_plan_date`), но сохранённые длительности округляет:
- `Длительность, минут` (26584, целочисленное поле) — `ceil` (#3635 п.4);
- `Резка и Лидер` (`cut_time`, 96778) в `persistCutSetupColumns` считалась как `round(c.duration + лидер)` — т.е. от уже **ceil'нутой** длительности.

Пример с боевой базы (станок 1, `500×8`): намотка по факту 20.25 мин → `duration` 21, `cut_time` 36.25→37. Бар = наладка 30 + `Резка+Лидер` 37 = **67 мин** → конец **09:07**, а следующее задание стартует **09:06:15** → налезание ~45 сек (видно в тикете: `09:07` vs `09:06`).

Автор тикета уже сделал поля `Наладка ножей`/`Сырье/намотка`/`Резка и Лидер` (96067/96069/96778) **дробными** (type 14), чтобы туда писались точные значения.

## Фикс
1. **Планировщик** (`persistCutSetupColumns`) пишет в дробные поля **точные** минуты:
   - `Резка и Лидер` = `scheduleDurationMinutes(...)` (точная намотка из метража и норм, как расписание) + лидер — **не** из ceil'нутой `c.duration`;
   - наладки — `round3` вместо `round`; diff тоже по `round3`.
   - `Длительность, минут` (целое поле) оставлена ceil'нутой для отображения.
   После пересохранения/перегенерации `cut_time` = 36.25 → бар = 30 + 36.25 = 66.25 = ровно старт следующего (проверено симуляцией: зазор 0).
2. **Гант (страховка)** — бар не заходит за старт следующего задания того же станка: `cutBarTime(maxEndMs)` + обрезка `widthPx` в `layoutGroups`. Работает и для легаси-данных, пока `cut_time` не переписан. Завершённые задания (есть фактический финиш) **не** режем — реальную длительность показываем как есть (конфликт виден).

## Тесты
`node experiments/atex-cut-gantt.test.js` — 95 ✓ (+7 на обрезку). Планировочные тесты — без новых падений (2 пред-существующих в основном тесте — не регрессия).

## Прочее
- `VERSION` 59→60.
- Ветка от свежего `origin/main` (PR #3707 уже влит).

🤖 Generated with [Claude Code](https://claude.com/claude-code)