### PR TITLE
fix(#3902): по «Создать» индикатор генерации появляется сразу (не зависает UI)

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -8648,11 +8648,23 @@
     // склад (та же Партия ГП без своего обеспечения). Зависимые _m_new не параллелятся.
     AtexProductionPlanning.prototype.runGenerateCuts = function(layouts, skipped, strategy) {
         var self = this;
-        // #3865: окно прогресса показываем сразу по «Создать» — синхронная подготовка (раскладка
-        // по дням, выравнивание загрузки станков) выполняется до первых запросов; ниже окно
-        // сменится счётчиком «N из M». Без этого по «Создать» какое-то время не было индикатора.
-        this.showProgress('Генерация заданий…', 0);
-        this.updateProgress(0, 'Подготовка и выравнивание загрузки станков…');
+        // #3865/#3902: окно прогресса показываем сразу по «Создать» И уступаем кадр браузеру,
+        // чтобы индикатор успел ОТРИСОВАТЬСЯ перед тяжёлой синхронной подготовкой (раскладка по
+        // дням + выравнивание загрузки станков по ВСЕМ резкам выполняются синхронно, до первых
+        // запросов). Один showProgress кадр не рисует: сразу за ним главный поток занимает
+        // подготовка, браузер не перерисовывается, и по «Создать» UI «висит» ~минуту без
+        // индикатора (#3902). setTimeout(0) отдаёт кадр на отрисовку, затем входим повторно и
+        // выполняем подготовку. Ниже окно сменится счётчиком «N из M».
+        if (!this._genPrepYielded) {
+            this.showProgress('Генерация заданий…', 0);
+            this.updateProgress(0, 'Подготовка и выравнивание загрузки станков…');
+            return new Promise(function(resolve) { setTimeout(resolve, 0); }).then(function() {
+                self._genPrepYielded = true;
+                return Promise.resolve(self.runGenerateCuts(layouts, skipped, strategy)).then(
+                    function(r) { self._genPrepYielded = false; return r; },
+                    function(e) { self._genPrepYielded = false; throw e; });
+            });
+        }
         var cutMeta = this.meta.cut;
         var finishedBatchMeta = this.meta.finishedBatch;   // #3242: состав резки = «Партия ГП»
         var supplyMeta = this.meta.supply;


### PR DESCRIPTION
Closes #3902.

## Симптом
По кнопке **«Создать»** интерфейс «висит» почти минуту, и только потом появляется «Генерация заданий…».

## Причина
`runGenerateCuts` вызывает `showProgress('Генерация заданий…')`, но **сразу за ним** идёт тяжёлая **синхронная** подготовка — `layouts.forEach` по всем раскладкам (подбор партии FIFO, выбор станка `chooseSlitterBySetup`, раскладка по дням + выравнивание загрузки станков). Главный поток занят, браузер **не перерисовывается**, поэтому окно прогресса не появляется, пока подготовка не дойдёт до первого сетевого запроса (там поток наконец уступается) — отсюда «висит ~минуту, потом индикатор».

`showProgress` сам по себе кадр не рисует: добавление элемента в DOM не вызывает синхронной перерисовки, а следующий кадр браузер нарисует только когда освободится поток. #3865 показывал прогресс, но без уступки кадра он не отрисовывался.

## Фикс
После `showProgress`/`updateProgress` уступаем кадр (`setTimeout(resolve, 0)`) и только потом запускаем подготовку — индикатор «Генерация заданий… Подготовка и выравнивание загрузки станков…» рисуется **сразу**. Повторный вход в `runGenerateCuts` после уступки помечается флагом `_genPrepYielded`, чтобы не зациклить.

```js
if (!this._genPrepYielded) {
    this.showProgress('Генерация заданий…', 0);
    this.updateProgress(0, 'Подготовка и выравнивание загрузки станков…');
    return new Promise(function(resolve){ setTimeout(resolve, 0); }).then(function(){
        self._genPrepYielded = true;
        return Promise.resolve(self.runGenerateCuts(layouts, skipped, strategy))
            .then(function(r){ self._genPrepYielded = false; return r; },
                  function(e){ self._genPrepYielded = false; throw e; });
    });
}
```

## Проверки
- Сюита: **583 PASS / 5 pre-existing FAIL** с изменением и без (zero regressions); модуль грузится.
- Длительность самой подготовки не трогаю — это отдельный перф-вопрос; здесь чиним именно «висит без индикатора». Если нужно, следом сделаю инкрементальный прогресс внутри `layouts.forEach` (счётчик «раскладка N из M»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)