### PR TITLE
feat(atex): срок изготовления позиции в .atex-pp-strip-row + расцветка по DAYS_FORECAST (#3769)

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -377,6 +377,23 @@
     color: var(--pp-info-text);
     font-variant-numeric: tabular-nums;
 }
+/* #3769: расцветка строки по «Сроку изготовления» позиции относительно «Даты план».
+   Красный — срок раньше планирования (не успеваем); жёлтый — срок дальше план+DAYS_FORECAST
+   (делаем сильно заранее); в окне — без изменения (цвет выше). */
+.atex-pp-cut-material .atex-pp-strip-row.is-overdue {
+    color: #b91c1c;
+    font-weight: 600;
+    background: rgba(185, 28, 28, .10);
+    border-radius: 4px;
+    padding: 1px 6px;
+}
+.atex-pp-cut-material .atex-pp-strip-row.is-far {
+    color: #a16207;
+    font-weight: 600;
+    background: rgba(202, 138, 4, .12);
+    border-radius: 4px;
+    padding: 1px 6px;
+}
 /* #3354 п.1: строка времени резки теперь встроена в первую строку карточки
    (между номером и сырьём), а не отдельным рядом ниже — поэтому без margin-top. */
 .atex-pp-cut-time {

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -1308,6 +1308,56 @@
         return isNaN(t) ? Infinity : t;
     }
 
+    // #3769: YYYYMMDD-ключ (как у planDateDayKey/batchDateKey для дат) → Date (полночь
+    // местного времени) для арифметики по календарным дням. Невалидный/Infinity → null.
+    function dayKeyToDate(key) {
+        var n = Number(key);
+        if (!isFinite(n) || n < 10000101 || n > 99991231) return null;
+        var y = Math.floor(n / 10000), m = Math.floor(n / 100) % 100, d = n % 100;
+        if (m < 1 || m > 12 || d < 1 || d > 31) return null;
+        var dt = new Date(y, m - 1, d);
+        return isNaN(dt.getTime()) ? null : dt;
+    }
+
+    // #3769: YYYYMMDD-ключ → «DD.MM.YYYY» для подписи срока. Невалидный → ''.
+    function formatDayKey(key) {
+        var dt = dayKeyToDate(key);
+        if (!dt) return '';
+        var p2 = function(x) { return (x < 10 ? '0' : '') + x; };
+        return p2(dt.getDate()) + '.' + p2(dt.getMonth() + 1) + '.' + dt.getFullYear();
+    }
+
+    // #3769: класс расцветки строки .atex-pp-strip-row по «Сроку изготовления» позиции
+    // (dueKey, YYYYMMDD) относительно «Даты план» задания (planKey, YYYYMMDD):
+    //   срок РАНЬШЕ планы            → 'is-overdue' (красный — не успеваем);
+    //   срок дальше планы+forecast   → 'is-far'     (жёлтый — делаем сильно заранее);
+    //   срок в окне [план; план+forecast] включительно → '' (без изменения цвета).
+    // forecastDays === null/отрицательный → жёлтый отключён (нет настройки), красный работает.
+    function dueColorClass(dueKey, planKey, forecastDays) {
+        var due = dayKeyToDate(dueKey), plan = dayKeyToDate(planKey);
+        if (!due || !plan) return '';
+        var diffDays = Math.round((due.getTime() - plan.getTime()) / 86400000);
+        if (diffDays < 0) return 'is-overdue';
+        if (forecastDays != null && forecastDays >= 0 && diffDays > forecastDays) return 'is-far';
+        return '';
+    }
+
+    // #3769: отсортированные уникальные ключи «Срока изготовления» позиций, которые
+    // обеспечивает резка (supplies cutId→positionId → genPositions[pos].dueKey).
+    // Позиции без срока или выпавшие из активного positions_list — пропускаются.
+    function cutDueKeys(cut, supplies, genPositions) {
+        var posMap = positionMap(genPositions);
+        var seen = {}, keys = [];
+        (supplies || []).forEach(function(s) {
+            if (!cut || !s || String(s.cutId) !== String(cut.id)) return;
+            var p = s.positionId != null ? posMap[String(s.positionId)] : null;
+            var k = p && p.dueKey;
+            if (k == null || !isFinite(k) || k === Infinity) return;
+            if (!seen[k]) { seen[k] = true; keys.push(k); }
+        });
+        return keys.sort(function(a, b) { return a - b; });
+    }
+
     // Отображение «Номера» резки: «номер» = плановая дата начала (cut_plan_date, #3242),
     // приходит unix-штампом (секунды) → форматируем как дату-время. Короткие record id
     // и не-штампы не форматируем как 1970-дату.
@@ -4086,6 +4136,10 @@
         cutFulfillmentIds: cutFulfillmentIds,             // #3691
         extractApiError: extractApiError,
         planDateDayKey: planDateDayKey,
+        dayKeyToDate: dayKeyToDate,             // #3769
+        formatDayKey: formatDayKey,             // #3769
+        dueColorClass: dueColorClass,           // #3769
+        cutDueKeys: cutDueKeys,                 // #3769
         dayOffsetFromBase: dayOffsetFromBase,   // #3652
         formatPlanDayHeading: formatPlanDayHeading,
         buildFields: buildFields,
@@ -4418,7 +4472,8 @@
                 // #3342: \u043F\u043E\u043C\u0438\u043C\u043E \u0440\u0430\u0431\u043E\u0447\u0435\u0433\u043E \u043E\u043A\u043D\u0430 \u0447\u0438\u0442\u0430\u0435\u043C \u043D\u0430\u0441\u0442\u0440\u043E\u0439\u043A\u0438 \u043E\u0431\u0435\u0434\u0430 LUNCH_START/LUNCH_DURATION.
                 if (key !== 'DAY_START_HOUR' && key !== 'DAY_END_HOUR' &&
                     key !== 'LUNCH_START' && key !== 'LUNCH_DURATION' &&
-                    key !== 'TOTAL_INTERVALS') return;   // #3599: буфер перед уборкой (мин)
+                    key !== 'TOTAL_INTERVALS' &&        // #3599: буфер перед уборкой (мин)
+                    key !== 'DAYS_FORECAST') return;    // #3769: окно срока изготовления (дни) для расцветки строк
                 var type = String(r[1] == null ? '' : r[1]).trim().toUpperCase();
                 var val = String(r[2] == null ? '' : r[2]).trim();
                 if (val === '') return;
@@ -4432,6 +4487,14 @@
             });
             self.daySettings = values;
         });
+    };
+
+    // #3769: DAYS_FORECAST из «Настройки» — окно срока изготовления (дни) для расцветки
+    // строк .atex-pp-strip-row. Нет/некорректно → null (жёлтый отключён, красный работает).
+    AtexProductionPlanning.prototype.daysForecast = function() {
+        var v = this.daySettings ? this.daySettings.DAYS_FORECAST : null;
+        var n = Number(v);
+        return (isFinite(n) && n >= 0) ? n : null;
     };
 
     AtexProductionPlanning.prototype.workingWindow = function() {
@@ -8551,14 +8614,25 @@
             if (stripGroups.length) {
                 // #3686: обратный резолв (факт→номинал) сверяет j= с «Номинальной шириной» рулона
                 var jumboWidth = self.nominalWidthByMaterial ? self.nominalWidthByMaterial[String(c.materialId)] : null;
+                // #3769: «Срок изготовления» обеспечиваемых позиций — в скобках в конце строки.
+                // Срок один на задание (позиции резки кластеризованы по сроку), поэтому
+                // показываем общий набор сроков и красим строку по самому раннему (срочному):
+                // раньше «Даты план» → красный, дальше план+DAYS_FORECAST → жёлтый, в окне → как есть.
+                var dueKeys = cutDueKeys(c, self.supplies, self.genPositions);
+                var dueClass = dueKeys.length ? dueColorClass(dueKeys[0], planDateDayKey(c.planDate), self.daysForecast()) : '';
+                var dueSuffix = '';
+                if (dueKeys.length) {
+                    var dueLabels = dueKeys.map(formatDayKey).filter(function(s) { return s; });
+                    if (dueLabels.length) dueSuffix = ' (' + (dueLabels.length > 1 ? 'сроки: ' : 'срок: ') + dueLabels.join(', ') + ')';
+                }
                 var matRows = stripGroups.map(function(g) {
                     // #3408: полосы хранят ФАКТИЧЕСКУЮ ширину (#3372: p.width = факт.),
                     // поэтому g.width — это факт.ширина. В сводку выводим сначала номинал
                     // (обратный резолв по справочнику), а после тире — реальные мм.
                     var ctx = { jumbo: jumboWidth, inches: null };
                     var nominal = resolveNominalWidth(g.width, ctx, self.actualWidthIndex);
-                    return el('div', { class: 'atex-pp-strip-row',
-                        text: formatStripSummaryLine(c, { width: nominal, count: g.count }, g.width, runLengthForCut) });
+                    return el('div', { class: 'atex-pp-strip-row' + (dueClass ? ' ' + dueClass : ''),
+                        text: formatStripSummaryLine(c, { width: nominal, count: g.count }, g.width, runLengthForCut) + dueSuffix });
                 });
                 cardPanel.appendChild(el('div', { class: 'atex-pp-cut-material' }, matRows));
             }

--- a/experiments/atex-production-planning-3769.test.js
+++ b/experiments/atex-production-planning-3769.test.js
@@ -1,0 +1,77 @@
+// Тест issue #3769 (download/atex/js/production-planning.js):
+// В конце .atex-pp-strip-row — «Срок изготовления» позиций задания; строка красится по
+// сроку относительно «Даты план»: раньше → красный (is-overdue), дальше план+DAYS_FORECAST
+// → жёлтый (is-far), в окне → без класса.
+var assert = require('assert');
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+function eq(a, b, msg) { assert.strictEqual(a, b, msg + ' (получено: ' + JSON.stringify(a) + ')'); }
+function deq(a, b, msg) { assert.deepStrictEqual(a, b, msg + ' (получено: ' + JSON.stringify(a) + ')'); }
+
+// --- dayKeyToDate: YYYYMMDD → Date / невалидное → null ---
+var d = planning.dayKeyToDate(20260624);
+assert(d instanceof Date && d.getFullYear() === 2026 && d.getMonth() === 5 && d.getDate() === 24, 'dayKeyToDate(20260624) → 24.06.2026');
+eq(planning.dayKeyToDate(Infinity), null, 'dayKeyToDate(Infinity) → null');
+eq(planning.dayKeyToDate(0), null, 'dayKeyToDate(0) → null');
+eq(planning.dayKeyToDate(20261324), null, 'dayKeyToDate(13-й месяц) → null');
+
+// --- formatDayKey: YYYYMMDD → DD.MM.YYYY ---
+eq(planning.formatDayKey(20260624), '24.06.2026', 'formatDayKey 20260624');
+eq(planning.formatDayKey(20260101), '01.01.2026', 'formatDayKey с ведущими нулями');
+eq(planning.formatDayKey(Infinity), '', 'formatDayKey(Infinity) → пусто');
+
+// round-trip: batchDateKey("DD.MM.YYYY") → formatDayKey == исходная строка
+eq(planning.formatDayKey(planning.batchDateKey('24.06.2026')), '24.06.2026', 'round-trip batchDateKey→formatDayKey');
+
+// --- dueColorClass: правила расцветки ---
+var plan = 20260620;             // «Дата план» = 20.06.2026
+var FC = 10;                     // DAYS_FORECAST = 10
+eq(planning.dueColorClass(20260619, plan, FC), 'is-overdue', 'срок 19.06 < план 20.06 → красный');
+eq(planning.dueColorClass(20260601, plan, FC), 'is-overdue', 'срок сильно раньше → красный');
+eq(planning.dueColorClass(20260620, plan, FC), '', 'срок = план (день 0) → в окне, без класса');
+eq(planning.dueColorClass(20260625, plan, FC), '', 'срок +5 дней (≤10) → в окне');
+eq(planning.dueColorClass(20260630, plan, FC), '', 'срок +10 дней включительно → в окне');
+eq(planning.dueColorClass(20260701, plan, FC), 'is-far', 'срок +11 дней (через границу месяца) → жёлтый');
+eq(planning.dueColorClass(20260705, plan, FC), 'is-far', 'срок далеко в будущем → жёлтый');
+
+// forecast выключен (null) → жёлтого нет, красный остаётся
+eq(planning.dueColorClass(20260701, plan, null), '', 'forecast=null → нет жёлтого');
+eq(planning.dueColorClass(20260619, plan, null), 'is-overdue', 'forecast=null → красный работает');
+
+// невалидные ключи → без класса
+eq(planning.dueColorClass(Infinity, plan, FC), '', 'нет срока → без класса');
+eq(planning.dueColorClass(20260620, Infinity, FC), '', 'нет даты план → без класса');
+
+// --- cutDueKeys: уникальные отсортированные сроки позиций задания ---
+var genPositions = [
+    { id: '1', dueKey: planning.batchDateKey('24.06.2026') }, // 20260624
+    { id: '2', dueKey: planning.batchDateKey('20.06.2026') }, // 20260620
+    { id: '3', dueKey: Infinity },                            // без срока
+    { id: '4', dueKey: planning.batchDateKey('24.06.2026') }  // дубль срока
+];
+var supplies = [
+    { cutId: '10', positionId: '1' },
+    { cutId: '10', positionId: '2' },
+    { cutId: '10', positionId: '1' },  // дубль позиции
+    { cutId: '10', positionId: '3' },  // позиция без срока
+    { cutId: '10', positionId: '4' },  // тот же срок, что у поз.1
+    { cutId: '99', positionId: '2' }   // чужое задание — не учитываем
+];
+deq(planning.cutDueKeys({ id: '10' }, supplies, genPositions), [20260620, 20260624],
+    'cutDueKeys: уникальные сроки задания 10, отсортированы, Infinity и чужой cut отброшены');
+deq(planning.cutDueKeys({ id: '77' }, supplies, genPositions), [], 'cutDueKeys: нет обеспечений → []');
+deq(planning.cutDueKeys({ id: '10' }, [], genPositions), [], 'cutDueKeys: нет supplies → []');
+
+// --- интеграция: самый ранний срок задаёт цвет ---
+var keys = planning.cutDueKeys({ id: '10' }, supplies, genPositions); // [20260620, 20260624]
+// план 25.06.2026 → ранний срок 20.06 раньше → красный
+eq(planning.dueColorClass(keys[0], 20260625, FC), 'is-overdue', 'интеграция: ранний срок раньше плана → красный');
+// план 19.06.2026, forecast 10 → ранний срок 20.06 через +1 день → в окне
+eq(planning.dueColorClass(keys[0], 20260619, FC), '', 'интеграция: ранний срок в окне → без класса');
+
+// planDateDayKey (unix-штамп) совместим с dueColorClass
+var planKeyFromTs = planning.planDateDayKey(String(Math.floor(Date.UTC(2026, 5, 20, 9, 0, 0) / 1000)));
+assert(planKeyFromTs === 20260620 || planKeyFromTs === 20260619 || planKeyFromTs === 20260621,
+    'planDateDayKey(unix) даёт YYYYMMDD ~20.06.2026 (зависит от TZ): ' + planKeyFromTs);
+
+console.log('OK: atex-production-planning-3769.test');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 63);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 64);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3769

## Что сделано

В сводке полос карточки задания (`.atex-pp-cut-material .atex-pp-strip-row`, production-planning) в конце строки выводится **«Срок изготовления»** обеспечиваемых позиций, а строка **красится** в зависимости от «Даты план» задания и настройки `DAYS_FORECAST` (таблица «Настройка», table/269):

| Условие | Цвет строки |
|---|---|
| срок **раньше** «Даты план» | 🔴 красный (`is-overdue`) — не успеваем |
| срок в окне `[план; план + DAYS_FORECAST]` включительно | без изменения |
| срок **дальше** `план + DAYS_FORECAST` | 🟡 жёлтый (`is-far`) — делаем сильно заранее |

Подпись: `… = N шт. (срок: ДД.ММ.ГГГГ)` (или `(сроки: Д1, Д2)`, если задание обеспечивает позиции с разными сроками).

## Данные

- **«Срок изготовления»** — реквизит **8627** (DATE) позиции (таблица 1076). В отчёте `positions_list` приходит как `position_due_date` («ДД.ММ.ГГГГ») → `dueKey` (YYYYMMDD) в `genPositions` (через существующий `batchDateKey`).
- Резка связана с позициями через `supplies` (`cutId → positionId`); `position` → `dueKey`.
- `DAYS_FORECAST` лежит в таблице «Настройка» (269, `ATEH = 10`) рядом с `DAY_START_HOUR`/`LUNCH_*`; читается тем же `loadDaySettings`.
- Сроки позиций одного задания кластеризованы (`WINDOW_DAYS`), поэтому показываем общий набор сроков и красим строку по **самому раннему** (срочному) сроку. Позиции вне активного `positions_list` срока не дают — строка остаётся без подписи и цвета (мягкая деградация).

## Решения по реализации (отмечу для ревью)

- Цвет/срок — **на уровне задания**, одинаковые на всех строках полос карточки (сроки задания кластеризованы; надёжнее, чем гадать соответствие ширина-полосы → позиция). Если нужна гранулярность по ширине — скажите, доработаю.
- Цвет по **самому раннему** сроку (красный важнее жёлтого).
- Нет настройки `DAYS_FORECAST` → жёлтый отключается, красный (просрочка) продолжает работать.

## Изменения
- `download/atex/js/production-planning.js` — чистые `dayKeyToDate` / `formatDayKey` / `dueColorClass` / `cutDueKeys` (экспортированы для тестов); `loadDaySettings` читает `DAYS_FORECAST`; метод `daysForecast()`; рендер `.atex-pp-strip-row` дополняет текст и класс цвета.
- `download/atex/css/production-planning.css` — `.atex-pp-strip-row.is-overdue` / `.is-far`.
- `index.php` — `VERSION` 63 → 64 (cache-bust ассетов atex).

## Тесты

`experiments/atex-production-planning-3769.test.js`: правила расцветки (включая границу месяца и включительность `DAYS_FORECAST`), `cutDueKeys` (уникальность/сортировка/чужой cut/без срока), round-trip `batchDateKey ↔ formatDayKey`. Проходит в TZ `Europe/Moscow` и `UTC`. Существующие `atex-production-planning*.test.js` — без новых падений (2 предсуществующих FAIL в `-3619` и базовом тесте идентичны на `origin/main`).

Проверено на боевой базе **ateh**: `DAYS_FORECAST=10` в табл. 269; `position_due_date` (8627) приходит как «ДД.ММ.ГГГГ»; все активные позиции `positions_list` несут срок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)