### PR TITLE
#3808: переходящее задание без сырья — лечим «Вид сырья» по цепочке (станок|намотка|ножи)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -4044,6 +4044,46 @@
         return out;
     }
 
+    // #3808: восстановить «Вид сырья» переходящих сегментов с ПУСТЫМ материалом. Сегмент-
+    // продолжение дробления по дням физически тот же, что и голова цепочки (станок|намотка|
+    // набор ножей) — отличается только днём. `continuationSignature` ВКЛЮЧАЕТ materialId,
+    // поэтому пустой материал продолжения не давал ему слиться с головой в
+    // `mergeContinuationChains` → `materialForCutId` (#3795) не находил голову и не лечил его:
+    // переходящее задание оставалось без сырья («—»). Группируем материал-АГНОСТИЧНО
+    // (станок|намотка|набор ножей — это `continuationSignature` без materialId) и, если в
+    // группе ровно одно непустое сырьё, проставляем его сегментам с пустым. Неоднозначные
+    // группы (несколько разных сырьёв) не трогаем — лечим только безопасные случаи. Мутирует
+    // `c.materialId`; → массив id вылеченных резок. Чистая (тест).
+    function healContinuationMaterials(cuts){
+        var groups = {};
+        (cuts || []).forEach(function(c){
+            var ks = ((c && c.knifeWidths) || []).slice().map(Number).sort(function(a, b){ return a - b; }).join(',');
+            var key = [
+                (c && c.slitter && c.slitter.id) == null ? '' : String(c.slitter.id),
+                normWinding(c && c.winding),
+                ks
+            ].join('|');
+            (groups[key] = groups[key] || []).push(c);
+        });
+        var healed = [];
+        Object.keys(groups).forEach(function(key){
+            var arr = groups[key];
+            var mats = {};
+            arr.forEach(function(c){
+                var m = c && c.materialId != null ? String(c.materialId).trim() : '';
+                if (m) mats[m] = true;
+            });
+            var distinct = Object.keys(mats);
+            if (distinct.length !== 1) return;   // нет источника / неоднозначно — не трогаем
+            var mat = distinct[0];
+            arr.forEach(function(c){
+                var m = c && c.materialId != null ? String(c.materialId).trim() : '';
+                if (m === '') { c.materialId = mat; healed.push(String(c.id)); }
+            });
+        });
+        return healed;
+    }
+
     // #3785: при равной стоимости перехода тай-брейк — число полос (ножей) ПО УБЫВАНИЮ
     // («при прочих равных» больше полос — раньше), затем уже ширина ролика и id.
     function startKey(c){ return [-(Number(c.knifeCount) || 0), Number(c.rollerWidth) || 0, String(c.id)]; }
@@ -4599,6 +4639,7 @@
         reserveFifo: reserveFifo,
         fifoBatchesForMaterial: fifoBatchesForMaterial,
         materialByCut: materialByCut,
+        healContinuationMaterials: healContinuationMaterials,   // #3808
         windingPointsFromTimes: windingPointsFromTimes,
         foilWindingPointsFromTimes: foilWindingPointsFromTimes,
         foilWindingMinutes: foilWindingMinutes,   // #3742
@@ -5653,6 +5694,19 @@
             if (m) {
                 c.materialId = m;
                 c.materialName = (self.materialNameById && self.materialNameById[m]) || c.materialName || '';
+            }
+        });
+        // #3808: переходящие сегменты с пустым «Видом сырья» (обеспечения которых ведут на
+        // НЕактивную позицию → materialByCut их не восстановил) лечим по цепочке станок|намотка|
+        // ножи (см. healContinuationMaterials). После этого materialId согласован у всей цепочки,
+        // поэтому continuationSignature снова объединяет сегменты, и applySplitPlan (#3795) при
+        // ближайшем сохранении пропишет «Вид сырья» в БД (т.е. лечение и отображается, и
+        // персистится).
+        var healed = healContinuationMaterials(this.cuts);
+        healed.forEach(function(id) {
+            var c = self.cuts.filter(function(x) { return String(x.id) === String(id); })[0];
+            if (c && !c.materialName) {
+                c.materialName = (self.materialNameById && self.materialNameById[String(c.materialId)]) || c.materialName || '';
             }
         });
     };

--- a/experiments/atex-production-planning-3808.test.js
+++ b/experiments/atex-production-planning-3808.test.js
@@ -1,0 +1,83 @@
+// Unit tests for #3808 — «Почему опять в переходящем задании нет сырья? См. станок 4.»
+//
+// Корень: continuationSignature (станок|сырьё|намотка|ножи) ВКЛЮЧАЕТ materialId. Переходящий
+// сегмент дробления по дням с ПУСТЫМ «Видом сырья» получал другую сигнатуру, чем его голова,
+// → mergeContinuationChains не сливал их в цепочку → materialForCutId (#3795) не находил голову
+// и не лечил сегмент: переходящее задание оставалось «—». materialByCut тоже не восстанавливал
+// (обеспечения продолжения ведут на НЕактивную позицию).
+//
+// Фикс: healContinuationMaterials — материал-АГНОСТИЧНАЯ группировка (станок|намотка|ножи); если
+// в группе ровно одно непустое сырьё, проставляем его сегментам с пустым. Неоднозначные группы
+// (несколько сырьёв) не трогаем.
+//
+// Run with: node experiments/atex-production-planning-3808.test.js
+
+process.env.TZ = 'UTC';
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else { console.log('  expected:', JSON.stringify(expected)); console.log('  actual:  ', JSON.stringify(actual)); process.exitCode = 1; }
+}
+function cut(id, slitter, materialId, winding, kw) {
+    return { id: id, slitter: { id: slitter }, materialId: materialId, winding: winding, knifeWidths: kw };
+}
+
+// ── 1) Базовый случай: голова M + переходящий сегмент с пустым сырьём (та же конфигурация) ──
+var c1 = [
+    cut('head', '4', '2158', 'IN', [55, 33]),   // голова дня N — сырьё MW411
+    cut('cont', '4', '',     'IN', [55, 33])    // переходящий сегмент дня N+1 — сырьё пустое
+];
+var healed1 = planning.healContinuationMaterials(c1);
+assertEqual(healed1, ['cont'], '#3808: вылечен переходящий сегмент (id cont)');
+assertEqual(c1[1].materialId, '2158', '#3808: переходящему сегменту проставлено сырьё головы (2158)');
+assertEqual(c1[0].materialId, '2158', '#3808: сырьё головы не тронуто');
+
+// ── 2) Цепочка из нескольких сегментов ──
+var c2 = [
+    cut('h', '4', 'M', 'OUT', [40, 40]),
+    cut('a', '4', '',  'OUT', [40, 40]),
+    cut('b', '4', '',  'OUT', [40, 40])
+];
+assertEqual(planning.healContinuationMaterials(c2).sort(), ['a', 'b'], '#3808: вылечены оба пустых сегмента цепочки');
+assertEqual([c2[1].materialId, c2[2].materialId], ['M', 'M'], '#3808: обоим проставлено сырьё головы');
+
+// ── 3) Неоднозначность: две головы с разным сырьём, та же конфигурация → НЕ трогаем ──
+var c3 = [
+    cut('x', '4', 'M1', 'IN', [50, 50]),
+    cut('y', '4', 'M2', 'IN', [50, 50]),
+    cut('z', '4', '',   'IN', [50, 50])   // непонятно, чьё продолжение → оставляем пустым
+];
+assertEqual(planning.healContinuationMaterials(c3), [], '#3808: неоднозначная группа (2 сырья) — не лечим');
+assertEqual(c3[2].materialId, '', '#3808: пустой сегмент остаётся пустым при неоднозначности');
+
+// ── 4) Разные ножи → разные цепочки: пустой сегмент с ДРУГИМ набором ножей не лечится чужим ──
+var c4 = [
+    cut('p', '4', 'M', 'IN', [55, 33]),
+    cut('q', '4', '',  'IN', [20, 20])    // другой набор ножей — не та же цепочка
+];
+assertEqual(planning.healContinuationMaterials(c4), [], '#3808: другой набор ножей — не сливаем в цепочку');
+assertEqual(c4[1].materialId, '', '#3808: сегмент с другими ножами остаётся пустым');
+
+// ── 5) Разные станки не смешиваем ──
+var c5 = [
+    cut('s4', '4', 'M', 'IN', [60, 60]),
+    cut('s3', '3', '',  'IN', [60, 60])   // другой станок
+];
+assertEqual(planning.healContinuationMaterials(c5), [], '#3808: другой станок — отдельная группа, не лечим');
+
+// ── 6) Источника нет (все пустые) → ничего не лечим ──
+var c6 = [ cut('e1', '4', '', 'IN', [10, 10]), cut('e2', '4', '', 'IN', [10, 10]) ];
+assertEqual(planning.healContinuationMaterials(c6), [], '#3808: нет непустого сырья в группе — лечить нечем');
+
+// ── 7) После лечения continuationSignature головы и продолжения СОВПАДАЮТ (ключевой эффект:
+//        mergeContinuationChains снова объединит их, и applySplitPlan #3795 пропишет сырьё) ──
+var c7 = [ cut('H', '4', '777', 'IN', [33, 55]), cut('C', '4', '', 'IN', [33, 55]) ];
+planning.healContinuationMaterials(c7);
+assertEqual(planning.continuationSignature(c7[0]), planning.continuationSignature(c7[1]),
+    '#3808: после лечения сигнатуры головы и продолжения равны (цепочка снова сливается)');
+
+console.log('\n' + passed + ' passed');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 67);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 68);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
## Проблема (#3808)

Переходящее задание (сегмент-продолжение дробления по дням) на **станке 4** показывалось
**без сырья** («—»). «Опять» — потому что #3795 уже добавил лечение «Вида сырья» продолжений,
но оно не доставало до пустых сегментов.

## Причина (курица-яйцо)

`continuationSignature` = `станок|сырьё|намотка|ножи` — **включает `materialId`**. У сегмента
с **пустым** «Видом сырья» сигнатура отличается от головы цепочки → `mergeContinuationChains`
**не сливает** их в одну логическую резку → `chainHeadById` указывает на сам сегмент →
`materialForCutId` (#3795) возвращает его **собственное пустое** сырьё → запись ничего не
прописывает. Самоподдерживающееся состояние.

`materialByCut` тоже не восстанавливает: обеспечения продолжения ведут на **неактивную**
позицию (`positions_list` отдаёт только активные ~46), поэтому `posMat[positionId]` пуст.

## Решение

`healContinuationMaterials` — **материал-агностичная** группировка `станок|намотка|ножи`
(это `continuationSignature` без `materialId`). Если в группе **ровно одно** непустое сырьё,
проставляем его сегментам с пустым; неоднозначные группы (несколько разных сырьёв) не трогаем
(лечим только безопасные случаи). Вызывается в `resolveCutMaterials` после `materialByCut`.

После лечения `materialId` согласован у всей цепочки → `continuationSignature` снова объединяет
сегменты, и `applySplitPlan` (#3795) при ближайшем сохранении **пропишет «Вид сырья» в БД** —
т.е. лечение и **отображается сразу**, и **персистится**.

## Проверка

- Код `download/atex/js/production-planning.js`: подтверждено, что `continuationSignature`
  (line ~3424) содержит `materialId`, а `materialForCutId` (#3795) опирается на
  `mergeContinuationChains` → разрыв цепочки у пустого сегмента.
- Объектный отчёт `report/cut_planning` и `object/1078` с реквизитами на проде сейчас
  таймаутят (>75с на JSON_KV-рендере), поэтому проверка — юнит-репро (12 тестов).

## Изменения

- `download/atex/js/production-planning.js` — `healContinuationMaterials` + вызов в
  `resolveCutMaterials`.
- `index.php` — `VERSION` 67 → 68 (cache-bust правки js).
- `experiments/atex-production-planning-3808.test.js` — 12 тестов (#3808).

## Тесты

`node experiments/atex-production-planning-3808.test.js` → **12 passed**. Полный прогон
`atex-production-planning*` → только **6 предсуществующих FAIL** на `origin/main`
(rowsToPlanning #3242, rowsToGenPositions #3340/#3433, isCutVisible #3249, три #3619) — к
этой правке отношения не имеют.

Fixes #3808

🤖 Generated with [Claude Code](https://claude.com/claude-code)