### PR TITLE
fix(table): «по ID» на DATE/DATETIME — текстовое поле, а не дата-пикер (#3777)

### DIFF
--- a/experiments/test-issue-3777-id-filter-input.js
+++ b/experiments/test-issue-3777-id-filter-input.js
@@ -1,0 +1,60 @@
+// Тест issue #3777 (js/integram-table.js):
+// На DATE/DATETIME-колонке оператор «по ID» (@ / !@) должен показывать ТЕКСТОВОЕ
+// поле (ID или список), а не дата-пикер. Баг: при выборе @ без ранее заданного
+// фильтра ячейка оставалась дата-пикером, т.к. re-render сравнивал с oldType=undefined,
+// а отображалась ДЕФОЛТНАЯ форма (DATETIME по умолчанию '=' → дата-пикер).
+// filterInputKind — чистый метод; инстанс через Object.create без конструктора.
+const path = require('path');
+const assert = require('assert');
+
+const IntegramTable = require(path.join(__dirname, '..', 'js', 'integram-table.js'));
+assert(typeof IntegramTable === 'function', 'IntegramTable exported');
+
+const t = Object.create(IntegramTable.prototype);
+
+// --- filterInputKind: единый источник истины для формы поля ---
+assert.strictEqual(t.filterInputKind('DATETIME', '='), 'date-picker', 'DATETIME = → дата-пикер');
+assert.strictEqual(t.filterInputKind('DATETIME', '@'), 'text', 'DATETIME @ → текст (ID)');
+assert.strictEqual(t.filterInputKind('DATETIME', '!@'), 'text', 'DATETIME !@ → текст (ID)');
+assert.strictEqual(t.filterInputKind('DATETIME', '...'), 'range', 'DATETIME ... → диапазон');
+assert.strictEqual(t.filterInputKind('DATE', '>'), 'date-picker', 'DATE > → дата-пикер');
+assert.strictEqual(t.filterInputKind('DATE', '@'), 'text', 'DATE @ → текст (ID)');
+assert.strictEqual(t.filterInputKind('NUMBER', '...'), 'range', 'NUMBER ... → диапазон');
+assert.strictEqual(t.filterInputKind('NUMBER', '='), 'text', 'NUMBER = → текст');
+assert.strictEqual(t.filterInputKind('SHORT', '@'), 'text', 'SHORT @ → текст');
+
+// --- решение о ре-рендере (повторяет логику showFilterTypeMenu) ---
+// re-render нужен, когда форма поля меняется; old|| дефолт учитывает «фильтр ещё не задан».
+function shouldReRender(format, oldType, symbol) {
+    const effectiveOldType = oldType || t.getDefaultFilterType(format);
+    return format !== 'REF' &&
+        t.filterInputKind(format, effectiveOldType) !== t.filterInputKind(format, symbol);
+}
+
+// БАГ #3777: на DATETIME без ранее заданного фильтра (oldType undefined) выбор @ → ре-рендер в текст
+assert.strictEqual(shouldReRender('DATETIME', undefined, '@'), true,
+    'DATETIME: дефолтный дата-пикер → @ должен ре-рендериться в текст (issue #3777)');
+assert.strictEqual(shouldReRender('DATETIME', undefined, '!@'), true,
+    'DATETIME: дефолтный дата-пикер → !@ должен ре-рендериться в текст');
+assert.strictEqual(shouldReRender('DATETIME', undefined, '...'), true,
+    'DATETIME: дефолтный дата-пикер → ... должен ре-рендериться в диапазон');
+
+// Переключение @ ↔ !@ (оба текст) — без ре-рендера (нет мигания, ввод не сбрасывается)
+assert.strictEqual(shouldReRender('DATETIME', '@', '!@'), false, 'DATETIME: @ ↔ !@ без ре-рендера');
+
+// Дефолтный '=' → явный '=' — без ре-рендера (форма та же)
+assert.strictEqual(shouldReRender('DATETIME', undefined, '='), false, 'DATETIME: дефолт = → = без ре-рендера');
+
+// Дата-пикер → @ (с заданным oldType) — ре-рендер
+assert.strictEqual(shouldReRender('DATETIME', '=', '@'), true, 'DATETIME: = → @ ре-рендер');
+// @ → дата-пикер обратно — ре-рендер
+assert.strictEqual(shouldReRender('DATETIME', '@', '='), true, 'DATETIME: @ → = ре-рендер');
+// диапазон → @ — ре-рендер
+assert.strictEqual(shouldReRender('DATETIME', '...', '@'), true, 'DATETIME: ... → @ ре-рендер');
+
+// NUMBER: дефолт '=' (текст) → '...' (диапазон) — ре-рендер
+assert.strictEqual(shouldReRender('NUMBER', undefined, '...'), true, 'NUMBER: дефолт = → ... ре-рендер');
+// SHORT: дефолт '^' (текст) → '@' (текст) — без ре-рендера
+assert.strictEqual(shouldReRender('SHORT', undefined, '@'), false, 'SHORT: дефолт ^ → @ без ре-рендера');
+
+console.log('OK: test-issue-3777-id-filter-input');

--- a/js/integram-table.js
+++ b/js/integram-table.js
@@ -1585,6 +1585,22 @@ class IntegramTable{
             return baseTypes;
         }
 
+        /**
+         * The kind of input renderFilterCell draws for a (format, type) pair.
+         * Single source of truth shared by renderFilterCell and the re-render-on-
+         * type-switch decision so the two cannot drift (issues #1008, #3542, #3777).
+         * REF columns are handled separately (text input vs dropdown).
+         * @returns {'date-picker'|'range'|'text'}
+         */
+        filterInputKind(format, type) {
+            const datePickerTypes = ['=', '≥', '≤', '>', '<'];
+            if ((format === 'DATE' || format === 'DATETIME') && datePickerTypes.includes(type)) {
+                return 'date-picker';
+            }
+            if (type === '...') return 'range';
+            return 'text';
+        }
+
         applyFilter(params, column, filter) {
             const type = filter.type || '^';
             const value = filter.value;
@@ -2058,10 +2074,9 @@ class IntegramTable{
             }
 
             // For DATE/DATETIME formats with value-based filter types, render a date/datetime picker (issue #1008)
-            // Filter types that need a date picker: =, ≥, ≤, >, < (not %, !%, or ...)
+            // Filter types that need a date picker: =, ≥, ≤, >, < (not %, !%, or ...) — see filterInputKind.
             const dateFormats = ['DATE', 'DATETIME'];
-            const datePickerFilterTypes = new Set(['=', '≥', '≤', '>', '<']);
-            if (dateFormats.includes(format) && datePickerFilterTypes.has(currentFilter.type)) {
+            if (this.filterInputKind(format, currentFilter.type) === 'date-picker') {
                 const isDateTime = format === 'DATETIME';
                 const inputType = isDateTime ? 'datetime-local' : 'date';
                 // Convert stored display value (DD.MM.YYYY or DD.MM.YYYY HH:MM:SS) to HTML5 format
@@ -2084,7 +2099,7 @@ class IntegramTable{
 
             // Range filter ('...'): two separate from/to fields instead of one comma-separated
             // input — the comma syntax was unclear (issue #3542). Stored value stays "from,to".
-            if (currentFilter.type === '...') {
+            if (this.filterInputKind(format, currentFilter.type) === 'range') {
                 const isDate = dateFormats.includes(format);
                 const isDateTime = format === 'DATETIME';
                 let inputType = 'text';
@@ -7561,6 +7576,11 @@ class IntegramTable{
                 opt.addEventListener('click', () => {
                     const symbol = opt.dataset.symbol;
                     const oldType = this.filters[columnId]?.type;
+                    // When no filter is set yet, the cell already shows the DEFAULT input shape
+                    // (DATE/DATETIME default to '=', a date picker). Compare against the effective
+                    // type so switching to a non-picker operator (e.g. '@' by ID, '...') re-renders
+                    // the input instead of leaving a stale date picker (issue #3777).
+                    const effectiveOldType = oldType || this.getDefaultFilterType(format);
                     if (!this.filters[columnId]) {
                         this.filters[columnId] = { type: this.getDefaultFilterType(format), value: '' };
                     }
@@ -7590,22 +7610,12 @@ class IntegramTable{
                         }
                     }
 
-                    // For DATE/DATETIME columns, re-render when switching between date-picker types
-                    // and non-picker types (e.g. switching from '=' to '...' changes input from date to text) (issue #1008)
-                    if (format === 'DATE' || format === 'DATETIME') {
-                        const datePickerTypes = new Set(['=', '≥', '≤', '>', '<']);
-                        const wasDatePicker = datePickerTypes.has(oldType);
-                        const isDatePicker = datePickerTypes.has(symbol);
-                        if (wasDatePicker !== isDatePicker) {
-                            this.filters[columnId].value = '';
-                            this.render();
-                            return;
-                        }
-                    }
-
-                    // Switching to/from range ('...') changes the cell from one input to two
-                    // from/to fields (issue #3542) — clear the value and re-render to swap inputs.
-                    if ((symbol === '...') !== (oldType === '...')) {
+                    // Re-render when the rendered input shape changes: date picker ↔ text ↔
+                    // range two-field. Comparing the effective old type means a column still
+                    // showing its DEFAULT date picker (no filter set yet) correctly swaps to a
+                    // text field when an ID operator '@'/'!@' is picked (issues #1008, #3542, #3777).
+                    if (format !== 'REF' &&
+                        this.filterInputKind(format, effectiveOldType) !== this.filterInputKind(format, symbol)) {
                         this.filters[columnId].value = '';
                         this.render();
                         return;

--- a/js/integram-table/03-filters-core.js
+++ b/js/integram-table/03-filters-core.js
@@ -31,6 +31,22 @@
             return baseTypes;
         }
 
+        /**
+         * The kind of input renderFilterCell draws for a (format, type) pair.
+         * Single source of truth shared by renderFilterCell and the re-render-on-
+         * type-switch decision so the two cannot drift (issues #1008, #3542, #3777).
+         * REF columns are handled separately (text input vs dropdown).
+         * @returns {'date-picker'|'range'|'text'}
+         */
+        filterInputKind(format, type) {
+            const datePickerTypes = ['=', '≥', '≤', '>', '<'];
+            if ((format === 'DATE' || format === 'DATETIME') && datePickerTypes.includes(type)) {
+                return 'date-picker';
+            }
+            if (type === '...') return 'range';
+            return 'text';
+        }
+
         applyFilter(params, column, filter) {
             const type = filter.type || '^';
             const value = filter.value;

--- a/js/integram-table/04-render-table.js
+++ b/js/integram-table/04-render-table.js
@@ -362,10 +362,9 @@
             }
 
             // For DATE/DATETIME formats with value-based filter types, render a date/datetime picker (issue #1008)
-            // Filter types that need a date picker: =, ≥, ≤, >, < (not %, !%, or ...)
+            // Filter types that need a date picker: =, ≥, ≤, >, < (not %, !%, or ...) — see filterInputKind.
             const dateFormats = ['DATE', 'DATETIME'];
-            const datePickerFilterTypes = new Set(['=', '≥', '≤', '>', '<']);
-            if (dateFormats.includes(format) && datePickerFilterTypes.has(currentFilter.type)) {
+            if (this.filterInputKind(format, currentFilter.type) === 'date-picker') {
                 const isDateTime = format === 'DATETIME';
                 const inputType = isDateTime ? 'datetime-local' : 'date';
                 // Convert stored display value (DD.MM.YYYY or DD.MM.YYYY HH:MM:SS) to HTML5 format
@@ -388,7 +387,7 @@
 
             // Range filter ('...'): two separate from/to fields instead of one comma-separated
             // input — the comma syntax was unclear (issue #3542). Stored value stays "from,to".
-            if (currentFilter.type === '...') {
+            if (this.filterInputKind(format, currentFilter.type) === 'range') {
                 const isDate = dateFormats.includes(format);
                 const isDateTime = format === 'DATETIME';
                 let inputType = 'text';

--- a/js/integram-table/10-filter-ui.js
+++ b/js/integram-table/10-filter-ui.js
@@ -25,6 +25,11 @@
                 opt.addEventListener('click', () => {
                     const symbol = opt.dataset.symbol;
                     const oldType = this.filters[columnId]?.type;
+                    // When no filter is set yet, the cell already shows the DEFAULT input shape
+                    // (DATE/DATETIME default to '=', a date picker). Compare against the effective
+                    // type so switching to a non-picker operator (e.g. '@' by ID, '...') re-renders
+                    // the input instead of leaving a stale date picker (issue #3777).
+                    const effectiveOldType = oldType || this.getDefaultFilterType(format);
                     if (!this.filters[columnId]) {
                         this.filters[columnId] = { type: this.getDefaultFilterType(format), value: '' };
                     }
@@ -54,22 +59,12 @@
                         }
                     }
 
-                    // For DATE/DATETIME columns, re-render when switching between date-picker types
-                    // and non-picker types (e.g. switching from '=' to '...' changes input from date to text) (issue #1008)
-                    if (format === 'DATE' || format === 'DATETIME') {
-                        const datePickerTypes = new Set(['=', '≥', '≤', '>', '<']);
-                        const wasDatePicker = datePickerTypes.has(oldType);
-                        const isDatePicker = datePickerTypes.has(symbol);
-                        if (wasDatePicker !== isDatePicker) {
-                            this.filters[columnId].value = '';
-                            this.render();
-                            return;
-                        }
-                    }
-
-                    // Switching to/from range ('...') changes the cell from one input to two
-                    // from/to fields (issue #3542) — clear the value and re-render to swap inputs.
-                    if ((symbol === '...') !== (oldType === '...')) {
+                    // Re-render when the rendered input shape changes: date picker ↔ text ↔
+                    // range two-field. Comparing the effective old type means a column still
+                    // showing its DEFAULT date picker (no filter set yet) correctly swaps to a
+                    // text field when an ID operator '@'/'!@' is picked (issues #1008, #3542, #3777).
+                    if (format !== 'REF' &&
+                        this.filterInputKind(format, effectiveOldType) !== this.filterInputKind(format, symbol)) {
                         this.filters[columnId].value = '';
                         this.render();
                         return;


### PR DESCRIPTION
Closes #3777
Follow-up к #3771 / #3772 (поиск по ID для первой колонки).

## Проблема

На первой колонке типа **DATETIME** (или DATE) пользователь выбирает оператор «@ по ID: включая» / «!@ по ID: исключая», но ячейка фильтра остаётся **дата-пикером** (`дд.мм.гггг --:--`) — ввести ID или список ID нельзя.

<img width="600" alt="до" src="https://github.com/user-attachments/assets/15aeda30-0cc9-4ec8-80d1-99159ee74577" />

## Причина

Решение «перерисовать ли поле при смене оператора» сравнивало с `oldType = this.filters[col]?.type`, который равен `undefined`, пока фильтр ещё не задан. Но ячейка уже показывает **дефолтную** форму: у DATE/DATETIME оператор по умолчанию — `=`, то есть дата-пикер. Поэтому переход `=`(дефолт)→`@` не перерисовывал поле: `wasDatePicker = has(undefined) = false`, `isDatePicker = has('@') = false` → «не изменилось» → дата-пикер оставался на месте, хотя оператор стал `@`.

## Фикс (и защита от повторения)

Это уже второй баг от того, что правила «когда перерисовать» разъезжались с тем, что реально рисует `renderFilterCell`. Ввёл единый источник истины:

- **`03-filters-core.js`** — `filterInputKind(format, type)` → `'date-picker' | 'range' | 'text'`. Один метод, общий для `renderFilterCell` и решения о ре-рендере.
- **`10-filter-ui.js`** — сравниваем `effectiveOldType = oldType || getDefaultFilterType(format)`, поэтому дефолтный дата-пикер корректно меняется на текстовое поле при `@`/`!@` (и на два поля при `...`). Два прежних блока (#1008 для дат, #3542 для диапазона) свёрнуты в одну проверку через `filterInputKind`. REF — как прежде (свой блок text/dropdown).
- **`04-render-table.js`** — `renderFilterCell` использует `filterInputKind` для веток дата-пикера и диапазона (рендер и ре-рендер больше не могут разойтись).
- **`js/integram-table.js`** — пересобран через `build.sh` (правятся исходные модули).

Текстовое поле для `@`/`!@` уже умеет ввод списка: ввод санируется до цифр и запятых, `applyFilter` собирает `@IN(id1,id2)` для нескольких ID — то есть «ID или даже список» работает.

## Тесты

`experiments/test-issue-3777-id-filter-input.js`: `filterInputKind` по форматам/операторам; решение о ре-рендере — DATETIME дефолт-пикер → `@`/`!@`/`...` перерисовывает в текст/диапазон (#3777), `@`↔`!@` без ре-рендера (нет мигания), дефолт `=` → `=` без ре-рендера. Без регрессий: `test-issue-3542`, `test-issue-3763`, `test-date-filter`, `test-filter-fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)