### PR TITLE
fix(#3810): подхватывать в настройке импорта колонку, добавленную в таблицу после сохранения

### DIFF
--- a/experiments/test-issue-3810-upload-added-column.js
+++ b/experiments/test-issue-3810-upload-added-column.js
@@ -1,0 +1,139 @@
+// Regression test for issue #3810.
+//
+// templates/upload.html — when the user picks a SAVED import setting, applySet()
+// re-fetches the table schema and the `case 'type'` branch of intApi() rebuilds
+// the draggable field list. The reconciliation loop only walked the *saved*
+// importMap, so a requisite ADDED to the table AFTER the setting was saved (it is
+// present in json.req_order but absent from the saved importMap) silently
+// disappeared and could not be mapped.
+//
+// The fix appends any current requisite (and the main value, defensively) that is
+// missing from the saved importMap to the end of the field list, reusing the same
+// addSortable(...) calls as the fresh-setting branch.
+//
+// This test extracts the real `case 'type'` block from the template and runs it
+// under tiny shims, replaying the exact scenario from the issue: the «Заказанное
+// количество» table (type 1076) gained column «Ед.изм.» (req 129370) after a
+// setting was saved without it.
+
+var fs = require('fs');
+var path = require('path');
+
+var passed = 0, failed = 0;
+function check(name, ok){
+  console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+  if (ok) passed++; else { failed++; process.exitCode = 1; }
+}
+
+// ── Extract the real `case 'type'` block source from the template ────────────
+var template = fs.readFileSync(path.join(__dirname, '..', 'templates', 'upload.html'), 'utf8');
+var start = template.indexOf("case 'type':");
+if (start < 0) throw new Error("case 'type' not found in template");
+// The block is terminated by its own `break;` (16-space indent). No inner
+// switch/loop uses break inside it, so the first such marker closes the case.
+var brk = template.indexOf('\n                break;', start);
+if (brk < 0) throw new Error("closing break of case 'type' not found");
+// Body = everything after `case 'type':` up to (but not including) the break.
+var caseBody = template.slice(start + "case 'type':".length, brk);
+
+// The fix must be present and must guard with === undefined (index 0 is falsy).
+check('source appends current req_order entries missing from saved importMap',
+  /for\(i in json\.req_order\)/.test(caseBody) &&
+  /uploadSets\[chosenSet\]\.importMap\[json\.req_order\[i\]\]===undefined/.test(caseBody));
+check('source also appends the main value when missing from importMap',
+  /uploadSets\[chosenSet\]\.importMap\[json\.type\.id\]===undefined/.test(caseBody));
+
+// ── addSortable shim: emits a marker carrying the field id so we can assert ──
+function addSortable(id, val, base, baseId){
+  return '[FIELD id=' + id + ' name="' + val + '" base=' + base + ']';
+}
+// `---` placeholders come through as base=--- / --; real fields carry a numeric id.
+
+// ── jQuery shim: captures $('#sortable').html(h); answers the rest harmlessly ─
+function makeShim(store){
+  return function(sel){
+    var id = (typeof sel === 'string' && sel.charAt(0) === '#') ? sel.slice(1) : sel;
+    var api = {
+      html: function(v){ if (arguments.length){ store[id] = v; return api; } return store[id] || ''; },
+      val: function(){ return api; },
+      prop: function(){ return api; },
+      attr: function(){ return api; },
+      append: function(){ return api; },
+      addClass: function(){ return api; },
+      removeClass: function(){ return api; },
+      show: function(){ return api; },
+      hide: function(){ return api; },
+      remove: function(){ return api; }
+    };
+    return api;
+  };
+}
+
+function runCaseType(scenario){
+  var store = {};
+  var $ = makeShim(store);
+  var noop = function(){};
+  var factory = new Function(
+    '$', 'addSortable', 'getParent', 'getUpType', 'gatherSet', 'setAutoParent',
+    'selectItem', 'json', 'chosenSet', 'uploadSets', 'formulas',
+    'var h="", i, j, chosenType, chosenTypeName, upType, origMap={}, xlsxSavedSel;\n' +
+    caseBody +
+    '\nreturn $("#sortable").html();'
+  );
+  return factory(
+    $, addSortable,
+    function(){ return ''; },   // getParent → '' (no parent block)
+    function(){ return ''; },   // getUpType
+    noop, noop, noop,           // gatherSet / setAutoParent / selectItem
+    scenario.json, scenario.chosenSet, scenario.uploadSets, scenario.formulas || {}
+  );
+}
+
+// ── Scenario from the issue ──────────────────────────────────────────────────
+// «Заказанное количество» type 1076. The saved setting knew columns up to req
+// 66418; the table later gained req 129370 «Ед.изм.» (and we also drop a column,
+// req 9999, that no longer exists in the table to confirm the removal placeholder
+// still works).
+var REQ = {
+  '1138': 'Вид сырья', '1141': 'Ширина, мм', '1143': 'Длина, м', '16325': 'Статус позиции',
+  '1147': 'Обеспечение', '8194': 'Диаметр втулки', '8463': 'Тип намотки',
+  '8571': 'Дата согласования', '8627': 'Срок изготовления', '13671': 'Задача на втулки',
+  '66405': 'Примечание', '66409': 'Лидер', '66418': 'Доп. втулка',
+  '129370': 'Ед.изм.'   // ← added to the table AFTER the setting was saved
+};
+var req_order = Object.keys(REQ);                 // current table schema
+var req_type = {}, req_base = {}, req_base_id = {};
+req_order.forEach(function(id){ req_type[id] = REQ[id]; req_base[id] = 'SHORT'; req_base_id[id] = ''; });
+
+// Saved importMap (from the issue body) — note it has NO 129370, and it has 1076
+// (the main value). We add a stale 9999 to exercise the removed-column path.
+var savedImportMap = {
+  '1076': 7, '1077': 8, '1080': 12, '1138': 2, '1141': 3, '1143': 5, '8194': 9,
+  '8463': 10, '8571': 11, '8627': 4, '16325': 6, '66405': 0, '66409': 13, '66418': 14,
+  '9999': 15   // column removed from the table after the setting was saved
+};
+
+var json = {
+  type: { id: '1076', val: 'Заказанное количество', base: 'LONG' },
+  base: { id: '' },
+  req_order: req_order, req_type: req_type, req_base: req_base, req_base_id: req_base_id
+};
+var html = runCaseType({
+  json: json, chosenSet: 'Заказанное количество',
+  uploadSets: { 'Заказанное количество': { type: '1076', importMap: savedImportMap, formulas: {} } }
+});
+
+// ── Assertions ───────────────────────────────────────────────────────────────
+check('added column «Ед.изм.» (req 129370) now appears in the field list',
+  /\[FIELD id=129370 name="Ед\.изм\." /.test(html));
+check('main value (type 1076) still present exactly once',
+  (html.match(/\[FIELD id=1076 /g) || []).length === 1);
+check('added column «Ед.изм.» appears exactly once (no duplicate)',
+  (html.match(/\[FIELD id=129370 /g) || []).length === 1);
+check('a pre-existing mapped column (req 1138) is still present',
+  /\[FIELD id=1138 /.test(html));
+check('removed column (req 9999, gone from table) is NOT rendered as a real field',
+  !/\[FIELD id=9999 /.test(html) && /base=---/.test(html));
+
+console.log('\n' + passed + ' passed, ' + failed + ' failed');
+process.exit(failed ? 1 : 0);

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -960,6 +960,17 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                         j++;
                     }
                     h=m.join('');
+                    // issue #3810: реквизиты (и главное значение), добавленные в таблицу
+                    // ПОСЛЕ сохранения настройки, отсутствуют в сохранённом importMap, поэтому
+                    // циклы выше их пропускают. Дописываем такие поля в конец списка — как новые
+                    // входные колонки следом за уже размеченными, чтобы их можно было разложить
+                    // и задать формулу (по аналогии с веткой свежей настройки). Проверка
+                    // === undefined, т.к. индекс входной колонки может быть 0 (ложь по truthiness).
+                    if(uploadSets[chosenSet].importMap[json.type.id]===undefined)
+                        h+=addSortable(json.type.id,json.type.val,json.type.base,json.base.id);
+                    for(i in json.req_order)
+                        if(uploadSets[chosenSet].importMap[json.req_order[i]]===undefined)
+                            h+=addSortable(json.req_order[i],json.req_type[json.req_order[i]],json.req_base[json.req_order[i]],json.req_base_id[json.req_order[i]]);
                     $('#header').prop('checked',uploadSets[chosenSet].header);
                     $('#trim').prop('checked',uploadSets[chosenSet].trim);
                     $('#delim').val(uploadSets[chosenSet].delimiter);


### PR DESCRIPTION
Closes #3810

## Проблема
В массовом импорте (`templates/upload.html`) при выборе **сохранённой** настройки `applySet()` заново читает схему таблицы и в ветке `case 'type'` пересобирает список полей. Цикл реконсиляции проходил **только по сохранённому `importMap`**, поэтому реквизит, добавленный в таблицу **после** сохранения настройки (он есть в `json.req_order`, но отсутствует в `importMap`), молча исчезал — его нельзя было разметить.

Пример из тикета: в таблицу «Заказанное количество» (тип `1076`) добавили колонку «Ед.изм.» (req `129370`), но в сохранённой настройке её не было.

## Фикс
После сборки списка полей дописываем в конец недостающие поля — реквизиты из `json.req_order` (и, на всякий случай, главное значение `json.type.id`), которых нет в сохранённом `importMap`, — теми же вызовами `addSortable()`, что и ветка свежей настройки. Новые поля становятся новыми входными колонками следом за уже размеченными; `gatherSet()` присваивает им индексы, `doSaveSet` персистит. Проверка `=== undefined` (а не truthiness), т.к. индекс входной колонки может быть `0`.

Удаление колонки уже обрабатывалось заглушкой `---` (issue #3358) — путь не тронут.

```diff
                     h=m.join('');
+                    if(uploadSets[chosenSet].importMap[json.type.id]===undefined)
+                        h+=addSortable(json.type.id,json.type.val,json.type.base,json.base.id);
+                    for(i in json.req_order)
+                        if(uploadSets[chosenSet].importMap[json.req_order[i]]===undefined)
+                            h+=addSortable(json.req_order[i],json.req_type[json.req_order[i]],json.req_base[json.req_order[i]],json.req_base_id[json.req_order[i]]);
                     $('#header').prop('checked',uploadSets[chosenSet].header);
```

## Тест
`experiments/test-issue-3810-upload-added-column.js` извлекает реальный блок `case 'type'` из шаблона и проигрывает сценарий из тикета (таблица `1076` + новая колонка «Ед.изм.» `129370`, плюс контрольная удалённая колонка). Падает на старом коде (4 fail), проходит на новом (7 pass).

```
node experiments/test-issue-3810-upload-added-column.js
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
