### PR TITLE
fix(ai-agent): не вызывать ai/agent?JSON, если имя пользователя ≠ имя базы (#3716)

### DIFF
--- a/experiments/test-issue-3410-ai-agent-dom.js
+++ b/experiments/test-issue-3410-ai-agent-dom.js
@@ -84,7 +84,8 @@ function makeEnv(fetchHandler){
         addEventListener: function(){},
         querySelector: function(){ return null; }
     };
-    global.window = { db: 'acme', location: { pathname: '/acme/main' } };
+    // #3716: ИИ-агент доступен только владельцу (имя пользователя = имя базы).
+    global.window = { db: 'acme', user: 'acme', location: { pathname: '/acme/main' } };
     global.__intervals = [];
     global.setInterval = function(fn, ms){ var h = { fn: fn, ms: ms, cleared: false }; global.__intervals.push(h); return h; };
     global.clearInterval = function(h){ if(h) h.cleared = true; };

--- a/experiments/test-issue-3716-ai-agent-owner-only.js
+++ b/experiments/test-issue-3716-ai-agent-owner-only.js
@@ -1,0 +1,111 @@
+/*
+ * Issue #3716: /{db}/ai/agent?JSON не вызывается, если имя пользователя ≠ имя базы.
+ * https://github.com/ideav/crm/issues/3716
+ *
+ * Лёгкий харнесс без jsdom: подменяем document/window/fetch и проверяем:
+ *   1) isAgentAllowed() — сравнение имени пользователя и имени базы;
+ *   2) НЕ владелец (user != db): init не делает НИ ОДНОГО fetch к ai/agent,
+ *      кнопка ИИ-агента скрыта;
+ *   3) владелец (user == db): init поднимает последнюю задачу (resume → ai/agent?JSON),
+ *      кнопка видна.
+ *
+ * Run with: node experiments/test-issue-3716-ai-agent-owner-only.js
+ */
+'use strict';
+
+var path = require.resolve('../js/ai-agent-chat.js');
+var realSetTimeout = global.setTimeout;
+var failures = 0;
+function expect(cond, name){ if(cond){ console.log('PASS: ' + name); } else { console.log('FAIL: ' + name); failures++; } }
+function flush(){ return new Promise(function(res){ realSetTimeout(res, 0); }); }
+
+// --- минимальный фейковый DOM ---
+function FE(){
+    this.style = {}; this.attrs = {}; this.listeners = {}; this.hidden = false; this.value = '';
+    var self = this; this._cls = {};
+    this.classList = {
+        add: function(c){ self._cls[c] = 1; }, remove: function(c){ delete self._cls[c]; },
+        contains: function(c){ return !!self._cls[c]; }, toggle: function(c){ self._cls[c] = !self._cls[c]; }
+    };
+}
+FE.prototype.addEventListener = function(e, f){ this.listeners[e] = f; };
+FE.prototype.setAttribute = function(k, v){ this.attrs[k] = v; };
+FE.prototype.removeAttribute = function(k){ delete this.attrs[k]; };
+FE.prototype.getAttribute = function(k){ return this.attrs.hasOwnProperty(k) ? this.attrs[k] : null; };
+FE.prototype.focus = function(){}; FE.prototype.click = function(){};
+FE.prototype.querySelector = function(){ return null; };
+FE.prototype.appendChild = function(c){ return c; };
+Object.defineProperty(FE.prototype, 'textContent', { get: function(){ return this._t || ''; }, set: function(v){ this._t = v; } });
+Object.defineProperty(FE.prototype, 'innerHTML', { get: function(){ return this._h || ''; }, set: function(v){ this._h = v; } });
+
+var IDS = ['ai-chat-toggle','ai-agent-panel','ai-agent-backdrop','ai-agent-close','ai-agent-input',
+           'ai-agent-send','ai-agent-attach','ai-agent-files','ai-agent-messages','ai-agent-attachments','ai-agent-status'];
+
+function makeEnv(userName, dbName){
+    var els = {}; IDS.forEach(function(id){ els[id] = new FE(); });
+    global.document = {
+        readyState: 'complete',
+        getElementById: function(id){ return els[id] || null; },
+        createElement: function(){ return new FE(); },
+        addEventListener: function(){}, querySelector: function(){ return null; }
+    };
+    global.window = { db: dbName, user: userName, location: { pathname: '/' + dbName + '/main' } };
+    var calls = [];
+    global.fetch = function(url, opts){ calls.push({ url: url, opts: opts || {} });
+        return Promise.resolve({ ok: true, status: 200, json: function(){ return Promise.resolve({ job: null }); } }); };
+    global.__calls = calls;
+    global.setInterval = function(){ return {}; }; global.clearInterval = function(){};
+    return els;
+}
+function fresh(userName, dbName){ var els = makeEnv(userName, dbName); delete require.cache[path]; var agent = require(path); return { agent: agent, els: els }; }
+
+// ===================== 1) isAgentAllowed (логика) =====================
+// require без auto-init: document отсутствует.
+delete global.document;
+delete require.cache[path];
+var A = require(path);
+A.getCurrentDbName = function(){ return 'acme'; };
+A.getCurrentUserName = function(){ return 'acme'; };
+expect(A.isAgentAllowed() === true, '#3716: user == db → разрешён');
+A.getCurrentUserName = function(){ return 'bob'; };
+expect(A.isAgentAllowed() === false, '#3716: user != db → запрещён');
+A.getCurrentUserName = function(){ return ''; };
+expect(A.isAgentAllowed() === false, '#3716: пустой user → запрещён');
+A.getCurrentUserName = function(){ return 'acme'; };
+A.getCurrentDbName = function(){ return ''; };
+expect(A.isAgentAllowed() === false, '#3716: пустая база → запрещён');
+// регистронезависимо (зеркало strtolower на сервере).
+A.getCurrentUserName = function(){ return 'ACME'; };
+A.getCurrentDbName = function(){ return 'acme'; };
+expect(A.isAgentAllowed() === true, '#3716: разный регистр (ACME/acme) → разрешён');
+A.getCurrentUserName = function(){ return 'Acme'; };
+A.getCurrentDbName = function(){ return 'AcMe'; };
+expect(A.isAgentAllowed() === true, '#3716: разный регистр (Acme/AcMe) → разрешён');
+
+// ===================== 2) НЕ владелец: ноль вызовов =====================
+function scNotOwner(){
+    var ctx = fresh('bob', 'acme');   // имя пользователя ≠ имя базы
+    return flush().then(flush).then(function(){
+        var calls = global.__calls || [];
+        expect(calls.length === 0, '#3716: НЕ владелец → НИ ОДНОГО вызова ai/agent?JSON');
+        expect(ctx.els['ai-chat-toggle'].style.display === 'none', '#3716: НЕ владелец → кнопка ИИ-агента скрыта');
+    });
+}
+
+// ===================== 3) Владелец: работает как прежде =====================
+function scOwner(){
+    var ctx = fresh('acme', 'acme');  // имя пользователя = имя базы
+    return flush().then(flush).then(function(){
+        var calls = global.__calls || [];
+        expect(calls.length >= 1, '#3716: владелец → resume обращается к ai/agent?JSON');
+        expect(calls.length >= 1 && /\/acme\/ai\/agent\?JSON=1/.test(calls[0].url),
+            '#3716: владелец → URL ai/agent текущей базы (?latest)');
+        expect(ctx.els['ai-chat-toggle'].style.display !== 'none', '#3716: владелец → кнопка видна');
+    });
+}
+
+scNotOwner().then(scOwner).then(function(){
+    console.log('');
+    if(failures){ console.log('FAILED: ' + failures + ' check(s) failed'); process.exit(1); }
+    console.log('ALL TESTS PASSED');
+}).catch(function(e){ console.log('ERROR: ' + (e && e.stack ? e.stack : e)); process.exit(1); });

--- a/js/ai-agent-chat.js
+++ b/js/ai-agent-chat.js
@@ -55,6 +55,14 @@
             // Без панели и кнопки вызова работать нечему — тихо выходим.
             if (!this.toggle || !this.panel) return false;
 
+            // Issue #3716: не владельцу базы (имя пользователя ≠ имя базы) ИИ-агент
+            // недоступен — прячем кнопку вызова и НЕ обращаемся к ai/agent?JSON
+            // (ни resume, ни send, ни опросы здесь не навешиваются).
+            if (!this.isAgentAllowed()) {
+                this.toggle.style.display = 'none';
+                return false;
+            }
+
             var self = this;
 
             this.toggle.addEventListener('click', function () { self.togglePanel(); });
@@ -125,6 +133,23 @@
             if (typeof window !== 'undefined' && window.db) return String(window.db);
             var parts = window.location.pathname.split('/').filter(Boolean);
             return parts.length > 0 ? parts[0] : '';
+        },
+
+        // Имя текущего пользователя (глобаль `user` из main.html: '{_global_.user}').
+        getCurrentUserName: function () {
+            if (typeof user !== 'undefined' && user) return String(user);
+            if (typeof window !== 'undefined' && window.user) return String(window.user);
+            return '';
+        },
+
+        // Issue #3716: ИИ-агент доступен (и на сервере, и в UI) только пользователю,
+        // чьё имя совпадает с именем базы. Для остальных не делаем НИ ОДНОГО запроса
+        // /{db}/ai/agent?JSON — сервер их всё равно отклоняет (403), а лишние вызовы шумят.
+        // Сравнение зеркалит серверное aiAgentRequireOwner (index.php): strtolower обоих.
+        isAgentAllowed: function () {
+            var u = this.getCurrentUserName().toLowerCase();
+            var d = this.getCurrentDbName().toLowerCase();
+            return u !== '' && u === d;
         },
 
         getXsrfToken: function () {


### PR DESCRIPTION
Closes #3716.

## Проблема
Сервер (`index.php` → `aiAgentRequireOwner`) разрешает ИИ-агента только владельцу базы — пользователю, чьё имя совпадает с именем базы (`strtolower` обоих), остальным отвечает **403**. Но фронт (`js/ai-agent-chat.js`) на каждой загрузке страницы вызывал `resume()` → `GET /{db}/ai/agent?JSON&latest` для **любого** пользователя — лишние запросы и 403-шум в логах/сети.

## Решение
`init()` проверяет `isAgentAllowed()` — **зеркало серверного правила** (имя пользователя == имя базы, регистронезависимо):
- **не владелец** → кнопка ИИ-агента скрывается и **НИ ОДИН** запрос `ai/agent?JSON` не выполняется (обработчики `send`/опросов не навешиваются, `resume()` не вызывается);
- **владелец** → поведение без изменений.

Имя пользователя — глобаль `user` (`{_global_.user}` в `templates/main.html`), имя базы — `db` (`{_global_.z}`).

## Файлы
- `js/ai-agent-chat.js` — `getCurrentUserName()` + `isAgentAllowed()` + ранний выход в `init()` (скрыть кнопку, не делать запросов).
- `experiments/test-issue-3716-ai-agent-owner-only.js` — 11 проверок (логика `isAgentAllowed` вкл. регистр; не владелец → 0 вызовов + кнопка скрыта; владелец → resume вызывает ai/agent?JSON + кнопка видна).
- `experiments/test-issue-3410-ai-agent-dom.js` — харнесс ставит `user == db` (агент работает только у владельца).

## Проверки
- `node --check js/ai-agent-chat.js` — ок.
- Новый тест **11/11**; регрессии `test-issue-3410-ai-agent-async` / `-dom` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)