### PR TITLE
atex: оценка времени резки в оптимизаторе — минуты/часы/дни (#3744)

### DIFF
--- a/download/atex/css/cut-optimizer.css
+++ b/download/atex/css/cut-optimizer.css
@@ -385,6 +385,11 @@
 .atex-co-rolls-got { font-size: 32px; font-weight: 800; }
 .atex-co-rolls-of { font-size: 15px; font-weight: 600; color: var(--co-muted); }
 
+/* #3744: «Время на резку» — минуты крупно (наследуют размер метрики), часы/дни мельче
+   и приглушённо строкой ниже. */
+.atex-co-time { display: flex; flex-direction: column; gap: 1px; }
+.atex-co-time-sub { font-size: 14px; font-weight: 600; color: var(--co-muted); }
+
 .atex-co-nominal { color: var(--co-muted); }
 
 /* Тосты-уведомления (без alert/confirm/prompt) */

--- a/download/atex/js/cut-optimizer.js
+++ b/download/atex/js/cut-optimizer.js
@@ -83,6 +83,14 @@
     // #3573: допуск на отход по умолчанию (мм). Берётся из Вида сырья («Допуск, мм»),
     // а если у материала он не задан — действует это значение. По нему красится отход.
     var DEFAULT_TOLERANCE = 21;
+    // #3744: оценка времени планирования резки для менеджера. Таблица «Время операции,
+    // мин» — те же нормы метража WIND_<метры>, что использует production-planning.js
+    // (windingMinutes). Формула: единожды настройка SETUP_ONCE_MIN + «Всего резок» ×
+    // время намотки одного рулона. Перевод в дни — по MINUTES_PER_DAY рабочих минут.
+    var OP_TIMES_TABLE = 'Время операции, мин';
+    var OP_TIMES_CODE_REQ = 'Код операции';
+    var SETUP_ONCE_MIN = 45;       // единожды: настройка/переналадка станка на резку
+    var MINUTES_PER_DAY = 450;     // 1 рабочий день = 450 минут (для единицы «дни»)
 
     // ───────────────────────── Чистое ядро расчёта ─────────────────────────
 
@@ -407,6 +415,60 @@
         return round3(toNumber(width) / scale * 100);
     }
 
+    // #3744: точки «намотка N метров → минуты» из кодов WIND_<метры> таблицы «Время
+    // операции, мин» (WIND_300=1.2 … WIND_1100=5.6). Та же модель метража, что в
+    // production-planning.js (windingPointsFromTimes). Спец-коды (WIND_FOIL_*) не парсим.
+    function windingPointsFromTimes(opTimes) {
+        var pts = [];
+        Object.keys(opTimes || {}).forEach(function(code) {
+            var m = /^WIND_(\d+)$/.exec(code);
+            if (m) pts.push({ m: Number(m[1]), min: toNumber(opTimes[code]) });
+        });
+        pts.sort(function(a, b) { return a.m - b.m; });
+        return pts;
+    }
+
+    // #3744: минуты намотки runMeters по точкам — кусочно-линейно (зеркало
+    // production-planning.js windingMinutes): ниже первой точки — пропорция от 0; между
+    // точками — линейно; выше последней — экстраполяция последним отрезком (при одной
+    // точке клампим). Нет точек / runMeters ≤ 0 → 0.
+    function windingMinutes(runMeters, points) {
+        var x = toNumber(runMeters);
+        var p = (points || []).slice().sort(function(a, b) { return a.m - b.m; });
+        if (!p.length || x <= 0) return 0;
+        if (x <= p[0].m) return round3(p[0].min * (x / p[0].m));
+        for (var i = 1; i < p.length; i++) {
+            if (x <= p[i].m) {
+                var t = (x - p[i - 1].m) / (p[i].m - p[i - 1].m);
+                return round3(p[i - 1].min + t * (p[i].min - p[i - 1].min));
+            }
+        }
+        if (p.length < 2) return round3(p[p.length - 1].min);
+        var a = p[p.length - 2], b = p[p.length - 1];
+        var slope = (b.min - a.min) / (b.m - a.m);
+        return round3(b.min + slope * (x - b.m));
+    }
+
+    // #3744: общие минуты планирования резки = единожды настройка (SETUP_ONCE_MIN) + по
+    // каждой резке («Всего резок» = passes) время намотки одного рулона windingMinutes от
+    // длины рулона и норм WIND_*. Резок нет → 0. Норм нет → только настройка.
+    function planningMinutes(passes, rollLength, windPoints) {
+        var n = Math.max(0, Math.round(toNumber(passes)));
+        if (n <= 0) return 0;
+        return round3(SETUP_ONCE_MIN + n * windingMinutes(rollLength, windPoints));
+    }
+
+    // #3744: минуты → три единицы для менеджера. Часы и дни — с одним знаком после
+    // запятой; день = MINUTES_PER_DAY рабочих минут. { minutes, hours, days }.
+    function planningTimeUnits(mins) {
+        var m = round3(mins);
+        return {
+            minutes: Math.round(m),
+            hours: Math.round(m / 60 * 10) / 10,
+            days: Math.round(m / MINUTES_PER_DAY * 10) / 10
+        };
+    }
+
     var core = {
         toNumber: toNumber,
         round3: round3,
@@ -421,7 +483,11 @@
         partitionsAtMost: partitionsAtMost,
         expandSegments: expandSegments,
         computePlan: computePlan,
-        widthPercent: widthPercent
+        widthPercent: widthPercent,
+        windingPointsFromTimes: windingPointsFromTimes,
+        windingMinutes: windingMinutes,
+        planningMinutes: planningMinutes,
+        planningTimeUnits: planningTimeUnits
     };
 
     // ─────────────────────────── Браузерный слой ───────────────────────────
@@ -493,7 +559,8 @@
         this.root = root;
         this.db = (typeof window !== 'undefined' && window.db) || root.getAttribute('data-db') || '';
         this.xsrf = root.getAttribute('data-xsrf') || (typeof window !== 'undefined' && window.xsrf) || '';
-        this.meta = { material: null, actualWidth: null, order: null, position: null, sleeve: null, client: null, leader: null };
+        this.meta = { material: null, actualWidth: null, order: null, position: null, sleeve: null, client: null, leader: null, opTimes: null };
+        this.opTimes = {};        // #3744: нормы метража WIND_* из «Время операции, мин»
         this.materials = [];      // [{ id, label, width, length }]
         this.sleeves = [];        // [{ id, label }]
         this.clients = [];        // [{ id, label }]
@@ -566,6 +633,7 @@
             self.meta.sleeve = byName(TABLE.sleeve);
             self.meta.client = byName(TABLE.client);
             self.meta.leader = byName(TABLE.leader);  // #3592
+            self.meta.opTimes = byName(OP_TIMES_TABLE);  // #3744: нормы метража (необязательна)
             if (!self.meta.material) throw new Error('В метаданных не найдена таблица «' + TABLE.material + '»');
         });
     };
@@ -637,6 +705,27 @@
         }).catch(function() { self.batches = []; });
     };
 
+    // #3744: нормы метража из таблицы «Время операции, мин» — коды WIND_<метры> → минуты
+    // намотки (та же таблица и чтение, что в production-planning.js loadOperationTimes).
+    // Главное значение записи = минуты, колонка «Код операции» = код. Нет таблицы/доступа
+    // → пустые нормы (оценка времени тихо деградирует к одной настройке 45 мин).
+    AtexCutOptimizer.prototype.loadOperationTimes = function() {
+        var self = this;
+        this.opTimes = {};
+        var meta = this.meta.opTimes;
+        if (!meta) return Promise.resolve();
+        var codeIdx = colIndex(meta, OP_TIMES_CODE_REQ);
+        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,200').then(function(rows) {
+            var raw = {};
+            (rows || []).forEach(function(rec) {
+                var r = rec.r || [];
+                var code = codeIdx >= 0 ? String(r[codeIdx] == null ? '' : r[codeIdx]).trim() : '';
+                if (code) raw[code] = toNumber(r[0]);   // r[0] — главное значение = минуты
+            });
+            self.opTimes = raw;
+        }).catch(function() { self.opTimes = {}; });
+    };
+
     AtexCutOptimizer.prototype.materialById = function(id) {
         var wanted = String(id);
         return this.materials.filter(function(m) { return String(m.id) === wanted; })[0] || null;
@@ -672,7 +761,8 @@
                     self.loadRefList(self.meta.order).then(function(l) {
                         self.orders = l.map(function(o) { return { id: o.id, number: o.label }; });
                     }),
-                    self.loadMaterialBatches()
+                    self.loadMaterialBatches(),
+                    self.loadOperationTimes()   // #3744: нормы метража для оценки времени резки
                 ]);
             })
             .then(function() { self.renderForm(); })
@@ -1048,7 +1138,20 @@
         summary.appendChild(metric('Общий отход, м²', p.rollLength > 0 ? p.totalWasteAreaM2 : '—', true));
         summary.appendChild(metric('Карт раскроя', p.mapCount));
         summary.appendChild(metric('Всего резок', p.totalPasses));
+        // #3744: общие минуты планирования резки в трёх единицах (минуты/часы/дни):
+        // единожды настройка 45 мин + «Всего резок» × время намотки рулона (нормы
+        // метража WIND_* из «Время операции, мин», как в production-planning.js).
+        var planMins = planningMinutes(p.totalPasses, p.rollLength, windingPointsFromTimes(this.opTimes || {}));
+        var units = planningTimeUnits(planMins);
+        var timeVal = el('span', { class: 'atex-co-time' }, [
+            el('span', { class: 'atex-co-time-min', text: ruNum(units.minutes) + ' мин' }),
+            el('span', { class: 'atex-co-time-sub', text: ruNum(units.hours) + ' ч · ' + ruNum(units.days) + ' дн' })
+        ]);
+        summary.appendChild(metric('Время на резку', timeVal, true));
         return summary;
+
+        // Русский десятичный разделитель (запятая) для часов/дней.
+        function ruNum(n) { return String(n).replace('.', ','); }
 
         function metric(label, value, primary) {
             var valueEl = el('span', { class: 'atex-co-metric-value' });

--- a/experiments/atex-cut-optimizer.test.js
+++ b/experiments/atex-cut-optimizer.test.js
@@ -171,4 +171,23 @@ assertEqual({ passes: plan9.totalPasses, wasteMm: plan9.totalWasteWidth, areaM2:
 assertEqual(core.widthPercent(60, 880, 880), 6.818, 'widthPercent scales to input width');
 assertEqual(core.widthPercent(50, 0, 0), 0, 'widthPercent is 0 when scale is 0');
 
+// ── #3744: оценка времени планирования резки (нормы метража WIND_* + настройка 45 мин) ──
+var ot = { WIND_300: 1.2, WIND_600: 3, WIND_900: 5, KNIFE: 30, MATERIAL_WINDING: 15 };
+var wp = core.windingPointsFromTimes(ot);
+assertEqual(wp, [{ m: 300, min: 1.2 }, { m: 600, min: 3 }, { m: 900, min: 5 }],
+    'windingPointsFromTimes parses WIND_<m> codes (special codes ignored), sorted');
+assertEqual(core.windingMinutes(600, wp), 3, 'windingMinutes hits an exact norm point');
+assertEqual(core.windingMinutes(450, wp), 2.1, 'windingMinutes interpolates between 300 and 600');
+assertEqual(core.windingMinutes(150, wp), 0.6, 'windingMinutes scales proportionally below the first point');
+assertEqual(core.windingMinutes(450, []), 0, 'windingMinutes with no norms → 0');
+// единожды настройка 45 + «Всего резок» × намотка рулона.
+assertEqual(core.planningMinutes(10, 450, wp), 66, 'planningMinutes = 45 + 10 × 2.1');
+assertEqual(core.planningMinutes(0, 450, wp), 0, 'planningMinutes is 0 when there are no cuts');
+assertEqual(core.planningMinutes(5, 450, []), 45, 'planningMinutes falls back to setup-only without norms');
+// три единицы: минуты целые, часы/дни — 1 знак; день = 450 минут.
+assertEqual(core.planningTimeUnits(66), { minutes: 66, hours: 1.1, days: 0.1 },
+    'planningTimeUnits splits minutes into minutes/hours/days (day = 450 min)');
+assertEqual(core.planningTimeUnits(900), { minutes: 900, hours: 15, days: 2 },
+    'planningTimeUnits: 900 мин = 15 ч = 2 дня');
+
 console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Closes #3744

В рабочем месте atex «Расчёт оптимальной резки» (`templates/atex/cut-optimizer.html` → `download/atex/js/cut-optimizer.js`) сводка плана теперь показывает **общие минуты планирования резки в трёх единицах: минуты / часы / дни** — метрика «Время на резку».

### Формула (согласована с заказчиком)
```
общие минуты = 45 (единожды настройка) + «Всего резок» × время_намотки_рулона
```
- **Время намотки одного рулона** берётся из норм метража `WIND_<метры>` таблицы «Время операции, мин» — **та же модель, что в `production-planning.js`** (`windingPointsFromTimes` + кусочно-линейная `windingMinutes` от длины рулона). «Бери из настроек метража, как это делает production-planning.js».
- **45 минут** — разовая настройка/переналадка станка на резку (`SETUP_ONCE_MIN`), добавляется один раз.
- **Дни**: 1 рабочий день = **450 минут** (`MINUTES_PER_DAY`). Часы/дни — с одним знаком после запятой.

Пример: 10 резок, рулон 450 м, нормы WIND_300=1.2 / WIND_600=3 → намотка рулона 2.1 мин → 45 + 10×2.1 = **66 мин · 1,1 ч · 0,1 дн**.

### Поведение
- Нет таблицы «Время операции, мин» / норм `WIND_*` или нет доступа — оценка тихо деградирует к одной настройке (45 мин), без ошибок.
- Метрика показывается только для выполнимого плана (`renderResult` выходит раньше при `!feasible`), т.е. «Всего резок» ≥ 1.

### Файлы
- `download/atex/js/cut-optimizer.js` — загрузка «Время операции, мин» (`loadOperationTimes`, по аналогии с production-planning), чистые функции `windingPointsFromTimes` / `windingMinutes` / `planningMinutes` / `planningTimeUnits` (экспортированы в `core`), вывод метрики в `renderSummary`.
- `download/atex/css/cut-optimizer.css` — стиль `.atex-co-time` / `.atex-co-time-sub`.
- `experiments/atex-cut-optimizer.test.js` — тесты на нормы метража, интерполяцию, формулу и перевод в единицы.

### Проверки
- `node experiments/atex-cut-optimizer.test.js` → **57 assertions passed** (включая 11 новых для #3744).
- `node -e require(...)` — модуль грузится.

🤖 Generated with [Claude Code](https://claude.com/claude-code)