### PR TITLE
fix(atex): планирование — нахлёст ограничен одним шагом, разбивка на границе дня (#3760)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1559,6 +1559,34 @@
         return { knifeMin: round3(knife), materialWindingMin: round3(matWind) };
     }
 
+    // #3760: какие компоненты настройки положить в хвост смены, когда настройка целиком
+    // не влезает. Берём ПОДМНОЖЕСТВО компонентов с суммой ≥ остатка дня (дотягивает до конца
+    // смены) и МИНИМАЛЬНОЙ суммой (минимальный нахлёст). Остальное — на следующий день.
+    //   parts — [{minutes}], avail — остаток дня (мин), total — сумма всех компонентов.
+    // Примеры (ножи 30, сырьё 15): avail 8 → сырьё 15 (нахлёст 7); avail 20 → ножи 30
+    // (сырьё 15 < 20 не дотягивает, оставило бы простой); avail 35 → ножи+сырьё 45.
+    // Полный набор (сумма total ≥ avail в этой ветке) всегда годится; компонентов мало —
+    // полный перебор подмножеств. → минуты настройки в хвост (round3).
+    function minOverlapTailSetupMinutes(parts, avail, total) {
+        var mins = (parts || []).map(function(p){ return Number(p && p.minutes) || 0; })
+            .filter(function(m){ return m > 0; });
+        var tot = Number(total) || mins.reduce(function(s, m){ return s + m; }, 0);
+        if (!mins.length) return round3(tot);
+        var a = Number(avail) || 0, n = mins.length, best = tot;
+        if (n <= 16) {
+            for (var mask = 1; mask < (1 << n); mask++) {
+                var s = 0;
+                for (var b = 0; b < n; b++) if (mask & (1 << b)) s += mins[b];
+                if (s >= a && s < best) best = s;
+            }
+        } else {
+            var sorted = mins.slice().sort(function(x, y){ return y - x; }), acc = 0;
+            for (var i = 0; i < sorted.length && acc < a; i++) acc += sorted[i];
+            best = acc || tot;
+        }
+        return round3(best);
+    }
+
     // #3698: активности переналадки на каждую резку упорядоченной очереди ОДНОГО станка
     // (порядок исполнения — по «Очередности», как в Ганте orderCutsInGroup). Первая резка —
     // от текущей заправки станка (carryPrevCut из prev_cut_setup, строится вызывающим через
@@ -2653,11 +2681,13 @@
             }
             // не влезает до конца окна (резерв обеда, если не вставлен) → 08:00 след. дня.
             // #3688: в окно должны влезть резка И лидер после неё (станок занят до конца лидера).
-            // #3739: при gapFill нахлёст за конец смены разрешён — НЕ выталкиваем на след. день,
-            // чтобы отображение совпало с планом (splitMachineQueue кладёт резку на её день,
-            // якорь по «Дате план» уводит на нужный день вперёд, а в пределах дня — нахлёст).
+            // #3739/#3760: при gapFill нахлёст за конец смены ограничен ОДНИМ шагом — резку,
+            // чьё ОКНО (начало настройки = start − setup) уже за концом смены, выталкиваем на
+            // следующий день; резка, начавшаяся в пределах смены, может выйти за край (один
+            // нахлёст), но следующая за ней уйдёт на завтра. Так тайминг не накапливается в ночь.
             var fitEnd = day * 1440 + shiftEnd - ((lunch && !lunchDone[day]) ? lunch.durationMin : 0);
-            if (hasWindow && !opts.gapFill && start + dur + leaderMin > fitEnd) {
+            var pushNextDay = opts.gapFill ? ((start - setup) >= fitEnd) : (start + dur + leaderMin > fitEnd);
+            if (hasWindow && pushNextDay) {
                 day += 1;
                 start = day * 1440 + shiftStart + setup;
                 if (lunch && !lunchDone[day] && (start - day * 1440) >= lunch.startMin) {
@@ -2836,43 +2866,43 @@
                 var perPassEffG = st.perPass + leader;
                 var setupG = st.isCont ? (Number(st.pendingSetup) || 0) : setupCostFor(prevPhysical, c);
                 var availG = effCapacity(day) - clock;
-                var maxPassesG = Math.floor((availG - setupG) / perPassEffG);
-                if (maxPassesG >= 1) {
-                    var passesNowG = Math.min(st.remaining, maxPassesG);
+                if (availG >= setupG) {
+                    // #3760: настройка влезает. Кладём проходы, что помещаются БЕЗ нахлёста, плюс
+                    // ОДИН нахлёстный (первый, пересекающий конец смены): «сколько успели сегодня
+                    // с нахлёстом — сохраняем, после первого нахлёста — остальное на завтра».
+                    var fittingG = Math.floor((availG - setupG) / perPassEffG);
+                    if (fittingG < 0) fittingG = 0;
+                    var overlapsG = fittingG < st.remaining;            // не все проходы влезли → нахлёст
+                    var passesNowG = Math.min(st.remaining, fittingG + (overlapsG ? 1 : 0));
                     var wsG = day * 1440 + dayStart + clock, durG = passesNowG * perPassEffG;
                     segments.push({ cutId: pick, dayOffset: day, runs: passesNowG,
                         windowStartMin: round3(wsG), startMin: round3(wsG + setupG), setupMin: round3(setupG),
                         durationMin: round3(durG), isContinuation: st.isCont, parentCutId: st.isCont ? pick : null });
-                    clock += setupG + durG; st.remaining -= passesNowG; st.isCont = true; st.pendingSetup = 0;
-                    prevPhysical = c;
-                } else if (clock === 0) {
-                    // Пустой день не вмещает даже setup+1 проход — кладём 1 проход (нахлёст), как база.
-                    var wsO = day * 1440 + dayStart + clock, durO = 1 * perPassEffG;
-                    segments.push({ cutId: pick, dayOffset: day, runs: 1,
-                        windowStartMin: round3(wsO), startMin: round3(wsO + setupG), setupMin: round3(setupG),
-                        durationMin: round3(durO), isContinuation: st.isCont, parentCutId: st.isCont ? pick : null });
-                    clock += setupG + durO; st.remaining -= 1; st.isCont = true; st.pendingSetup = 0;
-                    prevPhysical = c;
-                } else if (setupG <= 0) {
-                    day += 1; clock = 0;   // продолжение без настройки на след. день
-                } else {
-                    // Хвост вмещает только настройку: целиком (#3635) либо КРУПНЕЙШИЙ компонент
-                    // с минимальным нахлёстом (#3739), остаток настройки — на след. день.
-                    var tailSetup, restSetup;
-                    if (availG >= setupG) { tailSetup = setupG; restSetup = 0; }
-                    else {
-                        var parts = st.isCont ? [{ minutes: setupG }] : setupPartsFor(prevPhysical, c);
-                        var largest = 0;
-                        parts.forEach(function(p){ var m = Number(p.minutes) || 0; if (m > largest) largest = m; });
-                        if (!(largest > 0)) largest = setupG;
-                        tailSetup = largest; restSetup = round3(setupG - largest);
-                    }
+                    st.remaining -= passesNowG; st.isCont = true; st.pendingSetup = 0; prevPhysical = c;
+                    if (overlapsG) { day += 1; clock = 0; }            // после первого нахлёста — на завтра
+                    else { clock += setupG + durG; }
+                } else if (clock > 0) {
+                    // #3760: хвост не вмещает настройку целиком — кладём подмножество компонентов,
+                    // дотягивающее до конца смены с МИНИМАЛЬНЫМ нахлёстом (minOverlapTailSetupMinutes);
+                    // остаток настройки + проходы — на следующий день как продолжение.
+                    var partsG = st.isCont ? [{ minutes: setupG }] : setupPartsFor(prevPhysical, c);
+                    var tailSetup = minOverlapTailSetupMinutes(partsG, availG, setupG);
+                    var restSetup = round3(setupG - tailSetup);
                     var wsS = day * 1440 + dayStart + clock;
                     segments.push({ cutId: pick, dayOffset: day, runs: 0,
                         windowStartMin: round3(wsS), startMin: round3(wsS + tailSetup), setupMin: round3(tailSetup),
                         durationMin: 0, isContinuation: false, parentCutId: null, setupOnly: true });
                     clock += tailSetup; prevPhysical = c;
                     st.isCont = true; st.pendingSetup = restSetup;
+                    day += 1; clock = 0;
+                } else {
+                    // Пустой день не вмещает даже настройку (вырожденно: настройка > целого окна) —
+                    // кладём настройку + 1 проход с нахлёстом, остальное на следующий день.
+                    var wsO = day * 1440 + dayStart + clock, durO = 1 * perPassEffG;
+                    segments.push({ cutId: pick, dayOffset: day, runs: 1,
+                        windowStartMin: round3(wsO), startMin: round3(wsO + setupG), setupMin: round3(setupG),
+                        durationMin: round3(durO), isContinuation: st.isCont, parentCutId: st.isCont ? pick : null });
+                    st.remaining -= 1; st.isCont = true; st.pendingSetup = 0; prevPhysical = c;
                     day += 1; clock = 0;
                 }
             }
@@ -4116,6 +4146,7 @@
         firstSetupCost: firstSetupCost,
         setupBreakdown: setupBreakdown,
         setupActivityMinutes: setupActivityMinutes,   // #3698
+        minOverlapTailSetupMinutes: minOverlapTailSetupMinutes,   // #3760
         setupActivityColumns: setupActivityColumns,   // #3698
         planningStrategy: planningStrategy,
         planningStrategyLabel: planningStrategyLabel,

--- a/experiments/atex-production-planning-3760.test.js
+++ b/experiments/atex-production-planning-3760.test.js
@@ -1,0 +1,77 @@
+// Unit tests for #3760 — «Время за пределами рабочего дня»: нахлёст ограничен ОДНИМ шагом,
+// резку разбиваем на границе дня.
+//   1) Настройка в хвост: подмножество компонентов с суммой ≥ остатка дня и МИНИМАЛЬНЫМ
+//      нахлёстом; остальное — на завтра. Реконсиляция #3739/#3760:
+//        хвост 20 (ножи 30, сырьё 15) → ножи 30 (сырьё не дотягивает);
+//        хвост 8  (ножи 30, сырьё 15) → сырьё 15 (оба дотягивают, берём меньший).
+//   2) Проходы: влезающие + ОДИН нахлёстный сохраняем сегодня, после первого нахлёста —
+//      остальное на завтра.
+//   3) buildSchedule: тайминг не накапливается в ночь — резка, чьё окно начинается за концом
+//      смены, уходит на следующий день (один нахлёст на день, не до 23:00).
+//
+// Run with: node experiments/atex-production-planning-3760.test.js
+
+process.env.TZ = 'UTC';
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else { console.log('  expected:', JSON.stringify(expected)); console.log('  actual:  ', JSON.stringify(actual)); process.exitCode = 1; }
+}
+function cut(id, material, kw, runs) {
+    return { id: id, slitter: { id: 'm1' }, materialId: material, winding: 'OUT',
+        knifeWidths: kw, knifeCount: kw.length, rollerWidth: 0, plannedRuns: runs };
+}
+var TIMES = { BETWEEN_CUTS: 0 };   // KNIFE 30 / MATERIAL_WINDING 15 (дефолт)
+
+// ── 1) minOverlapTailSetupMinutes: подмножество, дотягивающее до границы, мин. нахлёст ──
+assertEqual(planning.minOverlapTailSetupMinutes([{minutes:30},{minutes:15}], 8, 45), 15,
+    '#3760: хвост 8 — сырьё 15 (оба компонента дотягивают, берём меньший, нахлёст 7)');
+assertEqual(planning.minOverlapTailSetupMinutes([{minutes:30},{minutes:15}], 20, 45), 30,
+    '#3739: хвост 20 — ножи 30 (сырьё 15 < 20 не дотягивает, оставило бы простой)');
+assertEqual(planning.minOverlapTailSetupMinutes([{minutes:30},{minutes:15}], 35, 45), 45,
+    '#3760: хвост 35 — оба компонента (45), иначе простой');
+assertEqual(planning.minOverlapTailSetupMinutes([{minutes:30}], 5, 30), 30,
+    '#3760: один компонент — он и идёт в хвост');
+
+// ── 2) Настройка на границе (канон #3760): хвост 8 → сырьё 15, ножи + проходы на завтра ──
+var sp = planning.splitMachineQueue(
+    [ cut('A', 'M1', [59, 59], 6), cut('B', 'M2', [30, 30], 3) ],
+    { dayStartMin: 0, dayEndMin: 68, times: TIMES,
+      perPassByCut: { A: 10, B: 10 }, runsByCut: { A: 6, B: 3 },
+      dayAnchorByCut: { A: 0, B: 0 }, gapFill: true });
+var bSet = sp.filter(function(s){ return s.cutId === 'B' && s.setupOnly; })[0];
+var bPas = sp.filter(function(s){ return s.cutId === 'B' && !s.setupOnly; })[0];
+assertEqual(bSet && { day: bSet.dayOffset, setup: bSet.setupMin, runs: bSet.runs }, { day: 0, setup: 15, runs: 0 },
+    '#3760: в хвост дня 0 — сырьё 15 (нахлёст), не ножи');
+assertEqual(bPas && { day: bPas.dayOffset, setup: bPas.setupMin, runs: bPas.runs }, { day: 1, setup: 30, runs: 3 },
+    '#3760: ножи 30 + проходы B — на следующий день');
+
+// ── 3) Проходы: влезающие + один нахлёстный сегодня, остальное на завтра ──
+var pp = planning.splitMachineQueue(
+    [ cut('A', 'M1', [59, 59], 15) ],
+    { dayStartMin: 0, dayEndMin: 100, times: TIMES,
+      perPassByCut: { A: 10 }, runsByCut: { A: 15 }, dayAnchorByCut: { A: 0 }, gapFill: true });
+assertEqual(pp.map(function(s){ return { day: s.dayOffset, runs: s.runs }; }),
+    [ { day: 0, runs: 11 }, { day: 1, runs: 4 } ],
+    '#3760: день 0 — 10 влезших + 1 нахлёстный = 11 проходов; остаток 4 — на завтра');
+
+// ── 4) buildSchedule: один нахлёст на день, без накопления в ночь ──
+// Три резки одной конфигурации (setup 0) по 60 мин, окно 100. C1 (0–60), C2 нахлёстом
+// (60–120, один нахлёст), C3 — окно за концом смены → на следующий день (а не 120–180 в ночь).
+function dcut(id, dur) {
+    return { id: id, slitter: { id: 'm1' }, materialId: 'M1', winding: 'OUT',
+        knifeWidths: [59, 59], knifeCount: 2, rollerWidth: 0, plannedRuns: 0, duration: dur };
+}
+var sched = planning.buildSchedule([ dcut('C1', 60), dcut('C2', 60), dcut('C3', 60) ],
+    { shiftStartMin: 0, shiftEndMin: 100, times: TIMES, runLengthByCut: {}, windPoints: [],
+      dayAnchorByCut: { C1: 0, C2: 0, C3: 0 }, gapFill: true });
+function dayOf(sc) { return Math.floor((Number(sc.startMin) || 0) / 1440); }
+var byId = {}; sched.forEach(function(s){ byId[s.cutId] = s; });
+assertEqual([dayOf(byId.C1), dayOf(byId.C2), dayOf(byId.C3)], [0, 0, 1],
+    '#3760: C1,C2 на дне 0 (C2 — один нахлёст), C3 уходит на день 1 (не копится в ночь)');
+
+console.log('\n' + passed + ' passed');


### PR DESCRIPTION
Closes #3760. Корректирует #3739.

## Корень проблемы
#3739 сделал нахлёст за конец смены **неограниченным** (`buildSchedule` перестал выталкивать), поэтому тайминг копился за весь день в ночь — отсюда старты вроде **22:11** и «готово **23:17**» в модалке.

## Что просили (2 правила)
1. **Настройка на границе:** в хвост — компонент, дотягивающий до конца смены с **минимальным нахлёстом**; остальное на завтра. Пример: хвост ~8 мин (16:22→16:30) → «смена сырья 15 мин», ножи+резка на завтра.
2. **Проходы:** влезшие + **первый нахлёстный** сохраняем сегодня, после первого нахлёста — остальное на завтра.

## Реализация
- **`splitMachineQueue` (gapFill):**
  - Проходы: влезающие + один нахлёстный, затем день закрывается → остаток на завтра.
  - Настройка в хвост: **`minOverlapTailSetupMinutes`** — подмножество компонентов с суммой ≥ остатка дня и минимальной суммой (мин. нахлёст), остаток на завтра. **Реконсиляция с #3739:** хвост 20 → ножи 30 (сырьё 15 не дотягивает, оставило бы простой); хвост 8 → сырьё 15 (оба дотягивают, берём меньший). Прежний «крупнейший компонент» исправлен.
- **`buildSchedule` (gapFill):** резку, чьё ОКНО (начало настройки = `start − setup`) уже за концом смены, выталкиваем на следующий день; начавшаяся в пределах смены может выйти за край (один нахлёст), но следующая уходит на завтра → тайминг больше не уезжает в ночь.

## Тест / безопасность
`experiments/atex-production-planning-3760.test.js` — 8 проверок (выбор компонента; настройка-на-границе канон; проходы с одним нахлёстом; `buildSchedule` без накопления). `minOverlapTailSetupMinutes` экспортирован. **Идемпотентность (#3427) сохранена** (round-trip сходится). Регрессий нет (`3619`/`atex-production-planning` красны на `main` независимо). Флаг `gapFill` изолирован.

## ⚠️ Известное ограничение (возможный follow-up)
Модалка/карточка «Тайминг резки» **пересчитывает** настройку через `changeoverCost`, поэтому запись-настройка в хвосте покажет СУММАРНОЕ время настройки, а не отдельный компонент («сырьё 15»). В ПЛАНЕ (персистентность) разбивка верная — это отдельные записи (хвост-настройка сегодня + проходы завтра), но точный показ компонента в модалке требует посегментного хранения настройки (поля #3698). Готов сделать отдельным PR, если нужно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
