### PR TITLE
feat(atex): панель atex-pp-cut — показывать втулку резки после лидера (#3738)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -344,6 +344,23 @@
     color: var(--pp-danger, #c0392b);
     font-weight: 600;
 }
+/* #3738: втулка резки — после лидера. Название «Диаметр втулки» бывает длинным,
+   поэтому плашка ужимается и обрезается многоточием (полное имя — в title).
+   Смешанные втулки (легаси) — предупреждающий стиль, как у лидера. */
+.atex-pp-cut-sleeve {
+    flex: 0 1 auto;
+    min-width: 0;
+    max-width: 16em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+    color: var(--pp-muted);
+}
+.atex-pp-cut-sleeve-mixed {
+    color: var(--pp-danger, #c0392b);
+    font-weight: 600;
+}
 /* #3354 п.1: сводка полос по ширинам под первой строкой карточки. Контейнер —
    .atex-pp-cut-material (переиспользован), одна текстовая строка на ширину. */
 .atex-pp-cut-material {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -964,13 +964,21 @@
                     orderApprovalDate: str(row.order_approval_date || row.item_approval_date),
                     // #3472: лидеры резки (из cut_leader по всем строкам). Новые резки —
                     // один лидер; легаси (до ограничения по лидеру) могут мешать несколько.
-                    leaders: []
+                    leaders: [],
+                    // #3738: втулки резки (из cut_sleeve по всем строкам). Резка
+                    // единодиаметровая (layoutPositionGroups разбивает позиции по втулке) —
+                    // обычно одна; несколько (легаси-смешение) выделяем предупреждением.
+                    sleeves: []
                 };
                 order.push(cutId);
             }
             if (cutId && cutsById[cutId]) {
                 var leaderVal = str(row.cut_leader).trim();
                 if (leaderVal && cutsById[cutId].leaders.indexOf(leaderVal) < 0) cutsById[cutId].leaders.push(leaderVal);
+                // #3738: втулка из cut_sleeve (имя «Диаметр втулки» позиции). trim() —
+                // в справочнике встречается ведущий таб у некоторых названий.
+                var sleeveVal = str(row.cut_sleeve).trim();
+                if (sleeveVal && cutsById[cutId].sleeves.indexOf(sleeveVal) < 0) cutsById[cutId].sleeves.push(sleeveVal);
             }
             var supplyId = str(row.supply_id);
             if (supplyId) {
@@ -8311,6 +8319,18 @@
                     class: 'atex-pp-cut-leader' + (mixed ? ' atex-pp-cut-leader-mixed' : ''),
                     title: (mixed ? 'В резке смешаны разные лидеры: ' : 'Лидер: ') + cutLeaders.join(', '),
                     text: 'лидер: ' + cutLeaders.join(', ')
+                }));
+            }
+            // #3738: втулка резки — сразу после лидера. Источник — cut_sleeve (имя
+            // «Диаметр втулки» обеспеченной позиции). Одна втулка — обычная плашка;
+            // несколько (легаси-смешение до разбивки по втулке) — предупреждение, как у лидера.
+            var cutSleeves = (c.sleeves || []).filter(function(s) { return s; });
+            if (cutSleeves.length) {
+                var sleeveMixed = cutSleeves.length > 1;
+                infoChildren.push(el('span', {
+                    class: 'atex-pp-cut-sleeve' + (sleeveMixed ? ' atex-pp-cut-sleeve-mixed' : ''),
+                    title: (sleeveMixed ? 'В резке смешаны разные втулки: ' : 'Втулка: ') + cutSleeves.join(', '),
+                    text: 'втулка: ' + cutSleeves.join(', ')
                 }));
             }
             infoChildren.push(el('span', { class: 'atex-pp-cut-supplies', text: supplies ? ('связей: ' + supplies) : 'нет связей' }));

--- a/experiments/atex-production-planning-3738.test.js
+++ b/experiments/atex-production-planning-3738.test.js
@@ -1,0 +1,72 @@
+// Unit tests for #3738 — «Выводить в панели atex-pp-cut инфо о Втулке — после лидера».
+// Отчёт cut_planning отдаёт колонку cut_sleeve (имя «Диаметр втулки» обеспеченной
+// позиции, аналогично cut_leader). rowsToPlanning агрегирует её в cut.sleeves по всем
+// строкам резки: одна резка единодиаметровая (обычно одна втулка), несколько — легаси-
+// смешение (в панели выделяется предупреждением). Значения тримятся — в справочнике
+// у части названий встречается ведущий таб.
+//
+// Run with: node experiments/atex-production-planning-3738.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+function row(cutId, supplyId, posId, leader, sleeve) {
+    return {
+        cut_id: cutId, cut_plan_date: '1780963200',
+        cut_slitter_id: 'm4', cut_slitter: 'Станок 4',
+        supply_id: supplyId, supply_position_id: posId,
+        cut_leader: leader, cut_sleeve: sleeve
+    };
+}
+
+// ── 1) Одна резка, два обеспечения с ОДНОЙ втулкой → одна плашка (dedup) ──
+var oneSleeve = planning.rowsToPlanning([
+    row('C1', 's1', 'p1', 'MONOCHROME', 'Втулка картонная 1" длина 1 метр'),
+    row('C1', 's2', 'p2', 'MONOCHROME', 'Втулка картонная 1" длина 1 метр')
+]);
+assertEqual(byId(oneSleeve).C1.sleeves, ['Втулка картонная 1" длина 1 метр'],
+    '#3738: одна втулка на резку — без дублей');
+
+// ── 2) Смешение втулок (легаси) + ведущий таб тримится ──
+var mixed = planning.rowsToPlanning([
+    row('C2', 's3', 'p3', 'Прозрачный', '\tВтулка пластиковая фиолетовая 1" ширина 110 мм'),
+    row('C2', 's4', 'p4', 'Прозрачный', 'Втулка картонная 0.5" ширина 57 мм')
+]);
+assertEqual(byId(mixed).C2.sleeves,
+    ['Втулка пластиковая фиолетовая 1" ширина 110 мм', 'Втулка картонная 0.5" ширина 57 мм'],
+    '#3738: разные втулки сохраняются по порядку; ведущий таб обрезан');
+
+// ── 3) Нет втулки (пустой cut_sleeve) → пустой массив (плашка не рисуется) ──
+var none = planning.rowsToPlanning([
+    row('C3', 's5', 'p5', 'MONOCHROME', '')
+]);
+assertEqual(byId(none).C3.sleeves, [], '#3738: пустой cut_sleeve → нет втулок');
+
+// ── 4) Резка без обеспечения (supply_id пуст) остаётся в очереди, втулок нет ──
+var noSupply = planning.rowsToPlanning([
+    row('C4', '', '', '', '')
+]);
+assertEqual(byId(noSupply).C4.sleeves, [], '#3738: резка без обеспечения — без втулок');
+assertEqual(noSupply.supplies.length, 0, '#3738: пустой supply_id не создаёт обеспечение');
+
+function byId(res) {
+    var m = {};
+    (res.cuts || []).forEach(function(c) { m[c.id] = c; });
+    return m;
+}
+
+console.log('\n' + passed + ' passed');


### PR DESCRIPTION
Closes #3738. Логически зависит от #3733 (разбивка позиций по `sleeve_id` в `layoutPositionGroups` — уже в `main`, поэтому резка единодиаметровая).

## Что
Карточка резки в очереди планирования (`.atex-pp-cut`) теперь показывает плашку **«втулка: …»** сразу после лидера — симметрично лидеру.

## Как
- **Отчёт `cut_planning`** (БД, боевая `ateh`, запись запроса `8384`): добавлена колонка `cut_sleeve` — имя «Диаметр втулки» обеспеченной позиции (источник — поле `8194`, `ref→8188`, формат `SHORT`). Полный аналог `cut_leader` (поле `66409`). Колонка достижима через уже существующий join резка→обеспечение→позиция.
- **`rowsToPlanning`** агрегирует `cut_sleeve` в `cut.sleeves` по всем строкам резки (dedup + `trim` — в справочнике у части названий ведущий таб), точь-в-точь как `cut.leaders`.
- **Рендер**: плашка `.atex-pp-cut-sleeve` после лидера, перед сводкой связей. Одна втулка — обычный стиль; несколько (легаси-смешение) — `.atex-pp-cut-sleeve-mixed` (предупреждение, как у лидера). Длинное имя ужимается многоточием, полное — в `title`.

Почему через отчёт, а не клиентский деривейт из `positions_list`: поля позиции специально дублируются в `cut_planning` (см. #3624/#3633 — `order_no`, габариты), чтобы данные были даже когда позиция выпала из активного `positions_list`. Втулка выводится тем же способом.

## ⚠️ Деплой БД
На боевой `ateh` колонка `cut_sleeve` уже добавлена в отчёт `cut_planning` и проверена (отчёт грузится, 84 строки). **Другим базам нужна та же колонка запроса** (источник — поле `8194` «Диаметр втулки» позиции). Без неё JS молча не покажет плашку.

## Тест
`experiments/atex-production-planning-3738.test.js` — 5 проверок (одна втулка/dedup, смешение+trim, пусто, резка без обеспечения). Прогон всех тестов планирования зелёный (преексистинг-фейл `3619` к этой правке отношения не имеет — падает и на чистом `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
