### PR TITLE
fix(#3892): «ID первой части» (голова цепочки) + связанные позиции — реальный метраж

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -120,7 +120,15 @@
         fixed: 'Зафиксировано',  // #3508: булев флаг (id 81530, type 11) — задание нельзя менять/удалять
         knifeSetupMin: 'Наладка ножей, мин',      // #3698: расчётная наладка ножей (KNIFE), мин (id 96067)
         materialWindingMin: 'Сырье/намотка, мин', // #3698: расчётная смена сырья/намотки (MATERIAL_WINDING), мин (id 96069)
-        cutAndLeader: 'Резка и Лидер'             // #3700: намотка («Длительность, минут») + лидер (BETWEEN_CUTS × резок), мин (id 96778)
+        cutAndLeader: 'Резка и Лидер',            // #3700: намотка («Длительность, минут») + лидер (BETWEEN_CUTS × резок), мин (id 96778)
+        // #3892: ЯВНАЯ ссылка на голову цепочки дробления — id ПЕРВОГО сегмента логической резки
+        // (id 196458, type 3/string). Все сегменты одной резки (голова + продолжения по дням)
+        // несут одинаковый «ID первой части» = id головы; голова ссылается на саму себя. Заменяет
+        // прежнюю эвристику continuationSignature (станок|сырьё|намотка|ножи + смежные дни),
+        // которая рвалась при пустом «Виде сырья»/несовпадении сигнатуры (#3795/#3808/#3781) и
+        // утекала делёными метражами/настройкой в очередь. Пустой (легаси-запись до миграции) →
+        // откат на эвристику в mergeContinuationChains; следующее сохранение проставит маркер.
+        firstPart: 'ID первой части'
     };
     var CUT_PLANNED_RUN_COLUMNS = [
         'cut_planned_runs',
@@ -138,6 +146,10 @@
     var CUT_MATERIAL_WINDING_COLUMNS = ['cut_material_winding_min', 'cut_material_setup_min', 'cut_setup_material_min'];
     // #3700: хранимое «Резка и Лидер» (намотка + лидер), в отчёте cut_planning — поле cut_time.
     var CUT_TIME_COLUMNS = ['cut_time', 'cut_cut_leader_min', 'cut_run_leader_min'];
+    // #3892: «ID первой части» (голова цепочки) из отчёта cut_planning. Колонку на сервере в
+    // отчёт добавить (как #3698 добавил cut_knife_setup_min); нет колонки → пусто → откат на
+    // эвристику цепочки (mergeContinuationChains), запись маркера при этом не ломается.
+    var CUT_FIRST_PART_COLUMNS = ['cut_first_part', 'cut_first_part_id', 'cut_head_id', 'cut_chain_head'];
     var CUT_RUN_LENGTH_COLUMNS = ['cut_length', 'cut_footage', 'cut_footage_m'];
     var SUPPLY_FOOTAGE_COLUMNS = ['supply_footage', 'supply_length', 'supply_length_m'];
     var CUT_WRITE_LABELS = {
@@ -1078,6 +1090,9 @@
                     storedKnifeSetupMin: rowValue(row, CUT_KNIFE_SETUP_COLUMNS),
                     storedMaterialWindingMin: rowValue(row, CUT_MATERIAL_WINDING_COLUMNS),
                     storedCutAndLeaderMin: rowValue(row, CUT_TIME_COLUMNS),   // #3700: «Резка и Лидер» (cut_time)
+                    // #3892: «ID первой части» (голова цепочки дробления). Пусто (нет колонки/легаси) →
+                    // mergeContinuationChains откатывается на эвристику continuationSignature.
+                    firstPartId: rowValue(row, CUT_FIRST_PART_COLUMNS),
                     isFoil: /фольг/i.test(str(row.cut_material)),
                     orderId: str(row.order_id),
                     orderApprovalDate: str(row.order_approval_date || row.item_approval_date),
@@ -4070,21 +4085,59 @@
     // → { cuts:[логические резки], deletes:[id записей-продолжений], chainByLogical:{logicalId:[id…]} }.
     // Вход не мутирует.
     function mergeContinuationChains(cuts){
-        var groups = {}, order = [];
-        (cuts || []).forEach(function(c){
-            var s = continuationSignature(c);
-            if (!groups[s]) { groups[s] = []; order.push(s); }
-            groups[s].push(c);
-        });
         var logical = [], deletes = [], chainByLogical = {};
-        order.forEach(function(s){
-            var arr = groups[s].slice().sort(function(a, b){
+        function sortByDay(arr){
+            return arr.slice().sort(function(a, b){
                 var da = planDayNumber(a), db = planDayNumber(b);
                 if (da == null && db == null) return 0;
                 if (da == null) return 1;
                 if (db == null) return -1;
                 return da - db;
             });
+        }
+        // chain — записи одной логической резки по возрастанию дня (chain[0] = голова).
+        function emitChain(chain){
+            var head = chain[0];
+            var lg = {};
+            for (var k in head) { if (Object.prototype.hasOwnProperty.call(head, k)) lg[k] = head[k]; }
+            lg.plannedRuns = chain.reduce(function(sum, c){ return sum + (Number(c.plannedRuns) || 0); }, 0);
+            logical.push(lg);
+            chainByLogical[String(head.id)] = chain.map(function(c){ return String(c.id); });
+            for (var m = 1; m < chain.length; m++) deletes.push(String(chain[m].id));
+        }
+        // #3892: основной признак цепочки — ЯВНЫЙ «ID первой части» (firstPartId = id головы).
+        // Записи с непустым маркером группируем по нему (надёжно: не зависит от совпадения
+        // сигнатуры/сырья и не склеивает разные заказы одной конфигурации соседних дней).
+        // Записи без маркера (легаси до миграции) — прежней эвристикой (сигнатура + смежные дни).
+        var explicitGroups = {}, explicitOrder = [], legacyCuts = [];
+        (cuts || []).forEach(function(c){
+            var fp = (c && c.firstPartId != null) ? String(c.firstPartId).trim() : '';
+            if (fp !== '') {
+                if (!explicitGroups[fp]) { explicitGroups[fp] = []; explicitOrder.push(fp); }
+                explicitGroups[fp].push(c);
+            } else {
+                legacyCuts.push(c);
+            }
+        });
+        explicitOrder.forEach(function(fp){
+            var arr = sortByDay(explicitGroups[fp]);
+            // Голова = запись, чей id == маркеру (ссылается на себя). Нет такой (голову удалили/
+            // перенесли) → самый ранний сегмент становится головой; следующее сохранение
+            // перепроставит маркер на его id. Голову держим первой, остальное — по дню.
+            var headIdx = -1;
+            for (var i = 0; i < arr.length; i++) { if (String(arr[i].id) === fp) { headIdx = i; break; } }
+            if (headIdx > 0) { var h = arr.splice(headIdx, 1)[0]; arr.unshift(h); }
+            emitChain(arr);
+        });
+        // Легаси-эвристика (#3280): одинаковая continuationSignature + смежные календарные дни.
+        var groups = {}, order = [];
+        legacyCuts.forEach(function(c){
+            var s = continuationSignature(c);
+            if (!groups[s]) { groups[s] = []; order.push(s); }
+            groups[s].push(c);
+        });
+        order.forEach(function(s){
+            var arr = sortByDay(groups[s]);
             var i = 0;
             while (i < arr.length) {
                 var chain = [arr[i]];
@@ -4096,13 +4149,7 @@
                     chain.push(arr[j]);
                     j++;
                 }
-                var head = chain[0];
-                var lg = {};
-                for (var k in head) { if (Object.prototype.hasOwnProperty.call(head, k)) lg[k] = head[k]; }
-                lg.plannedRuns = chain.reduce(function(sum, c){ return sum + (Number(c.plannedRuns) || 0); }, 0);
-                logical.push(lg);
-                chainByLogical[String(head.id)] = chain.map(function(c){ return String(c.id); });
-                for (var m = 1; m < chain.length; m++) deletes.push(String(chain[m].id));
+                emitChain(chain);
                 i = j;
             }
         });
@@ -4266,6 +4313,9 @@
                         creates.push({ parentCutId: head, sequence: idx + 1, planStartTs: ts, plannedRuns: seg.runs });
                     }
                 }
+                // #3892: «ID первой части» (голова цепочки) НЕ кладём в ops — applySplitPlan
+                // выводит её из chainHeadById (для update) / parentCutId (для create), чтобы не
+                // менять контракт planCutOperations (строгие сравнения ops в тестах #3280/#3427).
             });
         });
         // Лишние записи цепочки (сегментов стало меньше, чем записей) — на удаление. Цепочки
@@ -9414,8 +9464,10 @@
             winding: reqIdByName(cutMeta, CUT_REQ.winding),
             leader: reqIdByName(cutMeta, CUT_REQ.leader),   // #3569: лидер копируется в запись-продолжение
             length: lengthReqId,   // #3781: «Метраж, м» — длина прогона (одинакова у всех сегментов цепочки)
-            material: reqIdByName(cutMeta, CUT_REQ.material)   // #3795: «Вид сырья» — копируется в продолжение, иначе очередь следующего дня без сырья
+            material: reqIdByName(cutMeta, CUT_REQ.material),   // #3795: «Вид сырья» — копируется в продолжение, иначе очередь следующего дня без сырья
+            firstPart: reqIdByName(cutMeta, CUT_REQ.firstPart)   // #3892: «ID первой части» (голова цепочки) — на голову и все продолжения
         };
+        var firstPartReqId = cutReqIds.firstPart;
         // #3781: длина прогона по id любой записи цепочки = длина прогона её ГОЛОВЫ. Записи-
         // продолжения дробления по дням раньше не получали «Метраж, м», и cutRunLength
         // откатывался к ПОДЕЛЁННОМУ метражу обеспечения (splitSupplyShares делит footage
@@ -9489,6 +9541,14 @@
                         var umat = materialForCutId(u.cutId);
                         if (umat) fields['t' + matReqId] = umat;
                     }
+                    // #3892: «ID первой части» — голова цепочки (для головы = собственный id).
+                    // Проставляем явный маркер на существующие записи, чтобы цепочка опознавалась
+                    // без эвристики; в planCutOperations firstPartId всегда задан.
+                    if (firstPartReqId) {
+                        var uHead = (u.firstPartId != null && u.firstPartId !== '')
+                            ? String(u.firstPartId) : (chainHeadById[String(u.cutId)] || String(u.cutId));
+                        if (uHead) fields['t' + firstPartReqId] = uHead;
+                    }
                     if (!Object.keys(fields).length) return;
                     return self.post('_m_set/' + u.cutId + '?JSON', fields);
                 });
@@ -9560,7 +9620,10 @@
                             leader: self.resolveLeaderId(parentCut && parentCut.leaders && parentCut.leaders.length === 1 ? parentCut.leaders[0] : ''),
                             // #3781: «Метраж, м» = длина прогона цепочки. Без неё cutRunLength брал
                             // поделённый метраж обеспечения и показывал заниженную длину.
-                            length: parentRunLen > 0 ? round3(parentRunLen) : ''
+                            length: parentRunLen > 0 ? round3(parentRunLen) : '',
+                            // #3892: «ID первой части» = id головы (parentId) — связывает продолжение
+                            // с первой частью явно, без эвристики continuationSignature.
+                            firstPart: (cr.firstPartId != null && cr.firstPartId !== '') ? String(cr.firstPartId) : String(parentId)
                         });
                         cutFields = addMainValueField(cutMeta, cutFields, cr.planStartTs);
                         return self.post('_m_new/' + cutMeta.id + '?JSON&up=1', cutFields).then(function(res) {
@@ -10905,9 +10968,15 @@
         } else {
             var posById = {};
             this.positions.forEach(function(p) { posById[p.id] = p; });
+            // #3892: метраж берём по ВСЕЙ резке (длина прогона = «Метраж, м», одинакова у всех
+            // сегментов цепочки, #3781), а НЕ из «Метраж, м» обеспечения этого сегмента. У
+            // переходящей (дроблёной) резки обеспечение делится по дням (splitSupplyShares), и
+            // raw-метраж сегмента — бессмысленная дробь (напр. 348.496 вместо 450). cutRunLength
+            // стартует с cut.length (head) и игнорирует делёные доли → реальная длина прогона.
+            var cutRunLen = cutRunLength(cut, self.supplies, self.footageBySupply);
             linked.forEach(function(s) {
-                // #3406 п.1: подпись + «Количество» позиции заказа + рулоны/метраж обеспечения.
-                var foot = supplyFootage(s, self.footageBySupply);
+                // #3406 п.1: подпись + «Количество» позиции заказа + рулоны/метраж.
+                var foot = cutRunLen > 0 ? cutRunLen : supplyFootage(s, self.footageBySupply);
                 var label = formatLinkedPositionLabel(posById[s.positionId], s.positionId, s.rolls, foot, s.orderNo, s.positionWidth, s.positionLength);
                 var children = [el('span', { class: 'atex-pp-linked-label', text: label })];
                 var del = el('button', { class: 'atex-pp-linked-del', type: 'button', text: '×', title: 'Убрать из задания' });

--- a/experiments/atex-production-planning-3892.test.js
+++ b/experiments/atex-production-planning-3892.test.js
@@ -1,0 +1,201 @@
+// Tests for ideav/crm#3892 — ЯВНЫЙ «ID первой части» (голова цепочки дробления) вместо
+// эвристики continuationSignature, и defect C (раздел «Связанные позиции» показывал делёный
+// метраж обеспечения сегмента, напр. 348.496, вместо реальной длины прогона 450).
+//
+// Что проверяем:
+//   1. mergeContinuationChains группирует сегменты по ЯВНОМУ firstPartId (а не по сигнатуре):
+//      1a — голова + продолжение с одинаковым маркером сливаются в одну логическую резку;
+//      1b — два РАЗНЫХ заказа одной конфигурации в смежные дни (которые эвристика СКЛЕИЛА бы)
+//           с разными маркерами НЕ сливаются;
+//      1c — записи без маркера (легаси) сливаются прежней эвристикой (поведение сохранено);
+//      1d — смешанный набор (маркер + легаси) обрабатывается независимо.
+//   2. planCutOperations проставляет firstPartId = id головы на голову (=своя) и продолжения.
+//   3. applySplitPlan пишет «ID первой части» (t196458-аналог) на голову (update) и продолжение
+//      (create); при отсутствии firstPartId в ops — фолбэк на голову цепочки/собственный id.
+//   4. cutRunLength (источник метража для «Связанных позиций») возвращает длину прогона головы
+//      (450), игнорируя делёную долю обеспечения сегмента (348.496) — корень defect C.
+//
+// Run with: node experiments/atex-production-planning-3892.test.js
+
+process.env.TZ = 'UTC';
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else {
+        console.log('  expected:', JSON.stringify(expected));
+        console.log('  actual:  ', JSON.stringify(actual));
+        process.exitCode = 1;
+    }
+}
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) { passed++; } else { process.exitCode = 1; }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Часть 1 + 2 + 4: чистые функции planning.
+// ─────────────────────────────────────────────────────────────────────────────
+var planning = require('../download/atex/js/production-planning.js').planning;
+var mergeContinuationChains = planning.mergeContinuationChains;
+var planCutOperations = planning.planCutOperations;
+var cutRunLength = planning.cutRunLength;
+
+var DAY = 86400;   // секунда-смещение смежного дня (planDate в секундах)
+function widths(pairs) { var o = []; pairs.forEach(function(pr) { for (var i = 0; i < pr[1]; i++) o.push(pr[0]); }); return o; }
+// Резка для mergeContinuationChains: одинаковая сигнатура у X/Y (material/winding/knives),
+// различает их только firstPartId. planDate в секундах (день = planDate/86400).
+function ch(id, firstPartId, dayOffset, runs) {
+    return {
+        id: id, firstPartId: firstPartId,
+        slitter: { id: 'S1' }, materialId: 'M7', winding: 'OUT',
+        knifeWidths: widths([[59, 16]]), knifeCount: 16,
+        plannedRuns: runs == null ? 1 : runs,
+        planDate: String(1780963200 + dayOffset * DAY), orderId: 'O' + id
+    };
+}
+
+// ── 1a: явная цепочка (голова H + продолжение B, один маркер 'H') сливается в одну логическую.
+(function () {
+    var m = mergeContinuationChains([ ch('H', 'H', 0, 10), ch('B', 'H', 1, 5) ]);
+    assertEqual(m.chainByLogical, { H: ['H', 'B'] }, '1a: цепочка по маркеру — голова H, продолжение B');
+    assertEqual(m.cuts.length, 1, '1a: одна логическая резка');
+    assertEqual(m.cuts[0].plannedRuns, 15, '1a: проходы цепочки суммируются (10+5)');
+    assertEqual(m.deletes, ['B'], '1a: продолжение B помечено на удаление при пере-разбиении');
+})();
+
+// ── 1b: два РАЗНЫХ заказа одной конфигурации в смежные дни. Эвристика continuationSignature
+//        склеила бы их в одну цепочку; явные разные маркеры (каждый ссылается на себя) — нет.
+(function () {
+    var m = mergeContinuationChains([ ch('X', 'X', 0, 3), ch('Y', 'Y', 1, 4) ]);
+    assertEqual(m.chainByLogical, { X: ['X'], Y: ['Y'] }, '1b: разные маркеры — две раздельные цепочки (НЕ склеены)');
+    assertEqual(m.cuts.length, 2, '1b: две логические резки');
+    assertEqual(m.deletes, [], '1b: ничего не удаляется (это не продолжения)');
+})();
+
+// ── 1c: легаси (нет firstPartId) — прежняя эвристика (сигнатура + смежные дни) сливает.
+(function () {
+    var a = ch('A', '', 0, 7); var b = ch('Acont', '', 1, 3);
+    var m = mergeContinuationChains([ a, b ]);
+    assertEqual(m.chainByLogical, { A: ['A', 'Acont'] }, '1c: легаси-эвристика сливает смежные дни одной сигнатуры');
+    assertEqual(m.cuts[0].plannedRuns, 10, '1c: проходы суммируются (7+3)');
+    assertEqual(m.deletes, ['Acont'], '1c: продолжение на удаление');
+})();
+
+// ── 1d: смешанно — явная цепочка H/B + одиночная легаси-резка L другой конфигурации.
+(function () {
+    var L = { id: 'L', firstPartId: '', slitter: { id: 'S1' }, materialId: 'M9', winding: 'IN',
+        knifeWidths: widths([[100, 2]]), knifeCount: 2, plannedRuns: 2, planDate: String(1780963200), orderId: 'OL' };
+    var m = mergeContinuationChains([ ch('H', 'H', 0, 10), ch('B', 'H', 1, 5), L ]);
+    assertEqual(m.chainByLogical, { H: ['H', 'B'], L: ['L'] }, '1d: явная цепочка и легаси-одиночка независимы');
+    assertEqual(m.deletes, ['B'], '1d: на удаление только продолжение явной цепочки');
+})();
+
+// ── 2: planCutOperations при дроблении даёт продолжения с parentCutId = головой. Контракт ops
+//       НЕ расширяем (строгие сравнения в #3280/#3427) — «ID первой части» applySplitPlan выводит
+//       из parentCutId (create) / chainHeadById (update), что и проверяет часть 3.
+function pcut(id, material, knifeWidths, runs, sequence) {
+    return { id: id, slitter: { id: 'm3' }, materialId: material, winding: 'OUT',
+        knifeWidths: knifeWidths, knifeCount: knifeWidths.length, plannedRuns: runs,
+        planDate: '1780963200', sequence: sequence };
+}
+(function () {
+    // A(15 проходов × 10 мин = 150 > день 100) дробится: голова сегодня + продолжение.
+    var ops = planCutOperations(
+        [ pcut('A', 'MW308', widths([[152, 6]]), 15, 1) ],
+        { perPassByCut: { A: 10 }, dayStartMin: 0, dayEndMin: 100,
+          times: { BETWEEN_CUTS: 0 }, planBaseMidnightMs: 1780963200000, preserveOrder: true }
+    );
+    var aHead = ops.updates.filter(function (u) { return u.cutId === 'A'; })[0];
+    assert(aHead && aHead.firstPartId === undefined, '2: контракт ops НЕ изменён (firstPartId в ops не кладём)');
+    assert(ops.creates.length >= 1, '2: A не влезла в день → есть продолжение');
+    assert(ops.creates.every(function (c) { return c.parentCutId === 'A'; }),
+        '2: продолжение(я) ссылаются на голову A (parentCutId) — отсюда applySplitPlan берёт «ID первой части»');
+})();
+
+// ── 4: cutRunLength = длина прогона головы (cut.length=450), а НЕ делёная доля обеспечения
+//       сегмента (footage 348.496). Это значение «Связанные позиции» теперь и показывают.
+(function () {
+    var headCut = { id: 'C1', length: 450 };
+    var supplies = [{ id: 'SUP', cutId: 'C1', footage: 348.496 }];   // делёная доля сегмента (#3280)
+    assertEqual(cutRunLength(headCut, supplies, {}), 450,
+        '4: cutRunLength игнорирует делёную долю обеспечения (348.496) → реальные 450 (defect C)');
+})();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Часть 3: applySplitPlan пишет «ID первой части» на голову и продолжение (реальный writer).
+// ─────────────────────────────────────────────────────────────────────────────
+global.window = { db: 'testdb', xsrf: 'x' };
+var api = require('../download/atex/js/production-planning.js');
+var Controller = api.Controller;
+
+function meta(id, pairs) {
+    return { id: String(id), reqs: pairs.map(function (p) { return { id: String(p[0]), val: p[1] }; }) };
+}
+var FP = '188';   // «ID первой части» (произвольный id; важно имя)
+var cutMeta = meta(100, [
+    ['190', 'Вид сырья'], ['191', 'Слиттер'], ['192', 'Партия сырья'], ['193', 'Кол-во план'],
+    ['194', 'Статус'], ['195', 'Очередность'], ['196', 'Тип намотки'], ['198', 'Лидер'],
+    ['197', 'Метраж, м'], ['199', 'Длительность, минут'], [FP, 'ID первой части']
+]);
+var fbMeta = meta(200, [['201', 'Ширина, мм'], ['202', 'Кол-во полос'], ['203', 'Кол-во рулонов'],
+    ['204', 'Кол-во план'], ['205', 'В работе']]);
+var supMeta = meta(300, [['301', 'Метраж, м'], ['302', 'Кол-во рулонов'], ['303', 'В работе'],
+    ['304', 'Статус'], ['305', 'Партия ГП']]);
+
+function makeController() {
+    var root = { getAttribute: function () { return 'testdb'; } };
+    var c = new Controller(root);
+    c.meta.cut = cutMeta; c.meta.finishedBatch = fbMeta; c.meta.supply = supMeta;
+    c.cuts = [{ id: 'H', length: 450, materialId: 'M7', status: 'В работе', slitter: { id: 'S1' },
+        batchId: 'B1', winding: 'IN', leaders: [] }];
+    c.supplies = [{ id: 'SUP1', cutId: 'H', rolls: 8, footage: 450, finishedBatchId: 'FB1', positionId: 'P1' }];
+    c.footageBySupply = {};
+    c._posts = [];
+    var idc = 0;
+    c.post = function (path, params) { c._posts.push({ path: path, params: params || {} }); return Promise.resolve({ obj: 'NEW' + (++idc) }); };
+    c.loadStripsForCut = function () { return Promise.resolve([]); };
+    c.resolveLeaderId = function () { return ''; };
+    c.reload = function () { return Promise.resolve(); };
+    c.persistCutSetupColumns = function () { return Promise.resolve(); };
+    c.setBusy = function () {}; c.showProgress = function () {}; c.updateProgress = function () {};
+    c.hideProgress = function () {}; c.render = function () {}; c.notify = function () {};
+    return c;
+}
+
+var tFP = 't' + FP;
+// 3a: ops с явным firstPartId — голова и продолжение получают t188 = 'H'.
+var c1 = makeController();
+c1.applySplitPlan({
+    updates: [{ cutId: 'H', sequence: 1, planStartTs: 1000, plannedRuns: 5, firstPartId: 'H' }],
+    creates: [{ parentCutId: 'H', sequence: 2, planStartTs: 2000, plannedRuns: 3, firstPartId: 'H' }],
+    deletes: []
+}).then(function () {
+    var upd = c1._posts.filter(function (p) { return p.path === '_m_set/H?JSON'; });
+    assert(upd.length === 1 && String(upd[0].params[tFP]) === 'H',
+        '3a: обновление головы пишет «ID первой части» = H (ссылка на себя)');
+    var cre = c1._posts.filter(function (p) { return p.path === '_m_new/100?JSON&up=1'; });
+    assert(cre.length === 1 && String(cre[0].params[tFP]) === 'H',
+        '3a: создаваемое продолжение пишет «ID первой части» = H (голова цепочки)');
+
+    // 3b: ops БЕЗ firstPartId — фолбэк: голова → собственный id, продолжение → parentId.
+    var c2 = makeController();
+    return c2.applySplitPlan({
+        updates: [{ cutId: 'H', sequence: 1, planStartTs: 1000, plannedRuns: 5 }],
+        creates: [{ parentCutId: 'H', sequence: 2, planStartTs: 2000, plannedRuns: 3 }],
+        deletes: []
+    }).then(function () {
+        var upd2 = c2._posts.filter(function (p) { return p.path === '_m_set/H?JSON'; });
+        assert(upd2.length === 1 && String(upd2[0].params[tFP]) === 'H',
+            '3b: без firstPartId голова всё равно получает маркер = H (фолбэк chainHeadById/own id)');
+        var cre2 = c2._posts.filter(function (p) { return p.path === '_m_new/100?JSON&up=1'; });
+        assert(cre2.length === 1 && String(cre2[0].params[tFP]) === 'H',
+            '3b: без firstPartId продолжение получает маркер = H (фолбэк на parentId)');
+        console.log('\n' + passed + ' assertions passed.');
+    });
+}).catch(function (err) {
+    console.log('FAIL — applySplitPlan бросил: ' + (err && err.stack || err));
+    process.exitCode = 1;
+});


### PR DESCRIPTION
Issue #3892 — три дефекта РМ «Планирование производства» (atex), у всех один корень:
цепочка переходящей резки (сегменты по дням) восстанавливалась **эвристикой**
`continuationSignature` (станок|сырьё|намотка|ножи + смежные дни) без явного маркера, а
очередь/Гант с #3846 рисуют сохранённый план как есть.

## Что в этом PR (часть 1 из 3)

**Явный «ID первой части» (id 196458, реквизит уже добавлен в таблицу 1078) вместо эвристики:**
- `CUT_REQ.firstPart` + `CUT_FIRST_PART_COLUMNS`; `rowsToPlanning` читает `c.firstPartId`
  (нет колонки в отчёте/легаси-запись → пусто → откат на прежнюю эвристику — поведение сохранено).
- `mergeContinuationChains`: записи с непустым маркером группируются по нему — надёжно, **не
  склеивает разные заказы одной конфигурации соседних дней** (чего эвристика не различала) и не
  рвётся при пустом «Виде сырья» (#3795/#3808/#3781).
- `applySplitPlan` пишет «ID первой части» на голову (= собственный id) и на продолжения (= id
  головы). Если маркера нет в ops — выводит голову из `chainHeadById`/`parentCutId`, поэтому
  **контракт `planCutOperations` не меняется** (строгие сравнения ops в тестах #3280/#3427 целы).

**Defect C — «Связанные позиции» показывали делёную долю обеспечения сегмента** (напр.
`348.496 м` вместо реальных `450`): `renderLink` теперь берёт длину прогона головы
(`cutRunLength`, старт с `cut.length`, #3781), а не делёный `supply_footage` сегмента.

## Тесты
`experiments/atex-production-planning-3892.test.js` — 20 проверок (явная цепочка; запрет склейки
разных заказов; легаси-фолбэк; запись маркера на голову/продолжение + фолбэк без маркера;
defect C). Полный прогон suite — **без новых падений** (8=8 относительно origin/main: #3619 и
`document is not defined` в основном тесте были и до правки).

## Осталось (следующие части, та же ветка)
- **Defect A — «настройка не разделена»** (и ножи, и сырьё в день N перед намоткой дня N+1):
  по-сегментные минуты — каждая часть несёт ровно те минуты ножей/сырья/резки, что в ней
  выполняются (перенос tail-split настройки из `buildSchedule` в сохраняемые значения
  `computeCutSetupUpdates`/`applySplitPlan`).
- **Defect B — «732 мин / старт 11:25»**: переполненный день (после отпуска станка 06–12.07 на
  13.07 свалился весь бэклог) не разложен по дням. «732» — это сумма работ дня, «11:25» —
  сохранённый старт первой части (не следствие #3886, которое лишь превратило нахлёст в каскад).
  Чиню в пути записи/переноса (почему scope-перепланирование #3660 не вытолкнуло хвост на 14.07)
  — после проверки реального состояния 13.07.

Per-segment minutes и day-split опираются на явный маркер из этого PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)