### PR TITLE
feat(atex): планирование — gap-fill хвостов смены, нахлёст разрешён (#3739)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -2631,8 +2631,11 @@
             }
             // не влезает до конца окна (резерв обеда, если не вставлен) → 08:00 след. дня.
             // #3688: в окно должны влезть резка И лидер после неё (станок занят до конца лидера).
+            // #3739: при gapFill нахлёст за конец смены разрешён — НЕ выталкиваем на след. день,
+            // чтобы отображение совпало с планом (splitMachineQueue кладёт резку на её день,
+            // якорь по «Дате план» уводит на нужный день вперёд, а в пределах дня — нахлёст).
             var fitEnd = day * 1440 + shiftEnd - ((lunch && !lunchDone[day]) ? lunch.durationMin : 0);
-            if (hasWindow && start + dur + leaderMin > fitEnd) {
+            if (hasWindow && !opts.gapFill && start + dur + leaderMin > fitEnd) {
                 day += 1;
                 start = day * 1440 + shiftStart + setup;
                 if (lunch && !lunchDone[day] && (start - day * 1440) >= lunch.startMin) {
@@ -2731,6 +2734,127 @@
                 clock += lunch.durationMin;
                 lunchDone[day] = true;
             }
+        }
+        // #3739: setup (минуты) и его компоненты для переналадки prev→c с учётом первой
+        // резки/заправки станка. cost == changeoverCost(...) — единый источник.
+        function setupPartsFor(prev, c) {
+            if (prev) return changeoverParts(prev, c, times);
+            if (opts.carryPrevCut) return changeoverParts(opts.carryPrevCut, c, times);   // #3688
+            if (opts.firstCutSetup) return firstSetupParts(c, times);                     // #3669
+            return [];
+        }
+        function setupCostFor(prev, c) {
+            return setupPartsFor(prev, c).reduce(function(s, p){ return s + (Number(p.minutes) || 0); }, 0);
+        }
+        // #3739: gap-fill. Вместо простоя в хвосте смены тянем будущую резку вперёд (раньше
+        // срока — допустимо, «с запасом по сроку») и заполняем день; нахлёст за конец смены
+        // разрешён. Выбор следующей резки — по НЕПРЕРЫВНОСТИ КОНФИГУРАЦИИ (минимальная
+        // переналадка от предыдущей): «начинать с той конфигурации, на которой закончили».
+        // Когда в хвост влезает только настройка — кладём КРУПНЕЙШИЙ её компонент (ножи/сырьё)
+        // с минимальным нахлёстом, остаток настройки — на след. день перед проходами.
+        if (opts.gapFill) {
+            var state = {};
+            var poolOrder = [];
+            (orderedCuts || []).forEach(function(c, i){
+                var id = String(c && c.id);
+                state[id] = {
+                    cut: c, idx: i,
+                    remaining: Math.round(Number(runsByCut[id] != null ? runsByCut[id] : c && c.plannedRuns) || 0),
+                    perPass: Number(perPassByCut[id] != null ? perPassByCut[id] : 0) || 0,
+                    anchor: anchorByCut[id] != null ? anchorByCut[id] : null,
+                    isCont: false, pendingSetup: 0
+                };
+                poolOrder.push(id);
+            });
+            function pending() {
+                return poolOrder.filter(function(id){ return state[id].remaining > 0 || (state[id].perPass <= 0 && !state[id].placedEmpty); });
+            }
+            // R3: среди кандидатов — минимальная переналадка от prevPhysical (непрерывность
+            // конфигурации), затем фольга в конец (#3717), затем исходный порядок (срок/очередь).
+            function selectByConfig(ids) {
+                var best = null;
+                ids.forEach(function(id){
+                    var c = state[id].cut;
+                    var key = [ (c && c.isFoil) ? 1 : 0, setupCostFor(prevPhysical, c), state[id].idx ];
+                    if (!best) { best = { id: id, key: key }; return; }
+                    for (var k = 0; k < key.length; k++) {
+                        if (key[k] < best.key[k]) { best = { id: id, key: key }; return; }
+                        if (key[k] > best.key[k]) return;
+                    }
+                });
+                return best && best.id;
+            }
+            // Предохранитель от зацикливания: каждая итерация уменьшает remaining либо
+            // ставит настройку и двигает день (после чего проход точно ложится). Верхняя
+            // оценка — по суммарным проходам + запас на дни/настройки. На практике не срабатывает.
+            var totalRuns = 0;
+            poolOrder.forEach(function(id){ totalRuns += Math.max(0, state[id].remaining); });
+            var guard = 0, guardMax = (totalRuns + (orderedCuts || []).length + 8) * 8 + 1024;
+            while (guard++ < guardMax) {
+                var rem = pending();
+                if (!rem.length) break;
+                // Незавершённая резка (продолжение, ножи на станке) — доводим её первой.
+                var inProgress = rem.filter(function(id){ return state[id].isCont && state[id].remaining > 0; });
+                var due = rem.filter(function(id){ return state[id].anchor == null || state[id].anchor <= day; });
+                var pick = inProgress.length ? selectByConfig(inProgress)
+                    : (due.length ? selectByConfig(due) : selectByConfig(rem));   // нет «по сроку» → тянем будущую вперёд
+                var st = state[pick], c = st.cut;
+                insertLunchBefore();
+                // Резка без проходов/окна — один сегментик (как базовая ветка).
+                if (!(st.remaining > 0) || !(st.perPass > 0) || !hasWindow) {
+                    var s0 = leader + setupCostFor(prevPhysical, c);
+                    var w0 = day * 1440 + dayStart + clock;
+                    segments.push({ cutId: pick, dayOffset: day, runs: st.remaining,
+                        windowStartMin: round3(w0), startMin: round3(w0 + s0), setupMin: round3(s0),
+                        durationMin: 0, isContinuation: false, parentCutId: null });
+                    clock += s0;
+                    prevPhysical = c; st.remaining = 0; st.placedEmpty = true;
+                    continue;
+                }
+                var perPassEffG = st.perPass + leader;
+                var setupG = st.isCont ? (Number(st.pendingSetup) || 0) : setupCostFor(prevPhysical, c);
+                var availG = effCapacity(day) - clock;
+                var maxPassesG = Math.floor((availG - setupG) / perPassEffG);
+                if (maxPassesG >= 1) {
+                    var passesNowG = Math.min(st.remaining, maxPassesG);
+                    var wsG = day * 1440 + dayStart + clock, durG = passesNowG * perPassEffG;
+                    segments.push({ cutId: pick, dayOffset: day, runs: passesNowG,
+                        windowStartMin: round3(wsG), startMin: round3(wsG + setupG), setupMin: round3(setupG),
+                        durationMin: round3(durG), isContinuation: st.isCont, parentCutId: st.isCont ? pick : null });
+                    clock += setupG + durG; st.remaining -= passesNowG; st.isCont = true; st.pendingSetup = 0;
+                    prevPhysical = c;
+                } else if (clock === 0) {
+                    // Пустой день не вмещает даже setup+1 проход — кладём 1 проход (нахлёст), как база.
+                    var wsO = day * 1440 + dayStart + clock, durO = 1 * perPassEffG;
+                    segments.push({ cutId: pick, dayOffset: day, runs: 1,
+                        windowStartMin: round3(wsO), startMin: round3(wsO + setupG), setupMin: round3(setupG),
+                        durationMin: round3(durO), isContinuation: st.isCont, parentCutId: st.isCont ? pick : null });
+                    clock += setupG + durO; st.remaining -= 1; st.isCont = true; st.pendingSetup = 0;
+                    prevPhysical = c;
+                } else if (setupG <= 0) {
+                    day += 1; clock = 0;   // продолжение без настройки на след. день
+                } else {
+                    // Хвост вмещает только настройку: целиком (#3635) либо КРУПНЕЙШИЙ компонент
+                    // с минимальным нахлёстом (#3739), остаток настройки — на след. день.
+                    var tailSetup, restSetup;
+                    if (availG >= setupG) { tailSetup = setupG; restSetup = 0; }
+                    else {
+                        var parts = st.isCont ? [{ minutes: setupG }] : setupPartsFor(prevPhysical, c);
+                        var largest = 0;
+                        parts.forEach(function(p){ var m = Number(p.minutes) || 0; if (m > largest) largest = m; });
+                        if (!(largest > 0)) largest = setupG;
+                        tailSetup = largest; restSetup = round3(setupG - largest);
+                    }
+                    var wsS = day * 1440 + dayStart + clock;
+                    segments.push({ cutId: pick, dayOffset: day, runs: 0,
+                        windowStartMin: round3(wsS), startMin: round3(wsS + tailSetup), setupMin: round3(tailSetup),
+                        durationMin: 0, isContinuation: false, parentCutId: null, setupOnly: true });
+                    clock += tailSetup; prevPhysical = c;
+                    st.isCont = true; st.pendingSetup = restSetup;
+                    day += 1; clock = 0;
+                }
+            }
+            return segments;
         }
         (orderedCuts || []).forEach(function(c){
             var cid = c && c.id;
@@ -3065,7 +3189,8 @@
                 perPassByCut: perPass, runsByCut: runsByCut,
                 lunchStartMin: opts.lunchStartMin, lunchDurationMin: opts.lunchDurationMin,
                 dayAnchorByCut: opts.dayAnchorByCut,   // #3658: привязка к дню «Даты план»
-                firstCutSetup: opts.firstCutSetup   // #3669 п.2: настройка ножей первой задачи (от вызывающего)
+                firstCutSetup: opts.firstCutSetup,   // #3669 п.2: настройка ножей первой задачи (от вызывающего)
+                gapFill: opts.gapFill   // #3739: заполнять хвосты смены будущими резками, нахлёст разрешён
             });
             // headId → индекс продолжения в цепочке (0=голова, 1,2,… — продолжения по дням).
             var contIndexByHead = {};
@@ -7638,7 +7763,8 @@
             dayAnchorByCut: dayAnchorByCut,   // #3658: привязка к дню «Даты план»
             scopeFromKey: fromStr === '' ? null : planDateDayKey(fromStr),   // #3660: scope = диапазон фильтра
             scopeToKey: toStr === '' ? null : planDateDayKey(toStr),
-            firstCutSetup: true   // #3669 п.2: первая задача очереди резервирует настройку ножей
+            firstCutSetup: true,   // #3669 п.2: первая задача очереди резервирует настройку ножей
+            gapFill: true   // #3739: не оставлять простоев в смене — тянуть будущие резки в хвост, нахлёст разрешён
         });
 
         // Родители разбиений нужны в updates всегда (для расчёта долей Обеспечения).
@@ -8167,7 +8293,8 @@
             setupTaskIds: setupTaskIds,
             dayAnchorByCut: dayAnchorByCut,
             carryPrevCut: carryPrevCut,   // #3688: заправка станка для первой резки
-            firstCutSetup: true   // #3669 п.2: fallback — настройка ножей с нуля (нет данных prev_cut_setup)
+            firstCutSetup: true,   // #3669 п.2: fallback — настройка ножей с нуля (нет данных prev_cut_setup)
+            gapFill: true   // #3739: нахлёст разрешён — отображение тайминга совпадает с планом
         };
         // #3562: зафиксированные задания планируются наравне со всеми — автогенерация может
         // двигать их по времени в течение дня и менять очередность (пины #3508 п.6 убраны).

--- a/experiments/atex-production-planning-3739.test.js
+++ b/experiments/atex-production-planning-3739.test.js
@@ -1,0 +1,101 @@
+// Unit tests for #3739 — «Расписание и gap-fill: не оставлять простоев в смене, нахлёст разрешён».
+// splitMachineQueue в режиме gapFill заполняет хвост смены будущими резками (раньше срока —
+// допустимо), нахлёст за конец смены разрешён, а выбор следующей резки идёт по НЕПРЕРЫВНОСТИ
+// КОНФИГУРАЦИИ (минимальная переналадка от предыдущей: «начинать с той конфигурации, на
+// которой закончили»). Когда в хвост влезает только настройка — кладём КРУПНЕЙШИЙ её компонент
+// (ножи/сырьё) с минимальным нахлёстом, остаток настройки — на след. день перед проходами.
+//
+// Run with: node experiments/atex-production-planning-3739.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// changeover от prev: ножи (KNIFE 30) если набор ножей разный; сырьё (MATERIAL_WINDING 15)
+// если materialId/намотка разные. Одинаковая конфигурация → переналадка 0.
+function cut(id, material, knifeWidths, runs, anchorDate) {
+    return { id: id, slitter: { id: 'm1' }, materialId: material, winding: 'OUT',
+        knifeWidths: knifeWidths, knifeCount: knifeWidths.length, rollerWidth: 0,
+        plannedRuns: runs, planDate: anchorDate };
+}
+var TIMES = { BETWEEN_CUTS: 0 };   // KNIFE/MATERIAL_WINDING — дефолтные 30/15
+function ids(segs) { return segs.map(function(s){ return s.cutId; }); }
+
+// ── 1) Непрерывность конфигурации: из двух будущих резок в хвост тянем БЛИЖАЙШУЮ ──
+// День 0: A (та же конфигурация, что C) занимает 60 из 100. B и C заякорены на день 2.
+// gapFill тянет в хвост C (переналадка от A = 0), а не B (ножи+сырьё = 45). Порядок: A, C, …, B.
+var sel = planning.splitMachineQueue(
+    [ cut('A', 'M1', [59, 59], 6, '1'),
+      cut('B', 'M2', [30, 30], 3, '2'),    // далёкая конфигурация
+      cut('C', 'M1', [59, 59], 4, '2') ],  // == A
+    { dayStartMin: 0, dayEndMin: 100, times: TIMES,
+      perPassByCut: { A: 10, B: 10, C: 10 }, runsByCut: { A: 6, B: 3, C: 4 },
+      dayAnchorByCut: { A: 0, B: 2, C: 2 }, gapFill: true });
+var firstC = ids(sel).indexOf('C'), firstB = ids(sel).indexOf('B');
+assertEqual(firstC < firstB, true, '#3739: в хвост тянем C (та же конфигурация), а не B (далёкая) — C раньше B');
+assertEqual(sel.filter(function(s){ return s.cutId === 'C'; })[0].dayOffset, 0,
+    '#3739: C подтянута вперёд в день 0 (раньше своего срока), хвост не простаивает');
+
+// ── 2) Мин. нахлёст настройки (канонический пример): хвост 20 мин, ножи 30 + сырьё 15 ──
+// День 0: A занимает 60 из 80 (хвост 20). Дальше B (другое сырьё И ножи → ножи 30 + сырьё 15).
+// В хвост 20 кладём НОЖИ (30, нахлёст 10), сырьё (15) — на след. день перед проходами B.
+var ov = planning.splitMachineQueue(
+    [ cut('A', 'M1', [59, 59], 6, '1'),
+      cut('B', 'M2', [30, 30], 3, '1') ],
+    { dayStartMin: 0, dayEndMin: 80, times: TIMES,
+      perPassByCut: { A: 10, B: 10 }, runsByCut: { A: 6, B: 3 },
+      dayAnchorByCut: { A: 0, B: 0 }, gapFill: true });
+var bSetup = ov.filter(function(s){ return s.cutId === 'B' && s.setupOnly; })[0];
+var bPass = ov.filter(function(s){ return s.cutId === 'B' && !s.setupOnly; })[0];
+assertEqual(bSetup && { day: bSetup.dayOffset, setup: bSetup.setupMin, runs: bSetup.runs },
+    { day: 0, setup: 30, runs: 0 },
+    '#3739: в хвост дня 0 — ножи (30 мин, нахлёст 10 за конец смены 80), сегмент настройки');
+assertEqual(bPass && { day: bPass.dayOffset, setup: bPass.setupMin, runs: bPass.runs },
+    { day: 1, setup: 15, runs: 3 },
+    '#3739: остаток настройки (сырьё 15) + проходы B — на следующий день');
+
+// ── 3) Заполнение хвоста переносом будущей резки вперёд (без gapFill — простой/прыжок) ──
+// A на день 0 (40 из 100), B заякорена на день 3. С gapFill B подтягивается в день 0.
+var args = { dayStartMin: 0, dayEndMin: 100, times: TIMES,
+    perPassByCut: { A: 10, B: 10 }, runsByCut: { A: 4, B: 4 }, dayAnchorByCut: { A: 0, B: 3 } };
+var queue = [ cut('A', 'M1', [59, 59], 4, '1'), cut('B', 'M1', [59, 59], 4, '4') ];
+var withGap = planning.splitMachineQueue(queue, Object.assign({}, args, { gapFill: true }));
+var noGap = planning.splitMachineQueue(queue, args);
+assertEqual(withGap.filter(function(s){ return s.cutId === 'B'; })[0].dayOffset, 0,
+    '#3739: gapFill подтягивает B в день 0 (хвост заполнен, простоя нет)');
+assertEqual(noGap.filter(function(s){ return s.cutId === 'B'; })[0].dayOffset, 3,
+    '#3739: без gapFill B остаётся на своём дне 3 (поведение не изменилось — флаг изолирован)');
+
+// ── 4) buildSchedule (отображение тайминга) при gapFill — нахлёст НЕ выталкивается на ──
+// следующий день, чтобы карточка осталась на запланированном дне. A(60м) + B(setup45+60м)
+// не влезают в окно 100. Без gapFill B уезжает на день 1; с gapFill — остаётся на дне 0 (нахлёст).
+function dcut(id, material, dur) {
+    return { id: id, slitter: { id: 'm1' }, materialId: material, winding: 'OUT',
+        knifeWidths: id === 'A' ? [59, 59] : [30, 30], knifeCount: 2, rollerWidth: 0,
+        plannedRuns: 0, duration: dur };
+}
+var schedArgs = { shiftStartMin: 0, shiftEndMin: 100, times: TIMES, runLengthByCut: {},
+    windPoints: [], dayAnchorByCut: { A: 0, B: 0 } };
+var qsched = [ dcut('A', 'M1', 60), dcut('B', 'M2', 60) ];
+var sGap = planning.buildSchedule(qsched, Object.assign({}, schedArgs, { gapFill: true }));
+var sNo = planning.buildSchedule(qsched, schedArgs);
+function dayOf(sc) { return Math.floor((Number(sc.startMin) || 0) / 1440); }
+assertEqual(dayOf(sGap.filter(function(s){ return s.cutId === 'B'; })[0]), 0,
+    '#3739: buildSchedule(gapFill) — B остаётся на дне 0 (нахлёст), отображение совпадает с планом');
+assertEqual(dayOf(sNo.filter(function(s){ return s.cutId === 'B'; })[0]), 1,
+    '#3739: buildSchedule без gapFill — B уезжает на день 1 (прежнее поведение, флаг изолирован)');
+
+console.log('\n' + passed + ' passed');


### PR DESCRIPTION
Closes #3739.

## Что
В планировщике появился режим **gap-fill**: не оставлять простоев в смене. После размещения резок по срокам в хвосте дня может оставаться пустое время — вместо простоя туда тянется будущая резка (раньше срока — допустимо, «с запасом по сроку»), **нахлёст за конец смены разрешён**.

## Как
- **`splitMachineQueue(opts.gapFill)`** — новый пул-цикл, заполняющий каждый день:
  - **R1 — заполнение хвоста с нахлёстом:** если по сроку на текущий день резок не осталось, тянем будущую вперёд; не влезает целиком — кладём с нахлёстом за конец смены (не переносим на след. день).
  - **R3 — непрерывность конфигурации:** следующая резка выбирается по **минимальной переналадке от предыдущей** — «всегда начинать с той конфигурации, на которой закончили». Незавершённое продолжение доводится первым; фольга остаётся в конце дня (#3717).
  - **R2 — мин. нахлёст настройки:** когда в хвост влезает только настройка — кладём её целиком (#3635) либо, если не влезает, **крупнейший компонент** (ножи/сырьё), остаток настройки — на след. день перед проходами. Пример из тикета: хвост 20 мин, ножи 30 + сырьё 15 → в хвост **ножи** (нахлёст 10), сырьё — на след. день.
- **`buildSchedule(opts.gapFill)`** — отображение тайминга не выталкивает резку с нахлёстом на следующий день, чтобы карточка осталась на запланированном дне (якорь «Даты план» по-прежнему уводит на нужный день вперёд).
- `planCutOperations` прокидывает `gapFill`; **живой путь планирования и расписание рендера включают `gapFill: true`**.

## Безопасность изменения
- **Флаг изолирован:** без `gapFill` поведение ровно прежнее — существующие тесты не задеты, риск для других путей нулевой.
- **Идемпотентность (#3427) сохранена:** round-trip (прогон → имитация применения/пере-датировки → повторный прогон) сходится без `creates`/`deletes` на сценариях переноса+расщепления, непрерывности конфигурации и разброса по дням (повторная «Сгенерировать резки» не плодит записи и не дробит Обеспечение).

## Тест
`experiments/atex-production-planning-3739.test.js` — 8 проверок (непрерывность конфигурации; мин-нахлёст настройки по канону; перенос вперёд; отображение `buildSchedule`; изоляция флага). Регрессий нет.

⚠️ Известные красные тесты на `main` (НЕ от этой правки, не относятся к gapFill-пути): `atex-production-planning-3619` (конфликт ожиданий #3619 vs #3635) и `atex-production-planning` — были красными до PR.

## Замечание для ревью/деплоя
Это правка самого деликатного узла — планировщика. Перед опорой на боевом РМ стоит прогнать «Сгенерировать резки» на реальном диапазоне и глазами сверить раскладку (нахлёст за 16:30 — ожидаемое поведение). Карточки нахлёста показываются на своём дне; сегмент настройки в хвосте — как «⚙ Настройка ножей и сырья» (#3635).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
