### PR TITLE
fix(table): вернуть поиск по ID для первой колонки — фикс в исходных модулях (#3771)

### DIFF
--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1541,31 +1541,64 @@ class IntegramTable{
             return equalDefaultFormats.includes(format) ? '=' : '^';
         }
 
+        /**
+         * Is this the first (main value) column of the table?
+         * The first built column carries the record's own identity (id === metadata.id),
+         * so it can be filtered by record ID like a reference column (issue #3542).
+         */
+        isFirstColumn(column) {
+            return !!(column && Array.isArray(this.columns) && this.columns.length > 0 &&
+                column.id === this.columns[0].id);
+        }
+
+        /**
+         * Filter operators available for a column.
+         * Base set comes from the column format; the first column of ANY type additionally
+         * gets ID-based search (@ / !@), the same way reference columns do (issue #3542).
+         * REF already includes @ / !@, so it is not augmented.
+         */
+        getColumnFilterTypes(column) {
+            const format = column.format || 'SHORT';
+            const baseTypes = this.filterTypes[format] || this.filterTypes['SHORT'];
+            if (this.isFirstColumn(column) && format !== 'REF') {
+                return baseTypes.concat([
+                    { symbol: '@', name: 'по ID: включая', format: 'FR_{ T }=@{ X }' },
+                    { symbol: '!@', name: 'по ID: исключая', format: 'FR_{ T }=!@{ X }' }
+                ]);
+            }
+            return baseTypes;
+        }
+
         applyFilter(params, column, filter) {
             const type = filter.type || '^';
             const value = filter.value;
             const colId = column.id;
 
             const format = column.format || 'SHORT';
-            const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
+            const filterGroup = this.getColumnFilterTypes(column);
             const filterDef = filterGroup.find(f => f.symbol === type);
 
             if (!filterDef) return;
 
             if (type === '@' || type === '!@') {
-                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819)
+                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819).
+                // Available on reference columns and on the first column of any type (issue #3542).
+                // Multiple IDs use the IN(...) form — the bare @(id,id) form is NOT understood by
+                // the backend (verified on live: returns nothing for both REF and first columns) (issue #3542).
                 const ids = value.split(',').map(v => v.trim()).filter(v => /^\d+$/.test(v));
                 if (ids.length === 0) return;
                 const formatted = ids.length === 1
                     ? `${type}${ids[0]}`
-                    : `${type}(${ids.join(',')})`;
+                    : `${type}IN(${ids.join(',')})`;
                 params.append(`FR_${ colId }`, formatted);
             } else if (type === '...') {
-                const values = value.split(',').map(v => v.trim());
-                if (values.length >= 2) {
-                    params.append(`FR_${ colId }`, values[0]);
-                    params.append(`TO_${ colId }`, values[1]);
-                }
+                // Range: two separate values from/to (issue #3542). Either side may be empty
+                // for an open-ended range — append only the bounds that were filled in.
+                const values = value.split(',');
+                const from = (values[0] || '').trim();
+                const to = (values[1] || '').trim();
+                if (from) params.append(`FR_${ colId }`, from);
+                if (to) params.append(`TO_${ colId }`, to);
             } else if (type === '%' || type === '!%') {
                 params.append(`FR_${ colId }`, type === '%' ? '%' : '!%');
             } else {
@@ -1659,6 +1692,8 @@ class IntegramTable{
             if (focusedElement && focusedElement.classList.contains('filter-input-with-icon')) {
                 focusState = {
                     columnId: focusedElement.dataset.columnId,
+                    // Range cells have two inputs sharing a columnId — remember which one (issue #3542)
+                    rangePart: focusedElement.dataset.rangePart || null,
                     selectionStart: focusedElement.selectionStart,
                     selectionEnd: focusedElement.selectionEnd
                 };
@@ -1903,7 +1938,10 @@ class IntegramTable{
             // position when a filter input lives outside the visible scroll viewport
             // (issue #2744).
             if (focusState) {
-                const newInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${focusState.columnId}"]`);
+                const selector = focusState.rangePart
+                    ? `.filter-range-input[data-column-id="${focusState.columnId}"][data-range-part="${focusState.rangePart}"]`
+                    : `.filter-input-with-icon[data-column-id="${focusState.columnId}"]`;
+                const newInput = this.container.querySelector(selector);
                 if (newInput) {
                     newInput.focus({ preventScroll: true });
                     // Restore cursor position (only for text inputs, not date pickers)
@@ -2023,6 +2061,49 @@ class IntegramTable{
                                    data-column-id="${ column.id }"
                                    data-is-datetime="${ isDateTime ? '1' : '0' }"
                                    value="${ html5Value }">
+                        </div>
+                    </td>
+                `;
+            }
+
+            // Range filter ('...'): two separate from/to fields instead of one comma-separated
+            // input — the comma syntax was unclear (issue #3542). Stored value stays "from,to".
+            if (currentFilter.type === '...') {
+                const isDate = dateFormats.includes(format);
+                const isDateTime = format === 'DATETIME';
+                let inputType = 'text';
+                if (isDate) inputType = isDateTime ? 'datetime-local' : 'date';
+                else if (format === 'NUMBER' || format === 'SIGNED') inputType = 'number';
+
+                const parts = (currentFilter.value || '').split(',');
+                const rawFrom = (parts[0] || '').trim();
+                const rawTo = (parts[1] || '').trim();
+                const fromVal = isDate ? (rawFrom ? this.formatDateForHtml5(rawFrom, isDateTime) : '') : rawFrom;
+                const toVal = isDate ? (rawTo ? this.formatDateForHtml5(rawTo, isDateTime) : '') : rawTo;
+                const dtAttr = isDate ? ` data-is-datetime="${ isDateTime ? '1' : '0' }"` : '';
+                const escAttr = v => String(v).replace(/"/g, '&quot;');
+
+                return `
+                    <td>
+                        <div class="filter-cell-wrapper filter-range-wrapper">
+                            <span class="filter-icon-inside" data-column-id="${ column.id }">
+                                ${ currentFilter.type }
+                            </span>
+                            <input type="${ inputType }"
+                                   class="filter-input-with-icon filter-range-input"
+                                   data-column-id="${ column.id }"
+                                   data-range-part="from"${ dtAttr }
+                                   value="${ escAttr(fromVal) }"
+                                   placeholder="от"
+                                   autocomplete="off">
+                            <span class="filter-range-sep">—</span>
+                            <input type="${ inputType }"
+                                   class="filter-input-with-icon filter-range-input"
+                                   data-column-id="${ column.id }"
+                                   data-range-part="to"${ dtAttr }
+                                   value="${ escAttr(toVal) }"
+                                   placeholder="до"
+                                   autocomplete="off">
                         </div>
                     </td>
                 `;
@@ -4015,6 +4096,8 @@ class IntegramTable{
             filterInputs.forEach(input => {
                 // Skip date pickers — they are handled separately via 'change' event (issue #1008)
                 if (input.classList.contains('filter-date-picker')) return;
+                // Skip range from/to inputs — handled separately below (issue #3542)
+                if (input.classList.contains('filter-range-input')) return;
                 // Use 'input' event to apply filter on text change
                 input.addEventListener('input', (e) => {
                     const colId = input.dataset.columnId;
@@ -4068,6 +4151,44 @@ class IntegramTable{
                     delete this.filters[colId].displayValue;
 
                     this.handleFilterOverride(colId, displayValue);
+
+                    clearTimeout(this.filterTimeout);
+                    this.filterTimeout = setTimeout(() => {
+                        this.data = [];
+                        this.loadedRecords = 0;
+                        this.hasMore = true;
+                        this.totalRows = null;
+                        this.loadData(false);
+                    }, 500);
+                });
+            });
+
+            // Range filter from/to inputs (issue #3542): combine both halves into the stored
+            // "from,to" value. Date inputs fire 'change'; number/text inputs fire 'input'.
+            const filterRangeInputs = this.container.querySelectorAll('.filter-range-input');
+            filterRangeInputs.forEach(input => {
+                const evtName = (input.type === 'date' || input.type === 'datetime-local') ? 'change' : 'input';
+                input.addEventListener(evtName, () => {
+                    const colId = input.dataset.columnId;
+                    if (!this.filters[colId]) {
+                        this.filters[colId] = { type: '...', value: '' };
+                    }
+                    const wrapper = input.closest('.filter-cell-wrapper');
+                    const readPart = part => {
+                        const el = wrapper && wrapper.querySelector(`.filter-range-input[data-range-part="${ part }"]`);
+                        if (!el || !el.value) return '';
+                        // Date inputs carry data-is-datetime → convert HTML5 value to display format
+                        if (el.dataset.isDatetime === '1' || el.dataset.isDatetime === '0') {
+                            return this.convertHtml5DateToDisplay(el.value, el.dataset.isDatetime === '1');
+                        }
+                        return el.value.trim();
+                    };
+                    const from = readPart('from');
+                    const to = readPart('to');
+                    this.filters[colId].value = `${ from },${ to }`;
+                    delete this.filters[colId].displayValue;
+
+                    this.handleFilterOverride(colId, this.filters[colId].value);
 
                     clearTimeout(this.filterTimeout);
                     this.filterTimeout = setTimeout(() => {
@@ -7400,7 +7521,7 @@ class IntegramTable{
         showFilterTypeMenu(target, columnId) {
             const column = this.columns.find(c => c.id === columnId);
             const format = column.format || 'SHORT';
-            const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
+            const filterGroup = this.getColumnFilterTypes(column);
 
             document.querySelectorAll('.filter-type-menu').forEach(m => m.remove());
 
@@ -7464,6 +7585,14 @@ class IntegramTable{
                             this.render();
                             return;
                         }
+                    }
+
+                    // Switching to/from range ('...') changes the cell from one input to two
+                    // from/to fields (issue #3542) — clear the value and re-render to swap inputs.
+                    if ((symbol === '...') !== (oldType === '...')) {
+                        this.filters[columnId].value = '';
+                        this.render();
+                        return;
                     }
 
                     // For Empty (%) and Not Empty (!%) filters, clear input and apply immediately

--- a/js/integram-table/03-filters-core.js
+++ b/js/integram-table/03-filters-core.js
@@ -3,31 +3,64 @@
             return equalDefaultFormats.includes(format) ? '=' : '^';
         }
 
+        /**
+         * Is this the first (main value) column of the table?
+         * The first built column carries the record's own identity (id === metadata.id),
+         * so it can be filtered by record ID like a reference column (issue #3542).
+         */
+        isFirstColumn(column) {
+            return !!(column && Array.isArray(this.columns) && this.columns.length > 0 &&
+                column.id === this.columns[0].id);
+        }
+
+        /**
+         * Filter operators available for a column.
+         * Base set comes from the column format; the first column of ANY type additionally
+         * gets ID-based search (@ / !@), the same way reference columns do (issue #3542).
+         * REF already includes @ / !@, so it is not augmented.
+         */
+        getColumnFilterTypes(column) {
+            const format = column.format || 'SHORT';
+            const baseTypes = this.filterTypes[format] || this.filterTypes['SHORT'];
+            if (this.isFirstColumn(column) && format !== 'REF') {
+                return baseTypes.concat([
+                    { symbol: '@', name: 'по ID: включая', format: 'FR_{ T }=@{ X }' },
+                    { symbol: '!@', name: 'по ID: исключая', format: 'FR_{ T }=!@{ X }' }
+                ]);
+            }
+            return baseTypes;
+        }
+
         applyFilter(params, column, filter) {
             const type = filter.type || '^';
             const value = filter.value;
             const colId = column.id;
 
             const format = column.format || 'SHORT';
-            const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
+            const filterGroup = this.getColumnFilterTypes(column);
             const filterDef = filterGroup.find(f => f.symbol === type);
 
             if (!filterDef) return;
 
             if (type === '@' || type === '!@') {
-                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819)
+                // ID-based filter: user enters one or more IDs (digits, comma-separated) (issue #1819).
+                // Available on reference columns and on the first column of any type (issue #3542).
+                // Multiple IDs use the IN(...) form — the bare @(id,id) form is NOT understood by
+                // the backend (verified on live: returns nothing for both REF and first columns) (issue #3542).
                 const ids = value.split(',').map(v => v.trim()).filter(v => /^\d+$/.test(v));
                 if (ids.length === 0) return;
                 const formatted = ids.length === 1
                     ? `${type}${ids[0]}`
-                    : `${type}(${ids.join(',')})`;
+                    : `${type}IN(${ids.join(',')})`;
                 params.append(`FR_${ colId }`, formatted);
             } else if (type === '...') {
-                const values = value.split(',').map(v => v.trim());
-                if (values.length >= 2) {
-                    params.append(`FR_${ colId }`, values[0]);
-                    params.append(`TO_${ colId }`, values[1]);
-                }
+                // Range: two separate values from/to (issue #3542). Either side may be empty
+                // for an open-ended range — append only the bounds that were filled in.
+                const values = value.split(',');
+                const from = (values[0] || '').trim();
+                const to = (values[1] || '').trim();
+                if (from) params.append(`FR_${ colId }`, from);
+                if (to) params.append(`TO_${ colId }`, to);
             } else if (type === '%' || type === '!%') {
                 params.append(`FR_${ colId }`, type === '%' ? '%' : '!%');
             } else {

--- a/js/integram-table/04-render-table.js
+++ b/js/integram-table/04-render-table.js
@@ -12,6 +12,8 @@
             if (focusedElement && focusedElement.classList.contains('filter-input-with-icon')) {
                 focusState = {
                     columnId: focusedElement.dataset.columnId,
+                    // Range cells have two inputs sharing a columnId — remember which one (issue #3542)
+                    rangePart: focusedElement.dataset.rangePart || null,
                     selectionStart: focusedElement.selectionStart,
                     selectionEnd: focusedElement.selectionEnd
                 };
@@ -256,7 +258,10 @@
             // position when a filter input lives outside the visible scroll viewport
             // (issue #2744).
             if (focusState) {
-                const newInput = this.container.querySelector(`.filter-input-with-icon[data-column-id="${focusState.columnId}"]`);
+                const selector = focusState.rangePart
+                    ? `.filter-range-input[data-column-id="${focusState.columnId}"][data-range-part="${focusState.rangePart}"]`
+                    : `.filter-input-with-icon[data-column-id="${focusState.columnId}"]`;
+                const newInput = this.container.querySelector(selector);
                 if (newInput) {
                     newInput.focus({ preventScroll: true });
                     // Restore cursor position (only for text inputs, not date pickers)
@@ -376,6 +381,49 @@
                                    data-column-id="${ column.id }"
                                    data-is-datetime="${ isDateTime ? '1' : '0' }"
                                    value="${ html5Value }">
+                        </div>
+                    </td>
+                `;
+            }
+
+            // Range filter ('...'): two separate from/to fields instead of one comma-separated
+            // input — the comma syntax was unclear (issue #3542). Stored value stays "from,to".
+            if (currentFilter.type === '...') {
+                const isDate = dateFormats.includes(format);
+                const isDateTime = format === 'DATETIME';
+                let inputType = 'text';
+                if (isDate) inputType = isDateTime ? 'datetime-local' : 'date';
+                else if (format === 'NUMBER' || format === 'SIGNED') inputType = 'number';
+
+                const parts = (currentFilter.value || '').split(',');
+                const rawFrom = (parts[0] || '').trim();
+                const rawTo = (parts[1] || '').trim();
+                const fromVal = isDate ? (rawFrom ? this.formatDateForHtml5(rawFrom, isDateTime) : '') : rawFrom;
+                const toVal = isDate ? (rawTo ? this.formatDateForHtml5(rawTo, isDateTime) : '') : rawTo;
+                const dtAttr = isDate ? ` data-is-datetime="${ isDateTime ? '1' : '0' }"` : '';
+                const escAttr = v => String(v).replace(/"/g, '&quot;');
+
+                return `
+                    <td>
+                        <div class="filter-cell-wrapper filter-range-wrapper">
+                            <span class="filter-icon-inside" data-column-id="${ column.id }">
+                                ${ currentFilter.type }
+                            </span>
+                            <input type="${ inputType }"
+                                   class="filter-input-with-icon filter-range-input"
+                                   data-column-id="${ column.id }"
+                                   data-range-part="from"${ dtAttr }
+                                   value="${ escAttr(fromVal) }"
+                                   placeholder="от"
+                                   autocomplete="off">
+                            <span class="filter-range-sep">—</span>
+                            <input type="${ inputType }"
+                                   class="filter-input-with-icon filter-range-input"
+                                   data-column-id="${ column.id }"
+                                   data-range-part="to"${ dtAttr }
+                                   value="${ escAttr(toVal) }"
+                                   placeholder="до"
+                                   autocomplete="off">
                         </div>
                     </td>
                 `;

--- a/js/integram-table/07-inline-edit.js
+++ b/js/integram-table/07-inline-edit.js
@@ -333,6 +333,8 @@
             filterInputs.forEach(input => {
                 // Skip date pickers — they are handled separately via 'change' event (issue #1008)
                 if (input.classList.contains('filter-date-picker')) return;
+                // Skip range from/to inputs — handled separately below (issue #3542)
+                if (input.classList.contains('filter-range-input')) return;
                 // Use 'input' event to apply filter on text change
                 input.addEventListener('input', (e) => {
                     const colId = input.dataset.columnId;
@@ -386,6 +388,44 @@
                     delete this.filters[colId].displayValue;
 
                     this.handleFilterOverride(colId, displayValue);
+
+                    clearTimeout(this.filterTimeout);
+                    this.filterTimeout = setTimeout(() => {
+                        this.data = [];
+                        this.loadedRecords = 0;
+                        this.hasMore = true;
+                        this.totalRows = null;
+                        this.loadData(false);
+                    }, 500);
+                });
+            });
+
+            // Range filter from/to inputs (issue #3542): combine both halves into the stored
+            // "from,to" value. Date inputs fire 'change'; number/text inputs fire 'input'.
+            const filterRangeInputs = this.container.querySelectorAll('.filter-range-input');
+            filterRangeInputs.forEach(input => {
+                const evtName = (input.type === 'date' || input.type === 'datetime-local') ? 'change' : 'input';
+                input.addEventListener(evtName, () => {
+                    const colId = input.dataset.columnId;
+                    if (!this.filters[colId]) {
+                        this.filters[colId] = { type: '...', value: '' };
+                    }
+                    const wrapper = input.closest('.filter-cell-wrapper');
+                    const readPart = part => {
+                        const el = wrapper && wrapper.querySelector(`.filter-range-input[data-range-part="${ part }"]`);
+                        if (!el || !el.value) return '';
+                        // Date inputs carry data-is-datetime → convert HTML5 value to display format
+                        if (el.dataset.isDatetime === '1' || el.dataset.isDatetime === '0') {
+                            return this.convertHtml5DateToDisplay(el.value, el.dataset.isDatetime === '1');
+                        }
+                        return el.value.trim();
+                    };
+                    const from = readPart('from');
+                    const to = readPart('to');
+                    this.filters[colId].value = `${ from },${ to }`;
+                    delete this.filters[colId].displayValue;
+
+                    this.handleFilterOverride(colId, this.filters[colId].value);
 
                     clearTimeout(this.filterTimeout);
                     this.filterTimeout = setTimeout(() => {

--- a/js/integram-table/10-filter-ui.js
+++ b/js/integram-table/10-filter-ui.js
@@ -1,7 +1,7 @@
         showFilterTypeMenu(target, columnId) {
             const column = this.columns.find(c => c.id === columnId);
             const format = column.format || 'SHORT';
-            const filterGroup = this.filterTypes[format] || this.filterTypes['SHORT'];
+            const filterGroup = this.getColumnFilterTypes(column);
 
             document.querySelectorAll('.filter-type-menu').forEach(m => m.remove());
 
@@ -65,6 +65,14 @@
                             this.render();
                             return;
                         }
+                    }
+
+                    // Switching to/from range ('...') changes the cell from one input to two
+                    // from/to fields (issue #3542) — clear the value and re-render to swap inputs.
+                    if ((symbol === '...') !== (oldType === '...')) {
+                        this.filters[columnId].value = '';
+                        this.render();
+                        return;
                     }
 
                     // For Empty (%) and Not Empty (!%) filters, clear input and apply immediately


### PR DESCRIPTION
Closes #3771

## Причина

Поиск по ID для первой (главной) колонки любого типа и диапазон двумя полями (#3542 / PR #3543) **пропали из `main`**. Тот PR правил **только собранный** `js/integram-table.js`, не трогая исходники `js/integram-table/*.js`. Файл генерируется автоматически (`build.sh` конкатенирует 26 модулей), поэтому следующая же сборка — `build.sh` в PR #3572 — перегенерировала `js/integram-table.js` из модулей и стёрла фичу.

```
1adf66bf  PR #3543 — feature в js/integram-table.js (getColumnFilterTypes = 3)
76dd3a1a  PR #3572 — build.sh пересобрал из модулей → getColumnFilterTypes = 0  ← фича стёрта
```

## Фикс

Перенёс изменения #3543 в **исходные модули** и пересобрал — теперь правка переживёт любую сборку:

- **`03-filters-core.js`** — `isFirstColumn()` / `getColumnFilterTypes()`: первой колонке любого типа добавляются операторы «@ по ID: включая» / «!@ по ID: исключая» (REF уже их имеет — не дублируем). `applyFilter` строит `@IN(...)` для нескольких ID и открытый диапазон (только `FR_` и/или `TO_`).
- **`04-render-table.js`** — сохранение/восстановление фокуса по `data-range-part`; ветка двух полей «от/до» в `renderFilterCell` для оператора «…».
- **`07-inline-edit.js`** — общий обработчик пропускает `.filter-range-input`; отдельные слушатели полей диапазона собирают значение `"from,to"`.
- **`10-filter-ui.js`** — меню операторов через `getColumnFilterTypes`; ре-рендер при переключении на/с «…».
- **`js/integram-table.js`** — пересобран через `build.sh`.

Стили `.filter-range-*` в `css/integram-table.css` уже в `main` (css не генерируется). 

## Тесты

`experiments/test-issue-3542-table-filter.js` (require'ит собранный `js/integram-table.js`) проходит на пересобранном файле; `test-filter-fix.js`, `test-date-filter.js` — без регрессий.

| Проверка | Результат |
|---|---|
| `isFirstColumn` / `getColumnFilterTypes` (первая/обычная/REF) | ✅ |
| `applyFilter` `@`/`!@` (один ID и `IN(...)`) | ✅ |
| Диапазон: оба значения / только от / только до / пусто | ✅ |
| Все `+`-строки PR #3543 присутствуют в пересобранном файле (130/130) | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)