### PR TITLE
feat(atex): оптимизатор раскроя — одна ширина, убрать «Добавить ширину» (#3749)

### DIFF
--- a/download/atex/css/cut-optimizer.css
+++ b/download/atex/css/cut-optimizer.css
@@ -129,23 +129,13 @@
 
 .atex-co-rows-head { margin: 6px 0 6px; }
 .atex-co-rows { display: flex; flex-direction: column; gap: 8px; margin-bottom: 8px; }
+/* #3749: одна ширина — строка из двух полей (ширина + количество), без кнопки удаления. */
 .atex-co-row {
     display: grid;
-    grid-template-columns: 1fr 90px 32px;
+    grid-template-columns: 1fr 90px;
     gap: 8px;
     align-items: center;
 }
-.atex-co-row-del {
-    border: 1px solid var(--co-border);
-    border-radius: 6px;
-    background: var(--co-surface);
-    color: var(--co-muted);
-    cursor: pointer;
-    font-size: 18px;
-    line-height: 1;
-    padding: 6px 0;
-}
-.atex-co-row-del:hover { color: var(--co-warn); border-color: var(--co-warn); }
 
 .atex-co-btn {
     border: 1px solid var(--co-border);

--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -740,10 +740,7 @@
         form.appendChild(this.rowsEl);
         this.renderRows();
 
-        var addBtn = el('button', { class: 'atex-co-btn atex-co-btn-secondary', type: 'button', text: '+ Добавить ширину' });
-        addBtn.addEventListener('click', function() { self.rows.push({ width: '', qty: '1' }); self.renderRows(); self.maybeRecalc(); });
-        form.appendChild(addBtn);
-
+        // #3749: оптимизатор работает с ОДНОЙ шириной — добавление/удаление ширин убрано.
         var calcBtn = el('button', { class: 'atex-co-btn atex-co-btn-primary', type: 'button', text: 'Рассчитать' });
         calcBtn.addEventListener('click', function() { self.calculate(); });
         form.appendChild(calcBtn);
@@ -801,27 +798,21 @@
         }
     };
 
+    // #3749: одна ширина — единственная строка (ширина + количество), без кнопок
+    // добавления/удаления. this.rows всегда содержит ровно одну запись.
     AtexCutOptimizer.prototype.renderRows = function() {
         var self = this;
         var box = this.rowsEl;
         box.innerHTML = '';
-        this.rows.forEach(function(row, idx) {
-            var widthInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
-                placeholder: 'ширина, мм', value: row.width });
-            widthInput.addEventListener('input', function() { row.width = widthInput.value; self.maybeRecalc(); });
-            // Кол-во — целое, числовое, шаг 5 (#3478).
-            var qtyInput = el('input', { class: 'atex-co-input', type: 'number', inputmode: 'numeric',
-                min: '0', step: '5', placeholder: 'кол-во', value: row.qty });
-            qtyInput.addEventListener('input', function() { row.qty = qtyInput.value; self.maybeRecalc(); });
-            var del = el('button', { class: 'atex-co-row-del', type: 'button', title: 'Удалить', text: '×' });
-            del.addEventListener('click', function() {
-                self.rows.splice(idx, 1);
-                if (!self.rows.length) self.rows.push({ width: '', qty: '1' });
-                self.renderRows();
-                self.maybeRecalc();
-            });
-            box.appendChild(el('div', { class: 'atex-co-row' }, [widthInput, qtyInput, del]));
-        });
+        var row = this.rows[0] || (this.rows[0] = { width: '', qty: '1' });
+        var widthInput = el('input', { class: 'atex-co-input', type: 'text', inputmode: 'decimal',
+            placeholder: 'ширина, мм', value: row.width });
+        widthInput.addEventListener('input', function() { row.width = widthInput.value; self.maybeRecalc(); });
+        // Кол-во — целое, числовое, шаг 5 (#3478).
+        var qtyInput = el('input', { class: 'atex-co-input', type: 'number', inputmode: 'numeric',
+            min: '0', step: '5', placeholder: 'кол-во', value: row.qty });
+        qtyInput.addEventListener('input', function() { row.qty = qtyInput.value; self.maybeRecalc(); });
+        box.appendChild(el('div', { class: 'atex-co-row' }, [widthInput, qtyInput]));
     };
 
     // Комбобокс «Длина рулона»: текстовое поле (свой ввод) + кнопка-стрелка,


### PR DESCRIPTION
Closes #3749.

## Что
Калькулятор «Расчёт оптимальной резки» (`/atex/cut-optimizer`) теперь работает с **одной шириной**: убрана возможность добавлять несколько ширин.

## Как
- `cut-optimizer.js`: убрана кнопка **«+ Добавить ширину»** и `×`-удаление строки; `renderRows` рисует единственную строку (ширина + количество); `this.rows` всегда ровно одна запись.
- `cut-optimizer.css`: `.atex-co-row` → сетка `1fr 90px` (без колонки под кнопку удаления), удалены неиспользуемые правила `.atex-co-row-del`.

Логика расчёта (`computeOptimization`/`packGroup`/раскрой) **не тронута** — она корректно работает с одной шириной (одна карта раскроя). Тест `experiments/atex-cut-optimizer.test.js` — 47/47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
