### PR TITLE
fix(table): экспорт DATE/DATETIME как дата/время, а не unix-штамп (#3763)

### DIFF
--- a/experiments/test-issue-3763-export-datetime.js
+++ b/experiments/test-issue-3763-export-datetime.js
@@ -1,0 +1,65 @@
+// Тест issue #3763 (js/integram-table.js):
+// При экспорте таблицы (CSV/XLSX/буфер) DATE/DATETIME-колонки должны выгружаться
+// как дата/дата-время (DD.MM.YYYY / DD.MM.YYYY HH:MM:SS), а не сырым unix-штампом.
+// prepareExportDataFromRows — чистый метод; инстанс через Object.create без конструктора.
+const path = require('path');
+const assert = require('assert');
+
+const IntegramTable = require(path.join(__dirname, '..', 'js', 'integram-table.js'));
+assert(typeof IntegramTable === 'function', 'IntegramTable exported');
+
+const t = Object.create(IntegramTable.prototype);
+
+// Колонки: первая текстовая, DATE, DATETIME, BOOLEAN, REF — порядок как в таблице.
+t.columns = [
+    { id: '1', format: 'SHORT' },     // примечание (текст)
+    { id: '2', format: 'DATE' },      // отпуск (дата)
+    { id: '3', format: 'DATETIME' },  // окончание (дата-время)
+    { id: '4', format: 'BOOLEAN' },   // флаг
+    { id: '5', format: 'REF', ref_id: 7 } // ссылка "id:Значение"
+];
+
+// Значения штампов из реального экспорта (issue #3763).
+const TS_DATE = '1783314000';
+const TS_DT = '1783889940';
+
+// Строка данных в том же порядке, что this.columns.
+const row = ['Тех. обслуживание', TS_DATE, TS_DT, '1', '42:ООО Ромашка'];
+
+const out = t.prepareExportDataFromRows([row], t.columns)[0];
+
+// --- DATE: штамп → дата как на экране ---
+const expectedDate = t.formatDateDisplay(t.parseDDMMYYYY(TS_DATE));
+assert(/^\d{2}\.\d{2}\.\d{4}$/.test(out[1]), `DATE экспортируется как DD.MM.YYYY, получено: ${ out[1] }`);
+assert.notStrictEqual(out[1], TS_DATE, 'DATE НЕ должна остаться сырым штампом');
+assert.strictEqual(out[1], expectedDate, 'DATE-экспорт совпадает с отображением ячейки');
+
+// --- DATETIME: штамп → дата-время как на экране ---
+const expectedDT = t.formatDateTimeDisplay(t.parseDDMMYYYYHHMMSS(TS_DT));
+assert(/^\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}:\d{2}$/.test(out[2]), `DATETIME экспортируется как DD.MM.YYYY HH:MM:SS, получено: ${ out[2] }`);
+assert.notStrictEqual(out[2], TS_DT, 'DATETIME НЕ должна остаться сырым штампом');
+assert.strictEqual(out[2], expectedDT, 'DATETIME-экспорт совпадает с отображением ячейки');
+
+// --- остальные форматы не сломаны ---
+assert.strictEqual(out[0], 'Тех. обслуживание', 'текст без изменений');
+assert.strictEqual(out[3], 'Да', 'BOOLEAN → Да/Нет');
+assert.strictEqual(out[4], 'ООО Ромашка', 'REF без префикса "id:"');
+
+// --- пустые DATE/DATETIME остаются пустыми ---
+const emptyRow = ['', '', '', '', ''];
+const emptyOut = t.prepareExportDataFromRows([emptyRow], t.columns)[0];
+assert.strictEqual(emptyOut[1], '', 'пустая DATE остаётся пустой');
+assert.strictEqual(emptyOut[2], '', 'пустая DATETIME остаётся пустой');
+
+// --- уже отформатированная дата проходит как есть (не штамп) ---
+const humanRow = ['x', '01.06.2026', '01.06.2026 10:30:00', '', ''];
+const humanOut = t.prepareExportDataFromRows([humanRow], t.columns)[0];
+assert.strictEqual(humanOut[1], '01.06.2026', 'готовая DATE-строка без изменений');
+assert.strictEqual(humanOut[2], '01.06.2026 10:30:00', 'готовая DATETIME-строка без изменений');
+
+// --- resolveColumnFormat: символьный формат и числовой тип дают одно и то же ---
+assert.strictEqual(t.resolveColumnFormat({ format: 'DATETIME' }), 'DATETIME', 'символьный формат');
+assert.strictEqual(t.resolveColumnFormat({ type: '4' }), 'DATETIME', 'числовой тип 4 → DATETIME');
+assert.strictEqual(t.resolveColumnFormat({ type: '9' }), 'DATE', 'числовой тип 9 → DATE');
+
+console.log('OK: test-issue-3763-export-datetime');

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -211,6 +211,22 @@ class IntegramTable{
         }
 
         /**
+         * Resolve a column's symbolic display format the same way renderCell does
+         * (issue #3763): an already-symbolic format wins, otherwise the numeric type
+         * is mapped. Keeps export output identical to what the cell shows.
+         * @param {Object} column - Column definition
+         * @returns {string} Symbolic format name (e.g. 'DATE', 'DATETIME', 'SHORT')
+         */
+        resolveColumnFormat(column) {
+            const validFormats = ['SHORT', 'CHARS', 'DATE', 'NUMBER', 'SIGNED', 'BOOLEAN',
+                                  'MEMO', 'DATETIME', 'FILE', 'HTML', 'BUTTON', 'PWD',
+                                  'GRANT', 'REPORT_COLUMN', 'PATH'];
+            const upperFormat = column && column.format ? String(column.format).toUpperCase() : '';
+            if (validFormats.includes(upperFormat)) return upperFormat;
+            return column && column.type ? this.normalizeFormat(column.type) : 'SHORT';
+        }
+
+        /**
          * Check if the table has WRITE access (issue #1508)
          * Returns true when tableGranted is null (not set) or equals "WRITE"
          * Returns false for any other granted value (e.g. "READ")
@@ -18259,13 +18275,14 @@ class IntegramTable{
                 const exportRow = [];
                 columns.forEach(col => {
                     const cellValue = row[this.columns.indexOf(col)];
-                    const format = col.format || 'SHORT';
+                    // Resolve the symbolic format exactly as renderCell does so the export
+                    // matches what is shown on screen (issue #3763).
+                    const format = this.resolveColumnFormat(col);
                     let value = cellValue || '';
 
                     // Issue #378, #925: For reference fields and GRANT/REPORT_COLUMN, remove "id:" prefix from "id:Value" format
                     const isRefField = col.ref_id != null || (col.ref && col.ref !== 0);
-                    const upperFormat = String(format).toUpperCase();
-                    const isGrantOrReportColumn = upperFormat === 'GRANT' || upperFormat === 'REPORT_COLUMN';
+                    const isGrantOrReportColumn = format === 'GRANT' || format === 'REPORT_COLUMN';
                     if ((isRefField || isGrantOrReportColumn) && value && typeof value === 'string') {
                         const colonIndex = value.indexOf(':');
                         if (colonIndex > 0) {
@@ -18282,6 +18299,18 @@ class IntegramTable{
                             // Only mask with asterisks if there's a value
                             value = (cellValue !== null && cellValue !== undefined && cellValue !== '') ? '******' : '';
                             break;
+                        case 'DATE': {
+                            // Export DATE as DD.MM.YYYY, not the raw Unix timestamp (issue #3763)
+                            const dateObj = this.parseDDMMYYYY(String(value));
+                            value = (dateObj && !isNaN(dateObj.getTime())) ? this.formatDateDisplay(dateObj) : String(value);
+                            break;
+                        }
+                        case 'DATETIME': {
+                            // Export DATETIME as DD.MM.YYYY HH:MM:SS, not the raw Unix timestamp (issue #3763)
+                            const dtObj = this.parseDDMMYYYYHHMMSS(String(value));
+                            value = (dtObj && !isNaN(dtObj.getTime())) ? this.formatDateTimeDisplay(dtObj) : String(value);
+                            break;
+                        }
                         case 'HTML':
                         case 'BUTTON':
                             // Strip HTML tags for export
@@ -18309,13 +18338,14 @@ class IntegramTable{
                 const exportRow = [];
                 columns.forEach(col => {
                     const cellValue = row[this.columns.indexOf(col)];
-                    const format = col.format || 'SHORT';
+                    // Resolve the symbolic format exactly as renderCell does so the export
+                    // matches what is shown on screen (issue #3763).
+                    const format = this.resolveColumnFormat(col);
                     let value = cellValue || '';
 
                     // Issue #378, #925: For reference fields and GRANT/REPORT_COLUMN, remove "id:" prefix from "id:Value" format
                     const isRefField = col.ref_id != null || (col.ref && col.ref !== 0);
-                    const upperFmt = String(format).toUpperCase();
-                    const isGrantOrReportColumn = upperFmt === 'GRANT' || upperFmt === 'REPORT_COLUMN';
+                    const isGrantOrReportColumn = format === 'GRANT' || format === 'REPORT_COLUMN';
                     if ((isRefField || isGrantOrReportColumn) && value && typeof value === 'string') {
                         const colonIndex = value.indexOf(':');
                         if (colonIndex > 0) {
@@ -18332,6 +18362,18 @@ class IntegramTable{
                             // Only mask with asterisks if there's a value
                             value = (cellValue !== null && cellValue !== undefined && cellValue !== '') ? '******' : '';
                             break;
+                        case 'DATE': {
+                            // Export DATE as DD.MM.YYYY, not the raw Unix timestamp (issue #3763)
+                            const dateObj = this.parseDDMMYYYY(String(value));
+                            value = (dateObj && !isNaN(dateObj.getTime())) ? this.formatDateDisplay(dateObj) : String(value);
+                            break;
+                        }
+                        case 'DATETIME': {
+                            // Export DATETIME as DD.MM.YYYY HH:MM:SS, not the raw Unix timestamp (issue #3763)
+                            const dtObj = this.parseDDMMYYYYHHMMSS(String(value));
+                            value = (dtObj && !isNaN(dtObj.getTime())) ? this.formatDateTimeDisplay(dtObj) : String(value);
+                            break;
+                        }
                         case 'HTML':
                         case 'BUTTON':
                             // Strip HTML tags for export

--- a/js/integram-table/01-core.js
+++ b/js/integram-table/01-core.js
@@ -194,6 +194,22 @@
         }
 
         /**
+         * Resolve a column's symbolic display format the same way renderCell does
+         * (issue #3763): an already-symbolic format wins, otherwise the numeric type
+         * is mapped. Keeps export output identical to what the cell shows.
+         * @param {Object} column - Column definition
+         * @returns {string} Symbolic format name (e.g. 'DATE', 'DATETIME', 'SHORT')
+         */
+        resolveColumnFormat(column) {
+            const validFormats = ['SHORT', 'CHARS', 'DATE', 'NUMBER', 'SIGNED', 'BOOLEAN',
+                                  'MEMO', 'DATETIME', 'FILE', 'HTML', 'BUTTON', 'PWD',
+                                  'GRANT', 'REPORT_COLUMN', 'PATH'];
+            const upperFormat = column && column.format ? String(column.format).toUpperCase() : '';
+            if (validFormats.includes(upperFormat)) return upperFormat;
+            return column && column.type ? this.normalizeFormat(column.type) : 'SHORT';
+        }
+
+        /**
          * Check if the table has WRITE access (issue #1508)
          * Returns true when tableGranted is null (not set) or equals "WRITE"
          * Returns false for any other granted value (e.g. "READ")

--- a/js/integram-table/23-bulk-export.js
+++ b/js/integram-table/23-bulk-export.js
@@ -722,13 +722,14 @@
                 const exportRow = [];
                 columns.forEach(col => {
                     const cellValue = row[this.columns.indexOf(col)];
-                    const format = col.format || 'SHORT';
+                    // Resolve the symbolic format exactly as renderCell does so the export
+                    // matches what is shown on screen (issue #3763).
+                    const format = this.resolveColumnFormat(col);
                     let value = cellValue || '';
 
                     // Issue #378, #925: For reference fields and GRANT/REPORT_COLUMN, remove "id:" prefix from "id:Value" format
                     const isRefField = col.ref_id != null || (col.ref && col.ref !== 0);
-                    const upperFormat = String(format).toUpperCase();
-                    const isGrantOrReportColumn = upperFormat === 'GRANT' || upperFormat === 'REPORT_COLUMN';
+                    const isGrantOrReportColumn = format === 'GRANT' || format === 'REPORT_COLUMN';
                     if ((isRefField || isGrantOrReportColumn) && value && typeof value === 'string') {
                         const colonIndex = value.indexOf(':');
                         if (colonIndex > 0) {
@@ -745,6 +746,18 @@
                             // Only mask with asterisks if there's a value
                             value = (cellValue !== null && cellValue !== undefined && cellValue !== '') ? '******' : '';
                             break;
+                        case 'DATE': {
+                            // Export DATE as DD.MM.YYYY, not the raw Unix timestamp (issue #3763)
+                            const dateObj = this.parseDDMMYYYY(String(value));
+                            value = (dateObj && !isNaN(dateObj.getTime())) ? this.formatDateDisplay(dateObj) : String(value);
+                            break;
+                        }
+                        case 'DATETIME': {
+                            // Export DATETIME as DD.MM.YYYY HH:MM:SS, not the raw Unix timestamp (issue #3763)
+                            const dtObj = this.parseDDMMYYYYHHMMSS(String(value));
+                            value = (dtObj && !isNaN(dtObj.getTime())) ? this.formatDateTimeDisplay(dtObj) : String(value);
+                            break;
+                        }
                         case 'HTML':
                         case 'BUTTON':
                             // Strip HTML tags for export
@@ -772,13 +785,14 @@
                 const exportRow = [];
                 columns.forEach(col => {
                     const cellValue = row[this.columns.indexOf(col)];
-                    const format = col.format || 'SHORT';
+                    // Resolve the symbolic format exactly as renderCell does so the export
+                    // matches what is shown on screen (issue #3763).
+                    const format = this.resolveColumnFormat(col);
                     let value = cellValue || '';
 
                     // Issue #378, #925: For reference fields and GRANT/REPORT_COLUMN, remove "id:" prefix from "id:Value" format
                     const isRefField = col.ref_id != null || (col.ref && col.ref !== 0);
-                    const upperFmt = String(format).toUpperCase();
-                    const isGrantOrReportColumn = upperFmt === 'GRANT' || upperFmt === 'REPORT_COLUMN';
+                    const isGrantOrReportColumn = format === 'GRANT' || format === 'REPORT_COLUMN';
                     if ((isRefField || isGrantOrReportColumn) && value && typeof value === 'string') {
                         const colonIndex = value.indexOf(':');
                         if (colonIndex > 0) {
@@ -795,6 +809,18 @@
                             // Only mask with asterisks if there's a value
                             value = (cellValue !== null && cellValue !== undefined && cellValue !== '') ? '******' : '';
                             break;
+                        case 'DATE': {
+                            // Export DATE as DD.MM.YYYY, not the raw Unix timestamp (issue #3763)
+                            const dateObj = this.parseDDMMYYYY(String(value));
+                            value = (dateObj && !isNaN(dateObj.getTime())) ? this.formatDateDisplay(dateObj) : String(value);
+                            break;
+                        }
+                        case 'DATETIME': {
+                            // Export DATETIME as DD.MM.YYYY HH:MM:SS, not the raw Unix timestamp (issue #3763)
+                            const dtObj = this.parseDDMMYYYYHHMMSS(String(value));
+                            value = (dtObj && !isNaN(dtObj.getTime())) ? this.formatDateTimeDisplay(dtObj) : String(value);
+                            break;
+                        }
                         case 'HTML':
                         case 'BUTTON':
                             // Strip HTML tags for export


### PR DESCRIPTION
Closes #3763

## Проблема

При экспорте таблицы (`.integram-table-export-container` → CSV / XLSX / XLS / копирование в буфер) колонки **DATE** и **DATETIME** выгружались сырым unix-штампом, а не датой/временем.

Из приложенного к issue файла `Отпуск_2026-06-27.xlsx`:

| Отпуск | Окончание | Примечания |
|---|---|---|
| `1783314000` | `1783889940` | Тех. обслуживание |

## Причина

`prepareExportDataFromRows` (общий путь для CSV, Excel и копирования в буфер) обрабатывал особые форматы `BOOLEAN` / `PWD` / `HTML` / `BUTTON`, но **не** `DATE` / `DATETIME` — они проваливались в `default → String(value)` и выгружались штампом. В ячейке таблицы (`renderCell`) дата при этом отображается корректно.

## Фикс

Экспорт форматирует дату/время точно так же, как ячейка на экране:

- **DATE** → `DD.MM.YYYY` (`parseDDMMYYYY` → `formatDateDisplay`)
- **DATETIME** → `DD.MM.YYYY HH:MM:SS` (`parseDDMMYYYYHHMMSS` → `formatDateTimeDisplay`)

Те же функции используются в `renderCell`, поэтому экспорт совпадает с отображением. Парс-сбой или пустое значение → значение остаётся как есть (пустое остаётся пустым).

После фикса (TZ Europe/Moscow): `1783314000 → 06.07.2026`, `1783889940 → 12.07.2026 23:59:00`.

### Изменения
- **`js/integram-table/01-core.js`** — помощник `resolveColumnFormat(column)`: разрешает символьный формат колонки так же, как `renderCell` (символьный формат → как есть, иначе `normalizeFormat(type)`). Экспорт использует его вместо сырого `col.format`, поэтому и остальные форматы совпадают с отображением.
- **`js/integram-table/23-bulk-export.js`** — ветки `DATE`/`DATETIME` в `prepareExportDataFromRows` (живой путь) и `prepareExportData`.
- **`js/integram-table.js`** — пересобран через `build.sh` (правятся исходные модули, не сборка).

## Тесты

`experiments/test-issue-3763-export-datetime.js` — штампы из реального экспорта → дата/дата-время (совпадает с отображением ячейки); пустые остаются пустыми; уже отформатированные строки не трогаются; `BOOLEAN`/`REF` без регрессий; `resolveColumnFormat` для символьного формата и числового типа. Проходит в TZ `Europe/Moscow` и `UTC`. `test-date-filter.js`, `test-filter-fix.js` — без регрессий.

🤖 Generated with [Claude Code](https://claude.com/claude-code)