### PR TITLE
#3770: сумма минут всех баров станка в заголовке «Диаграммы Ганта»

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -584,9 +584,12 @@
     // #3680: подпись охватывает ВСЁ задание (наладка + резка), а не только резку.
     // Начало = левый край бара (tr.startMs, та же точка, что у строки .atex-cg-label-main);
     // setupMin раздвигает только правый край — добавляет к окну минуты наладки перед резкой.
-    function cutBarTime(cut, setupMin, maxEndMs) {
+    // #3770: окно подписи бара (наладка+резка) как {startMs, endMs, mins} — единый источник
+    // и для текста бара (cutBarTime), и для суммы минут в заголовке станка (cutBarSpanMin),
+    // чтобы они никогда не расходились. Геометрия — как раньше в cutBarTime.
+    function cutBarWindow(cut, setupMin, maxEndMs) {
         var tr = cutTimeRange(cut);
-        if (!tr) return '';
+        if (!tr) return null;
         // #3705: правый край = старт + (резка+лидер) + наладка — ровно та же сумма минут, что у
         // ширины бара (cutBarSegments) и у окна планировщика. Раньше брали tr.endMs (намотка БЕЗ
         // лидера) + наладка → конец задания получался на лидер «между резками» короче плана.
@@ -597,8 +600,20 @@
         // на доли минуты длиннее реального окна и налезал на следующий бар.
         var maxMs = Number(maxEndMs);
         if (maxEndMs != null && isFinite(maxMs) && maxMs > startMs && endMs > maxMs) endMs = maxMs;
-        var mins = Math.max(1, Math.round((endMs - startMs) / 60000));
-        return formatTime(startMs) + '-' + formatTime(endMs) + ' (' + mins + ' мин)';
+        return { startMs: startMs, endMs: endMs, mins: Math.max(1, Math.round((endMs - startMs) / 60000)) };
+    }
+
+    function cutBarTime(cut, setupMin, maxEndMs) {
+        var w = cutBarWindow(cut, setupMin, maxEndMs);
+        if (!w) return '';
+        return formatTime(w.startMs) + '-' + formatTime(w.endMs) + ' (' + w.mins + ' мин)';
+    }
+
+    // #3770: целое число минут, отображаемое в подписи бара (.atex-cg-bar-main). Заголовок
+    // станка суммирует эти значения → «6 (262 мин)». Нет окна (нет времени) → 0.
+    function cutBarSpanMin(cut, setupMin, maxEndMs) {
+        var w = cutBarWindow(cut, setupMin, maxEndMs);
+        return w ? w.mins : 0;
     }
 
     // #3675 п.3: ширины сегментов бара (px) при масштабе pxPerMin: [наладка ножей][смена сырья][резка].
@@ -1071,9 +1086,12 @@
                     widthPx: widthPx,
                     segments: seg,
                     label: cutRowLabel(cut), barText: cutBarTime(cut, seg.setupMin, nextStartMs),
+                    barMin: cutBarSpanMin(cut, seg.setupMin, nextStartMs),   // #3770: минуты подписи бара
                     title: cutBarTitle(cut, tr, status)
                 };
             });
+            // #3770: суммарные минуты всех баров станка — для подписи «N (Σ мин)» в заголовке.
+            g.tasksMin = g.tasks.reduce(function(sum, t) { return sum + (t.barMin || 0); }, 0);
             delete g.cuts;
         });
         return { groups: groups, trackPx: trackPx, window: win, scale: scale, pxPerMin: pxPerMin };
@@ -1130,6 +1148,7 @@
         cutInRange: cutInRange,
         cutRowLabel: cutRowLabel,
         cutBarTime: cutBarTime,
+        cutBarSpanMin: cutBarSpanMin,   // #3770
         cutSetupMin: cutSetupMin,
         cutBarMinutes: cutBarMinutes,   // #3700
         cutBarSegments: cutBarSegments,
@@ -1452,9 +1471,12 @@
         data.groups.forEach(function(group) {
             // #3668 п.3/п.5: заголовок станка — строка-грид; первая ячейка (имя + число
             // заданий нежирным) фиксируется при горизонтальном скролле.
+            // #3770: число заданий + сумма минут всех баров станка, например «6 (262 мин)».
+            var countText = String(group.tasks.length)
+                + (group.tasksMin > 0 ? ' (' + group.tasksMin + ' мин)' : '');
             var nameCell = el('div', { class: 'atex-cg-label atex-cg-machine-cell' }, [
                 el('span', { class: 'atex-cg-machine-name', text: group.slitter.label }),
-                el('span', { class: 'atex-cg-machine-count', text: String(group.tasks.length) })
+                el('span', { class: 'atex-cg-machine-count', text: countText })
             ]);
             var headTrack = el('div', { class: 'atex-cg-track atex-cg-machine-track' });
             headTrack.style.minWidth = trackPx + 'px';

--- a/experiments/atex-cut-gantt.test.js
+++ b/experiments/atex-cut-gantt.test.js
@@ -112,6 +112,12 @@ assertEqual(gantt.cutBarTime({ planDate: '2026-06-10 08:00', startDate: '2026-06
 // конец = после наладки 45 мин + резки 4 мин; длительность = 49 мин (а не только 4 мин резки).
 assertEqual(gantt.cutBarTime({ planDate: '2026-06-10 08:00', duration: 4 }, 45),
     '08:00-08:49 (49 мин)', 'cutBarTime: наладка+резка одним окном (#3680)');
+// #3770: cutBarSpanMin — число минут той же подписи (для суммы в заголовке станка).
+assertEqual(gantt.cutBarSpanMin({ planDate: '2026-06-10 11:19', duration: 4 }), 4,
+    'cutBarSpanMin: минуты подписи бара');
+assertEqual(gantt.cutBarSpanMin({ planDate: '2026-06-10 08:00', duration: 4 }, 45), 49,
+    'cutBarSpanMin: наладка+резка одним окном (#3680)');
+assertEqual(gantt.cutBarSpanMin({}), 0, 'cutBarSpanMin: нет времени → 0');
 
 // ── cutSetupMin (#3675 п.3): минуты наладки только у запланированных (без факт. старта) ──
 assertEqual(gantt.cutSetupMin({ planDate: '2026-06-10 08:00', setupKnifeMin: 30, setupMaterialMin: 15 }),
@@ -400,6 +406,9 @@ assertEqual([ct[0].cut.id, ct[0].leftPx, ct[0].widthPx], ['A', 0, 66],
     'layoutGroups #3708: бар A обрезан с 67 до 66 мин (старт B)');
 assertEqual(ct[0].barText, '08:00-09:06 (66 мин)', 'layoutGroups #3708: подпись A совпадает с планом (до 09:06)');
 assertEqual(ct[0].leftPx + ct[0].widthPx, ct[1].leftPx, 'layoutGroups #3708: A встык к B — налезания нет');
+// #3770: заголовок станка суммирует минуты всех баров (A=66 + B=64 → «2 (130 мин)»).
+assertEqual([ct[0].barMin, ct[1].barMin, laidClamp.groups[0].tasksMin], [66, 64, 130],
+    'layoutGroups #3770: tasksMin = сумма минут баров станка (66+64=130)');
 // Завершённое задание (есть факт. финиш) не режем — показываем реальную длительность.
 var doneThenNext = [
     { id: 'D', planDate: '2026-06-10 08:00', startDate: '2026-06-10 08:00', endDate: '2026-06-10 09:10', sequence: 1, slitter: { id: '1', label: 'Станок 1' } },


### PR DESCRIPTION
Closes #3770.

В заголовке станка «Диаграммы Ганта (задания)» (`templates/atex/cut-gantt.html` → `js/cut-gantt.js`) рядом с числом заданий в `.atex-cg-machine-count` теперь показываем суммарные минуты всех баров станка, например **«6 (262 мин)»**.

## Что изменено
**`download/atex/js/cut-gantt.js`**
- Выделил единый источник окна подписи бара `cutBarWindow(cut, setupMin, maxEndMs)` → `{startMs, endMs, mins}`. На нём теперь стоит `cutBarTime` — текст бара не изменился (старые тесты зелёные).
- Добавил `cutBarSpanMin(...)` — целое число минут той же подписи бара (нет времени → 0).
- В `layoutGroups`: на каждую задачу — `barMin`, на группу станка — `tasksMin` (сумма минут всех баров).
- В рендере заголовка станка `.atex-cg-machine-count` показывает `N (Σ мин)` (скобки только при сумме > 0).

**`experiments/atex-cut-gantt.test.js`** — 4 новые проверки: `cutBarSpanMin` (норма / наладка+резка / нет времени) и `layoutGroups` (`tasksMin = 66+64 = 130`).

Суммируются ровно те минуты, что показаны в каждом `.atex-cg-bar-main` — общая функция `cutBarWindow` гарантирует, что текст бара и сумма не разойдутся. CSS не менялся.

## Тест
`node experiments/atex-cut-gantt.test.js` → 122 assertions passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)