### PR TITLE
fix(atex): Гант — время не перекрывает дату на стыке дней (#3756)

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -513,13 +513,17 @@
     // показываем). По каждому окну: тик на левом крае окна с датой (начало смены/дня), далее по
     // сетке часов {1,2,4,…} до конца окна. Метка — «HH:00» (или фактическое начало окна при
     // раннем старте); дата — на первом тике каждого дня. Все деления одинаковым пунктиром.
+    // #3756: дни идут встык, поэтому правый край окна — это тик-дата СЛЕДУЮЩЕГО дня. Часовой
+    // тик впритык к нему (напр. 18:00 за 30 мин до 18:30) перекрывал бы дату «27.06». Поэтому
+    // часовые тики ближе minPx к краю окна (к дате слева/справа) не ставим — дата приоритетнее.
     function hourTicks(scale, pxPerMin, opts) {
         var o = opts || {};
         if (!scale || !scale.segments || !scale.segments.length) return [];
         var ppm = pxPerMin > 0 ? pxPerMin : GANTT_PX_PER_MIN;
+        var minPx = o.minPx > 0 ? o.minPx : GANTT_TICK_MIN_PX;   // #3756: зазор до тика-даты
         var stepMs = chooseHourStep(ppm * 60, o) * GANTT_HOUR_MS;
         var ticks = [];
-        scale.segments.forEach(function(seg) {
+        scale.segments.forEach(function(seg, si) {
             ticks.push({
                 ms: seg.startMs,
                 hour: new Date(seg.startMs).getHours(),
@@ -528,12 +532,20 @@
                 dateLabel: formatDateShort(seg.startMs),
                 newDay: true
             });
+            var segEndPx = seg.leftPx + seg.widthPx;
+            // #3756: справа дата есть только если за окном следует другой день (стык окон);
+            // у последнего окна правый край — конец дорожки, тик у края показываем.
+            var hasNextDay = si < scale.segments.length - 1;
             for (var ms = floorToHourMs(seg.startMs) + stepMs; ms <= seg.endMs + 0.5; ms += stepMs) {
                 if (ms <= seg.startMs) continue;
+                var leftPx = scale.toPx(ms);
+                // #3756: не ставим часовой тик впритык к дате дня — слева (дата своего окна,
+                // напр. при раннем старте) и справа (дата следующего дня на стыке окон).
+                if (leftPx - seg.leftPx < minPx || (hasNextDay && segEndPx - leftPx < minPx)) continue;
                 ticks.push({
                     ms: ms,
                     hour: new Date(ms).getHours(),
-                    leftPx: scale.toPx(ms),
+                    leftPx: leftPx,
                     label: formatTime(ms),
                     dateLabel: '',
                     newDay: false

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -300,6 +300,25 @@ assertEqual(gantt.orderCutsInGroup(orderCuts.slice()).map(function(c) { return c
     ['d1q1', 'd1q2', 'd2q1'],
     'orderCutsInGroup: #3747 хронологически (день1 целиком, потом день2), а не вперемешку по очередности');
 
+// hourTicks (#3756): на стыке дней часовой тик впритык к дате не ставим (время перекрывало
+// дату). Масштаб ~0.44 px/мин (Месяц+вписать) → шаг 2 ч ≈ 53px; 18:00 за 30 мин (13px) до
+// тика-даты следующего дня — выкидываем. У ПОСЛЕДНЕГО окна 18:00 у правого края остаётся.
+var dayScale = gantt.ganttScale([
+    { startMs: gantt.parseDateTimeMs('2026-06-26 08:00'), endMs: gantt.parseDateTimeMs('2026-06-26 18:30') },
+    { startMs: gantt.parseDateTimeMs('2026-06-27 08:00'), endMs: gantt.parseDateTimeMs('2026-06-27 18:30') }
+], 0.44);
+var dayTicks = gantt.hourTicks(dayScale, 0.44);
+var dateLefts = dayTicks.filter(function(t) { return t.newDay; }).map(function(t) { return t.leftPx; });
+var crowding = dayTicks.filter(function(t) {
+    return !t.newDay && dateLefts.some(function(d) { return Math.abs(d - t.leftPx) < 50; });
+});
+assertEqual(crowding.length, 0, 'hourTicks #3756: ни один часовой тик не стоит ближе 50px к дате дня');
+// 18:00 первого дня (перед датой 27.06) выкинут; 18:00 последнего дня (у края дорожки) есть.
+var day1Hours = dayTicks.filter(function(t) { return !t.newDay && t.leftPx < dateLefts[1]; }).map(function(t) { return t.label; });
+assertEqual(day1Hours.indexOf('18:00'), -1, 'hourTicks #3756: 18:00 перед стыком дней выкинут (не перекрывает дату)');
+var day2Hours = dayTicks.filter(function(t) { return !t.newDay && t.leftPx > dateLefts[1]; }).map(function(t) { return t.label; });
+assertEqual(day2Hours.indexOf('18:00') >= 0, true, 'hourTicks #3756: 18:00 последнего окна (у края дорожки) остаётся');
+
 // ── planningLink: ссылка на планировщик с датой/станком/заданием ──
 assertEqual(gantt.planningLink({ id: '85472', planDate: '06.05.2026', slitter: { id: '1285' } }),
     '/atex/production-planning?cut=85472&date=2026-05-06&slitter=1285',

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 62);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 63);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3756.

Доработка к уже смерженному #3747 (#3752 «убрать нерабочее время»): фикс вынесен отдельным PR, т.к. #3752 уже в `main`.

## Проблема
На свёрнутой оси дни идут встык, и правый край рабочего окна — это тик-дата следующего дня. При сжатии (режим «Месяц» / «вписать в экран», шаг сетки 2 ч) последний часовой тик дня (`18:00`) стоял за ~30 мин (≈13px) до `27.06 08:00` и наезжал на дату — на скриншоте `18:0027.06`.

## Решение
`hourTicks`: часовой тик ближе `minPx` (50px) к тику-дате не ставим — слева (дата своего окна при раннем старте) и справа (дата следующего дня на стыке окон). У последнего окна правый край — конец дорожки, тик у края остаётся. Дата приоритетнее часовой метки.

## Тесты
`experiments/atex-cut-gantt.test.js` (118 проверок): ни один часовой тик не ближе 50px к дате; `18:00` перед стыком дней выкинут, `18:00` последнего окна сохранён.

VERSION 62→63 (cache-bust ассетов atex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)