### PR TITLE
#3824: upload.html — t273 в тело POST (фикс 414 Request-URI Too Long)

### DIFF
--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1052,10 +1052,14 @@ function intApi(m,u,b,vars,index){ // Параметры: метод, адрес
                     saveSet['xlsx']={sheet:$('#xlsx-sheet').val(),r0:xlsxSel.r0,c0:xlsxSel.c0,r1:xlsxSel.r1,c1:xlsxSel.c1};
                 else if(uploadSets[chosenSet]&&uploadSets[chosenSet].xlsx)
                     saveSet['xlsx']=uploadSets[chosenSet].xlsx;
+                // issue #3824: значение настройки (t273 = JSON всего набора) кладём в ТЕЛО
+                // POST, а не в query-строку URL — иначе при большом наборе колонок/формул URL
+                // перерастал лимит и сервер отвечал 414 (Request-URI Too Long). intApi для
+                // строкового vars сам ставит Content-Type form-urlencoded и добавляет _xsrf.
                 if(json.object)
-                    intApi('POST','_m_set/'+json.object[0].id+'?JSON&t273='+encodeURIComponent(JSON.stringify(saveSet)),'save-set');
+                    intApi('POST','_m_set/'+json.object[0].id+'?JSON','save-set','t273='+encodeURIComponent(JSON.stringify(saveSet)));
                 else
-                    intApi('POST','_m_new/269?JSON&up=1&t271=UPLOAD&t269='+encodeURIComponent($('#save-set').val())+'&t273='+encodeURIComponent(JSON.stringify(saveSet)),'save-set');
+                    intApi('POST','_m_new/269?JSON&up=1','save-set','t271=UPLOAD&t269='+encodeURIComponent($('#save-set').val())+'&t273='+encodeURIComponent(JSON.stringify(saveSet)));
                 break;
                 
             case 'upload':


### PR DESCRIPTION
## Проблема (#3824)

```
upload:1460  POST https://ideav.ru/ateh/_m_set/130866?JSON&t273=
414 (Request-URI Too Long)
```

Сохранение настройки импорта (`doSaveSet`) отправляло весь набор колонок/формул как `t273=<JSON>` **в query-строке URL** запроса `_m_set`/`_m_new`. При большом наборе (много колонок, формулы, xlsx-диапазон) URL перерастал лимит длины → сервер отвечал **414 (Request-URI Too Long)**, и настройка не сохранялась.

## Фикс

Переносим значения реквизитов в **тело POST**, а не в URL:
- `_m_set/<id>?JSON` + тело `t273=<JSON>`
- `_m_new/269?JSON&up=1` + тело `t271=UPLOAD&t269=<имя>&t273=<JSON>`

Управляющие параметры (`up=1`, `JSON`) остаются в URL. `intApi` для строкового `vars` (4-й аргумент) сам ставит `Content-Type: application/x-www-form-urlencoded` и добавляет `_xsrf` — тело уходит как положено.

Это тот же способ передачи `t`-полей, что уже используют `templates/quiz.html` (та же функция `intApi`) и atex-модули (`production-planning.js`/`slitter.js`/`orders.js`/`warehouse.js` — `_m_set`/`_m_new` с полями в form-urlencoded теле).

## Проверка

`templates/upload.html` — серверный шаблон (inline-скрипт в ответе страницы), не версионируемый статик-ассет: bump VERSION / `build.sh` не требуются. Изменение — перенос `t`-полей из URL в тело, без смены семантики записи.

🤖 Generated with [Claude Code](https://claude.com/claude-code)