### PR TITLE
fix(atex): карточка резки — втулку не обрезать, связи не растягивать (#3758)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -326,11 +326,12 @@
     color: var(--pp-muted);
     white-space: nowrap;
 }
+/* #3758: сводка связей — компактная плашка в общем потоке строки. Раньше прижималась
+   вправо (margin-left:auto) и съедала всё свободное место, оттесняя втулку под обрезку. */
 .atex-pp-cut-supplies {
-    margin-left: auto;
+    flex: 0 0 auto;
     font-size: 12px;
     color: var(--pp-muted);
-    text-align: right;
     white-space: nowrap;
 }
 /* #3472: лидер резки. Смешанные лидеры (легаси) — предупреждающий стиль. */
@@ -344,15 +345,11 @@
     color: var(--pp-danger, #c0392b);
     font-weight: 600;
 }
-/* #3738: втулка резки — после лидера. Название «Диаметр втулки» бывает длинным,
-   поэтому плашка ужимается и обрезается многоточием (полное имя — в title).
-   Смешанные втулки (легаси) — предупреждающий стиль, как у лидера. */
+/* #3738: втулка резки — после лидера. #3758: НЕ обрезаем многоточием (обрезанную плашку
+   «втулка: …» было не видно) — показываем имя целиком, как у лидера; при нехватке места
+   строка переносится (flex-wrap). Смешанные втулки (легаси) — предупреждающий стиль. */
 .atex-pp-cut-sleeve {
-    flex: 0 1 auto;
-    min-width: 0;
-    max-width: 16em;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    flex: 0 0 auto;
     white-space: nowrap;
     font-size: 12px;
     color: var(--pp-muted);
@@ -457,7 +454,6 @@
 .atex-pp-cut > .atex-pp-strip-panel { margin: 10px 0 2px; cursor: default; }
 
 @media (max-width: 720px) {
-    .atex-pp-cut-supplies { margin-left: 0; }
     .atex-pp-filters { grid-template-columns: 1fr; }
 }
 

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 62);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 63);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Закрывает #3758.

## Проблема
В первой строке карточки резки `.atex-pp-cut-supplies` (сводка связей) прижималась вправо через `margin-left:auto` и съедала всё свободное место строки. Из-за этого `.atex-pp-cut-sleeve` (`max-width:16em` + многоточие) ужималась и обрезалась — плашку «втулка: …» было не видно.

## Решение (CSS-only)
- `.atex-pp-cut-sleeve`: убрана обрезка (`max-width` / `overflow:hidden` / `text-overflow:ellipsis`) — имя втулки показывается целиком, как у лидера; при нехватке места строка переносится (`.atex-pp-cut-info` уже `flex-wrap: wrap`). Полное имя по-прежнему и в `title`.
- `.atex-pp-cut-supplies`: убран `margin-left:auto` — компактная плашка в общем потоке строки, без растягивания; убран ставший лишним media-override `margin-left:0`.

## Проверка
Headless-рендер карточки (короткая и длинная втулка): втулка видна целиком (длинная переносится на след. строку, а не обрезается), связи идут компактно сразу за втулкой без правого «провала».

VERSION 62→63 (cache-bust ассетов atex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)