### PR TITLE
#3781: записи-продолжения дробления по дням получают «Метраж, м» (кривая длина 281.25)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -7580,6 +7580,7 @@
         var runsReqId = reqIdByAnyName(cutMeta, CUT_PLANNED_RUNS_NAMES);   // live: «Кол-во резок план»
         var mainKey = cutMeta.id != null ? 't' + cutMeta.id : null;
         var cutsById = {}; (self.cuts || []).forEach(function(c) { cutsById[String(c.id)] = c; });
+        var lengthReqId = reqIdByName(cutMeta, CUT_REQ.length);   // #3781: «Метраж, м» (длина прогона)
         var cutReqIds = {
             slitter: reqIdByName(cutMeta, CUT_REQ.slitter),
             materialBatch: reqIdByName(cutMeta, CUT_REQ.materialBatch),
@@ -7587,8 +7588,24 @@
             status: reqIdByName(cutMeta, CUT_REQ.status),
             sequence: seqReqId,
             winding: reqIdByName(cutMeta, CUT_REQ.winding),
-            leader: reqIdByName(cutMeta, CUT_REQ.leader)   // #3569: лидер копируется в запись-продолжение
+            leader: reqIdByName(cutMeta, CUT_REQ.leader),   // #3569: лидер копируется в запись-продолжение
+            length: lengthReqId   // #3781: «Метраж, м» — длина прогона (одинакова у всех сегментов цепочки)
         };
+        // #3781: длина прогона по id любой записи цепочки = длина прогона её ГОЛОВЫ. Записи-
+        // продолжения дробления по дням раньше не получали «Метраж, м», и cutRunLength
+        // откатывался к ПОДЕЛЁННОМУ метражу обеспечения (splitSupplyShares делит footage
+        // пропорционально проходам) → в очереди мелькала заниженная длина (281.25 вместо 450).
+        // Длина прогона одинакова у всех сегментов — берём её у головы и пишем во все сегменты.
+        var chainHeadById = {};
+        var splitChains = mergeContinuationChains(self.cuts || []).chainByLogical || {};
+        Object.keys(splitChains).forEach(function(head) {
+            (splitChains[head] || [head]).forEach(function(m) { chainHeadById[String(m)] = String(head); });
+        });
+        function runLenForCutId(cutId) {
+            var head = chainHeadById[String(cutId)] || String(cutId);
+            var hc = cutsById[head];
+            return hc ? cutRunLength(hc, self.supplies, self.footageBySupply) : 0;
+        }
         // buildFields ключ для проходов — по runsReqId (live «Кол-во резок план»).
         var createsByParent = {};
         (ops.creates || []).forEach(function(cr) { (createsByParent[cr.parentCutId] = createsByParent[cr.parentCutId] || []).push(cr); });
@@ -7625,6 +7642,13 @@
                     // расписание считает настройку длинной резкой, ломая раскладку по дням.
                     var durReqId = reqIdByName(cutMeta, CUT_REQ.duration);
                     if (Number(u.plannedRuns) === 0 && durReqId) fields['t' + durReqId] = '0';
+                    // #3781: восстановить «Метраж, м» = длине прогона головы цепочки. Для головы
+                    // это та же длина (запись no-op по значению), для реюзнутого продолжения —
+                    // лечит ранее пустую длину (иначе очередь брала поделённый метраж обеспечения).
+                    if (lengthReqId) {
+                        var ulen = runLenForCutId(u.cutId);
+                        if (ulen > 0) fields['t' + lengthReqId] = String(round3(ulen));
+                    }
                     if (!Object.keys(fields).length) return;
                     return self.post('_m_set/' + u.cutId + '?JSON', fields);
                 });
@@ -7636,6 +7660,7 @@
             var parentCut = cutsById[parentId];
             var crs = createsByParent[parentId];
             var upd = updateByCut[parentId];
+            var parentRunLen = runLenForCutId(parentId);   // #3781: длина прогона цепочки (для «Метраж, м» продолжений)
             var aRuns = upd ? (Number(upd.plannedRuns) || 0) : 0;
             var segRuns = [aRuns].concat(crs.map(function(c) { return Number(c.plannedRuns) || 0; }));
             chain = chain.then(function() { return self.loadStripsForCut(parentId); }).then(function(parentStrips) {
@@ -7687,7 +7712,10 @@
                             sequence: cr.sequence,
                             winding: normWinding(parentCut && parentCut.winding),
                             // #3569: лидер родителя (одна метка из cut_leader) → id справочника.
-                            leader: self.resolveLeaderId(parentCut && parentCut.leaders && parentCut.leaders.length === 1 ? parentCut.leaders[0] : '')
+                            leader: self.resolveLeaderId(parentCut && parentCut.leaders && parentCut.leaders.length === 1 ? parentCut.leaders[0] : ''),
+                            // #3781: «Метраж, м» = длина прогона цепочки. Без неё cutRunLength брал
+                            // поделённый метраж обеспечения и показывал заниженную длину.
+                            length: parentRunLen > 0 ? round3(parentRunLen) : ''
                         });
                         cutFields = addMainValueField(cutMeta, cutFields, cr.planStartTs);
                         return self.post('_m_new/' + cutMeta.id + '?JSON&up=1', cutFields).then(function(res) {

--- a/experiments/atex-production-planning-3781.test.js
+++ b/experiments/atex-production-planning-3781.test.js
@@ -1,0 +1,99 @@
+// Integration test for #3781 — записи-продолжения дробления по дням получают «Метраж, м»
+// (длину прогона цепочки). Без него cutRunLength откатывался к ПОДЕЛЁННОМУ метражу
+// обеспечения (splitSupplyShares делит footage пропорционально проходам) и в очереди
+// мелькала заниженная длина: 281.25 = 450 × (10/16) вместо 450. Проявлялось редко — когда
+// резка, изначально влезавшая в один день, при перепланировании начинала переполнять день.
+//
+// Гоняем НАСТОЯЩИЙ applySplitPlan поверх стаба post и проверяем, что:
+//   • создаваемая запись-продолжение пишет «Метраж, м» = длине прогона головы (450);
+//   • обновляемая запись (голова/реюзнутое продолжение) тоже получает «Метраж, м» (лечит старые).
+//
+// Run with: node experiments/atex-production-planning-3781.test.js
+
+process.env.TZ = 'UTC';
+
+// Без global.document модуль не запускает init при require (window есть, document — нет).
+global.window = { db: 'testdb', xsrf: 'x' };
+
+var api = require('../download/atex/js/production-planning.js');
+var Controller = api.Controller;
+var planning = api.planning;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) passed++; else process.exitCode = 1;
+}
+
+function meta(id, pairs) {
+    return { id: String(id), reqs: pairs.map(function(p) { return { id: String(p[0]), val: p[1] }; }) };
+}
+
+// id таблиц/реквизитов для теста (числа произвольные, важны имена).
+var LEN = '197';   // «Метраж, м» в «Задании в производство»
+var cutMeta = meta(100, [
+    [191, 'Слиттер'], [192, 'Партия сырья'], [193, 'Кол-во план'], [194, 'Статус'],
+    [195, 'Очередность'], [196, 'Тип намотки'], [198, 'Лидер'], [LEN, 'Метраж, м'],
+    [199, 'Длительность, минут']
+]);
+var fbMeta = meta(200, [[201, 'Ширина, мм'], [202, 'Кол-во полос'], [203, 'Кол-во рулонов'],
+    [204, 'Кол-во план'], [205, 'В работе']]);
+var supMeta = meta(300, [[301, 'Метраж, м'], [302, 'Кол-во рулонов'], [303, 'В работе'],
+    [304, 'Статус'], [305, 'Партия ГП']]);
+
+var root = { getAttribute: function() { return 'testdb'; } };
+var c = new Controller(root);
+c.meta.cut = cutMeta; c.meta.finishedBatch = fbMeta; c.meta.supply = supMeta;
+
+// Голова цепочки H: длина прогона (Метраж) = 450, 8 рулонов в обеспечении (метраж 450 = на рулон).
+c.cuts = [{ id: 'H', length: 450, status: 'В работе', slitter: { id: 'S1' }, batchId: 'B1',
+    winding: 'IN', leaders: [] }];
+c.supplies = [{ id: 'SUP1', cutId: 'H', rolls: 8, footage: 450, finishedBatchId: 'FB1', positionId: 'P1' }];
+c.footageBySupply = {};
+
+// Стабы побочных эффектов.
+var posts = [];
+var idc = 0;
+c.post = function(path, params) { posts.push({ path: path, params: params || {} }); return Promise.resolve({ obj: 'NEW' + (++idc) }); };
+c.loadStripsForCut = function() { return Promise.resolve([]); };
+c.resolveLeaderId = function() { return ''; };
+c.reload = function() { return Promise.resolve(); };
+c.persistCutSetupColumns = function() { return Promise.resolve(); };
+c.setBusy = function() {}; c.showProgress = function() {}; c.updateProgress = function() {};
+c.hideProgress = function() {}; c.render = function() {}; c.notify = function() {};
+
+// План: голова H (5 проходов) обновляется, продолжение B (3 прохода) создаётся.
+// splitSupplyShares(8, 450, [5,3]) → метраж обеспечения делится 281.25 / 168.75 — но длина
+// прогона записей ДОЛЖНА остаться 450.
+applySplitDone();
+function applySplitDone() {
+    c.applySplitPlan({
+        updates: [{ cutId: 'H', sequence: 1, planStartTs: 1000, plannedRuns: 5 }],
+        creates: [{ parentCutId: 'H', sequence: 2, planStartTs: 2000, plannedRuns: 3 }],
+        deletes: []
+    }).then(function() {
+        var tLen = 't' + LEN;
+
+        // 1) Создаваемое продолжение B (_m_new в таблицу резки) пишет «Метраж, м» = 450.
+        var createCut = posts.filter(function(p) { return p.path === '_m_new/100?JSON&up=1'; });
+        assert(createCut.length === 1, '#3781: создаётся ровно одна запись-продолжение резки');
+        assert(createCut[0] && String(createCut[0].params[tLen]) === '450',
+            '#3781: продолжение получает «Метраж, м» = 450 (длина прогона головы), а не делёный метраж');
+
+        // 2) Обновляемая запись головы тоже несёт «Метраж, м» = 450 (лечит старые пустые длины).
+        var updCut = posts.filter(function(p) { return p.path === '_m_set/H?JSON'; });
+        assert(updCut.length === 1 && String(updCut[0].params[tLen]) === '450',
+            '#3781: обновление записи пишет «Метраж, м» = 450 (восстановление длины)');
+
+        // 3) Контроль арифметики: 281.25 — это делёный метраж обеспечения (450 × доля проходов),
+        //    а НЕ длина прогона. Мы чиним длину РЕЗКИ; деление метража обеспечения не трогаем.
+        assert(round3(450 * 5 / 8) === 281.25 && round3(450 * 10 / 16) === 281.25,
+            '#3781: 281.25 = 450 × (доля проходов) — делёный метраж обеспечения, не длина прогона');
+
+        console.log('\n' + passed + ' assertions passed');
+    }).catch(function(err) {
+        console.log('FAIL — applySplitPlan бросил: ' + (err && err.stack || err));
+        process.exitCode = 1;
+    });
+}
+function round3(n) { return Math.round(n * 1000) / 1000; }


### PR DESCRIPTION
Закрывает #3781.

## Симптом
Изредка в очереди заданий у задания мелькает заниженная длина прогона — на скриншоте `MW308 IN — 281.25 x 10` и `MW308 60 x 281.25 IN — 59мм x 10 x 15 = 150 шт.`, где должно быть **450**. Число характерное: `281.25 = 450 × (10/16)`.

## Причина
`applySplitPlan` создаёт записи-**продолжения** дробления по дням, копируя слиттер/сырьё/проходы/очерёдность/лидер, но **не пишет «Метраж, м»**. На отображении `cutRunLength(cut, supplies)` берёт `max(cut.length, метраж обеспечения)`; у продолжения `cut.length` пуст, а метраж обеспечения у сегмента **поделён пропорционально проходам** (`splitSupplyShares`: `450 × 10/16 = 281.25`). Длина прогона одинакова у всех сегментов цепочки, поэтому делёный метраж обеспечения — неверный источник.

**Почему редко:** при обычной генерации (`runGenerateCuts`) «Метраж, м» пишется во все сегменты. Пустая длина возникает лишь когда резка, изначально влезавшая в один день, при перепланировании начинает переполнять день и `applySplitPlan` **создаёт новое** продолжение (а не реюзает уже готовое).

## Фикс
В `applySplitPlan` пишем «Метраж, м» = длине прогона **головы** цепочки (`cutRunLength` головы — она одинакова у всех сегментов):
- в **создаваемые** продолжения (основной фикс);
- в **обновляемые** записи — лечит ранее созданные пустые длины при следующем перепланировании (для головы это та же длина, no-op по значению).

Деление метража **обеспечения** (`splitSupplyShares`) намеренно не трогаю — там total-семантика, она протестирована и используется для долей рулонов/метража обеспечения по сегментам.

Существующие записи с пустой длиной самоизлечиваются при следующем перепланировании станка (autoSequenceQueue → applySplitPlan).

## Тесты
- `experiments/atex-production-planning-3781.test.js` — `applySplitPlan` поверх стаба `post`: и создаваемое продолжение, и обновляемая запись получают `t{Метраж}=450`; контроль арифметики `281.25 = 450 × доля`.
- Существующая `atex-production-planning-*` сюита прогнана: **без новых регрессий** (575 PASS в большом наборе как и на `origin/main`; предсуществующие фейлы `3619` и 3 устаревших фикстуры в большом тесте идентичны чистому `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)