### PR TITLE
#3907: резка не должна заканчиваться после конца смены при сдвиге за простой/выходные

### DIFF
--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3219,15 +3219,28 @@
     // (а) внутри рабочего окна и (б) не попадает в блокированный интервал; для сегмента длиной
     // len ещё и (в) ни один блок не НАЧИНАЕТСЯ внутри [m, m+len) (иначе сегмент въехал бы в
     // простой — выталкиваем целиком за конец блока). Итераций ≤ числа блоков + дни (ограничено).
-    function nextFreeWorkMinute(from, len, blocked, dayStart, dayEnd) {
+    // #3907: fitEnd (необяз.) — предел, до которого сегмент должен ЗАКОНЧИТЬСЯ (конец смены с
+    // учётом нахлёста-овертайма). Задан → сегмент, чей конец (start+len) выходит за fitEnd, но
+    // сам влезающий в рабочее окно дня, переносится на начало СЛЕДУЮЩЕГО рабочего дня (а не
+    // оставляется с нахлёстом за смену). Не задан → прежнее поведение (проверяли только старт).
+    // dayEnd по-прежнему граница, ПОСЛЕ которой новый сегмент не начинают.
+    function nextFreeWorkMinute(from, len, blocked, dayStart, dayEnd, fitEnd) {
         var m = Number(from);
         var L = Number(len) || 0;
-        var guard = 0, guardMax = (blocked || []).length * 2 + 8;
+        var hasFit = (fitEnd != null && isFinite(Number(fitEnd)));
+        var endLimit = hasFit ? Number(fitEnd) : 0;
+        var dayCap = endLimit - dayStart;   // длина рабочего окна дня (с овертаймом)
+        // #3907: с переносом за конец дня итераций больше (пропуск целых дней) — запас увеличен.
+        var guard = 0, guardMax = (blocked || []).length * 2 + 768;
         while (guard++ < guardMax) {
             var day = Math.floor(m / 1440);
             var within = m - day * 1440;
             if (within < dayStart) { m = day * 1440 + dayStart; continue; }
             if (within >= dayEnd) { m = (day + 1) * 1440 + dayStart; continue; }
+            // #3907: сегмент должен влезть в рабочее окно дня ЦЕЛИКОМ. Конец за fitEnd, а сам
+            // сегмент в день влезает (L ≤ dayCap) → на начало следующего дня. Сегмент длиннее
+            // целого окна разбить здесь нельзя — кладём как есть (вырожденный случай).
+            if (hasFit && (within + L > endLimit) && (L <= dayCap)) { m = (day + 1) * 1440 + dayStart; continue; }
             var bumped = false;
             for (var i = 0; i < (blocked || []).length; i++) {
                 var bS = blocked[i][0], bE = blocked[i][1];
@@ -3246,14 +3259,15 @@
     // окна-старта (минуты), длины (setup+намотка) и применения сдвига (delta) к элементу. blocked
     // — отсортированные [[s,e],…] (минуты от полуночи дня 0). Сохраняет встык-упаковку (курсор =
     // конец предыдущего): резку, сдвинутую простоем, догоняют следующие. Пустой blocked → no-op.
-    function shiftPlacementsPastDowntime(items, blocked, dayStart, dayEnd, acc) {
+    function shiftPlacementsPastDowntime(items, blocked, dayStart, dayEnd, acc, fitEnd) {
         if (!blocked || !blocked.length || !items || !items.length) return items;
         var cursor = -Infinity;
         items.forEach(function(it) {
             var ws = acc.windowStart(it);
             if (ws < cursor) ws = cursor;
             var len = acc.length(it);
-            var placed = nextFreeWorkMinute(ws, len, blocked, dayStart, dayEnd);
+            // #3907: fitEnd — не оставлять сегмент с нахлёстом за смену (см. nextFreeWorkMinute).
+            var placed = nextFreeWorkMinute(ws, len, blocked, dayStart, dayEnd, fitEnd);
             var delta = placed - acc.windowStart(it);
             if (delta !== 0) acc.shift(it, delta);
             cursor = placed + len;
@@ -3569,11 +3583,16 @@
         // buildSchedule). Окно сегмента — [windowStartMin, +setup+намотка]; пустой blockedRanges
         // → no-op. Вызываем перед каждым return (gapFill-ветка и базовая).
         function applyDowntime(segs) {
+            // #3907: предел конца сегмента при сдвиге за простой — конец смены с нахлёстом резки
+            // (dayEndHour + maxOverworkCuts), как в упаковке; нет овертайма → cutEndMin (dayEnd).
+            // Без него сегмент на целый день, сдвинутый простоем/выходным на старт в середине дня,
+            // вылезал за смену (#3907: 108 проходов с 10:35 до 17:26) — теперь переносится на завтра.
+            var fitEnd = overworkOn ? (dayEndHour + maxOverworkCuts) : dayEnd;
             if (hasWindow) shiftPlacementsPastDowntime(segs, opts.blockedRanges, dayStart, dayEnd, {
                 windowStart: function(s) { return s.windowStartMin; },
                 length: function(s) { return (Number(s.setupMin) || 0) + (Number(s.durationMin) || 0); },
                 shift: function(s, delta) { s.windowStartMin = round3(s.windowStartMin + delta); s.startMin = round3(s.startMin + delta); }
-            });
+            }, fitEnd);
             return segs;
         }
         // #3342: плавающий обед. lunch.startMin — минуты от полуночи; durationMin — длина.

--- a/experiments/atex-production-planning-3907.test.js
+++ b/experiments/atex-production-planning-3907.test.js
@@ -1,0 +1,104 @@
+// Unit tests for #3907 — окончание задания после конца смены (перелив дня) при выталкивании
+// через окна простоя/выходные.
+//
+// Контекст: splitMachineQueue корректно режет очередь по дням (каждый сегмент ≤ овертайм-кап).
+// Затем applyDowntime → shiftPlacementsPastDowntime переносит ЦЕЛЫЕ дневные сегменты за
+// блокированные интервалы (выходные #3788 / «Отпуск станка» #3764), укладывая их встык курсором.
+// Баг: nextFreeWorkMinute проверял только что НАЧАЛО within < dayEnd, но не что КОНЕЦ
+// (m + len) влезает в рабочее окно дня. Полнодневный сегмент, сдвинутый на середину дня
+// (например, после утреннего блока 08:00–10:35), вылезал за конец смены и НЕ перерезался.
+//
+// Реальный кейс ateh (#3907): резка 108 проходов после утреннего блока стартовала в 10:35
+// и заканчивалась в ~17:26 — после конца смены 16:30 (овертайм-кап 16:35).
+//
+// Фикс (opt-in через fitEnd): сегмент, который ЦЕЛИКОМ помещается в рабочий день, но при
+// текущем старте вылез бы за конец рабочего окна дня, выталкивается на 08:00 следующего
+// рабочего дня. Сегменты, которые и так помещаются, не двигаются (хирургичность).
+//
+// Run with: node experiments/atex-production-planning-3907.test.js
+
+process.env.TZ = 'UTC';
+
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) { passed++; } else { process.exitCode = 1; }
+}
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else { console.log('  expected:', JSON.stringify(expected)); console.log('  actual:  ', JSON.stringify(actual)); process.exitCode = 1; }
+}
+
+var TIMES = { BETWEEN_CUTS: 2, KNIFE: 30, MATERIAL_WINDING: 15, KNIFE_MOVE: 2, CLEANUP_SHIFT: 30 };
+function cut(id, runs) {
+    return { id: id, slitter: { id: 'm1' }, materialId: 'M1', winding: 'OUT',
+        knifeWidths: [100], knifeCount: 1, rollerWidth: 0, plannedRuns: runs };
+}
+
+// Реальная «Настройка» ateh: смена 08:00–16:30, овертайм резки +5 мин → кап 16:35 (995 мин).
+var DS = 480, DE_HOUR = 990, OVERWORK = 5;
+var OVERWORK_CAP = DE_HOUR + OVERWORK;   // 995 = 16:35
+var opts = {
+    dayStartMin: DS, dayEndMin: 970, dayEndHourMin: DE_HOUR,
+    maxOverworkCutsMin: OVERWORK, maxOverworkTuneMin: 10,
+    times: TIMES, lunchStartMin: 740, lunchDurationMin: 40, firstCutSetup: true
+};
+
+// time-of-day конца сегмента + его «реальный» день (после сдвига dayOffset устаревает,
+// поэтому день выводим из windowStartMin).
+function seg(s) {
+    var ws = s.windowStartMin, len = (Number(s.setupMin) || 0) + (Number(s.durationMin) || 0);
+    var day = Math.floor(ws / 1440);
+    return { day: day, todStart: ws - day * 1440, todEnd: (ws - day * 1440) + len };
+}
+
+// ── 1) Утренний блок 08:00–10:35: полнодневная резка (108 проходов) НЕ переливается ──
+// Без фикса стартовала бы в 10:35 и закончилась ~17:56 (перелив). С фиксом — на 08:00 след. дня.
+var bigSegs = planning.splitMachineQueue([cut('BIG', 108)],
+    Object.assign({}, opts, { perPassByCut: { BIG: 1.81 }, runsByCut: { BIG: 108 },
+        dayAnchorByCut: { BIG: 0 }, blockedRanges: [[480, 635]] }));
+assert(bigSegs.length === 1, '#3907: одна резка → один сегмент');
+var big = seg(bigSegs[0]);
+assert(big.todEnd <= OVERWORK_CAP,
+    '#3907: резка после утреннего блока не выходит за конец смены (todEnd ' +
+    Math.round(big.todEnd) + ' ≤ ' + OVERWORK_CAP + ')');
+assertEqual(big.day, 1, '#3907: переливавшая резка вытолкнута на следующий рабочий день (day 1)');
+assertEqual(big.todStart, DS, '#3907: и стартует с начала смены 08:00 (а не с 10:35)');
+
+// ── 2) Хирургичность: резка, которая ПОМЕЩАЕТСЯ после блока, остаётся в дне 0 ──
+var smallSegs = planning.splitMachineQueue([cut('SMALL', 20)],
+    Object.assign({}, opts, { perPassByCut: { SMALL: 1.81 }, runsByCut: { SMALL: 20 },
+        dayAnchorByCut: { SMALL: 0 }, blockedRanges: [[480, 635]] }));
+var small = seg(smallSegs[0]);
+assertEqual(small.day, 0, '#3907: помещающаяся резка не двигается — остаётся в дне 0');
+assertEqual(small.todStart, 635, '#3907: и стартует сразу после блока (10:35)');
+assert(small.todEnd <= OVERWORK_CAP, '#3907: и тоже в пределах смены');
+
+// ── 3) Выходные (#3788): резки, привязанные к разным дням, наложенные на день после выходных,
+//        не переливаются — каждая в пределах смены ──
+var many = [], mp = {}, mr = {}, ma = {};
+for (var d = 2; d <= 6; d++) { var id = 'd' + d; many.push(cut(id, 100)); mp[id] = 1.81; mr[id] = 100; ma[id] = d; }
+var wkSegs = planning.splitMachineQueue(many,
+    Object.assign({}, opts, { perPassByCut: mp, runsByCut: mr, dayAnchorByCut: ma,
+        blockedRanges: [[4 * 1440, 6 * 1440]] }));   // дни 4,5 — выходные
+var worstEnd = 0;
+wkSegs.forEach(function (s) { var e = seg(s).todEnd; if (e > worstEnd) worstEnd = e; });
+assert(worstEnd <= OVERWORK_CAP,
+    '#3907: после выходных ни одна резка не выходит за конец смены (worst END ' +
+    Math.round(worstEnd) + ' ≤ ' + OVERWORK_CAP + ')');
+// дни 4,5 заблокированы — ни один сегмент не должен стартовать в эти календарные дни
+var onWeekend = wkSegs.some(function (s) { var dd = Math.floor(s.windowStartMin / 1440); return dd === 4 || dd === 5; });
+assert(!onWeekend, '#3907: ни одна резка не попала на заблокированные выходные (дни 4,5)');
+
+// ── 4) Без блокировок поведение не меняется (фикс — opt-in только при сдвиге за простой) ──
+var plainSegs = planning.splitMachineQueue([cut('P', 108)],
+    Object.assign({}, opts, { perPassByCut: { P: 1.81 }, runsByCut: { P: 108 }, dayAnchorByCut: { P: 0 } }));
+var plain = seg(plainSegs[0]);
+assertEqual(plain.day, 0, '#3907: без блокировок резка стартует в дне 0 как раньше');
+assertEqual(plain.todStart, DS, '#3907: без блокировок старт — 08:00');
+
+console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Закрывает #3907 (часть 2 проблемы #3904 — «окончание задания после 17:00»; часть 1 «обед с утра» — PR #3905).

## Симптом
При «Сгенерировать» → «Создать» некоторые резки заканчиваются **после конца смены** (16:30). На ateh: резка 108 проходов шла с **10:35 до 17:26**. База «Задание в производство» перед генерацией была пуста — это результат текущей генерации, не старьё.

## Причина
`splitMachineQueue` корректно режет очередь по дням — каждый сегмент влезает в смену с овертайм-капом (16:35). Но затем `applyDowntime` → `shiftPlacementsPastDowntime` переносит **целые дневные сегменты** за блокированные интервалы (выходные #3788 / «Отпуск станка» #3764), укладывая их встык курсором.

`nextFreeWorkMinute` проверяла только, что **начало** сегмента `within < dayEnd`, но **не** что его **конец** `(start + len)` влезает в рабочее окно дня. Полнодневная резка, сдвинутая на середину дня (например, после утреннего блока 08:00–10:35), вылезала за конец смены — и **не перерезалась**, т.к. сдвиг выполняется уже после нарезки по дням.

## Фикс
Opt-in параметр `fitEnd` у `nextFreeWorkMinute` / `shiftPlacementsPastDowntime`. `applyDowntime` передаёт предел конца сегмента = `dayEndHour + maxOverworkCuts` (с овертаймом) или `cutEndMin` (без). Сегмент, который:
- **целиком помещается** в рабочий день (`len ≤ dayCap`), но
- при текущем старте **закончился бы за пределом** смены,

переносится на **08:00 следующего рабочего дня** (а не оставляется с нахлёстом). Сегменты, которые и так помещаются после блока, **не двигаются** (хирургичность). Путь `buildSchedule` не затронут — `fitEnd` туда не передаётся, поведение очереди-отображения прежнее.

## Проверка
`experiments/atex-production-planning-3907.test.js` — 11 проверок:
- резка 108 проходов после утреннего блока 08:00–10:35: было 10:35→17:56 (перелив), стало 08:00 след. дня →15:21;
- помещающаяся резка (20 проходов) остаётся в дне 0 (10:35→12:21);
- после выходных (блок дней 4–5) ни одна резка не выходит за смену и не попадает на выходные;
- без блокировок поведение не меняется.

Регрессов нет: существующие тесты #3764/#3788/#3821/#3847 (простой/календарь/овертайм) проходят; пред-существующие падения (#3619, cut-gantt, базовый production-planning) идентичны до и после изменения.

🤖 Generated with [Claude Code](https://claude.com/claude-code)