### PR TITLE
fix(#3895): «Упорядочить» не падает на «No such record» — пересборка применяется целиком

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -9514,6 +9514,31 @@
         var splitTotal = (ops.updates || []).length + Object.keys(createsByParent).length + (ops.deletes || []).length;
         var splitDone = 0;
         function splitBump() { self.updateProgress(++splitDone); }
+        // #3895: операции плана-разбиения НЕ должны валить всю пересборку из-за ОДНОЙ отсутствующей
+        // записи. Если запись (резка/обеспечение/Партия ГП) уже удалена (сервер: «No such record»),
+        // править/удалять нечего — пропускаем эту операцию и продолжаем, иначе единичная устаревшая
+        // ссылка обрывала applySplitPlan на середине → план применялся ЧАСТИЧНО, planStart-ы
+        // оставались с коллизиями (#3885), а «Упорядочить» падал «Ошибка разбиения заданий».
+        // Реальные (другие) ошибки по-прежнему пробрасываем.
+        function softSkip(err) {
+            var m = (err && err.message != null) ? String(err.message) : String(err);
+            if (/no such record/i.test(m)) {
+                if (typeof console !== 'undefined' && console.warn) console.warn('[pp] #3895: пропуск операции — запись не найдена (' + m + ')');
+                splitBump();   // учли как обработанную (запись отсутствует — делать нечего)
+                return;
+            }
+            throw err;
+        }
+        // #3895: _m_del уже отсутствующей записи — не ошибка (её и хотели удалить). Глотаем
+        // «No such record» НА КАЖДОЙ операции удаления, чтобы цепочка удаления (обеспечения →
+        // Партии ГП → сама резка) дошла до конца и не оставила запись-фантом в очереди/Ганте.
+        function delMissingOk(id) {
+            return self.post('_m_del/' + encodeURIComponent(id) + '?JSON', {}).catch(function(err) {
+                var m = (err && err.message != null) ? String(err.message) : String(err);
+                if (/no such record/i.test(m)) { if (typeof console !== 'undefined' && console.warn) console.warn('[pp] #3895: уже удалено: ' + id); return; }
+                throw err;
+            });
+        }
         this.setBusy(true);
         if (splitTotal > 0) this.showProgress('Сохранение плана резок…', splitTotal);
         var chain = Promise.resolve();
@@ -9565,7 +9590,7 @@
                     if (!Object.keys(fields).length) return;
                     return self.post('_m_set/' + u.cutId + '?JSON', fields);
                 });
-            }).then(splitBump);
+            }).then(splitBump).catch(softSkip);
         });
 
         // 2) Создать записи-продолжения с копией Полос и долей Обеспечения.
@@ -9686,7 +9711,7 @@
                     });
                 });
                 return cChain;
-            }).then(splitBump);
+            }).then(splitBump).catch(softSkip);
         });
 
         // 3) Удалить записи-продолжения прежних цепочек (их Полосы/дети каскадятся).
@@ -9710,25 +9735,19 @@
                     }
                 });
         
-                // 1) удаляем обеспечения
+                // 1) удаляем обеспечения (отсутствующие — пропускаем, #3895)
                 var inner = Promise.resolve();
                 supplyIds.forEach(function(sid) {
-                    inner = inner.then(function() {
-                        return self.post('_m_del/' + encodeURIComponent(sid) + '?JSON', {});
-                    });
+                    inner = inner.then(function() { return delMissingOk(sid); });
                 });
                 // 2) удаляем партии ГП
                 Object.keys(fbIds).forEach(function(fbId) {
-                    inner = inner.then(function() {
-                        return self.post('_m_del/' + encodeURIComponent(fbId) + '?JSON', {});
-                    });
+                    inner = inner.then(function() { return delMissingOk(fbId); });
                 });
                 // 3) удаляем саму резку
-                inner = inner.then(function() {
-                    return self.post('_m_del/' + encodeURIComponent(cutId) + '?JSON', {});
-                });
+                inner = inner.then(function() { return delMissingOk(cutId); });
                 return inner;
-            }).then(splitBump);
+            }).then(splitBump).catch(softSkip);
         });
         return chain.then(function() { return self.reload(); }).then(function() {
             return self.persistCutSetupColumns();   // #3698: активности переналадки по итогам план-разбиения

--- a/experiments/atex-production-planning-3895.test.js
+++ b/experiments/atex-production-planning-3895.test.js
@@ -1,0 +1,93 @@
+// Test for ideav/crm#3895 — applySplitPlan не должен валить ВСЮ пересборку из-за ОДНОЙ
+// отсутствующей записи. Раньше единичная устаревшая ссылка (сервер: «No such record» при
+// _m_set/_m_del) обрывала промис-цепочку на середине → план применялся ЧАСТИЧНО, planStart-ы
+// оставались с коллизиями (#3885) и каскадили в Ганте, а «Упорядочить» показывал «Ошибка
+// разбиения заданий: JSON: No such record» (и возвращал false → «Очередь уже оптимальна»).
+//
+// Теперь операции плана-разбиения глотают «No such record» (запись уже удалена — править/
+// удалять нечего) и продолжают; остальные (валидные) записи применяются.
+//
+// Run with: node experiments/atex-production-planning-3895.test.js
+
+process.env.TZ = 'UTC';
+global.window = { db: 'testdb', xsrf: 'x' };
+var api = require('../download/atex/js/production-planning.js');
+var Controller = api.Controller;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) { passed++; } else { process.exitCode = 1; }
+}
+function meta(id, pairs) { return { id: String(id), reqs: pairs.map(function (p) { return { id: String(p[0]), val: p[1] }; }) }; }
+var cutMeta = meta(100, [
+    ['190', 'Вид сырья'], ['191', 'Слиттер'], ['192', 'Партия сырья'], ['193', 'Кол-во план'],
+    ['194', 'Статус'], ['195', 'Очередность'], ['196', 'Тип намотки'], ['198', 'Лидер'],
+    ['197', 'Метраж, м'], ['199', 'Длительность, минут'], ['188', 'ID первой части']
+]);
+var fbMeta = meta(200, [['201', 'Ширина, мм'], ['202', 'Кол-во полос'], ['203', 'Кол-во рулонов'], ['204', 'Кол-во план'], ['205', 'В работе']]);
+var supMeta = meta(300, [['301', 'Метраж, м'], ['302', 'Кол-во рулонов'], ['303', 'В работе'], ['304', 'Статус'], ['305', 'Партия ГП']]);
+
+function makeController(missingIds) {
+    var root = { getAttribute: function () { return 'testdb'; } };
+    var c = new Controller(root);
+    c.meta.cut = cutMeta; c.meta.finishedBatch = fbMeta; c.meta.supply = supMeta;
+    c.cuts = [
+        { id: 'H', length: 450, materialId: 'M7', status: 'В работе', slitter: { id: 'S1' }, batchId: 'B1', winding: 'IN', leaders: [] },
+        { id: 'H2', length: 300, materialId: 'M7', status: 'В работе', slitter: { id: 'S1' }, batchId: 'B1', winding: 'IN', leaders: [] }
+    ];
+    c.supplies = []; c.footageBySupply = {};
+    c._posts = [];
+    c.post = function (path, params) {
+        c._posts.push(path);
+        // Сервер отвечает «No such record» для операций над отсутствующими записями.
+        var hit = (missingIds || []).some(function (id) { return path.indexOf('/' + id + '?') >= 0; });
+        if (hit) return Promise.reject(new Error('JSON: No such record'));
+        return Promise.resolve({ obj: 'NEW' });
+    };
+    c.loadStripsForCut = function () { return Promise.resolve([]); };
+    c.resolveLeaderId = function () { return ''; };
+    c.reload = function () { return Promise.resolve(); };
+    c.persistCutSetupColumns = function () { return Promise.resolve(); };
+    c.setBusy = function () {}; c.showProgress = function () {}; c.updateProgress = function () {};
+    c.hideProgress = function () {}; c.render = function () {}; c.notify = function () {};
+    return c;
+}
+
+// ── 1: удаление ОТСУТСТВУЮЩЕЙ записи не валит пересборку; валидный update применяется. ──
+var c1 = makeController(['GONE']);
+c1.applySplitPlan({
+    updates: [{ cutId: 'H', sequence: 1, planStartTs: 1000, plannedRuns: 5 }],
+    creates: [],
+    deletes: ['GONE']   // запись уже удалена на сервере → «No such record»
+}).then(function (ok) {
+    assert(ok === true, '1: applySplitPlan НЕ падает из-за отсутствующей записи в deletes (вернул true)');
+    assert(c1._posts.some(function (p) { return p.indexOf('_m_set/H?') >= 0; }),
+        '1: валидный update (H) всё равно применился, несмотря на сбой удаления GONE');
+
+    // ── 2: update ОТСУТСТВУЮЩЕЙ записи пропускается; СЛЕДУЮЩИЙ валидный update применяется. ──
+    var c2 = makeController(['GONE']);
+    return c2.applySplitPlan({
+        updates: [
+            { cutId: 'GONE', sequence: 1, planStartTs: 1000, plannedRuns: 5 },   // запись исчезла
+            { cutId: 'H2', sequence: 2, planStartTs: 2000, plannedRuns: 3 }       // валидная
+        ],
+        creates: [], deletes: []
+    }).then(function (ok2) {
+        assert(ok2 === true, '2: applySplitPlan НЕ падает из-за отсутствующей записи в updates');
+        assert(c2._posts.some(function (p) { return p.indexOf('_m_set/H2?') >= 0; }),
+            '2: следующий валидный update (H2) применился после пропуска GONE');
+
+        // ── 3: РЕАЛЬНАЯ (не «No such record») ошибка по-прежнему валит пересборку. ──
+        var c3 = makeController([]);
+        c3.post = function (path) { c3._posts.push(path); return Promise.reject(new Error('JSON: Server boom')); };
+        return c3.applySplitPlan({ updates: [{ cutId: 'H', sequence: 1, planStartTs: 1000, plannedRuns: 5 }], creates: [], deletes: [] })
+            .then(function (ok3) {
+                assert(ok3 === false, '3: посторонняя ошибка (не «No such record») по-прежнему ловится (вернул false)');
+                console.log('\n' + passed + ' assertions passed.');
+            });
+    });
+}).catch(function (err) {
+    console.log('FAIL — тест бросил: ' + (err && err.stack || err));
+    process.exitCode = 1;
+});


### PR DESCRIPTION
Issue #3895. «Упорядочить» (и перегенерация) обрывались с тостом **«Ошибка разбиения заданий:
JSON: No such record»** и откатывались — план применялся ЧАСТИЧНО. Из-за этого сохранённые
planStart-ы оставались с **коллизиями** (две записи на 03.07 08:00; задача на 108 проходов
сохранена на 02.07 10:35 с длительностью 411 мин, а следующие — на 10:46/11:08… ВНУТРИ её
окна), и Гант рисовал их каскадом до 00:26 «из других дней».

## Причина
`applySplitPlan` — единая промис-цепочка `updates → creates → deletes`. ПЕРВАЯ же операция над
уже отсутствующей записью (сервер отвечает «No such record» на `_m_set`/`_m_del`) роняла всю
цепочку → внешний `catch` показывал ошибку и возвращал `false` (отсюда и зелёный «Очередь уже
оптимальна»). Остальные — валидные — записи НЕ применялись, planStart-ы не пересчитывались.

## Фикс
Запись уже удалена — править/удалять нечего. Глотаем ИМЕННО «No such record»:
- `softSkip` на каждом сегменте (update/create/delete) — пропускаем сбойную операцию, цепочка
  продолжается, валидные записи применяются;
- `delMissingOk` на каждом `_m_del` внутри удаления (обеспечения → Партии ГП → сама резка) —
  цепочка удаления доходит до конца, не оставляя запись-фантом.

Любая ДРУГАЯ ошибка по-прежнему пробрасывается. Так «Упорядочить» доходит до конца и
**пересчитывает planStart-ы** — коллизии и каскад исчезают. Конкретная устаревшая ссылка
логируется (`console.warn` с id) для трассировки корня.

## Тесты
`experiments/atex-production-planning-3895.test.js` — 5 проверок (пропуск отсутствующей записи
в delete и в update; применение валидных; проброс посторонней ошибки). Полный прогон сьюта —
без новых падений (8=8 относительно origin/main).

## Как проверить
Установить, выбрать в «Дата плана» диапазон (напр. 01.07–13.07) и «Упорядочить» — ошибки быть
не должно, дни должны разложиться без каскада за полночь.

🤖 Generated with [Claude Code](https://claude.com/claude-code)