### PR TITLE
feat(atex): иконка Ганта у фильтра дат планирования → диаграмма на этом диапазоне (#3713)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -209,6 +209,21 @@
 .atex-pp-date-field > .atex-pp-date-nav:last-child { border-top-right-radius: 6px; border-bottom-right-radius: 6px; }
 .atex-pp-date-nav:hover { background: var(--pp-surface); }
 
+/* #3713: иконка-ссылка «Диаграмма Ганта» рядом с выбором дат (отделена от стрелок). */
+.atex-pp-date-field > .atex-pp-gantt-link {
+    flex: 0 0 auto;
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 34px;
+    margin-left: 6px;                 /* отделить от стрелок дат (перебивает схлоп границ) */
+    border: 1px solid var(--pp-border);
+    border-radius: 6px;
+    background: var(--pp-bg);
+    color: var(--pp-accent, #134174);
+    cursor: pointer;
+    text-decoration: none;
+}
+.atex-pp-date-field > .atex-pp-gantt-link:hover { background: var(--pp-surface); }
+
 .atex-pp-queue-group { margin-bottom: 16px; }
 
 /* Карточка резки — панель (#3120 п.1): информация + контролы + панель полос внутри. */

--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -269,6 +269,53 @@
         return shiftIsoDate(range.startIso, dir * step);
     }
 
+    // #3713: число дней между «С» и «По» включительно. Нужно для шага навигации и
+    // оценки плотности (px/мин) произвольного диапазона.
+    function rangeDaySpan(fromIso, toIso) {
+        var f = parseDateTimeMs(fromIso);
+        if (f == null) return 1;
+        var t = parseDateTimeMs(toIso);
+        if (t == null) t = f;
+        var days = Math.round((startOfLocalDayMs(t) - startOfLocalDayMs(f)) / GANTT_DAY_MS) + 1;
+        return days > 0 ? days : 1;
+    }
+
+    // #3713: режим (для px/мин и подсветки кнопки), наиболее подходящий диапазону в N дней.
+    function daySpanToMode(fromIso, toIso) {
+        var days = rangeDaySpan(fromIso, toIso);
+        if (days <= 1) return 'day';
+        if (days <= 3) return 'three';
+        if (days <= 7) return 'week';
+        return 'month';
+    }
+
+    // #3713: произвольный диапазон [С; По] (включительно по день «По») как период Ганта —
+    // форма совпадает с ganttRange. Гант открывается этим диапазоном из «Планирования
+    // производства» (deep-link ?from=..&to=..). mode подбирается по длине (px/мин, подсветка).
+    function ganttRangeFromTo(fromIso, toIso) {
+        var fromMs = parseDateTimeMs(fromIso);
+        if (fromMs == null) fromMs = startOfLocalDayMs(Date.now());
+        var startMs = startOfLocalDayMs(fromMs);
+        var toMs = parseDateTimeMs(toIso);
+        var endDayMs = toMs == null ? startMs : startOfLocalDayMs(toMs);
+        if (endDayMs < startMs) endDayMs = startMs;
+        var endMs = endDayMs + GANTT_DAY_MS;   // «По» включительно
+        var outDays = [];
+        for (var t = startMs; t < endMs; t += GANTT_DAY_MS) {
+            outDays.push({
+                iso: localIsoDateFromMs(t),
+                label: formatDateShort(t),
+                leftPct: round3(((t - startMs) / (endMs - startMs)) * 100)
+            });
+        }
+        return {
+            mode: daySpanToMode(localIsoDateFromMs(startMs), localIsoDateFromMs(endDayMs)),
+            startMs: startMs, endMs: endMs,
+            startIso: localIsoDateFromMs(startMs), endIso: localIsoDateFromMs(endMs),
+            label: rangeLabel(startMs, endMs), days: outDays
+        };
+    }
+
     function cutDeadlineMs(cut) {
         var planMs = parseDateTimeMs(cut && cut.planDate);
         var duration = stripNum(cut && cut.duration);
@@ -947,14 +994,15 @@
         var s = String(search == null ? '' : search);
         var qm = s.indexOf('?');
         if (qm >= 0) s = s.slice(qm + 1);
-        var out = { cut: '', date: '', slitter: '' };
+        // #3713: from/to — диапазон дат из «Планирования производства» (иконка Ганта у фильтра дат).
+        var out = { cut: '', date: '', slitter: '', from: '', to: '' };
         s.split('&').forEach(function(pair) {
             if (!pair) return;
             var eq = pair.indexOf('=');
             var key = eq >= 0 ? pair.slice(0, eq) : pair;
             var val = eq >= 0 ? pair.slice(eq + 1) : '';
             try { val = decodeURIComponent(val.replace(/\+/g, ' ')); } catch (e) {}
-            if (key === 'cut' || key === 'date' || key === 'slitter') out[key] = val;
+            if (key === 'cut' || key === 'date' || key === 'slitter' || key === 'from' || key === 'to') out[key] = val;
         });
         return out;
     }
@@ -967,6 +1015,8 @@
         localIsoDateFromMs: localIsoDateFromMs,
         shiftIsoDate: shiftIsoDate,
         ganttRange: ganttRange,
+        ganttRangeFromTo: ganttRangeFromTo,   // #3713
+        daySpanToMode: daySpanToMode,         // #3713
         shiftAnchor: shiftAnchor,
         cutStatus: cutStatus,
         cutTimeRange: cutTimeRange,
@@ -1029,7 +1079,9 @@
         this.busy = false;
         this.cuts = [];
         this.slitters = [];
-        this.state = { mode: 'day', anchor: todayISO(), slitter: '', status: '', zoom: 1 };   // #3683: дефолт — «День»; #3704: зум по горизонтали
+        // #3683: дефолт — «День»; #3704: зум по горизонтали; #3713: fromIso/toIso — произвольный
+        // диапазон из deep-link «Планирования» (если задан, период берётся из него, а не из mode).
+        this.state = { mode: 'day', anchor: todayISO(), slitter: '', status: '', zoom: 1, fromIso: '', toIso: '' };
     }
 
     // #3704: шаг/границы зума горизонтального масштаба (множитель к px/мин режима).
@@ -1134,7 +1186,11 @@
         var self = this;
         var st = this.state;
         st.mode = normalizeMode(st.mode);
-        var range = ganttRange(st.anchor || todayISO(), st.mode);
+        // #3713: задан произвольный диапазон (deep-link из «Планирования») → период по нему;
+        // иначе обычный режим день/3 дня/неделя/месяц от якоря.
+        var range = st.fromIso
+            ? ganttRangeFromTo(st.fromIso, st.toIso || st.fromIso)
+            : ganttRange(st.anchor || todayISO(), st.mode);
         if (!st.anchor) st.anchor = range.startIso;
         var nowMs = this.nowMs();
 
@@ -1151,20 +1207,39 @@
         var self = this;
         var st = this.state;
 
+        // #3713: при произвольном диапазоне (deep-link) ‹/› двигают весь диапазон на его длину;
+        // в обычном режиме — на период. Выбор режима/даты сбрасывает диапазон в режим от якоря.
+        function shiftPeriod(dir) {
+            if (st.fromIso) {
+                var span = rangeDaySpan(st.fromIso, st.toIso || st.fromIso);
+                st.fromIso = shiftIsoDate(st.fromIso, dir * span);
+                st.toIso = shiftIsoDate(st.toIso || st.fromIso, dir * span);
+            } else {
+                st.anchor = shiftAnchor(st.anchor || range.startIso, st.mode, dir);
+            }
+            self.render();
+        }
         var prevBtn = el('button', { class: 'atex-cg-arrow', type: 'button', text: '‹', title: 'Предыдущий период' });
         var nextBtn = el('button', { class: 'atex-cg-arrow', type: 'button', text: '›', title: 'Следующий период' });
-        prevBtn.addEventListener('click', function() { st.anchor = shiftAnchor(st.anchor || range.startIso, st.mode, -1); self.render(); });
-        nextBtn.addEventListener('click', function() { st.anchor = shiftAnchor(st.anchor || range.startIso, st.mode, 1); self.render(); });
+        prevBtn.addEventListener('click', function() { shiftPeriod(-1); });
+        nextBtn.addEventListener('click', function() { shiftPeriod(1); });
 
+        var activeMode = st.fromIso ? range.mode : st.mode;   // #3713: при диапазоне подсвечиваем подходящий режим
         var modeWrap = el('div', { class: 'atex-cg-modes', role: 'group', 'aria-label': 'Период' });
         GANTT_MODES.forEach(function(m) {
-            var btn = el('button', { class: 'atex-cg-mode' + (m.id === st.mode ? ' is-active' : ''), type: 'button', text: m.label, title: m.label });
-            btn.addEventListener('click', function() { st.mode = m.id; self.render(); });
+            var btn = el('button', { class: 'atex-cg-mode' + (m.id === activeMode ? ' is-active' : ''), type: 'button', text: m.label, title: m.label });
+            btn.addEventListener('click', function() {
+                if (st.fromIso) { st.anchor = range.startIso; st.fromIso = ''; st.toIso = ''; }   // #3713: выход из диапазона
+                st.mode = m.id;
+                self.render();
+            });
             modeWrap.appendChild(btn);
         });
 
-        var dateInput = el('input', { class: 'atex-cg-input atex-cg-date', type: 'date', value: st.anchor || range.startIso, title: 'Дата периода' });
-        dateInput.addEventListener('change', function() { if (dateInput.value) { st.anchor = dateInput.value; self.render(); } });
+        var dateInput = el('input', { class: 'atex-cg-input atex-cg-date', type: 'date', value: st.fromIso || st.anchor || range.startIso, title: 'Дата периода' });
+        dateInput.addEventListener('change', function() {
+            if (dateInput.value) { st.anchor = dateInput.value; st.fromIso = ''; st.toIso = ''; self.render(); }   // #3713: дата → выход из диапазона
+        });
 
         var slitterSelect = el('select', { class: 'atex-cg-input atex-cg-slitter', title: 'Станок' });
         slitterSelect.appendChild(el('option', { value: '', text: 'Все станки' }));
@@ -1198,7 +1273,7 @@
         var zoomWrap = el('div', { class: 'atex-cg-zoom', role: 'group', 'aria-label': 'Масштаб по горизонтали' }, [zoomOutBtn, zoomResetBtn, zoomInBtn]);
 
         var todayBtn = el('button', { class: 'atex-cg-btn', type: 'button', text: 'Сегодня', title: 'Перейти к текущей дате' });
-        todayBtn.addEventListener('click', function() { st.anchor = todayISO(); self.render(); });
+        todayBtn.addEventListener('click', function() { st.anchor = todayISO(); st.fromIso = ''; st.toIso = ''; self.render(); });   // #3713: выход из диапазона
         var refreshBtn = el('button', { class: 'atex-cg-btn', type: 'button', text: 'Обновить', title: 'Перечитать данные' });
         refreshBtn.addEventListener('click', function() { self.refresh(); });
 
@@ -1376,6 +1451,15 @@
         root.dataset.initialized = '1';
         var controller = new AtexCutGantt(root);
         root._atexCutGantt = controller;
+        // #3713: deep-link из «Планирования производства» (иконка Ганта у фильтра дат):
+        // ?from=ГГГГ-ММ-ДД&to=ГГГГ-ММ-ДД[&slitter=..] — открыть диаграмму на этом диапазоне.
+        // Совместимо со старым ?date=ГГГГ-ММ-ДД (один день).
+        var dl = (typeof window !== 'undefined' && window.location) ? parseDeepLink(window.location.search) : null;
+        if (dl) {
+            if (dl.from) { controller.state.fromIso = dl.from; controller.state.toIso = dl.to || dl.from; }
+            else if (dl.date) { controller.state.anchor = dl.date; }
+            if (dl.slitter) controller.state.slitter = String(dl.slitter);
+        }
         controller.start();
     }
 

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3809,8 +3809,40 @@
         return out;
     }
 
+    // #3713: URL рабочего места «Диаграмма Ганта» относительно текущего пути (последний
+    // сегмент → cut-gantt). /ateh/production-planning → /ateh/cut-gantt. Вне браузера — дефолт.
+    var DEFAULT_GANTT_URL = '/atex/cut-gantt';
+    function ganttBaseFromLocation() {
+        if (typeof window === 'undefined' || !window.location || !window.location.pathname) return DEFAULT_GANTT_URL;
+        var path = String(window.location.pathname).replace(/\/+$/, '');
+        var idx = path.lastIndexOf('/');
+        return (idx >= 0 ? path.slice(0, idx) : '') + '/cut-gantt';
+    }
+
+    // #3713: ссылка на Гант с диапазоном дат фильтра «Дата плана» (?from=..&to=..). Гант
+    // открывается ровно этим диапазоном (см. ganttRangeFromTo в cut-gantt). Пустой «По» →
+    // to = from (один день). Чистая → проверяется тестом.
+    function ganttRangeLink(fromIso, toIso, baseUrl) {
+        var base = baseUrl || DEFAULT_GANTT_URL;
+        var from = String(fromIso == null ? '' : fromIso).trim();
+        var to = String(toIso == null ? '' : toIso).trim();
+        var params = [];
+        if (from) params.push('from=' + encodeURIComponent(from));
+        if (to) params.push('to=' + encodeURIComponent(to));
+        else if (from) params.push('to=' + encodeURIComponent(from));
+        return params.length ? base + '?' + params.join('&') : base;
+    }
+
+    // #3713: иконка-Гант (горизонтальные полосы) для ссылки у фильтра дат.
+    var GANTT_ICON_SVG = '<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">' +
+        '<rect x="1" y="2.5" width="8" height="2.6" rx="1"></rect>' +
+        '<rect x="4" y="6.7" width="9" height="2.6" rx="1"></rect>' +
+        '<rect x="2" y="10.9" width="6" height="2.6" rx="1"></rect></svg>';
+
     var planning = {
         parseDeepLink: parseDeepLink,
+        ganttRangeLink: ganttRangeLink,                 // #3713
+        ganttBaseFromLocation: ganttBaseFromLocation,   // #3713
         cutClickSelectsCut: cutClickSelectsCut,
         parseRef: parseRef,
         parseMultiRefIds: parseMultiRefIds,
@@ -7930,7 +7962,16 @@
         var dateNext = el('button', { class: 'atex-pp-date-nav', type: 'button', text: '›', title: 'Сдвинуть диапазон на день вперёд' });
         datePrev.addEventListener('click', function() { if (!self.busy) shiftFilterDate(-1); });
         dateNext.addEventListener('click', function() { if (!self.busy) shiftFilterDate(1); });
-        var dateNav = el('div', { class: 'atex-pp-date-field' }, [datePrev, dateFrom, el('span', { class: 'atex-pp-date-sep', text: '–' }), dateTo, dateNext]);
+        // #3713: иконка-ссылка «Диаграмма Ганта» рядом с выбором дат — открывает Гант на этом же
+        // диапазоне (?from=..&to=..). href пересобирается при каждом renderQueue из текущего фильтра.
+        var ganttLink = el('a', {
+            class: 'atex-pp-gantt-link',
+            href: ganttRangeLink(this.filter.date, this.filter.dateTo, ganttBaseFromLocation()),
+            title: 'Открыть диаграмму Ганта на этом диапазоне дат',
+            'aria-label': 'Диаграмма Ганта',
+            html: GANTT_ICON_SVG
+        });
+        var dateNav = el('div', { class: 'atex-pp-date-field' }, [datePrev, dateFrom, el('span', { class: 'atex-pp-date-sep', text: '–' }), dateTo, dateNext, ganttLink]);
         // #3411: быстрый поиск между «Дата плана» и «Статус». Фильтрует карточки очереди
         // и пересчитывает счётчики на закладках станков (видно, в каком станке сколько
         // совпавших позиций). Поиск идёт по сырью/намотке/статусу и подписям связанных

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -271,12 +271,15 @@ assertEqual(gantt.planningLink({ id: '7', planDate: '', slitter: { id: null } })
 assertEqual(gantt.planningLink({ id: '7' }, '/x/pp'),
     '/x/pp?cut=7', 'planningLink: базовый URL переопределяется');
 
-// ── parseDeepLink: cut-gantt и planning разбирают одинаково ──
-var expectDL = { cut: '85472', date: '2026-05-06', slitter: '1285' };
-assertEqual(gantt.parseDeepLink('?cut=85472&date=2026-05-06&slitter=1285'), expectDL, 'parseDeepLink (gantt): полный');
-assertEqual(planning.parseDeepLink('?cut=85472&date=2026-05-06&slitter=1285'), expectDL, 'parseDeepLink (planning): полный');
-assertEqual(gantt.parseDeepLink(''), { cut: '', date: '', slitter: '' }, 'parseDeepLink: пусто');
-assertEqual(gantt.parseDeepLink('?foo=1&cut=9'), { cut: '9', date: '', slitter: '' }, 'parseDeepLink: лишние параметры игнорируются');
+// ── parseDeepLink: #3713 Гант дополнительно понимает from/to (диапазон из «Планирования») ──
+assertEqual(gantt.parseDeepLink('?cut=85472&date=2026-05-06&slitter=1285'),
+    { cut: '85472', date: '2026-05-06', slitter: '1285', from: '', to: '' }, 'parseDeepLink (gantt): полный');
+assertEqual(planning.parseDeepLink('?cut=85472&date=2026-05-06&slitter=1285'),
+    { cut: '85472', date: '2026-05-06', slitter: '1285' }, 'parseDeepLink (planning): полный');
+assertEqual(gantt.parseDeepLink('?from=2026-06-25&to=2026-06-27&slitter=1285'),
+    { cut: '', date: '', slitter: '1285', from: '2026-06-25', to: '2026-06-27' }, 'parseDeepLink (gantt) #3713: диапазон from/to');
+assertEqual(gantt.parseDeepLink(''), { cut: '', date: '', slitter: '', from: '', to: '' }, 'parseDeepLink: пусто');
+assertEqual(gantt.parseDeepLink('?foo=1&cut=9'), { cut: '9', date: '', slitter: '', from: '', to: '' }, 'parseDeepLink: лишние параметры игнорируются');
 
 // ── #3705: лидер «между резками» в конце задания (раньше терялся → бар короче плана) ──
 // Лидер = BETWEEN_CUTS × «Кол-во план» (порт cutLeaderRuns планировщика).
@@ -346,5 +349,24 @@ var laidDone = gantt.layoutGroups(doneThenNext, gantt.ganttRange('2026-06-10', '
     gantt.parseDateTimeMs('2026-06-10 07:00'), {}, { pxPerMin: 1 });
 assertEqual(laidDone.groups[0].tasks[0].widthPx, 70,
     'layoutGroups #3708: завершённое задание не обрезается (факт 70 мин, конфликт виден)');
+
+// ── #3713: произвольный диапазон [С;По] из «Планирования» (deep-link from/to) ──
+assertEqual(gantt.daySpanToMode('2026-06-25', '2026-06-25'), 'day', 'daySpanToMode: 1 день → day');
+assertEqual(gantt.daySpanToMode('2026-06-25', '2026-06-27'), 'three', 'daySpanToMode: 3 дня → three');
+assertEqual(gantt.daySpanToMode('2026-06-25', '2026-07-01'), 'week', 'daySpanToMode: 7 дней → week');
+assertEqual(gantt.daySpanToMode('2026-06-25', '2026-07-10'), 'month', 'daySpanToMode: >7 дней → month');
+var r3713 = gantt.ganttRangeFromTo('2026-06-25', '2026-06-27');
+assertEqual([r3713.startIso, gantt.localIsoDateFromMs(r3713.endMs - 1), r3713.mode, r3713.days.length],
+    ['2026-06-25', '2026-06-27', 'three', 3], 'ganttRangeFromTo #3713: 25–27 июня включительно (3 дня), mode three');
+assertEqual(gantt.ganttRangeFromTo('2026-06-25', '').mode, 'day', 'ganttRangeFromTo #3713: пустой «По» → один день');
+assertEqual([gantt.cutInRange({ planDate: '2026-06-26' }, r3713), gantt.cutInRange({ planDate: '2026-06-28' }, r3713)],
+    [true, false], 'cutInRange #3713: 26 в диапазоне, 28 — вне (По=27 включительно)');
+// planning.ganttRangeLink: иконка у фильтра дат → Гант с диапазоном.
+assertEqual(planning.ganttRangeLink('2026-06-25', '2026-06-27', '/ateh/cut-gantt'),
+    '/ateh/cut-gantt?from=2026-06-25&to=2026-06-27', 'ganttRangeLink #3713: from+to');
+assertEqual(planning.ganttRangeLink('2026-06-25', '', '/ateh/cut-gantt'),
+    '/ateh/cut-gantt?from=2026-06-25&to=2026-06-25', 'ganttRangeLink #3713: пустой «По» → to=from');
+assertEqual(planning.ganttRangeLink('', '', '/ateh/cut-gantt'), '/ateh/cut-gantt',
+    'ganttRangeLink #3713: без дат → базовый URL');
 
 console.log('\n' + passed + ' assertions passed');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 60);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 61);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3713. В «Планировании производства» рядом с выбором дат («Дата плана» С–По) добавлена иконка-ссылка **«Диаграмма Ганта»** — клик открывает Гант ровно на выбранном диапазоне.

## production-planning.js + .css
- `ganttBaseFromLocation()` — URL соседнего маршрута `cut-gantt` относительно текущего пути (как `planningBaseFromLocation` в Ганте); `ganttRangeLink(from, to)` → `?from=..&to=..` (пустой «По» → `to=from`).
- Иконка (inline SVG, `.atex-pp-gantt-link`) добавлена в `.atex-pp-date-field` после стрелок дат; `href` пересобирается при каждом `renderQueue` из текущего фильтра.

## cut-gantt.js (приём диапазона)
- `parseDeepLink` понимает `from`/`to` (совместимо со старым `?date=` и `?slitter=`).
- `ganttRangeFromTo(from, to)` — период по произвольному диапазону `[С; По]` (включительно по «По»); режим (для px/мин и подсветки кнопки) подбирается по длине: 1д→День, ≤3→3 дня, ≤7→Неделя, иначе Месяц.
- `state.fromIso/toIso`; `init` применяет deep-link. Тулбар при диапазоне: `‹/›` двигают весь диапазон на его длину; выбор режима/даты/«Сегодня» выходит из диапазона в обычный режим.

Round-trip проверен: планировщик строит `…/cut-gantt?from=2026-06-25&to=2026-06-27` → Гант показывает 25.06–27.06 (задание 26.06 видно, 28.06 — нет).

## Тесты
`node experiments/atex-cut-gantt.test.js` — 106 ✓ (+11: from/to deep-link, `ganttRangeFromTo`, `daySpanToMode`, `cutInRange`, `ganttRangeLink`). Планировочные тесты — без новых падений (2 пред-существующих — не регрессия).

## Прочее
- `VERSION` 60→61. Ветка от свежего `origin/main` (#3712 уже влит).

🤖 Generated with [Claude Code](https://claude.com/claude-code)