### PR TITLE
#3778: записывать тайминг резки при фиксации, не вычислять на лету

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -5564,6 +5564,14 @@
         }
         var fieldKey = 't' + fixedReqId;
         var flag = value ? '1' : '0';
+        // #3778: при ФИКСАЦИИ снимаем тайминг (Наладка ножей / Сырье-намотка / Резка и Лидер) в
+        // запись тем же _m_set, что и флаг. Раньше «Зафиксировать» писала ТОЛЬКО флаг, и у
+        // вручную созданных/зафиксированных заданий три поля оставались пустыми — гант пересчитывал
+        // их на лету. Считаем те же значения и в том же порядке, что план на экране
+        // (computeCutSetupUpdates), но пишем только для фиксируемых id. При снятии фиксации не трогаем.
+        var setupRes = value ? self.computeCutSetupUpdates(ids) : { reqs: {}, updates: [] };
+        var setupById = {};
+        setupRes.updates.forEach(function(u) { setupById[String(u.cutId)] = u; });
         this.setBusy(true);
         this.showProgress((value ? 'Фиксация' : 'Снятие фиксации') + ' заданий…', ids.length);
         var done = 0;
@@ -5571,6 +5579,11 @@
         ids.forEach(function(id) {
             chain = chain.then(function() {
                 var fields = {}; fields[fieldKey] = flag;
+                var u = setupById[String(id)];   // #3778: дополняем флаг снимком тайминга
+                if (u) {
+                    var tf = setupTimingFields(setupRes.reqs, u);
+                    Object.keys(tf).forEach(function(k) { fields[k] = tf[k]; });
+                }
                 return self.post('_m_set/' + encodeURIComponent(id) + '?JSON', fields)
                     .then(function() { self.updateProgress(++done); });
             });
@@ -7444,14 +7457,31 @@
     // изменившиеся (diff против отчётных значений), тихо и БЕЗ reload (свой экран РМ считает
     // наладку на лету). Колонок ещё нет в метаданных → no-op. Ошибки глотает: доп-колонки не
     // должны валить сохранение очереди/плана. Вызывается после сохранений порядка/плана.
-    AtexProductionPlanning.prototype.persistCutSetupColumns = function() {
-        var self = this;
+    // #3778: тайминг-поля задания (t96067 «Наладка ножей, мин» / t96069 «Сырье/намотка, мин» /
+    // t96778 «Резка и Лидер») одним набором реквизитов для _m_set. Отсутствующие reqId не пишем.
+    function setupTimingFields(reqs, u) {
+        var fields = {};
+        if (reqs.knifeReq) fields['t' + reqs.knifeReq] = String(u.knife);
+        if (reqs.matReq) fields['t' + reqs.matReq] = String(u.material);
+        if (reqs.cutTimeReq) fields['t' + reqs.cutTimeReq] = String(u.cutTime);   // #3700
+        return fields;
+    }
+
+    // #3778: вычислить тайминг-поля резок В ПОРЯДКЕ ПЛАНА и вернуть { reqs, updates } —
+    // updates только для резок, чьи хранимые значения ПУСТЫ или разошлись с расчётом (пустое
+    // хранимое всегда «изменилось» → force-write, отсюда наполняются «пустые опять» поля).
+    // onlyIds (массив id) ограничивает НАБОР ЗАПИСИ (снимок при «Зафиксировать»), но порядок и
+    // переналадка считаются по ВСЕЙ очереди станка — иначе у не-первой резки терялся предшественник.
+    AtexProductionPlanning.prototype.computeCutSetupUpdates = function(onlyIds) {
         var meta = this.meta.cut;
-        if (!meta) return Promise.resolve();
-        var knifeReq = reqIdByName(meta, CUT_REQ.knifeSetupMin);
-        var matReq = reqIdByName(meta, CUT_REQ.materialWindingMin);
-        var cutTimeReq = reqIdByName(meta, CUT_REQ.cutAndLeader);   // #3700: «Резка и Лидер»
-        if (!knifeReq && !matReq && !cutTimeReq) return Promise.resolve();   // колонок ещё нет в таблице
+        var reqs = { knifeReq: null, matReq: null, cutTimeReq: null };
+        if (!meta) return { reqs: reqs, updates: [] };
+        reqs.knifeReq = reqIdByName(meta, CUT_REQ.knifeSetupMin);
+        reqs.matReq = reqIdByName(meta, CUT_REQ.materialWindingMin);
+        reqs.cutTimeReq = reqIdByName(meta, CUT_REQ.cutAndLeader);   // #3700: «Резка и Лидер»
+        if (!reqs.knifeReq && !reqs.matReq && !reqs.cutTimeReq) return { reqs: reqs, updates: [] };   // колонок ещё нет в таблице
+        var onlySet = null;
+        if (onlyIds) { onlySet = {}; (onlyIds || []).forEach(function(id) { onlySet[String(id)] = true; }); }
         // #3702: считаем теми же временами и в ТОМ ЖЕ порядке, что и план на экране, иначе
         // у задания заполнялась «Сырье/намотка», которой в плане нет.
         //  • this.changeTimes — структурированные веса переналадок (MATERIAL_WINDING / KNIFE /
@@ -7472,6 +7502,7 @@
             var carryPrevCut = (carrySetup && arr.length) ? carryOverPrevCut(carrySetup, arr[0]) : null;
             var cols = setupActivityColumns(arr, times, carryPrevCut);
             arr.forEach(function(c) {
+                if (onlySet && !onlySet[String(c.id)]) return;   // снимок — только выбранные резки
                 var want = cols[String(c.id)] || { knifeMin: 0, materialWindingMin: 0 };
                 // #3715: пишем ЦЕЛЫЕ минуты (Math.round). Дробные значения (#3708) перестали
                 // записываться — поля не приняли нецелое, _m_set падал и обрывал запись всех трёх
@@ -7484,12 +7515,13 @@
                 var wantT = Math.round(stripNum(c.duration) + betweenCuts * cutLeaderRuns(c));
                 // Колонку учитываем в diff только если она есть в метаданных (иначе её не пишем
                 // и не считаем «изменившейся» — иначе были бы лишние записи на каждом сохранении).
+                // Пустое хранимое (cur пуст) → всегда «изменилось» → force-write (#3778).
                 function changed(req, cur, val) {
                     return req && (!(cur != null && cur !== '') || Math.round(stripNum(cur)) !== val);
                 }
-                if (changed(knifeReq, c.storedKnifeSetupMin, wantK)
-                    || changed(matReq, c.storedMaterialWindingMin, wantM)
-                    || changed(cutTimeReq, c.storedCutAndLeaderMin, wantT)) {
+                if (changed(reqs.knifeReq, c.storedKnifeSetupMin, wantK)
+                    || changed(reqs.matReq, c.storedMaterialWindingMin, wantM)
+                    || changed(reqs.cutTimeReq, c.storedCutAndLeaderMin, wantT)) {
                     updates.push({ cutId: c.id, knife: wantK, material: wantM, cutTime: wantT });
                     c.storedKnifeSetupMin = String(wantK);        // локально — чтобы не переписывать дважды
                     c.storedMaterialWindingMin = String(wantM);
@@ -7497,18 +7529,27 @@
                 }
             });
         });
+        return { reqs: reqs, updates: updates };
+    };
+
+    AtexProductionPlanning.prototype.persistCutSetupColumns = function() {
+        var self = this;
+        var res = this.computeCutSetupUpdates(null);
+        var reqs = res.reqs, updates = res.updates;
         if (!updates.length) return Promise.resolve();
         var chain = Promise.resolve();
         updates.forEach(function(u) {
             chain = chain.then(function() {
-                var fields = {};
-                if (knifeReq) fields['t' + knifeReq] = String(u.knife);
-                if (matReq) fields['t' + matReq] = String(u.material);
-                if (cutTimeReq) fields['t' + cutTimeReq] = String(u.cutTime);   // #3700
-                return self.post('_m_set/' + u.cutId + '?JSON', fields);
+                return self.post('_m_set/' + u.cutId + '?JSON', setupTimingFields(reqs, u));
             });
         });
-        return chain.catch(function() { /* тихо: доп-колонки не валят сохранение очереди */ });
+        // #3778: ошибки записи тайминга больше НЕ глотаем молча — раньше тихий catch скрывал,
+        // почему «Наладка ножей»/«Сырье/намотка»/«Резка и Лидер» оставались пустыми. Сохранение
+        // самой очереди (старт/очередность) идёт отдельной цепочкой — его не валим.
+        return chain.catch(function(err) {
+            self.notify('Не удалось сохранить тайминг заданий (Наладка ножей / Сырье-намотка / '
+                + 'Резка и Лидер): ' + (err && err.message || err), 'error');
+        });
     };
 
     // DRY-метод сохранения изменённых «Очередностей» (ручная перестановка ↑↓).

--- a/experiments/atex-production-planning.test.js
+++ b/experiments/atex-production-planning.test.js
@@ -2582,7 +2582,76 @@ function runGenerateCutsReannotatesActualWidthTest() {
     });
 }
 
+// #3778: «Зафиксировать» снимает тайминг (Наладка ножей / Сырье-намотка / Резка и Лидер) в
+// запись тем же _m_set, что и флаг; пустые поля наполняются (force-write), совпадающие — нет.
+function runFixSnapshotTimingTest() {
+    function makeController(stored) {
+        var controller = Object.create(api.Controller.prototype);
+        var posts = [];
+        controller.meta = { cut: { id: '1078', val: 'Производственная резка', reqs: [
+            req('1156', 'Слиттер'),
+            req('16403', 'Кол-во план'),
+            req('24308', 'Очередность'),
+            req('26584', 'Длительность, минут'),
+            req('81530', 'Зафиксировано'),
+            req('96067', 'Наладка ножей, мин'),
+            req('96069', 'Сырье/намотка, мин'),
+            req('96778', 'Резка и Лидер')
+        ] } };
+        controller.cuts = [{
+            id: 'c1', slitter: { id: '20', label: 'Станок 2' }, sequence: 1,
+            plannedRuns: 2, duration: 4, materialId: 'A', winding: 'IN',
+            storedKnifeSetupMin: stored ? stored.knife : '',
+            storedMaterialWindingMin: stored ? stored.material : '',
+            storedCutAndLeaderMin: stored ? stored.cutTime : ''
+        }];
+        controller.changeTimes = opT;
+        controller.prevSetupBySlitter = {};
+        controller.setBusy = function() {};
+        controller.showProgress = function() {};
+        controller.updateProgress = function() {};
+        controller.hideProgress = function() {};
+        controller.render = function() {};
+        controller.reload = function() { return Promise.resolve(); };
+        controller.notify = function() {};
+        controller.post = function(path, fields) { posts.push({ path: path, fields: fields || {} }); return Promise.resolve({}); };
+        controller._posts = posts;
+        return controller;
+    }
+    function setFor(controller) {
+        return controller._posts.filter(function(p) { return p.path.indexOf('_m_set/c1') === 0; })[0];
+    }
+
+    // 1) Пустые поля + фиксация → _m_set несёт флаг И три тайминг-поля.
+    var c1 = makeController(null);
+    return c1.setCutsFixed(['c1'], true).then(function() {
+        var set = setFor(c1);
+        assertEqual(!!set, true, 'fix #3778: записан _m_set для зафиксированной резки');
+        assertEqual(set.fields.t81530, '1', 'fix #3778: флаг «Зафиксировано»=1');
+        assertEqual([typeof set.fields.t96067, typeof set.fields.t96069, typeof set.fields.t96778],
+            ['string', 'string', 'string'], 'fix #3778: три тайминг-поля сняты вместе с флагом');
+        assertEqual(set.fields.t96778, '8', 'fix #3778: «Резка и Лидер» = Длительность(4) + лидер(2×2) = 8');
+
+        // 2) Те же значения уже хранятся → фиксация пишет ТОЛЬКО флаг (нет лишних записей).
+        var c2 = makeController({ knife: set.fields.t96067, material: set.fields.t96069, cutTime: set.fields.t96778 });
+        return c2.setCutsFixed(['c1'], true).then(function() {
+            assertEqual(Object.keys(setFor(c2).fields).sort(), ['t81530'],
+                'fix #3778: совпадающий тайминг не переписывается — только флаг');
+
+            // 3) Снятие фиксации тайминг не снимает (только флаг=0).
+            var c3 = makeController(null);
+            return c3.setCutsFixed(['c1'], false).then(function() {
+                var set3 = setFor(c3);
+                assertEqual(set3.fields.t81530, '0', 'fix #3778: снятие фиксации пишет флаг=0');
+                assertEqual(Object.keys(set3.fields).sort(), ['t81530'],
+                    'fix #3778: при снятии фиксации тайминг не трогаем');
+            });
+        });
+    });
+}
+
 runSaveSequencesT1078Test()
+    .then(runFixSnapshotTimingTest)
     .then(runApplySplitPlanTest)
     .then(runPreferredWidthsFilterTest)
     .then(runGenerateCutsDeferredGpTest)


### PR DESCRIPTION
Closes #3778.

Поля резки «Наладка ножей, мин» (96067), «Сырье/намотка, мин» (96069), «Резка и Лидер» (96778) оставались пустыми → `cut-gantt` пересчитывал время на лету и показывал разную длительность в зависимости от выбранной даты.

## Диагноз (сверено с боевой ateh)
Схема и отчёт **в порядке, серверная часть НЕ нужна**:
- В таблице 1078 реквизиты 96067/96069/96778 существуют.
- Отчёт `cut_planning` (8384) **уже отдаёт** их как `cut_knife_setup_min` / `cut_material_winding_min` / `cut_time` (док `integram-reports.md` устарел).
- `cut-gantt.js` уже использует эти поля (#3698/#3700) и «выдумывает» только когда они пусты.

Баг — чисто в JS-персистенции `production-planning.js`: три поля писал только `persistCutSetupColumns` (в цепочке генерации, **с молчаливым глотанием ошибок**), а кнопка **«Зафиксировать» снимок времён не делала** — писала только флаг `Зафиксировано`.

## Изменения (`download/atex/js/production-planning.js`)
1. **`setCutsFixed`** — при фиксации снимает тайминг (Наладка / Сырье-намотка / Резка и Лидер) в запись тем же `_m_set`, что и флаг. Считается тем же расчётом и порядком, что план на экране; пишется только для фиксируемых id; при снятии фиксации не трогается.
2. **`computeCutSetupUpdates(onlyIds)`** — расчёт тайминга вынесен из `persistCutSetupColumns` (DRY, используется обоими). Пустое хранимое значение всегда «изменилось» → **force-write** в пустые поля.
3. **`persistCutSetupColumns`** — ошибки записи больше **не глотаются молча**, показывается уведомление (раньше тихий `catch` скрывал причину пустых полей).

`cut-gantt.js` не менялся — он уже использует хранимые поля и перестанет «выдумывать», как только планировщик их наполнит.

Бэкфилл существующих записей не делается (по согласованию — только вперёд: поля заполнятся при следующей фиксации/генерации).

## Тесты
`experiments/atex-production-planning.test.js` (+7 проверок): фиксация пустой резки пишет флаг + 3 поля; «Резка и Лидер» = Длительность(4)+лидер(2×2)=8; совпадающий тайминг не переписывается; снятие фиксации тайминг не трогает.

Прогон: синтаксис OK; полный набор тестов планировщика без новых падений (`3619` и основной по 3 FAIL — преексистинг на `main`, сверено через stash); тест ганта — 122 зелёных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)