### PR TITLE
#3788: календарь — пропуск выходных и праздничных дней при планировании

### DIFF
--- a/download/atex/css/production-planning.css
+++ b/download/atex/css/production-planning.css
@@ -436,6 +436,22 @@
     font-variant-numeric: tabular-nums;
 }
 .atex-pp-day-date:first-child { margin-top: 2px; }
+/* #3788: день расписания — выходной/праздник, но задания на него есть → красный фон даты. */
+.atex-pp-day-date.is-dayoff {
+    background: var(--pp-warn);
+    color: #fff;
+    border-bottom-color: var(--pp-warn);
+    border-radius: 4px;
+    padding-left: 8px;
+    padding-right: 8px;
+}
+.atex-pp-day-date.is-dayoff .atex-pp-day-mins { color: rgba(255, 255, 255, .85); }
+/* #3788: пометка «Выходной день» перед «Заданий в очереди нет» в пустой очереди. */
+.atex-pp-dayoff-note {
+    color: var(--pp-warn);
+    font-weight: 700;
+    margin-bottom: 4px;
+}
 /* #3743: суммарные минуты заданий станка за день — после даты, мягче самой даты. */
 .atex-pp-day-mins {
     font-weight: 400;

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -63,7 +63,8 @@
         settings: 'Настройка',
         maxStock: 'Максимальный запас',  // #3391: какие номенклатуры «Партии ГП» целесообразно нарезать впрок
         leader: 'Лидер',                 // #3569: справочник «Лидер» (1132) — резолв метки лидера в id для записи в задание
-        downtime: 'Отпуск'               // #3764: подчинённая станку таблица «Отпуск» (122572) — окна простоя станка
+        downtime: 'Отпуск',              // #3764: подчинённая станку таблица «Отпуск» (122572) — окна простоя станка
+        calendar: 'Календарь'            // #3788: таблица «Календарь» (123162) — праздничные/рабочие дни (исключения)
     };
     // #3764: реквизиты подчинённой «Отпуск» (up = Слиттер). Главное значение записи —
     // НАЧАЛО окна простоя (DATETIME, unix-сек); «Окончание» — конец окна (DATETIME);
@@ -72,6 +73,16 @@
         end: 'Окончание',
         notes: 'Примечания'
     };
+    // #3788: «Календарь» (123162, тип DATE). Главное значение записи — дата (ДД.ММ.ГГГГ);
+    // реквизит «Тип дня» (ссылка) задаёт исключение из обычного правила выходных:
+    //   «Праздничный день» — нерабочий (даже будни), «Рабочий день» — рабочий (даже Сб/Вс).
+    // По умолчанию (нет записи в календаре) Сб/Вс — выходные, будни — рабочие.
+    var CALENDAR_REQ = { dayType: 'Тип дня' };
+    var DAY_TYPE_HOLIDAY = 'Праздничный день';
+    var DAY_TYPE_WORKING = 'Рабочий день';
+    // #3788: горизонт расчёта нерабочих дней расписания (дней вперёд от базы). Покрывает
+    // годовой набор праздников; дальше плановой очереди не бывает.
+    var CALENDAR_HORIZON_DAYS = 366;
     // Реквизиты «Максимального запаса» (#3391, table/67113). Главное значение записи —
     // максимально допустимый запас (число); реквизиты задают комбинацию параметров
     // «Партии ГП», для которой имеет смысл создавать запас. Резолв по имени.
@@ -2778,6 +2789,72 @@
         return out;
     }
 
+    // #3788: «ДД.ММ.ГГГГ» → числовой ключ дня ГГГГММДД (для карты календаря). null — мусор.
+    function parseDmyKey(str) {
+        var m = /^(\d{2})\.(\d{2})\.(\d{4})$/.exec(String(str == null ? '' : str).trim());
+        return m ? (Number(m[3]) * 10000 + Number(m[2]) * 100 + Number(m[1])) : null;
+    }
+
+    // #3788: миллисекунды → ключ дня ГГГГММДД (локальный день).
+    function dayKeyFromMs(ms) {
+        var d = new Date(Number(ms));
+        if (isNaN(d.getTime())) return null;
+        return d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+    }
+
+    // #3788: рабочий ли день. calendarByDay: { ГГГГММДД: 'Праздничный день'|'Рабочий день' }
+    // (исключения); dow — день недели (0=Вс … 6=Сб). «Рабочий день» делает выходной рабочим,
+    // «Праздничный день» — будни нерабочим; иначе обычное правило (Сб/Вс — выходные).
+    function dayTypeWorking(dayKey, dow, calendarByDay) {
+        var t = calendarByDay && calendarByDay[dayKey];
+        if (t === DAY_TYPE_WORKING) return true;
+        if (t === DAY_TYPE_HOLIDAY) return false;
+        return dow !== 0 && dow !== 6;
+    }
+
+    // #3788: рабочий ли календарный день (по мс). Пустая/битая дата → считаем рабочим (не блокируем).
+    function dayIsWorking(ms, calendarByDay) {
+        var d = new Date(Number(ms));
+        if (isNaN(d.getTime())) return true;
+        return dayTypeWorking(dayKeyFromMs(d.getTime()), d.getDay(), calendarByDay);
+    }
+
+    // #3788: нерабочие (выходные/праздничные) дни горизонта [0..horizonDays] от базы →
+    // блокированные интервалы в МИНУТАХ от полуночи дня 0 (та же ось, что blockedRanges #3764).
+    // Каждый нерабочий день — целиком [d*1440, (d+1)*1440]; смежные дни СЛИВАЮТСЯ в один
+    // интервал (выходные+праздники подряд → один блок, меньше работы свипу). Пустой calendarByDay
+    // → блокируются только Сб/Вс. baseMidnightMs нечисловой → []. Вход не мутирует.
+    function calendarBlockedRanges(calendarByDay, baseMidnightMs, horizonDays) {
+        var base = Number(baseMidnightMs);
+        if (!isFinite(base)) return [];
+        var bd = new Date(base);
+        if (isNaN(bd.getTime())) return [];
+        var H = Math.max(0, Number(horizonDays) || 0);
+        var offs = [];
+        for (var d = 0; d <= H; d++) {
+            // setDate(+d) — корректный календарный день (без накопления через DST, в МСК DST нет).
+            var day = new Date(bd.getFullYear(), bd.getMonth(), bd.getDate() + d, 0, 0, 0, 0);
+            if (!dayTypeWorking(dayKeyFromMs(day.getTime()), day.getDay(), calendarByDay)) offs.push(d);
+        }
+        var out = [];
+        for (var i = 0; i < offs.length; ) {
+            var s = offs[i], e = offs[i];
+            while (i + 1 < offs.length && offs[i + 1] === e + 1) { e = offs[++i]; }
+            out.push([s * 1440, (e + 1) * 1440]);   // целые сутки; стык на полуночь сольёт соседние
+            i++;
+        }
+        return out;
+    }
+
+    // #3788: слить два набора блокированных интервалов (минуты от базы) в один отсортированный
+    // массив (окна простоя станка #3764 ∪ нерабочие дни календаря). Дубли не схлопываем —
+    // свип (nextFreeWorkMinute) корректно работает с перекрытиями.
+    function mergeBlockedRanges(a, b) {
+        var out = (a || []).concat(b || []);
+        out.sort(function(x, y) { return x[0] - y[0]; });
+        return out;
+    }
+
     // #3764: рабочее окно дня для абсолютной минуты от полуночи дня 0. Если минута до начала
     // окна (ночь/утро) — подтягиваем к dayStart; если в/после конца окна — к dayStart следующего
     // дня. blocked — отсортированные [[s,e],…]. Возвращает ближайшую минуту ≥ from, которая
@@ -4326,6 +4403,12 @@
         scheduleStartTimestamp: scheduleStartTimestamp,
         planStartTimestamps: planStartTimestamps,
         downtimeBlockedRanges: downtimeBlockedRanges,             // #3764
+        parseDmyKey: parseDmyKey,                                 // #3788
+        dayKeyFromMs: dayKeyFromMs,                               // #3788
+        dayTypeWorking: dayTypeWorking,                           // #3788
+        dayIsWorking: dayIsWorking,                               // #3788
+        calendarBlockedRanges: calendarBlockedRanges,             // #3788
+        mergeBlockedRanges: mergeBlockedRanges,                   // #3788
         nextFreeWorkMinute: nextFreeWorkMinute,                   // #3764
         shiftPlacementsPastDowntime: shiftPlacementsPastDowntime, // #3764
         unixToDatetimeLocal: unixToDatetimeLocal,                 // #3764
@@ -4524,6 +4607,7 @@
             downtime: null        // #3764: подчинённая «Отпуск» (окна простоя станка)
         };
         this.downtimesBySlitter = {};  // #3764: карта slitterId → [{ id, start, end, notes }] (start/end — unix-сек)
+        this.calendarByDay = {};       // #3788: карта ГГГГММДД → 'Праздничный день'|'Рабочий день' (исключения календаря)
         this.sleeveBatches = [];   // #3340: партии втулок «в работе» (отчёт sleeve_batches_active) для FIFO
         this.sleeveCutterId = '';  // #3340: id втулкореза TC-20 (резолв по имени)
         this.slitters = [];        // справочник [{ id, label, stopMaterialIds }]
@@ -4640,6 +4724,7 @@
             self.meta.maxStock = byName(TABLE.maxStock);   // #3391: необязательная — фича включается её наличием
             self.meta.leader = byName(TABLE.leader);        // #3569: справочник «Лидер» (резолв метки → id)
             self.meta.downtime = byName(TABLE.downtime);    // #3764: необязательная — кнопка/пропуск простоя включаются её наличием
+            self.meta.calendar = byName(TABLE.calendar);    // #3788: необязательная — пропуск выходных/праздников включается её наличием
             if (!self.meta.cut) throw new Error('В метаданных не найдена таблица «' + TABLE.cut + '»');
             if (!self.meta.supply) throw new Error('В метаданных не найдена таблица «' + TABLE.supply + '»');
         });
@@ -4759,17 +4844,69 @@
         });
     };
 
-    // #3764: окна «Отпуска» станка → блокированные интервалы (минуты от полуночи дня 0) для
-    // планировщика. baseMidnightMs — база расписания (день фильтра «С»).
-    AtexProductionPlanning.prototype.blockedRangesForSlitter = function(slitterId, baseMidnightMs) {
-        return downtimeBlockedRanges((this.downtimesBySlitter || {})[String(slitterId)], baseMidnightMs);
+    // #3788: «Календарь» — исключения из обычных выходных. Таблица 123162 (тип DATE): главное
+    // значение — дата (ДД.ММ.ГГГГ), «Тип дня» (ссылка) = «Праздничный день»/«Рабочий день».
+    // Строим карту ГГГГММДД → тип. Таблицы нет в метаданных (старое окружение) → пустая карта,
+    // фича выключена (выходные/праздники не пропускаются, разметка дней не рисуется). Ошибка
+    // чтения не валит загрузку.
+    AtexProductionPlanning.prototype.loadCalendar = function() {
+        var self = this;
+        this.calendarByDay = {};
+        var meta = this.meta.calendar;
+        if (!meta) return Promise.resolve();
+        var typeIdx = columnIndex(meta, CALENDAR_REQ.dayType);
+        return this.getJson('object/' + meta.id + '/?JSON_OBJ&LIMIT=0,2000').then(function(rows) {
+            (rows || []).forEach(function(rec) {
+                var r = rec.r || [];
+                var key = parseDmyKey(r[0]);
+                if (key == null) return;
+                // «Тип дня» — ссылка «id:Метка»; берём метку (parseRef.label).
+                var typeLabel = (typeIdx >= 0 && r[typeIdx] != null) ? parseRef(r[typeIdx]).label : '';
+                if (typeLabel) self.calendarByDay[key] = typeLabel;
+            });
+            console.log('[pp] 📅 loadCalendar: дней-исключений в календаре:', Object.keys(self.calendarByDay).length);
+        }).catch(function(err) {
+            console.warn('[pp] 📅 loadCalendar: не удалось прочитать «' + TABLE.calendar + '»:', err && err.message);
+            self.calendarByDay = {};
+        });
     };
 
-    // #3764: карта slitterId → blockedRanges по всем станкам (для planCutOperations).
+    // #3788: нерабочие дни (выходные/праздники) горизонта → блокированные интервалы (минуты от
+    // базы). Фича включается наличием таблицы «Календарь»: без неё [] (расписание прежнее, дни
+    // не блокируются). baseMidnightMs — база расписания (день фильтра «С»). Глобальны для всех станков.
+    AtexProductionPlanning.prototype.calendarBlockedRanges = function(baseMidnightMs) {
+        if (!this.meta.calendar) return [];
+        return calendarBlockedRanges(this.calendarByDay, baseMidnightMs, CALENDAR_HORIZON_DAYS);
+    };
+
+    // #3788: рабочий ли день (по мс). Фича выключена (нет «Календаря») → всегда рабочий, чтобы
+    // разметка выходных не появлялась в старом окружении.
+    AtexProductionPlanning.prototype.dayIsWorking = function(ms) {
+        if (!this.meta.calendar) return true;
+        return dayIsWorking(ms, this.calendarByDay);
+    };
+
+    // #3764+#3788: блокированные интервалы станка = окна «Отпуска» этого станка ∪ нерабочие дни
+    // календаря (глобальные). baseMidnightMs — база расписания (день фильтра «С»).
+    AtexProductionPlanning.prototype.blockedRangesForSlitter = function(slitterId, baseMidnightMs) {
+        return mergeBlockedRanges(
+            downtimeBlockedRanges((this.downtimesBySlitter || {})[String(slitterId)], baseMidnightMs),
+            this.calendarBlockedRanges(baseMidnightMs)
+        );
+    };
+
+    // #3764+#3788: карта slitterId → blockedRanges по ВСЕМ станкам (для planCutOperations).
+    // Нерабочие дни календаря добавляем КАЖДОМУ станку (глобальны), поэтому строим по полному
+    // справочнику станков, а не только по тем, у кого есть отпуск.
     AtexProductionPlanning.prototype.blockedRangesBySlitter = function(baseMidnightMs) {
         var self = this, out = {};
-        Object.keys(this.downtimesBySlitter || {}).forEach(function(key) {
-            var ranges = downtimeBlockedRanges(self.downtimesBySlitter[key], baseMidnightMs);
+        var calBlocks = this.calendarBlockedRanges(baseMidnightMs);
+        var keys = {};
+        (this.slitters || []).forEach(function(s) { keys[String(s.id)] = true; });
+        Object.keys(this.downtimesBySlitter || {}).forEach(function(k) { keys[k] = true; });
+        Object.keys(keys).forEach(function(key) {
+            var ranges = mergeBlockedRanges(
+                downtimeBlockedRanges(self.downtimesBySlitter[key], baseMidnightMs), calBlocks);
             if (ranges.length) out[key] = ranges;
         });
         return out;
@@ -8877,6 +9014,10 @@
         var tabGroups = mergeStationTabs(this.slitters, groups);
 
         if (!tabGroups.length) {
+            // #3788: отображаемая дата — выходной/праздник → красным «Выходной день» перед подсказкой.
+            if (!this.dayIsWorking(planBaseMidnightFrom(this.filter && this.filter.date, controllerNowMs(this)))) {
+                box.appendChild(el('div', { class: 'atex-pp-dayoff-note', text: 'Выходной день' }));
+            }
             box.appendChild(el('div', { class: 'atex-pp-empty', text: 'Заданий в очереди нет' }));
             return;
         }
@@ -9272,7 +9413,13 @@
             if (cardSchedDay != null && cardSchedDay !== lastDayDateRendered) {
                 // #3743: после даты — суммарные минуты заданий станка за этот день: «(456 мин)».
                 var dayMins = Math.round(Number(dayMinutesBySched[cardSchedDay]) || 0);
-                groupEl.appendChild(el('div', { class: 'atex-pp-day-date' }, [
+                // #3788: день расписания пришёлся на выходной/праздник, но задания на него есть
+                // (вручную или вытеснены) — помечаем дату красным фоном.
+                var dayOff = !self.dayIsWorking(planBaseMidnightMs + cardSchedDay * 86400000);
+                groupEl.appendChild(el('div', {
+                    class: 'atex-pp-day-date' + (dayOff ? ' is-dayoff' : ''),
+                    title: dayOff ? 'Выходной/праздничный день — заданий быть не должно' : ''
+                }, [
                     formatPlanDayHeading(planBaseMidnightMs, cardSchedDay),
                     el('span', { class: 'atex-pp-day-mins', text: ' (' + dayMins + ' мин)' })
                 ]));
@@ -9339,6 +9486,11 @@
         if (hasQuery && !groupEl.childNodes.length) {
             groupEl.appendChild(el('div', { class: 'atex-pp-empty', text: 'В этом станке нет позиций по запросу «' + query + '».' }));
         } else if (!groupEl.childNodes.length) {
+            // #3788: отображаемая дата — выходной/праздник → красным «Выходной день» ПЕРЕД
+            // «Заданий в очереди нет» (планирование такие дни пропускает).
+            if (!self.dayIsWorking(planBaseMidnightMs)) {
+                groupEl.appendChild(el('div', { class: 'atex-pp-dayoff-note', text: 'Выходной день' }));
+            }
             // #3535: активный станок без резок в этот день — явная подсказка вместо пустоты.
             // #3787: если у станка есть отпуск(а), пересекающие отображаемую дату — дописываем
             // его детали: «Заданий в очереди нет, отпуск с … по …» (несколько — через запятую).
@@ -9611,6 +9763,7 @@
                     self.loadJumboWidths(),// ширина джамбо по сырью (для cut-layout)
                     self.loadOperationTimes(), // времена переналадок (веса очереди)
                     self.loadDaySettings(),    // DAY_START_HOUR/DAY_END_HOUR для рабочего окна
+                    self.loadCalendar(),       // #3788: праздничные/рабочие дни (пропуск выходных при планировании)
                     self.loadSupplyFootage(),  // метраж обеспечений (длительность/расписание)
                     self.loadConsumption(),    // расход сырья (FIFO-резерв, Фаза 1b)
                     self.loadSleeveBatches(),  // #3340: партии втулок «в работе» (FIFO) + втулкорез TC-20
@@ -9649,4 +9802,4 @@
 
  
  
-// @version 2026-06-27-issue-3764
+// @version 2026-06-27-issue-3788

--- a/experiments/atex-production-planning-3788-ui.test.js
+++ b/experiments/atex-production-planning-3788-ui.test.js
@@ -1,0 +1,100 @@
+// UI smoke test for #3788 — разметка выходного дня в очереди (поверх лёгкого DOM-стаба,
+// как issue-3411-search.test.js): на нерабочую дату пустая очередь показывает красным
+// «Выходной день» перед «Заданий в очереди нет»; на рабочую дату — нет. Плюс гейтинг
+// контроллерного dayIsWorking по наличию таблицы «Календарь».
+//
+// Run with: node experiments/atex-production-planning-3788-ui.test.js
+
+process.env.TZ = 'UTC';
+
+// ── Минимальный DOM-стаб ──
+function StubNode(tag) {
+    this.tagName = String(tag || '').toUpperCase();
+    this.childNodes = []; this.attributes = {}; this.dataset = {}; this.style = {};
+    this._className = ''; this._text = ''; this._listeners = {}; this.value = ''; this.disabled = false; this.options = [];
+    var self = this;
+    this.classList = {
+        add: function(c) { if (self._classes().indexOf(c) === -1) self._className = (self._className + ' ' + c).trim(); },
+        remove: function(c) { self._className = self._classes().filter(function(x) { return x !== c; }).join(' '); },
+        contains: function(c) { return self._classes().indexOf(c) !== -1; }
+    };
+}
+StubNode.prototype._classes = function() { return this._className.split(/\s+/).filter(Boolean); };
+Object.defineProperty(StubNode.prototype, 'className', { get: function() { return this._className; }, set: function(v) { this._className = String(v || ''); } });
+Object.defineProperty(StubNode.prototype, 'textContent', {
+    get: function() { if (this.childNodes.length) return this.childNodes.map(function(c) { return c.textContent; }).join(''); return this._text; },
+    set: function(v) { this._text = String(v == null ? '' : v); this.childNodes = []; } });
+Object.defineProperty(StubNode.prototype, 'innerHTML', { get: function() { return ''; }, set: function(v) { if (v === '') { this.childNodes = []; this._text = ''; } } });
+Object.defineProperty(StubNode.prototype, 'firstChild', { get: function() { return this.childNodes[0] || null; } });
+StubNode.prototype.appendChild = function(n) { this.childNodes.push(n); n.parentNode = this; if (this.tagName === 'SELECT' && n.tagName === 'OPTION') this.options.push(n); return n; };
+StubNode.prototype.removeChild = function(n) { this.childNodes = this.childNodes.filter(function(c) { return c !== n; }); return n; };
+StubNode.prototype.setAttribute = function(k, v) { this.attributes[k] = String(v); };
+StubNode.prototype.getAttribute = function(k) { return this.attributes[k] == null ? null : this.attributes[k]; };
+StubNode.prototype.addEventListener = function(ev, fn) { (this._listeners[ev] = this._listeners[ev] || []).push(fn); };
+StubNode.prototype.dispatch = function(ev, e) { (this._listeners[ev] || []).forEach(function(fn) { fn(e || {}); }); };
+StubNode.prototype.click = function() { this.dispatch('click', { target: this }); };
+StubNode.prototype.focus = function() {}; StubNode.prototype.setSelectionRange = function() {};
+StubNode.prototype._all = function(acc) { this.childNodes.forEach(function(c) { if (c instanceof StubNode) { acc.push(c); c._all(acc); } }); return acc; };
+StubNode.prototype.querySelectorAll = function(sel) { var cls = sel.replace(/^\./, ''); return this._all([]).filter(function(n) { return n.classList.contains(cls); }); };
+StubNode.prototype.querySelector = function(sel) { return this.querySelectorAll(sel)[0] || null; };
+
+global.document = {
+    createElement: function(tag) { return new StubNode(tag); },
+    createTextNode: function(t) { var n = new StubNode('#text'); n._text = String(t == null ? '' : t); return n; },
+    body: new StubNode('body'), readyState: 'loading', getElementById: function() { return null; }, addEventListener: function() {}
+};
+global.window = { db: 'testdb' };
+
+var api = require('../download/atex/js/production-planning.js');
+var Controller = api.Controller;
+
+var passed = 0;
+function assert(cond, name) { console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name); if (cond) passed++; else process.exitCode = 1; }
+
+function makeController(filterDate, withCalendar) {
+    var root = new StubNode('div'); root.attributes['data-db'] = 'testdb';
+    var c = new Controller(root);
+    c.queueEl = new StubNode('div'); c.linkEl = new StubNode('div');
+    c.filter = { slitter: '', status: '', date: filterDate, dateTo: filterDate, query: '' };
+    c.slitters = [{ id: '101', label: 'Слиттер №1' }];
+    c.activeSlitter = '101';
+    c.cuts = [];   // пустая очередь → ветка пустого состояния
+    c.positions = []; c.supplies = []; c.genBatches = [];
+    c.opTimes = {}; c.changeTimes = {}; c.footageBySupply = {}; c.consumptionByCut = {};
+    c.jumboWidthByMaterial = {}; c.actualWidthIndex = null; c.daySettings = {}; c.prevSetupBySlitter = {};
+    c.renderLink = function() {};
+    if (withCalendar) {
+        c.meta.calendar = { id: '123162', reqs: [{ id: '123165', val: 'Тип дня' }] };
+        c.calendarByDay = { 20260108: 'Праздничный день' };   // 08.01.2026 — праздник (Чт)
+    }
+    return c;
+}
+
+// ── 1) Нерабочая дата (праздник 08.01.2026) → «Выходной день» перед пустым состоянием ──
+var cHol = makeController('2026-01-08', true);
+cHol.renderQueue();
+var note = cHol.queueEl.querySelector('.atex-pp-dayoff-note');
+assert(!!note && /Выходной день/.test(note.textContent), '#3788-ui: на праздник 08.01 показано «Выходной день»');
+var empty = cHol.queueEl.querySelector('.atex-pp-empty');
+assert(!!empty && /Заданий в очереди нет/.test(empty.textContent), '#3788-ui: «Заданий в очереди нет» присутствует');
+// порядок: dayoff-note идёт раньше empty в общем порядке узлов
+var all = cHol.queueEl._all([]);
+assert(all.indexOf(note) < all.indexOf(empty), '#3788-ui: «Выходной день» отрисован ПЕРЕД «Заданий в очереди нет»');
+
+// ── 2) Рабочая дата (понедельник 12.01.2026) → без пометки ──
+var cWork = makeController('2026-01-12', true);
+cWork.renderQueue();
+assert(!cWork.queueEl.querySelector('.atex-pp-dayoff-note'), '#3788-ui: на рабочий понедельник 12.01 пометки нет');
+
+// ── 3) Гейтинг: без таблицы «Календарь» — даже воскресенье не помечается ──
+var cOff = makeController('2026-01-11', false);   // 11.01 — воскресенье, но фича выключена
+cOff.renderQueue();
+assert(!cOff.queueEl.querySelector('.atex-pp-dayoff-note'), '#3788-ui: без «Календаря» воскресенье не помечается (фича выключена)');
+assert(cOff.dayIsWorking(Date.UTC(2026, 0, 11)) === true, '#3788-ui: dayIsWorking без календаря → всегда рабочий');
+
+// ── 4) Контроллерный dayIsWorking с календарём ──
+var cM = makeController('2026-01-12', true);
+assert(cM.dayIsWorking(Date.UTC(2026, 0, 8)) === false, '#3788-ui: 08.01 (праздник) — нерабочий');
+assert(cM.dayIsWorking(Date.UTC(2026, 0, 12)) === true, '#3788-ui: 12.01 (Пн) — рабочий');
+
+console.log('\n' + passed + ' assertions passed');

--- a/experiments/atex-production-planning-3788.test.js
+++ b/experiments/atex-production-planning-3788.test.js
@@ -1,0 +1,75 @@
+// Unit tests for #3788 — пропуск выходных/праздничных дней при планировании по «Календарю».
+// «Праздничный день» делает дату нерабочей (даже будни), «Рабочий день» — рабочей (даже Сб/Вс);
+// иначе обычное правило (Сб/Вс — выходные). Нерабочие дни → блокированные интервалы расписания
+// (как окна «Отпуска» #3764), и тот же свип shiftPlacementsPastDowntime выталкивает задания на
+// ближайший рабочий день. Берём реальные данные ateh (январские праздники + рабочая суббота 10.01).
+//
+// Run with: node experiments/atex-production-planning-3788.test.js
+
+process.env.TZ = 'UTC';
+
+var api = require('../download/atex/js/production-planning.js');
+var planning = api.planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else { console.log('  expected:', JSON.stringify(expected)); console.log('  actual:  ', JSON.stringify(actual)); process.exitCode = 1; }
+}
+
+// Реальный фрагмент календаря ateh (январь 2026): праздники + рабочая суббота 10.01.
+var CAL = {};
+[20260101,20260102,20260105,20260106,20260107,20260108,20260109,20260223,20260309,20260501,20260509,20260612,20261104]
+    .forEach(function(k){ CAL[k] = 'Праздничный день'; });
+CAL[20260110] = 'Рабочий день';   // суббота, сделана рабочей
+
+// ── 1) parseDmyKey ──
+assertEqual(planning.parseDmyKey('01.01.2026'), 20260101, '#3788: «01.01.2026» → 20260101');
+assertEqual(planning.parseDmyKey('10.01.2026'), 20260110, '#3788: «10.01.2026» → 20260110');
+assertEqual(planning.parseDmyKey('  bad  '), null, '#3788: мусор → null');
+
+// ── 2) dayTypeWorking: исключения и обычные выходные ──
+assertEqual(planning.dayTypeWorking(20260101, 4, CAL), false, '#3788: праздник в будни (Чт) — нерабочий');
+assertEqual(planning.dayTypeWorking(20260110, 6, CAL), true, '#3788: «Рабочий день» в субботу — рабочий');
+assertEqual(planning.dayTypeWorking(20260111, 0, CAL), false, '#3788: обычное воскресенье — нерабочий');
+assertEqual(planning.dayTypeWorking(20260112, 1, CAL), true, '#3788: обычный понедельник — рабочий');
+assertEqual(planning.dayTypeWorking(20260613, 6, {}), false, '#3788: суббота без исключений — нерабочий');
+
+// База: 08.01.2026 (Чт, праздник). getDay контроль.
+var BASE = Date.UTC(2026, 0, 8, 0, 0, 0);
+assertEqual(new Date(BASE).getDay(), 4, '#3788: контроль — 08.01.2026 это четверг (getDay 4)');
+
+// ── 3) calendarBlockedRanges: горизонт 5 дней от 08.01 ──
+// d0=08(Чт,праздник)✗ d1=09(Пт,праздник)✗ d2=10(Сб,РАБОЧИЙ)✓ d3=11(Вс)✗ d4=12(Пн)✓ d5=13(Вт)✓
+// Нерабочие смещения [0,1,3] → слитые сутки [[0,2880],[4320,5760]]; рабочая суббота 10.01 — «дыра».
+assertEqual(planning.calendarBlockedRanges(CAL, BASE, 5), [[0, 2880], [4320, 5760]],
+    '#3788: выходные/праздники → блоки суток; рабочая суббота 10.01 не блокируется (дыра между блоками)');
+
+// Пустой календарь → блокируются только Сб/Вс (d2=10.01 как обычная суббота тоже ✗).
+assertEqual(planning.calendarBlockedRanges({}, BASE, 5), [[2880, 5760]],
+    '#3788: без исключений — блок выходных Сб+Вс (10–11.01) слит в [2880,5760]');
+
+// ── 4) mergeBlockedRanges: конкат + сортировка ──
+assertEqual(planning.mergeBlockedRanges([[4320, 5760]], [[0, 2880]]), [[0, 2880], [4320, 5760]],
+    '#3788: слияние блоков отпуска и календаря — отсортировано по началу');
+
+// ── 5) Интеграция: splitMachineQueue выталкивает задание с праздника на рабочую субботу ──
+function cut(id) {
+    return { id: id, slitter: { id: 'm1' }, materialId: 'M1', winding: 'OUT',
+        knifeWidths: [59, 59], knifeCount: 2, plannedRuns: 4 };
+}
+var DS = 480, DE = 990;   // 08:00–16:30
+var blocks = planning.calendarBlockedRanges(CAL, BASE, 10);
+var opts = { dayStartMin: DS, dayEndMin: DE, times: { BETWEEN_CUTS: 0 },
+    perPassByCut: { A: 10 }, runsByCut: { A: 4 }, dayAnchorByCut: { A: 0 } };
+
+var noCal = planning.splitMachineQueue([cut('A')], opts);
+assertEqual(noCal[0].windowStartMin, DS, '#3788: без календаря — задание стартует в день 0 (08:00)');
+
+var withCal = planning.splitMachineQueue([cut('A')], Object.assign({}, opts, { blockedRanges: blocks }));
+assertEqual(withCal[0].windowStartMin, 2 * 1440 + DS,
+    '#3788: с календарём — задание с праздника 08.01 уехало на рабочую субботу 10.01 (день 2, 08:00)');
+
+console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Закрывает #3788.

## Что сделано

Добавлена необязательная таблица **«Календарь»** (123162, тип DATE) — справочник исключений из обычного правила выходных. Главное значение записи — дата (ДД.ММ.ГГГГ), реквизит **«Тип дня»** (ссылка):

- **«Праздничный день»** — дата нерабочая, даже если это будни;
- **«Рабочий день»** — дата рабочая, даже если это Сб/Вс (перенос рабочей субботы).

По умолчанию (нет записи в календаре) Сб/Вс — выходные, будни — рабочие. **Фича включается наличием таблицы в метаданных** — в окружении без «Календаря» поведение полностью прежнее (дни не блокируются и не размечаются).

### Планирование
Нерабочие дни горизонта (366 дней вперёд от базы расписания) превращаются в блокированные интервалы — та же ось «минут от полуночи дня 0», что и окна «Отпуска» (#3764), смежные нерабочие дни сливаются в один блок. Эти интервалы объединяются с окнами простоя каждого станка (`blockedRangesForSlitter` / `blockedRangesBySlitter`), и тот же свип `shiftPlacementsPastDowntime` выталкивает **автоматически** сгенерированные задания на ближайший рабочий день. **Ручное** добавление задания на любой день (в т.ч. выходной) по-прежнему разрешено.

### UI
- Дата-заголовок дня расписания, попавшего на выходной/праздник, но **с заданиями** (добавлены вручную или вытеснены) — красный фон с подсказкой «заданий быть не должно».
- Пустая очередь на нерабочую дату пишет красным **«Выходной день»** перед «Заданий в очереди нет».

## Тесты
В `experiments/` (force-add, каталог под .gitignore):
- `atex-production-planning-3788.test.js` (14 проверок) — unit на `parseDmyKey` / `dayTypeWorking` / `calendarBlockedRanges` (с «дырой» от рабочей субботы) / `mergeBlockedRanges` + интеграция `splitMachineQueue` на реальных январских данных ateh (праздники + рабочая суббота 10.01): задание уезжает с праздника 08.01 на рабочую субботу 10.01.
- `atex-production-planning-3788-ui.test.js` (8 проверок) — DOM-смоук поверх лёгкого стаба: разметка «Выходной день» в пустой очереди на праздник, её отсутствие на рабочий день, гейтинг `dayIsWorking` без таблицы «Календарь».

Прогон всего набора `atex-production-planning-*`: новые тесты зелёные, регрессий нет (3 предсуществующих падения в `atex-production-planning.test.js` и 3 в `-3619.test.js` идентичны на чистом `origin/main` — устаревшие фикстуры, не связаны с этим PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)