### PR TITLE
atex: убрать «полос N» из тоста генерации заданий (#3754)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -7271,8 +7271,7 @@
             var reasons = self.groupSkipReasons(skipped);
             var sleeveMin = sleeveMinutes(nSleeves, self.opTimes || {});
             console.log('[pp] 🔧 runGenerateCuts: ГОТОВО за ' + totalElapsed + 'с. резок:', layouts.length, 'полос:', nStrips, 'втулок:', nSleeveTasks, 'пропущено:', skipped.length);
-            self.notify('Создано ' + nRecords + ' производственных заданий (' + planningStrategyLabel(planOptions.strategy) + '), полос ' + nStrips +
-                ', заданий на втулки ' + nSleeveTasks +
+            self.notify('Создано ' + nRecords + ' производственных заданий (' + planningStrategyLabel(planOptions.strategy) + '), заданий на втулки ' + nSleeveTasks +
                 (sleeveMin > 0 ? ' (' + sleeveMin + ' мин)' : '') +
                 ', пропущено ' + skipped.length + ' позиций' + (reasons ? ' (' + reasons + ')' : ''), 'success');
             // #3449: очередь по стратегии НЕ пересобираем — порядок оператора неприкосновенен.


### PR DESCRIPTION
Closes #3754

В рабочем месте atex «Планирование производства» по итогам генерации показывался тост вида:

> Создано 19 производственных заданий (минимум переналадок), **полос 31**, заданий на втулки 28 (32.82 мин), пропущено 0 позиций

Число **«полос 31»** (`nStrips` — счётчик созданных «Партий ГП» по ширинам полос) вводило в заблуждение: на скрине оно совпало с числом позиций (`Не обеспечено … позиций: 31`) и менеджеру пользы не несёт. Убрано из тоста.

Теперь:

> Создано 19 производственных заданий (минимум переналадок), заданий на втулки 28 (32.82 мин), пропущено 0 позиций

`nStrips` оставлен в `console.log` для диагностики — правка чисто текстовая, на логику генерации не влияет.

### Файл
- `download/atex/js/production-planning.js` (`runGenerateCuts`, success-notify) — удалён фрагмент `', полос ' + nStrips`.

### Проверки
- `node -e require(...)` — модуль грузится.
- `node --test experiments/atex-production-planning.test.js` — те же 3 предсуществующих падения, что и на чистом `origin/main` (rowsToPlanning / rowsToGenPositions / isCutVisible); новых нет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)