### PR TITLE
fix(#3892): «Упорядочить» — склеивать цепочку только в пределах одного заказа (день не переполняется)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -4130,6 +4130,18 @@
             emitChain(arr);
         });
         // Легаси-эвристика (#3280): одинаковая continuationSignature + смежные календарные дни.
+        // #3892: ДОПОЛНИТЕЛЬНО требуем СОВПАДЕНИЯ ЗАКАЗА (orderId) — как isDaySplitSibling (#3613).
+        // Без этого две РАЗНЫЕ резки одной конфигурации (один станок|сырьё|намотка|ножи) в соседние
+        // дни склеивались в одну «цепочку», её голова уезжала на более ранний день, и при scope по
+        // фильтру (#3660, ключ = дата ГОЛОВЫ) перепланирование пропускало всю цепочку — «Упорядочить»
+        // не трогал застрявшую переполненную резку (issue #3892: №7 на 03.07 не выталкивался, зазоры
+        // не схлопывались). Пустой orderId у любой из записей (легаси/#3808) — считаем совместимым,
+        // чтобы не осиротить настоящие продолжения с незаполненным заказом.
+        function sameOrder(a, b){
+            var oa = String((a && a.orderId) == null ? '' : a.orderId).trim();
+            var ob = String((b && b.orderId) == null ? '' : b.orderId).trim();
+            return oa === '' || ob === '' || oa === ob;
+        }
         var groups = {}, order = [];
         legacyCuts.forEach(function(c){
             var s = continuationSignature(c);
@@ -4146,6 +4158,7 @@
                     var prevDay = planDayNumber(arr[j - 1]);
                     var curDay = planDayNumber(arr[j]);
                     if (prevDay == null || curDay == null || (curDay - prevDay) !== 1) break;
+                    if (!sameOrder(chain[0], arr[j])) break;   // #3892: другой заказ — не продолжение
                     chain.push(arr[j]);
                     j++;
                 }

--- a/experiments/atex-production-planning-3892.test.js
+++ b/experiments/atex-production-planning-3892.test.js
@@ -47,13 +47,14 @@ var DAY = 86400;   // секунда-смещение смежного дня (p
 function widths(pairs) { var o = []; pairs.forEach(function(pr) { for (var i = 0; i < pr[1]; i++) o.push(pr[0]); }); return o; }
 // Резка для mergeContinuationChains: одинаковая сигнатура у X/Y (material/winding/knives),
 // различает их только firstPartId. planDate в секундах (день = planDate/86400).
-function ch(id, firstPartId, dayOffset, runs) {
+function ch(id, firstPartId, dayOffset, runs, order) {
     return {
         id: id, firstPartId: firstPartId,
         slitter: { id: 'S1' }, materialId: 'M7', winding: 'OUT',
         knifeWidths: widths([[59, 16]]), knifeCount: 16,
         plannedRuns: runs == null ? 1 : runs,
-        planDate: String(1780963200 + dayOffset * DAY), orderId: 'O' + id
+        planDate: String(1780963200 + dayOffset * DAY),
+        orderId: order == null ? ('O' + id) : order
     };
 }
 
@@ -75,13 +76,25 @@ function ch(id, firstPartId, dayOffset, runs) {
     assertEqual(m.deletes, [], '1b: ничего не удаляется (это не продолжения)');
 })();
 
-// ── 1c: легаси (нет firstPartId) — прежняя эвристика (сигнатура + смежные дни) сливает.
+// ── 1c: легаси (нет firstPartId), смежные дни, ОДИН заказ → прежняя эвристика сливает.
 (function () {
-    var a = ch('A', '', 0, 7); var b = ch('Acont', '', 1, 3);
+    var a = ch('A', '', 0, 7, 'ORD'); var b = ch('Acont', '', 1, 3, 'ORD');
     var m = mergeContinuationChains([ a, b ]);
-    assertEqual(m.chainByLogical, { A: ['A', 'Acont'] }, '1c: легаси-эвристика сливает смежные дни одной сигнатуры');
+    assertEqual(m.chainByLogical, { A: ['A', 'Acont'] }, '1c: легаси-эвристика сливает смежные дни одной сигнатуры И заказа');
     assertEqual(m.cuts[0].plannedRuns, 10, '1c: проходы суммируются (7+3)');
     assertEqual(m.deletes, ['Acont'], '1c: продолжение на удаление');
+})();
+
+// ── 1e (#3892, корень defect B): легаси, та же сигнатура, смежные дни, но РАЗНЫЕ заказы —
+//     НЕ сливаются (иначе голова уезжала на ранний день вне scope #3660 и «Упорядочить»
+//     пропускал застрявшую резку). Пустой orderId у любой — по-прежнему совместим (#3808).
+(function () {
+    var x = ch('X', '', 0, 3, 'ORDX'); var y = ch('Y', '', 1, 4, 'ORDY');
+    var m = mergeContinuationChains([ x, y ]);
+    assertEqual(m.chainByLogical, { X: ['X'], Y: ['Y'] }, '1e: разные ЗАКАЗЫ одной конфигурации соседних дней НЕ сливаются');
+    assertEqual(m.deletes, [], '1e: ничего не удаляется (две самостоятельные резки)');
+    var me = mergeContinuationChains([ ch('E1', '', 0, 3, ''), ch('E2', '', 1, 4, '') ]);
+    assertEqual(me.chainByLogical, { E1: ['E1', 'E2'] }, '1e: пустой orderId у обеих — продолжение всё ещё сливается (#3808)');
 })();
 
 // ── 1d: смешанно — явная цепочка H/B + одиночная легаси-резка L другой конфигурации.
@@ -113,6 +126,34 @@ function pcut(id, material, knifeWidths, runs, sequence) {
     assert(ops.creates.length >= 1, '2: A не влезла в день → есть продолжение');
     assert(ops.creates.every(function (c) { return c.parentCutId === 'A'; }),
         '2: продолжение(я) ссылаются на голову A (parentCutId) — отсюда applySplitPlan берёт «ID первой части»');
+})();
+
+// ── 3 (defect B, корень): под scope ОДНОГО дня (#3660) резка, у которой на СОСЕДНЕМ раннем дне
+//     есть резка той же конфигурации, но ДРУГОГО заказа, раньше склеивалась с ней в цепочку с
+//     головой вне scope → «Упорядочить» её ПРОПУСКАЛ (перелив не выталкивался, зазоры не
+//     схлопывались). После фикса orderId — резка дня в scope перепланируется, чужая ранняя — нет.
+(function () {
+    var planDateDayKey = planning.planDateDayKey;
+    var base = Date.UTC(2026, 6, 3) / 1000;   // 03.07.2026 00:00 UTC (сек)
+    function dayCut(id, order, dayOff, runs) {
+        return { id: id, slitter: { id: 'mB' }, materialId: 'MW308', winding: 'OUT',
+            knifeWidths: widths([[100, 1]]), knifeCount: 1, plannedRuns: runs,
+            planDate: String(base + dayOff * DAY), orderId: order };
+    }
+    var prev = dayCut('prev', 'ORDP', -1, 50);   // 02.07, другой заказ, та же конфигурация
+    var today = dayCut('today', 'ORDT', 0, 40);  // 03.07
+    var scopeKey = planDateDayKey(base);         // 20260703
+    var ops = planCutOperations([prev, today], {
+        perPassByCut: { prev: 3, today: 3 }, planBaseMidnightMs: base * 1000,
+        dayStartMin: 480, dayEndMin: 970, dayEndHourMin: 990, maxOverworkCutsMin: 5, maxOverworkTuneMin: 10,
+        times: { BETWEEN_CUTS: 0 }, gapFill: true,
+        scopeFromKey: scopeKey, scopeToKey: scopeKey,
+        dayAnchorByCut: { prev: -1, today: 0 }
+    });
+    var ids = (ops.updates || []).map(function (u) { return u.cutId; })
+        .concat((ops.creates || []).map(function (c) { return c.parentCutId; }));
+    assert(ids.indexOf('today') >= 0, '3(B): резка дня в scope перепланируется (не пропущена из-за чужой ранней резки)');
+    assert(ids.indexOf('prev') < 0, '3(B): чужая ранняя резка (вне scope) не трогается (#3660)');
 })();
 
 // ── 4: cutRunLength = длина прогона головы (cut.length=450), а НЕ делёная доля обеспечения


### PR DESCRIPTION
Issue #3892, defect B (продолжение PR #3893). «Упорядочить» на одном дне (фильтр 03.07–03.07)
не выталкивал переполнение на следующий рабочий день и не схлопывал зазоры — день оставался
679 мин с резкой, идущей до 20:51.

## Диагноз
Сам упаковщик **исправен**: при реальных настройках ateh («Настройка» tbl 269 — конец смены
16:30, TOTAL_INTERVALS=20, **MAX_OVERWORK_CUTS=5**, обед 12:20/40) и отпуске станка 06–12.07
`planCutOperations` дробит большую резку и выталкивает остаток на 13.07. Резка до 20:51 для
него невозможна (нахлёст за смену ≤ 5 мин). Значит 679/20:51 на экране — это РЕНДЕР
сохранённого, **непересчитанного** плана: «Упорядочить» эти резки пропускал.

**Причина:** легаси-эвристика `mergeContinuationChains` склеивала в «цепочку» две РАЗНЫЕ
резки одной конфигурации (станок|сырьё|намотка|ножи) в соседние дни, **не сверяя заказ**.
Голова цепочки уезжала на более ранний день; перепланирование со scope по фильтру (#3660,
ключ = дата ГОЛОВЫ) пропускало всю цепочку → застрявшая переполненная резка не двигалась,
зазоры не схлопывались. `isDaySplitSibling` (#3613) совпадение заказа уже требует — merge нет.

## Фикс
В легаси-склейке дополнительно требуем **совпадения `orderId`** (пустой у любой записи —
совместим, чтобы не осиротить продолжения с незаполненным заказом, #3808). Тогда резка дня
имеет голову на своём дне → попадает в scope → перепланируется: перелив уходит на следующий
рабочий день, зазоры схлопываются. Дополняет явный «ID первой части» из #3893 (после
пересохранения цепочка берётся по маркеру).

Репро подтвердил: до фикса `{p0:[p0,n7]}` (голова p0 на раннем дне), после — `{p0:[p0],
n7:[n7]}`, и n7 под scope одного дня перепланируется.

## Тесты
`experiments/atex-production-planning-3892.test.js`: +1e (разные заказы не сливаются; пустой —
сливается) и +3(B) (резка дня в scope перепланируется, чужая ранняя — нет). Полный прогон
сьюта — без новых падений (8=8 относительно origin/main).

## Примечание по эксплуатации
При фильтре в один день перелив создаётся на след. рабочем дне, но уже лежащий там бэклог не
трогается (#3660). Для чистой раскладки после отпуска выбирать ДИАПАЗОН «Дата плана».

🤖 Generated with [Claude Code](https://claude.com/claude-code)