### PR TITLE
fix(#3887): Гант — две резки не накладываются при коллизии сохранённого planStart (встык по дню)

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -670,13 +670,16 @@
     // #3770: окно подписи бара (наладка+резка) как {startMs, endMs, mins} — единый источник
     // и для текста бара (cutBarTime), и для суммы минут в заголовке станка (cutBarSpanMin),
     // чтобы они никогда не расходились. Геометрия — как раньше в cutBarTime.
-    function cutBarWindow(cut, setupMin, maxEndMs) {
+    function cutBarWindow(cut, setupMin, maxEndMs, startMsOverride) {
         var tr = cutTimeRange(cut);
         if (!tr) return null;
         // #3705: правый край = старт + (резка+лидер) + наладка — ровно та же сумма минут, что у
         // ширины бара (cutBarSegments) и у окна планировщика. Раньше брали tr.endMs (намотка БЕЗ
         // лидера) + наладка → конец задания получался на лидер «между резками» короче плана.
-        var startMs = tr.startMs;
+        // #3887: startMsOverride — старт бара, сдвинутый встык при коллизии сохранённых planStart
+        // (dedupeBarStarts); нужен, чтобы подпись времени совпала с позицией бара. Нет override —
+        // берём сохранённый старт (поведение не меняется для корректных данных).
+        var startMs = (startMsOverride != null && isFinite(Number(startMsOverride))) ? Number(startMsOverride) : tr.startMs;
         var endMs = startMs + (cutBarMinutes(cut) + (Number(setupMin) || 0)) * 60000;
         // #3708: не заходить за старт следующего задания того же станка. Длительности хранятся
         // округлёнными вверх (#3635 п.4), а cut_plan_date — по дробному времени, поэтому бар бывает
@@ -686,16 +689,16 @@
         return { startMs: startMs, endMs: endMs, mins: Math.max(1, Math.round((endMs - startMs) / 60000)) };
     }
 
-    function cutBarTime(cut, setupMin, maxEndMs) {
-        var w = cutBarWindow(cut, setupMin, maxEndMs);
+    function cutBarTime(cut, setupMin, maxEndMs, startMsOverride) {
+        var w = cutBarWindow(cut, setupMin, maxEndMs, startMsOverride);
         if (!w) return '';
         return formatTime(w.startMs) + '-' + formatTime(w.endMs) + ' (' + w.mins + ' мин)';
     }
 
     // #3770: целое число минут, отображаемое в подписи бара (.atex-cg-bar-main). Заголовок
     // станка суммирует эти значения → «6 (262 мин)». Нет окна (нет времени) → 0.
-    function cutBarSpanMin(cut, setupMin, maxEndMs) {
-        var w = cutBarWindow(cut, setupMin, maxEndMs);
+    function cutBarSpanMin(cut, setupMin, maxEndMs, startMsOverride) {
+        var w = cutBarWindow(cut, setupMin, maxEndMs, startMsOverride);
         return w ? w.mins : 0;
     }
 
@@ -1080,6 +1083,36 @@
         return params.length ? base + '?' + params.join('&') : base;
     }
 
+    // #3887: защита Ганта от испорченных сохранённых planStart — та же беда, что в очереди (#3885).
+    // Очередь («Планирование производства») и Гант рисуют ОДИН сохранённый план (t1078). Если у
+    // двух резок одного станка в один день старт совпал/пересёкся (след незавершённой пересборки
+    // времени старта: перенос до #3840 не трогал planStart, пересборка #3660 идёт лишь в scope
+    // фильтра), их бары встают в одну точку оси → наложение. scheduleFromStored (#3886) уже лечит
+    // это в очереди; здесь — то же для дорожки Ганта. Раскладываем встык: старт ОКНА бара
+    // (наладка+резка) не раньше конца окна предыдущей резки ТОГО ЖЕ дня. День берём по
+    // СОХРАНЁННОМУ старту (ось/заголовки/окна дней не уезжают). Двигаем только ПЛАНОВЫЕ бары (без
+    // факт. старта): у начатых/завершённых бар показывает реальное время, его не трогаем — но их
+    // окно всё равно отодвигает следующий ПЛАНОВЫЙ бар. Непересекающиеся сохранённые старты (в т.ч.
+    // обеденный зазор) не трогаем — display == сохранённое (философия #3846). ordered — резки
+    // станка в порядке дорожки (orderCutsInGroup). → массив старта бара (мс) по индексу, null где
+    // у резки нет времени. Чистая — покрыта тестом.
+    function dedupeBarStarts(ordered) {
+        var prevEndByDay = {};
+        return (ordered || []).map(function(cut) {
+            var tr = cutTimeRange(cut);
+            if (!tr) return null;
+            var day = startOfLocalDayMs(tr.startMs);                 // день — по сохранённому старту
+            var lenMs = (cutBarMinutes(cut) + cutSetupMin(cut).total) * 60000;
+            var startMs = tr.startMs;
+            var prevEnd = prevEndByDay[day];
+            // сдвигаем встык только плановый бар; реальное время (факт. старт) не двигаем
+            if (tr.actualStartMs == null && prevEnd != null && startMs < prevEnd) startMs = prevEnd;
+            var endMs = startMs + lenMs;
+            if (prevEnd == null || endMs > prevEnd) prevEndByDay[day] = endMs;   // окно занятости дня (макс)
+            return startMs;
+        });
+    }
+
     // #3668: размещение баров по РЕАЛЬНОМУ времени. Группировка по станку (сортировка по
     // метке), внутри станка — порядок строк по очерёдности/старту; каждое задание = отдельная
     // строка, бар на общей шкале времени окна (left/width по плану-факту, разрывы видны).
@@ -1139,25 +1172,31 @@
         groups.forEach(function(g) {
             orderCutsInGroup(g.cuts);
             var ordered = g.cuts;
+            // #3887: старты баров со снятым нахлёстом по сохранённому planStart (встык в дне).
+            // Для корректных данных barStarts[i] === сохранённый старт — поведение не меняется.
+            var barStarts = dedupeBarStarts(ordered);
             g.tasks = ordered.map(function(cut, i) {
                 var tr = cutTimeRange(cut) || { startMs: win.startMs, endMs: win.startMs };
+                var startMs = barStarts[i] != null ? barStarts[i] : tr.startMs;   // #3887: сдвинутый старт бара
                 var status = cutStatus(cut, nowMs);
                 // #3675 п.3 / #3680: ширина бара = наладка + резка; подпись времени — ВСЁ окно задания
                 // (от начала наладки до конца резки), а не только резка.
                 var seg = cutBarSegments(cut, pxPerMin, minPx);
                 // #3747: левый край бара — по СВЁРНУТОЙ оси (scale.toPx): нерабочее время не
                 // занимает места, дни идут встык. Ширина — по минутам (наладка+резка), как и раньше.
-                var leftPx = scale.toPx(tr.startMs);
+                var leftPx = scale.toPx(startMs);
                 var widthPx = seg.totalPx;
                 // #3708: бар не должен заходить за старт следующего задания того же станка —
                 // длительности хранятся вверх (#3635 п.4), а старты по дробному времени, поэтому бар
                 // бывал длиннее реального окна. Завершённые (есть факт. финиш) не режем — реальную
                 // длительность показываем как есть (конфликт виден). #3747: ширину-границу тоже
                 // считаем по свёрнутой оси, чтобы стык дней резал захлёст по краю рабочего окна.
+                // #3887: границу берём по СДВИНУТОМУ старту следующей резки — при коллизии planStart
+                // соседняя резка раздвинута встык, и эта проверка обрезает захлёст к ней.
                 var nextStartMs = null;
                 if (tr.actualEndMs == null && i + 1 < ordered.length) {
-                    var ntr = cutTimeRange(ordered[i + 1]);
-                    if (ntr && ntr.startMs > tr.startMs) nextStartMs = ntr.startMs;
+                    var nStart = barStarts[i + 1];
+                    if (nStart != null && nStart > startMs) nextStartMs = nStart;
                 }
                 if (nextStartMs != null) {
                     var maxWidthPx = round3(scale.toPx(nextStartMs) - leftPx);
@@ -1168,8 +1207,9 @@
                     leftPx: leftPx,
                     widthPx: widthPx,
                     segments: seg,
-                    label: cutRowLabel(cut), barText: cutBarTime(cut, seg.setupMin, nextStartMs),
-                    barMin: cutBarSpanMin(cut, seg.setupMin, nextStartMs),   // #3770: минуты подписи бара
+                    // #3887: подпись времени — по сдвинутому старту, чтобы текст совпал с позицией бара.
+                    label: cutRowLabel(cut), barText: cutBarTime(cut, seg.setupMin, nextStartMs, startMs),
+                    barMin: cutBarSpanMin(cut, seg.setupMin, nextStartMs, startMs),   // #3770: минуты подписи бара
                     title: cutBarTitle(cut, tr, status)
                 };
             });
@@ -1250,6 +1290,7 @@
         attachSetupMinutes: attachSetupMinutes,
         rowsToCuts: rowsToCuts,
         orderCutsInGroup: orderCutsInGroup,
+        dedupeBarStarts: dedupeBarStarts,   // #3887
         layoutGroups: layoutGroups,
         ganttWindow: ganttWindow,
         ganttTrackPx: ganttTrackPx,

--- a/experiments/atex-cut-gantt-3887.test.js
+++ b/experiments/atex-cut-gantt-3887.test.js
@@ -1,0 +1,147 @@
+// Unit tests for the cut-gantt anti-overlap guard (ideav/crm#3887).
+//
+// Sibling of the production-planning queue guard #3885/#3886. Both РМ — the queue
+// («Планирование производства», scheduleFromStored) and the Gantt diagram («Диаграмма
+// Ганта», layoutGroups) — draw ONE saved plan (planStart = t1078). When two cuts of the
+// SAME machine on one day carry the same / overlapping stored planStart (a leftover of an
+// incomplete start re-pack: a move before #3840, or a re-sequence limited to the filter
+// scope #3660), their bars land on the same axis point → they overlap. #3886 fixed the
+// queue; this fixes the Gantt track the same way.
+//
+// dedupeBarStarts lays same-day cuts edge to edge: a cut's window (setup + cut) never
+// starts before the previous same-day cut's window ends. Only PLANNED bars are moved —
+// started/finished cuts show real time as-is, but their window still pushes the next
+// planned bar. Non-overlapping saved starts (incl. lunch gaps) and cuts on different days
+// stay exactly as stored (display == saved, #3846 philosophy). layoutGroups then positions
+// and labels each bar by the deduped start, so two collided cuts no longer stack.
+//
+// Run with: node experiments/atex-cut-gantt-3887.test.js
+
+process.env.TZ = 'UTC';
+
+var gantt = require('../download/atex/js/cut-gantt.js').gantt;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+
+var ms = gantt.parseDateTimeMs;
+
+// Планируемая резка: окно = (наладка ножей + смена сырья) + «Резка и Лидер» (cutTimeMin).
+// Главное значение planStart = planDate; нет факт. старта → бар плановый (его и двигаем).
+function cut(id, planDate, knife, material, cutAndLeader, seq) {
+    return {
+        id: id, number: planDate, planDate: planDate,
+        sequence: seq == null ? null : seq,
+        slitter: { id: '4', label: 'Станок 4' },
+        setupKnifeMin: knife, setupMaterialMin: material, cutTimeMin: cutAndLeader
+    };
+}
+// Начатая резка: есть факт. старт → cutSetupMin/cutBarMinutes берут фактическое окно, бар
+// показывает реальное время и сдвигу не подлежит.
+function runningCut(id, startDate, endDate) {
+    return {
+        id: id, number: startDate, planDate: startDate,
+        startDate: startDate, endDate: endDate,
+        slitter: { id: '4', label: 'Станок 4' }
+    };
+}
+
+// ── 1. Коллизия #3885 в Ганте: обе резки Станка 4 / 03.07 сохранены на 08:00 ──
+// 188600: наладка 45 (30+15), резка+лидер 475 → окно 08:00–16:40.
+// 191769: наладка 45, резка+лидер 16 → сохранено тоже 08:00, должно встать на 16:40.
+(function () {
+    var starts = gantt.dedupeBarStarts([
+        cut('188600', '03.07.2026 08:00', 30, 15, 475, 1),
+        cut('191769', '03.07.2026 08:00', 30, 15, 16, 25)
+    ]);
+    assertEqual(starts, [ms('03.07.2026 08:00'), ms('03.07.2026 16:40')],
+        '#3887 коллизия — вторая резка встаёт за концом окна первой (не две в 08:00)');
+})();
+
+// ── 2. Непересекающиеся старты (в т.ч. обеденный зазор) не трогаем (#3846) ──
+(function () {
+    var starts = gantt.dedupeBarStarts([
+        cut('A', '03.07.2026 08:00', 0, 0, 200),   // 08:00–11:20
+        cut('B', '03.07.2026 12:20', 0, 0, 60)     // 12:20–13:20 (зазор 11:20→12:20 = обед, сохраняем)
+    ]);
+    assertEqual(starts, [ms('03.07.2026 08:00'), ms('03.07.2026 12:20')],
+        'непересечение — разные старты и обеденный зазор не трогаются');
+})();
+
+// ── 3. Одинаковое 08:00, но РАЗНЫЕ дни — не объединяем ──
+(function () {
+    var starts = gantt.dedupeBarStarts([
+        cut('D0', '03.07.2026 08:00', 0, 0, 60),
+        cut('D1', '04.07.2026 08:00', 0, 0, 60)
+    ]);
+    assertEqual(starts, [ms('03.07.2026 08:00'), ms('04.07.2026 08:00')],
+        'разные дни — оба в 08:00 остаются раздельными');
+})();
+
+// ── 4. Каскад: три резки сохранены на 08:00 — встают встык в порядке очереди ──
+(function () {
+    var starts = gantt.dedupeBarStarts([
+        cut('C1', '03.07.2026 08:00', 0, 0, 100),   // 08:00–09:40
+        cut('C2', '03.07.2026 08:00', 0, 0, 50),    // → 09:40–10:30
+        cut('C3', '03.07.2026 08:00', 0, 0, 30)     // → 10:30–11:00
+    ]);
+    assertEqual(starts, [ms('03.07.2026 08:00'), ms('03.07.2026 09:40'), ms('03.07.2026 10:30')],
+        'каскад — три резки с общим стартом встают встык');
+})();
+
+// ── 5. Частичный нахлёст (не точное совпадение старта) тоже снимается ──
+(function () {
+    var starts = gantt.dedupeBarStarts([
+        cut('P1', '03.07.2026 08:00', 0, 0, 120),   // 08:00–10:00
+        cut('P2', '03.07.2026 09:00', 0, 0, 40)     // сохранено 09:00 (нахлёст) → на 10:00
+    ]);
+    assertEqual(starts, [ms('03.07.2026 08:00'), ms('03.07.2026 10:00')],
+        'частичный нахлёст — поздняя резка вытолкнута за конец окна предыдущей');
+})();
+
+// ── 6. Начатую резку (есть факт. старт) НЕ двигаем — реальное время как есть ──
+// Плановая 08:00–16:40 ставит prevEnd=16:40, но начатая в 08:00 показывает свой реальный
+// старт и сдвигу не подлежит (хотя и пересекается — конфликт виден, время не искажаем).
+(function () {
+    var starts = gantt.dedupeBarStarts([
+        cut('PLAN', '03.07.2026 08:00', 30, 15, 475),
+        runningCut('RUN', '03.07.2026 08:00', '03.07.2026 08:40')
+    ]);
+    assertEqual(starts, [ms('03.07.2026 08:00'), ms('03.07.2026 08:00')],
+        'начатая резка не сдвигается — бар по факт. времени');
+})();
+
+// ── 7. Интеграция layoutGroups: коллизия → разные leftPx, встык, подпись по сдвигу ──
+// На дорожке Станка 4 две резки должны идти встык (вторая после первой), а не в одной точке.
+(function () {
+    var range = gantt.ganttRange('2026-07-03', 'day');
+    var now = ms('2026-07-03 09:00');
+    var laid = gantt.layoutGroups([
+        cut('188600', '03.07.2026 08:00', 30, 15, 475, 1),
+        cut('191769', '03.07.2026 08:00', 30, 15, 16, 25)
+    ], range, now, {}, { pxPerMin: 2 });
+    var tasks = laid.groups[0].tasks.map(function (t) {
+        return [t.cut.id, t.leftPx, t.widthPx, t.barText];
+    });
+    // 1-я резка: 08:00, окно 520 мин × 2 = 1040 px (наладка 60+30 + резка 950); подпись 08:00–16:40.
+    // 2-я резка: сдвинута на 16:40 → leftPx 1040 (= конец 1-й), без наложения; подпись 16:40–17:41.
+    assertEqual(tasks, [
+        ['188600', 0, 1040, '08:00-16:40 (520 мин)'],
+        ['191769', 1040, 122, '16:40-17:41 (61 мин)']
+    ], 'layoutGroups #3887 — бары встык, leftPx и подпись по сдвинутому старту');
+    // Инвариант «нет наложения»: вторая начинается не раньше конца первой.
+    var t0 = laid.groups[0].tasks[0], t1 = laid.groups[0].tasks[1];
+    assertEqual(t1.leftPx >= t0.leftPx + t0.widthPx, true,
+        'layoutGroups #3887 — нет наложения: leftPx 2-й ≥ правый край 1-й');
+})();
+
+console.log('\n' + passed + ' assertions passed.');


### PR DESCRIPTION
Закрывает #3887. Follow-up к #3885 / #3886 (заметка «на будущее» из PR #3886).

## Что происходило
С **#3846** оба РМ рисуют **СОХРАНЁННЫЙ** план (`planStart` = главное значение `t1078`), а не пересчитывают расписание на лету:
- очередь «Планирование производства» — через `scheduleFromStored`;
- «Диаграмма Ганта» — через свой `layoutGroups` (`download/atex/js/cut-gantt.js`).

#3885 показал коллизии `(станок, planStart)`: две резки одного станка в один день с **одинаковым** сохранённым стартом (напр. обе 08:00) — след незавершённой пересборки времени старта (перенос до #3840 не трогал `planStart`; пересборка #3660 идёт лишь в `scope` фильтра, «осиротевший» старт остаётся прежним).

**#3886 устранил наложение только в очереди.** Гант рисует те же сохранённые `planStart` своим кодом — для тех же данных обе резки вставали в одну точку оси (бары накладывались).

## Фикс
Перенёс защиту #3886 в Гант. Новая чистая функция `dedupeBarStarts(ordered)` раскладывает резки одного станка в один день **встык**: старт ОКНА бара (наладка + резка) не раньше конца окна предыдущей резки **этого дня**.

- День берём по **СОХРАНЁННОМУ** старту — ось, заголовки и окна дней (`workingSegments`) не уезжают; сдвиг лечит только нахлёст внутри дня.
- Двигаем только **плановые** бары (без факт. старта). Начатые/завершённые показывают реальное время как есть (их окно всё равно отодвигает следующий плановый бар).
- Непересекающиеся сохранённые старты (включая обеденный зазор) — **не трогаем** (display == сохранённое, философия #3846). Разные дни с одинаковым 08:00 — **не объединяем**.
- `layoutGroups` берёт по сдвинутому старту `leftPx`, границу ширины (#3708) **и** подпись времени бара (`cutBarTime`/`cutBarSpanMin` получили необязательный `startMsOverride`) — текст совпадает с позицией бара.

Полная очистка самих данных — отдельно: пересборка дня кнопкой «Сгенерировать»/«Упорядочить» перезапишет `planStart`.

## Тест
`experiments/atex-cut-gantt-3887.test.js` — 8 проверок: коллизия #3885 (две в 08:00 → встык), обеденный зазор не трогается, разные дни не сливаются, каскад из трёх, частичный нахлёст, начатая резка не сдвигается, интеграция `layoutGroups` (разные `leftPx`, подпись по сдвигу, инвариант «нет наложения»). Зелёные. Существующий `atex-cut-gantt.test.js` без регрессий (135).

## Заметки (вне scope)
- Защита — отображательная (как #3886). Корень — пути записи `planStart` (перенос/пересборка в узком `scope` #3660); их аудит стоит вести отдельно, чтобы коллизии не копились в данных.
- Патологический случай (две ДЛИННЫЕ резки обе в 08:00, сумма окон > смены) сдвинет бар за правый край дня — как и в очереди #3886; реальная порча — короткий «осиротевший» хвост после длинной резки, он укладывается в день.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
