### PR TITLE
#3787: в пустой очереди станка дописывать его отпуск(а) на отображаемую дату

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -775,6 +775,58 @@
         return Math.floor(d.getTime() / 1000);
     }
 
+    // #3787: unix-секунды → «DD.MM.YYYY» (время дописываем, только если не полночь — отпуск
+    // обычно цельными днями, «00:00» был бы шумом). Пусто/мусор → ''.
+    function formatDowntimeBound(sec) {
+        var n = Number(sec);
+        if (!isFinite(n) || n <= 0) return '';
+        var d = new Date(n * 1000);
+        if (isNaN(d.getTime())) return '';
+        function pad(x) { return (x < 10 ? '0' : '') + x; }
+        var s = pad(d.getDate()) + '.' + pad(d.getMonth() + 1) + '.' + d.getFullYear();
+        if (d.getHours() || d.getMinutes()) s += ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes());
+        return s;
+    }
+
+    // #3787: «ГГГГ-ММ-ДД» → полночь (мс, локально); null при нераспознанном (без подмены «сегодня»).
+    function isoDayMidnightMs(dateStr) {
+        var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(dateStr || '').trim());
+        if (!m) return null;
+        return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]), 0, 0, 0, 0).getTime();
+    }
+
+    // #3787: подпись об отпуске(ах) станка, пересекающих отображаемый диапазон [dateFrom; dateTo]
+    // (фильтр «Дата плана», 'ГГГГ-ММ-ДД'; пустой dateTo = один день dateFrom). downtimes — строки
+    // окон простоя [{ start, end, notes }] (unix-сек, как this.downtimesBySlitter[slitterId]).
+    // → «отпуск с DD.MM.YYYY по DD.MM.YYYY» (несколько — через запятую; причина из «Примечаний» в
+    // скобках — «все детали»). Открытое окно (нет «Окончания») → «отпуск с DD.MM.YYYY». Нет
+    // пересечений / нераспознанная дата → ''. Чистая — тестируется без DOM.
+    function downtimeRangeNote(downtimes, dateFrom, dateTo) {
+        var list = downtimes || [];
+        if (!list.length) return '';
+        var fromMs = isoDayMidnightMs(dateFrom);
+        if (fromMs == null) return '';
+        var toMid = isoDayMidnightMs(String(dateTo || '').trim() || dateFrom);
+        var winEndMs = (toMid == null ? fromMs : toMid) + 86400000;   // конец последнего дня диапазона (исключит.)
+        var parts = list.filter(function(d) {
+            var startMs = (d && d.start != null && d.start !== '') ? Number(d.start) * 1000 : null;
+            if (startMs == null || !isFinite(startMs)) return false;
+            var endMs = (d.end != null && d.end !== '') ? Number(d.end) * 1000 : null;
+            // пересечение [startMs; endMs|∞) с отображаемым окном [fromMs; winEndMs)
+            return startMs < winEndMs && (endMs == null || endMs > fromMs);
+        }).sort(function(a, b) {
+            return (Number(a.start) || 0) - (Number(b.start) || 0);
+        }).map(function(d) {
+            var s = 'с ' + formatDowntimeBound(d.start);
+            var e = formatDowntimeBound(d.end);
+            if (e) s += ' по ' + e;
+            var notes = d.notes == null ? '' : String(d.notes).trim();
+            if (notes) s += ' (' + notes + ')';
+            return s;
+        });
+        return parts.length ? ('отпуск ' + parts.join(', ')) : '';
+    }
+
     // Сборка полей `t{reqId}` для записи. reqIds — { ключ: числовойId },
     // values — { ключ: значение }. Пустые значения (''/null/undefined) опускаются,
     // чтобы не перетирать данные и не плодить пустые реквизиты.
@@ -4275,6 +4327,8 @@
         shiftPlacementsPastDowntime: shiftPlacementsPastDowntime, // #3764
         unixToDatetimeLocal: unixToDatetimeLocal,                 // #3764
         datetimeLocalToUnix: datetimeLocalToUnix,                 // #3764
+        downtimeRangeNote: downtimeRangeNote,                     // #3787
+        formatDowntimeBound: formatDowntimeBound,                 // #3787
         continuationSignature: continuationSignature,
         isDaySplitSibling: isDaySplitSibling,
         daySplitBadges: daySplitBadges,
@@ -9250,7 +9304,13 @@
             groupEl.appendChild(el('div', { class: 'atex-pp-empty', text: 'В этом станке нет позиций по запросу «' + query + '».' }));
         } else if (!groupEl.childNodes.length) {
             // #3535: активный станок без резок в этот день — явная подсказка вместо пустоты.
-            groupEl.appendChild(el('div', { class: 'atex-pp-empty', text: 'Заданий в очереди нет' }));
+            // #3787: если у станка есть отпуск(а), пересекающие отображаемую дату — дописываем
+            // его детали: «Заданий в очереди нет, отпуск с … по …» (несколько — через запятую).
+            var dtNote = downtimeRangeNote(
+                (self.downtimesBySlitter || {})[String(activeGroup.slitter && activeGroup.slitter.id)],
+                self.filter && self.filter.date, self.filter && self.filter.dateTo);
+            groupEl.appendChild(el('div', { class: 'atex-pp-empty',
+                text: 'Заданий в очереди нет' + (dtNote ? ', ' + dtNote : '') }));
         }
         box.appendChild(groupEl);
         console.log('[pp] 📊 renderQueue: отрисовано за ' + (Date.now() - t0) + 'мс. групп:', groups.length, 'резок:', self.cuts.length);

--- a/experiments/atex-production-planning-3764.test.js
+++ b/experiments/atex-production-planning-3764.test.js
@@ -112,4 +112,48 @@ assertEqual(planning.datetimeLocalToUnix('2026-06-27T14:30'), sec,
 assertEqual(planning.unixToDatetimeLocal(0), '', '#3764: 0/пусто → ""');
 assertEqual(planning.datetimeLocalToUnix(''), null, '#3764: пустая строка → null');
 
+// ── #3787: подпись об отпуске станка в пустой очереди («Заданий в очереди нет, отпуск с … по …») ──
+function dsec(y, mo, d, h, mi) { return Date.UTC(y, mo - 1, d, h || 0, mi || 0, 0) / 1000; }
+
+assertEqual(
+    planning.downtimeRangeNote([{ start: dsec(2026, 6, 10), end: dsec(2026, 6, 12) }], '2026-06-10', '2026-06-10'),
+    'отпуск с 10.06.2026 по 12.06.2026',
+    '#3787: одно окно, пересекает дату → «отпуск с … по …»');
+
+assertEqual(
+    planning.downtimeRangeNote([{ start: dsec(2026, 6, 10), end: dsec(2026, 6, 12), notes: 'ТО' }], '2026-06-11', ''),
+    'отпуск с 10.06.2026 по 12.06.2026 (ТО)',
+    '#3787: причина из «Примечаний» в скобках (все детали); пустой dateTo = один день');
+
+assertEqual(
+    planning.downtimeRangeNote([{ start: dsec(2026, 6, 10, 14, 30), end: dsec(2026, 6, 10, 16, 0) }], '2026-06-10', '2026-06-10'),
+    'отпуск с 10.06.2026 14:30 по 10.06.2026 16:00',
+    '#3787: ненулевое время дописывается к дате');
+
+assertEqual(
+    planning.downtimeRangeNote([
+        { start: dsec(2026, 6, 12), end: dsec(2026, 6, 13) },
+        { start: dsec(2026, 6, 10), end: dsec(2026, 6, 11) }
+    ], '2026-06-10', '2026-06-13'),
+    'отпуск с 10.06.2026 по 11.06.2026, с 12.06.2026 по 13.06.2026',
+    '#3787: несколько окон — через запятую, по возрастанию начала');
+
+assertEqual(
+    planning.downtimeRangeNote([{ start: dsec(2026, 6, 10), end: dsec(2026, 6, 12) }], '2026-07-01', '2026-07-01'),
+    '',
+    '#3787: окно вне отображаемой даты → пусто');
+
+assertEqual(
+    planning.downtimeRangeNote([{ start: dsec(2026, 6, 10), end: null }], '2026-06-15', '2026-06-15'),
+    'отпуск с 10.06.2026',
+    '#3787: открытое окно (нет «Окончания») → «отпуск с …», пересекает любую позднюю дату');
+
+assertEqual(planning.downtimeRangeNote([], '2026-06-10', '2026-06-10'), '',
+    '#3787: окон нет → пусто');
+
+assertEqual(
+    planning.downtimeRangeNote([{ start: dsec(2026, 6, 10), end: dsec(2026, 6, 12) }], '', ''),
+    '',
+    '#3787: нераспознанная дата → пусто (без подмены «сегодня»)');
+
 console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Closes #3787.

В «Планировании производства», когда у выбранного станка нет заданий, сообщение **«Заданий в очереди нет»** дополняется сведениями об отпуске(ах) станка (фича #3764), пересекающих отображаемую дату:

> Заданий в очереди нет, **отпуск с 10.06.2026 по 12.06.2026**

## Изменения (`download/atex/js/production-planning.js`)
- **`downtimeRangeNote(downtimes, dateFrom, dateTo)`** — чистая функция (экспортирована в `planning`, тестируется без DOM): берёт окна «Отпуска» станка (`this.downtimesBySlitter[slitterId]`, unix-сек), оставляет пересекающие отображаемый диапазон `[Дата плана С; По]`, форматирует `отпуск с DD.MM.YYYY по DD.MM.YYYY`:
  - несколько окон — **через запятую**, по возрастанию начала;
  - причина из «Примечаний» — **в скобках** (это «все детали» из заголовка issue);
  - открытое окно (без «Окончания») → `отпуск с …`;
  - время дописывается, только если не полночь (отпуск обычно цельными днями);
  - нераспознанная дата / нет пересечений → пусто.
- **`renderQueue`** — empty-сообщение активного станка дополняется этой подписью. Фича выключена (нет таблицы «Отпуск» в метаданных) → поведение прежнее.

## Объём
Реализована точная формулировка из **тела** issue (случай «заданий нет»). Заголовок шире, но тело конкретно описывает только пустую очередь — аннотацию у дат-заголовков дней (когда задания есть) можно добавить отдельным PR при необходимости.

## Тесты
`experiments/atex-production-planning-3764.test.js` (+8 проверок): одно/несколько окон, причина в скобках, ненулевое время, окно вне даты → пусто, открытое окно, пустой список, нераспознанная дата.

Прогон: синтаксис OK; набор тестов планировщика без новых падений (`3619` и основной по 3 FAIL — преексистинг на `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)