### PR TITLE
#3795: запись-продолжение дробления по дням несёт «Вид сырья»

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -8149,7 +8149,8 @@
             sequence: seqReqId,
             winding: reqIdByName(cutMeta, CUT_REQ.winding),
             leader: reqIdByName(cutMeta, CUT_REQ.leader),   // #3569: лидер копируется в запись-продолжение
-            length: lengthReqId   // #3781: «Метраж, м» — длина прогона (одинакова у всех сегментов цепочки)
+            length: lengthReqId,   // #3781: «Метраж, м» — длина прогона (одинакова у всех сегментов цепочки)
+            material: reqIdByName(cutMeta, CUT_REQ.material)   // #3795: «Вид сырья» — копируется в продолжение, иначе очередь следующего дня без сырья
         };
         // #3781: длина прогона по id любой записи цепочки = длина прогона её ГОЛОВЫ. Записи-
         // продолжения дробления по дням раньше не получали «Метраж, м», и cutRunLength
@@ -8165,6 +8166,13 @@
             var head = chainHeadById[String(cutId)] || String(cutId);
             var hc = cutsById[head];
             return hc ? cutRunLength(hc, self.supplies, self.footageBySupply) : 0;
+        }
+        // #3795: «Вид сырья» цепочки = сырьё её ГОЛОВЫ (у всех сегментов одно сырьё). Берём
+        // у головы, потому что у реюзнутого продолжения, созданного до фикса, поле пустое.
+        function materialForCutId(cutId) {
+            var head = chainHeadById[String(cutId)] || String(cutId);
+            var hc = cutsById[head];
+            return hc && hc.materialId != null && String(hc.materialId) !== '' ? String(hc.materialId) : '';
         }
         // buildFields ключ для проходов — по runsReqId (live «Кол-во резок план»).
         var createsByParent = {};
@@ -8209,6 +8217,14 @@
                         var ulen = runLenForCutId(u.cutId);
                         if (ulen > 0) fields['t' + lengthReqId] = String(round3(ulen));
                     }
+                    // #3795: восстановить «Вид сырья» = сырью головы цепочки. Для головы — no-op
+                    // (то же сырьё); для реюзнутого продолжения, созданного до фикса с пустым
+                    // «Вид сырья», лечит пустоту, иначе очередь следующего дня без сырья («—»).
+                    var matReqId = reqIdByName(cutMeta, CUT_REQ.material);
+                    if (matReqId) {
+                        var umat = materialForCutId(u.cutId);
+                        if (umat) fields['t' + matReqId] = umat;
+                    }
                     if (!Object.keys(fields).length) return;
                     return self.post('_m_set/' + u.cutId + '?JSON', fields);
                 });
@@ -8221,6 +8237,7 @@
             var crs = createsByParent[parentId];
             var upd = updateByCut[parentId];
             var parentRunLen = runLenForCutId(parentId);   // #3781: длина прогона цепочки (для «Метраж, м» продолжений)
+            var parentMaterial = materialForCutId(parentId);   // #3795: «Вид сырья» цепочки (для продолжений)
             var aRuns = upd ? (Number(upd.plannedRuns) || 0) : 0;
             var segRuns = [aRuns].concat(crs.map(function(c) { return Number(c.plannedRuns) || 0; }));
             chain = chain.then(function() { return self.loadStripsForCut(parentId); }).then(function(parentStrips) {
@@ -8268,6 +8285,10 @@
                             status: (parentCut && parentCut.status) || CUT_STATUSES[0],
                             slitter: parentCut && parentCut.slitter && parentCut.slitter.id,
                             materialBatch: parentCut && parentCut.batchId,
+                            // #3795: «Вид сырья» цепочки → продолжение. Карточка очереди берёт сырьё
+                            // из cut_material (своего реквизита резки), а обеспечения продолжения не
+                            // привязаны к нему по «Заданию», поэтому materialByCut его не восстановит.
+                            material: parentMaterial,
                             plannedRuns: cr.plannedRuns,
                             sequence: cr.sequence,
                             winding: normWinding(parentCut && parentCut.winding),

--- a/experiments/atex-production-planning-3795.test.js
+++ b/experiments/atex-production-planning-3795.test.js
@@ -1,0 +1,91 @@
+// Integration test for ideav/crm#3795 — записи-продолжения дробления по дням должны
+// нести «Вид сырья». Карточка очереди показывает сырьё из cut_material (своего реквизита
+// резки, грузится в c.materialId/materialName), а applySplitPlan копировал в продолжение
+// только Слиттер/Партию сырья/Полосы/Очередность/Намотку/Лидера/Метраж — но НЕ «Вид сырья».
+// Обеспечения продолжения привязаны к позиции (up=positionId), а не к самой резке по
+// «Заданию», поэтому materialByCut сырьё тоже не восстанавливал → у заказа, продолженного
+// с прошлого дня (напр. 3716), сырьё в очереди следующего дня показывалось как «—».
+//
+// Гоняем НАСТОЯЩИЙ applySplitPlan поверх стаба post и проверяем, что:
+//   • создаваемая запись-продолжение пишет «Вид сырья» = сырью головы цепочки;
+//   • обновляемая запись (голова/реюзнутое продолжение) тоже получает «Вид сырья»
+//     (лечит реюзнутые продолжения, созданные до фикса с пустым «Вид сырья»).
+//
+// Run with: node experiments/atex-production-planning-3795.test.js
+
+process.env.TZ = 'UTC';
+
+// Без global.document модуль не запускает init при require (window есть, document — нет).
+global.window = { db: 'testdb', xsrf: 'x' };
+
+var api = require('../download/atex/js/production-planning.js');
+var Controller = api.Controller;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) passed++; else process.exitCode = 1;
+}
+
+function meta(id, pairs) {
+    return { id: String(id), reqs: pairs.map(function(p) { return { id: String(p[0]), val: p[1] }; }) };
+}
+
+// id таблиц/реквизитов для теста (числа произвольные, важны имена).
+var MAT = '190';   // «Вид сырья» в «Задании в производство»
+var LEN = '197';   // «Метраж, м»
+var cutMeta = meta(100, [
+    [MAT, 'Вид сырья'], [191, 'Слиттер'], [192, 'Партия сырья'], [193, 'Кол-во план'],
+    [194, 'Статус'], [195, 'Очередность'], [196, 'Тип намотки'], [198, 'Лидер'],
+    [LEN, 'Метраж, м'], [199, 'Длительность, минут']
+]);
+var fbMeta = meta(200, [[201, 'Ширина, мм'], [202, 'Кол-во полос'], [203, 'Кол-во рулонов'],
+    [204, 'Кол-во план'], [205, 'В работе']]);
+var supMeta = meta(300, [[301, 'Метраж, м'], [302, 'Кол-во рулонов'], [303, 'В работе'],
+    [304, 'Статус'], [305, 'Партия ГП']]);
+
+var root = { getAttribute: function() { return 'testdb'; } };
+var c = new Controller(root);
+c.meta.cut = cutMeta; c.meta.finishedBatch = fbMeta; c.meta.supply = supMeta;
+
+// Голова цепочки H: «Вид сырья» = 'M7' (как грузится из cut_material_id). 8 рулонов обеспечения.
+c.cuts = [{ id: 'H', length: 450, materialId: 'M7', status: 'В работе', slitter: { id: 'S1' },
+    batchId: 'B1', winding: 'IN', leaders: [] }];
+c.supplies = [{ id: 'SUP1', cutId: 'H', rolls: 8, footage: 450, finishedBatchId: 'FB1', positionId: 'P1' }];
+c.footageBySupply = {};
+
+// Стабы побочных эффектов.
+var posts = [];
+var idc = 0;
+c.post = function(path, params) { posts.push({ path: path, params: params || {} }); return Promise.resolve({ obj: 'NEW' + (++idc) }); };
+c.loadStripsForCut = function() { return Promise.resolve([]); };
+c.resolveLeaderId = function() { return ''; };
+c.reload = function() { return Promise.resolve(); };
+c.persistCutSetupColumns = function() { return Promise.resolve(); };
+c.setBusy = function() {}; c.showProgress = function() {}; c.updateProgress = function() {};
+c.hideProgress = function() {}; c.render = function() {}; c.notify = function() {};
+
+// План: голова H (5 проходов) обновляется, продолжение B (3 прохода) создаётся.
+c.applySplitPlan({
+    updates: [{ cutId: 'H', sequence: 1, planStartTs: 1000, plannedRuns: 5 }],
+    creates: [{ parentCutId: 'H', sequence: 2, planStartTs: 2000, plannedRuns: 3 }],
+    deletes: []
+}).then(function() {
+    var tMat = 't' + MAT;
+
+    // 1) Создаваемое продолжение B (_m_new в таблицу резки) пишет «Вид сырья» = 'M7'.
+    var createCut = posts.filter(function(p) { return p.path === '_m_new/100?JSON&up=1'; });
+    assert(createCut.length === 1, '#3795: создаётся ровно одна запись-продолжение резки');
+    assert(createCut[0] && String(createCut[0].params[tMat]) === 'M7',
+        '#3795: продолжение получает «Вид сырья» = M7 (сырьё головы цепочки), а не пустоту');
+
+    // 2) Обновляемая запись головы тоже несёт «Вид сырья» = 'M7' (лечит реюзнутые продолжения).
+    var updCut = posts.filter(function(p) { return p.path === '_m_set/H?JSON'; });
+    assert(updCut.length === 1 && String(updCut[0].params[tMat]) === 'M7',
+        '#3795: обновление записи пишет «Вид сырья» = M7 (восстановление сырья реюзнутых продолжений)');
+
+    console.log('\n' + passed + ' assertions passed');
+}).catch(function(err) {
+    console.log('FAIL — applySplitPlan бросил: ' + (err && err.stack || err));
+    process.exitCode = 1;
+});

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 65);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 66);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
## Проблема (#3795)

У заказа, **продолженного с прошлого дня** (например 3716), в очереди следующего дня **не показывалось сырьё** (карточка выводила «—»). Если перелистнуть на день назад — сырьё есть.

## Причина

Карточка очереди показывает сырьё из `cut_material` — **собственного реквизита «Вид сырья» резки** (грузится в `c.materialId`/`c.materialName`, `production-planning.js:1039-1040`; вывод — `:9227`).

`applySplitPlan` при дроблении по дням копировал в запись-продолжение Слиттер / Партию сырья / Полосы / Очередность / Намотку / Лидера / Метраж — но **не «Вид сырья»**. А обеспечения продолжения привязаны к позиции (`up=positionId`), а не к самой резке по «Заданию», поэтому `materialByCut` сырьё тоже не восстанавливал → пустое поле → «—».

Это ровно тот же пробел, что чинил #3781 для «Метраж, м».

## Фикс (по образцу #3781)

«Вид сырья» цепочки = сырьё её **головы** (у всех сегментов одно сырьё), пишется:
- в **создаваемое** продолжение (`material: parentMaterial` в `cutFields`);
- в **обновляемую** запись (восстановление — лечит реюзнутые продолжения, созданные до фикса с пустым полем; при пере-генерации `#3280` продолжения переиспользуются через update-путь).

Изменения:
- `materialForCutId(cutId)` — helper рядом с `runLenForCutId` (сырьё головы цепочки);
- create-путь и update-путь `applySplitPlan`;
- `VERSION` 65→66 (cache-bust);
- тест `experiments/atex-production-planning-3795.test.js` — гоняет **настоящий** `applySplitPlan` поверх стаба `post`; **падает на исходном коде, проходит с фиксом**.

## Проверка

- `node experiments/atex-production-planning-3795.test.js` → 3/3 PASS (на исходном коде — 2 FAIL).
- Прогон всего набора `atex-production-planning*` + `atex-issue-37*` — мой фикс **не добавляет регрессий**: набор FAIL'ов в `atex-production-planning.test.js` (#3340/#3249) и `…-3619.test.js` бит-в-бит совпадает до и после правки (предсуществующие, к #3795 отношения не имеют).

🤖 Generated with [Claude Code](https://claude.com/claude-code)