### PR TITLE
fix(#3885): очередь — две резки не встают в одно время (встык по сохранённому плану)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3327,6 +3327,15 @@
         var base = Number(baseMidnightMs);
         function num(v) { return (v == null || v === '') ? 0 : (Number(v) || 0); }
         var out = [];
+        // #3885: сохранённые planStart двух резок ОДНОГО станка в один день могут совпасть
+        // (напр. обе t1078 = 08:00) — след незавершённой пересборки времени старта: перенос
+        // до #3840 не пересобирал planStart, а пересборка #3660 идёт только в scope фильтра, и
+        // «осиротевший» старт остаётся прежним. Раньше очередь пересчитывала расписание на лету
+        // (buildSchedule) и нахлёст не показывала; с #3846 (показ сохранённого) две карточки
+        // вставали в одно время. Резки приходят в порядке очереди (день → «Очередность»),
+        // поэтому раскладываем встык: старт ОКНА резки не раньше конца окна предыдущей резки
+        // ЭТОГО дня. Непересекающиеся сохранённые старты не трогаем (display == сохранённое).
+        var prevWindowEndByDay = {};
         (cuts || []).forEach(function(c) {
             if (!c) return;
             var tsSec = Number(c.planDate != null && c.planDate !== '' ? c.planDate : c.number);
@@ -3334,11 +3343,19 @@
             var windowStartMin = round3((tsSec * 1000 - base) / 60000);     // окно = начало настройки
             var setupMin = round3(num(c.storedKnifeSetupMin) + num(c.storedMaterialWindingMin));
             var durationMin = round3(num(c.storedCutAndLeaderMin) || num(c.duration));   // намотка + лидер
+            // #3885: устранить нахлёст с предыдущей резкой того же дня — сдвинуть начало окна к
+            // её концу. День берём по СОХРАНЁННОМУ старту (до сдвига), чтобы группировка по дате
+            // (заголовок/минуты дня) не уезжала; сдвиг лечит только нахлёст внутри дня.
+            var day = Math.floor(windowStartMin / 1440);
+            var prevEnd = prevWindowEndByDay[day];
+            if (prevEnd != null && windowStartMin < prevEnd) windowStartMin = prevEnd;
             var startMin = round3(windowStartMin + setupMin);               // старт намотки (после настройки)
+            var finishMin = round3(startMin + durationMin);
+            prevWindowEndByDay[day] = finishMin;   // окно занятости = setup + намотка (лидер уже в durationMin)
             out.push({
                 cutId: String(c.id),
                 startMin: startMin,
-                finishMin: round3(startMin + durationMin),
+                finishMin: finishMin,
                 setupMin: setupMin,
                 durationMin: durationMin,
                 // Лидер уже включён в durationMin (storedCutAndLeaderMin = намотка + лидер, #3700) —

--- a/experiments/atex-production-planning-3885.test.js
+++ b/experiments/atex-production-planning-3885.test.js
@@ -1,0 +1,115 @@
+// Unit tests for scheduleFromStored anti-overlap guard (ideav/crm#3885).
+//
+// Since #3846 the production-planning queue renders the SAVED plan (scheduleFromStored)
+// instead of recomputing on the fly (buildSchedule). If two cuts of the SAME machine in
+// one day carry the same stored planStart (t1078) — a leftover of an incomplete start
+// re-pack (move before #3840, or a re-sequence limited to the filter scope #3660) — the
+// queue used to draw two cards at the same time («2 резки в одно время», #3885).
+//
+// scheduleFromStored now lays same-day cuts edge to edge: a cut's window never starts
+// before the previous same-day cut's window ends. Non-overlapping saved starts (incl.
+// lunch gaps) and cuts on different days stay exactly as stored.
+//
+// Run with: node experiments/atex-production-planning-3885.test.js
+
+process.env.TZ = 'UTC';
+
+var planning = require('../download/atex/js/production-planning.js').planning;
+var scheduleFromStored = planning.scheduleFromStored;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+// base = 0 → windowStartMin = planDate(sec) / 60. 08:00 = 480 min → planDate 28800.
+var BASE = 0;
+var DAY = 1440;
+function cut(id, startMin, setupKnife, setupMaterial, cutAndLeader) {
+    return {
+        id: id,
+        planDate: String(startMin * 60),                 // unix-секунды старта окна
+        storedKnifeSetupMin: String(setupKnife),
+        storedMaterialWindingMin: String(setupMaterial),
+        storedCutAndLeaderMin: String(cutAndLeader)
+    };
+}
+// window-start (= startMin − setupMin) and window-end (= finishMin) per result entry.
+function windows(sched) {
+    return sched.map(function (sc) {
+        return { id: sc.cutId, ws: sc.startMin - sc.setupMin, we: sc.finishMin };
+    });
+}
+
+// ── 1. The #3885 collision: both cuts stored at 08:00 on Станок 4 / 03.07 ──
+// 188600: setup 45 (30+15), namotka+leader 475 → window 08:00–16:40 (480..1000).
+// 191769: setup 45, namotka+leader 16 → stored also at 08:00, must move to 16:40.
+(function () {
+    var sched = scheduleFromStored([
+        cut('188600', 480, 30, 15, 475),
+        cut('191769', 480, 30, 15, 16)
+    ], BASE);
+    assertEqual(windows(sched), [
+        { id: '188600', ws: 480, we: 1000 },   // first cut unchanged (08:00–16:40)
+        { id: '191769', ws: 1000, we: 1061 }    // pushed to 16:40–17:41 (no overlap)
+    ], '#3885 collision — second cut sequenced after the first (no two-at-08:00)');
+})();
+
+// ── 2. Non-overlapping saved starts (incl. lunch gap) stay verbatim (#3846) ──
+(function () {
+    var sched = scheduleFromStored([
+        cut('A', 480, 0, 0, 200),    // 08:00–11:20
+        cut('B', 740, 0, 0, 60)      // 12:20–13:20 (gap 11:20→12:20 = lunch, preserved)
+    ], BASE);
+    assertEqual(windows(sched), [
+        { id: 'A', ws: 480, we: 680 },
+        { id: 'B', ws: 740, we: 800 }
+    ], 'non-overlap — distinct stored starts and lunch gap untouched');
+})();
+
+// ── 3. Same stored 08:00 but on DIFFERENT days must NOT be merged ──
+(function () {
+    var sched = scheduleFromStored([
+        cut('D0', 480, 0, 0, 60),            // day 0, 08:00
+        cut('D1', DAY + 480, 0, 0, 60)       // day 1, 08:00
+    ], BASE);
+    assertEqual(windows(sched), [
+        { id: 'D0', ws: 480, we: 540 },
+        { id: 'D1', ws: DAY + 480, we: DAY + 540 }
+    ], 'different days — both at 08:00 stay separate');
+})();
+
+// ── 4. Cascading collision: three cuts stored at 08:00 stack in queue order ──
+(function () {
+    var sched = scheduleFromStored([
+        cut('C1', 480, 0, 0, 100),   // 08:00–09:40
+        cut('C2', 480, 0, 0, 50),    // → 09:40–10:30
+        cut('C3', 480, 0, 0, 30)     // → 10:30–11:00
+    ], BASE);
+    assertEqual(windows(sched), [
+        { id: 'C1', ws: 480, we: 580 },
+        { id: 'C2', ws: 580, we: 630 },
+        { id: 'C3', ws: 630, we: 660 }
+    ], 'cascading — three same-start cuts stack edge to edge');
+})();
+
+// ── 5. Partial overlap (not exact-equal start) is also removed ──
+(function () {
+    var sched = scheduleFromStored([
+        cut('P1', 480, 0, 0, 120),   // 08:00–10:00
+        cut('P2', 540, 0, 0, 40)     // stored 09:00 (overlaps) → moved to 10:00–10:40
+    ], BASE);
+    assertEqual(windows(sched), [
+        { id: 'P1', ws: 480, we: 600 },
+        { id: 'P2', ws: 600, we: 640 }
+    ], 'partial overlap — later cut pushed past the previous window end');
+})();
+
+console.log('\n' + passed + ' assertions passed.');


### PR DESCRIPTION
Закрывает #3885.

## Что происходило
Очередь Станок 4 на 03.07 показывала **две резки, обе с началом 08:00** — `188600` MW308 (08:00–16:40) и `191769` MWR200 (08:00–09:01).

## Почему
С **#3846** очередь рисует **СОХРАНЁННЫЙ** план (`scheduleFromStored`), а не пересчитывает расписание на лету (`buildSchedule`). Каждая резка ставится на ось по своему сохранённому `planStart` (главное значение `t1078`).

У обеих резок Станка 4 сохранённый `planStart` = **03.07 08:00** (одинаковый `t1078`), поэтому обе встали в одно время. Я воспроизвёл скрин ровно из сохранённых значений через `scheduleFromStored`.

До #3846 очередь звала `buildSchedule` на каждый рендер и нахлёст «прятала» (вторую резку выталкивала на ближайший рабочий день, Пн 06.07). #3846 убрал live‑пересчёт ради единого источника с Гантом — и **обнажил** уже испорченные данные.

## Это не единичный случай
Скан всех заданий выявил **3 коллизии `(станок, planStart)`, все ровно в 08:00**:

| Станок | День | Резки |
|---|---|---|
| Станок 1 | 01.07 08:00 | 190862 (Оч.1) + 190787 (Оч.13) |
| Станок 2 | 01.07 08:00 | 191717 (Оч.1) + 190703 (Оч.7) |
| Станок 4 | 03.07 08:00 | 188600 (Оч.1) + 191769 (Оч.25) ← #3885 |

В каждой паре резка с «Очередностью» 1 правомерно в 08:00, а вторая (бо́льшая «Очередность») тоже застряла в 08:00: сохранённый `planStart` и порядок очереди рассинхронизированы. Так бывает, когда время старта не пересобиралось после изменения очереди — перенос **до #3840** не трогал `planStart`, а пересборка **#3660** идёт только в `scope` фильтра, и «осиротевший» старт остаётся прежним.

## Фикс
`scheduleFromStored` теперь раскладывает резки **одного станка в один день встык**: старт ОКНА резки не раньше конца окна предыдущей резки этого дня (резки приходят уже в порядке день → «Очередность»). 

- Непересекающиеся сохранённые старты (включая обеденный зазор) — **не трогаем** (display == сохранённое, философия #3846 для корректных данных сохранена).
- Резки разных дней с одинаковым 08:00 — **не объединяем**.

Полная очистка самих данных — пересборка дня кнопкой «Сгенерировать»/«Упорядочить» (перезапишет `planStart`).

## Тест
`experiments/atex-production-planning-3885.test.js` — 5 проверок (коллизия, каскад из 3, частичный нахлёст, обеденный зазор не трогается, разные дни не сливаются). Зелёные. Существующий набор `atex-production-planning-*` без регрессий (8 падений в `-3619`/основном — преды­дущие, не связаны: `splitMachineQueue`/`document is not defined`).

## Заметки на будущее (вне scope PR)
- РМ «Диаграмма Ганта» рисует те же сохранённые `planStart` своим кодом — для тех же испорченных данных бары наложатся; при желании туда стоит добавить такую же защиту.
- Стоит провести аудит путей записи `planStart` (перенос/пересборка в узком `scope` #3660), чтобы коллизии не накапливались в данных.

🤖 Generated with [Claude Code](https://claude.com/claude-code)