### PR TITLE
#3844: кнопка «ОК» в модалке «Отпуск станка» — закрывает окно

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -9090,6 +9090,31 @@
         });
     };
 
+    // #3764/#3844: построить модалку «Отпуск» (заголовок, тело-таблица, «×», «ОК»).
+    // «×» и «ОК» (справа) закрывают окно; поля «Отпуска» сохраняются по change, поэтому
+    // отдельного «Сохранить» нет. Та же механика оверлея, что у формы/тайминга (×/оверлей/Esc).
+    AtexProductionPlanning.prototype.buildDowntimeModal = function() {
+        var self = this;
+        var dtTitle = el('h2', { class: 'atex-pp-form-title atex-pp-dt-title', text: 'Отпуск станка' });
+        var dtBody = el('div', { class: 'atex-pp-dt-body' });
+        var dtDialog = el('div', { class: 'atex-pp-modal-dialog atex-pp-dt-dialog' });
+        var dtClose = el('button', { class: 'atex-pp-modal-close', type: 'button', text: '×', title: 'Закрыть' });
+        dtClose.addEventListener('click', function() { self.closeDowntime(); });
+        // #3844: «ОК» (справа) — закрывает окно (поля сохраняются по change, отдельного «Сохранить» нет).
+        var dtOk = el('button', { class: 'atex-pp-btn atex-pp-btn-primary atex-pp-dt-ok', type: 'button', text: 'ОК', title: 'Закрыть' });
+        dtOk.addEventListener('click', function() { self.closeDowntime(); });
+        dtDialog.appendChild(dtClose);
+        dtDialog.appendChild(dtTitle);
+        dtDialog.appendChild(dtBody);
+        dtDialog.appendChild(el('div', { class: 'atex-pp-supply-actions' }, [dtOk]));
+        this.downtimeModalTitleEl = dtTitle;
+        this.downtimeModalBodyEl = dtBody;
+        this.downtimeModalEl = el('div', { class: 'atex-pp-modal atex-pp-dt-modal' }, [dtDialog]);
+        this.downtimeModalEl.addEventListener('click', function(e) { if (e.target === self.downtimeModalEl) self.closeDowntime(); });
+        this.root.appendChild(this.downtimeModalEl);
+        return this.downtimeModalEl;
+    };
+
     AtexProductionPlanning.prototype.openDowntime = function() {
         if (!this.meta.downtime) { this.notify('В метаданных нет таблицы «' + TABLE.downtime + '»', 'error'); return; }
         var act = this.downtimeActiveSlitter;
@@ -10264,21 +10289,9 @@
         this.timingModalEl.addEventListener('click', function(e) { if (e.target === self.timingModalEl) self.closeCutTiming(); });
         this.root.appendChild(this.timingModalEl);
 
-        // #3764: модалка «Отпуск» (окна простоя станка) — заголовок, редактируемая таблица и
-        // кнопка «+ Отпуск». Та же механика оверлея, что у формы/тайминга (×/оверлей/Esc).
-        var dtTitle = el('h2', { class: 'atex-pp-form-title atex-pp-dt-title', text: 'Отпуск станка' });
-        var dtBody = el('div', { class: 'atex-pp-dt-body' });
-        var dtDialog = el('div', { class: 'atex-pp-modal-dialog atex-pp-dt-dialog' });
-        var dtClose = el('button', { class: 'atex-pp-modal-close', type: 'button', text: '×', title: 'Закрыть' });
-        dtClose.addEventListener('click', function() { self.closeDowntime(); });
-        dtDialog.appendChild(dtClose);
-        dtDialog.appendChild(dtTitle);
-        dtDialog.appendChild(dtBody);
-        this.downtimeModalTitleEl = dtTitle;
-        this.downtimeModalBodyEl = dtBody;
-        this.downtimeModalEl = el('div', { class: 'atex-pp-modal atex-pp-dt-modal' }, [dtDialog]);
-        this.downtimeModalEl.addEventListener('click', function(e) { if (e.target === self.downtimeModalEl) self.closeDowntime(); });
-        this.root.appendChild(this.downtimeModalEl);
+        // #3764/#3844: модалка «Отпуск» (окна простоя станка) — заголовок, редактируемая
+        // таблица, кнопка «+ Отпуск» и «ОК»/«×» для закрытия. Скаффолд — buildDowntimeModal.
+        this.buildDowntimeModal();
 
         if (typeof document !== 'undefined') {
             document.addEventListener('keydown', function(e) {

--- a/experiments/atex-production-planning-3764-ui.test.js
+++ b/experiments/atex-production-planning-3764-ui.test.js
@@ -149,5 +149,15 @@ c.notify = function(msg, kind) { notices.push({ msg: msg, kind: kind }); };
     await c.deleteDowntimeRow('101', { id: null });
     assert(posts.length === 0, '#3764-ui: удаление не сохранённой строки не дёргает сервер');
 
+    // ── 7) #3844: кнопка «ОК» (справа) закрывает окно ──
+    c.buildDowntimeModal();
+    var okBtn = c.downtimeModalEl.querySelector('.atex-pp-dt-ok');
+    assert(okBtn && okBtn.textContent === 'ОК', '#3844-ui: в модалке есть кнопка «ОК»');
+    var actions = c.downtimeModalEl.querySelector('.atex-pp-supply-actions');
+    assert(actions && actions.querySelector('.atex-pp-dt-ok'), '#3844-ui: «ОК» в правой панели действий (flex-end)');
+    c.downtimeModalEl.classList.add('is-open');
+    okBtn.click();
+    assert(!c.downtimeModalEl.classList.contains('is-open'), '#3844-ui: клик «ОК» закрывает окно (снимает is-open)');
+
     console.log('\n' + passed + ' assertions passed');
 })();

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@ define("RETRIES_LIMIT", 5);
 define("CHECKCODE_RETRIES_LIMIT", 2);
 define("TOKEN", 125);
 define("SECRET", 130);
-define("VERSION", 74);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
+define("VERSION", 75);  # cache-bust версия ассетов (?0{_global_.version}); бить при правках js/css — #3418
 define("VAL_LIM", 127);  # Maximum length of the value (val) field on UI
 
 $com = explode("?", strtolower($_SERVER["REQUEST_URI"]));


### PR DESCRIPTION
Closes #3844.

## Что сделано

В модалку **«Отпуск станка»** (окна простоя слиттера, #3764/#3780) добавлена primary-кнопка **«ОК»** правее таблицы — закрывает окно.

- Кнопка лежит в панели действий `atex-pp-supply-actions` (`justify-content: flex-end` → **справа**), как у других модалок (перенос/обеспечение).
- Закрытие — через существующий `closeDowntime()` (та же механика, что у «×», `Esc` и клика по оверлею). Отдельного «Сохранить» нет: поля «Отпуска» сохраняются по `change`, поэтому «ОК» только закрывает окно.
- Скаффолд модалки вынесен из `start()` в метод `buildDowntimeModal()` — поведение прежнее, но конструкция стала тестируемой.

## Тесты

`experiments/atex-production-planning-3764-ui.test.js` — +3 проверки (#3844): наличие кнопки «ОК», её размещение в правой панели действий, закрытие окна по клику (снимается `is-open`). Всего 18 проверок зелёные. Регрессий нет: `atex-production-planning.test.js` (586), `atex-production-planning-3764.test.js` (26).

`index.php` VERSION 74→75 (cache-bust ассетов).

🤖 Generated with [Claude Code](https://claude.com/claude-code)