### PR TITLE
#3909 + #3910: потолок дня = cutEndMin+нахлёст (16:15/16:20); обед фиксируется в 12:20

### DIFF
--- a/download/atex/js/cut-gantt.js
+++ b/download/atex/js/cut-gantt.js
@@ -517,13 +517,22 @@
             // короткой переходящей резки) ошибочно помечался обедом. LUNCH_START неизвестен (нет
             // ключа/настройка не загрузилась) → проверку пропускаем (поведение как было).
             if (isFinite(lunchStart) && (curStart - day) / 60000 < lunchStart) continue;
-            var startMs = curStart - lunchDur * 60000;           // привязка к началу послеобеденной резки
+            // #3909: при известном LUNCH_START обед ФИКСИРУЕМ в 12:20 (а не в зазоре после задания,
+            // куда генерация зашила +40). Зазор лежит сразу после «несущего» задания (ordered[i-1]),
+            // чьё окно содержит 12:20 — его полосу растягиваем до старта послеобеденного задания
+            // (carrierIndex/postStartMs, см. render), а обед рисуем ВНУТРИ этого пролёта. LUNCH_START
+            // неизвестен → прежняя привязка к началу послеобеденной резки (зазор как есть).
+            var fixed = isFinite(lunchStart);
+            var startMs = fixed ? (day + lunchStart * 60000) : (curStart - lunchDur * 60000);
+            var endMs = fixed ? (day + (lunchStart + lunchDur) * 60000) : curStart;
             out.push({
                 beforeIndex: i,
+                carrierIndex: fixed ? (i - 1) : null,   // #3909: задание, растягиваемое обедом (несущее 12:20)
+                postStartMs: fixed ? curStart : null,   // #3909: старт послеобеденного задания (предел растяжки)
                 startMs: startMs,
-                endMs: curStart,
+                endMs: endMs,
                 leftPx: scale.toPx(startMs),
-                widthPx: Math.max(round3(scale.toPx(curStart) - scale.toPx(startMs)), 1),
+                widthPx: Math.max(round3(scale.toPx(endMs) - scale.toPx(startMs)), 1),
                 durationMin: lunchDur
             });
             lunchByDay[day] = true;
@@ -1222,6 +1231,7 @@
                     cut: cut, status: status,
                     leftPx: leftPx,
                     widthPx: widthPx,
+                    startMs: startMs,   // #3909: старт бара (для растяжки «несущего» обед задания)
                     segments: seg,
                     // #3887: подпись времени — по сдвинутому старту, чтобы текст совпал с позицией бара.
                     label: cutRowLabel(cut), barText: cutBarTime(cut, seg.setupMin, nextStartMs, startMs),
@@ -1234,6 +1244,20 @@
             // #3846: маркеры обеда (зазор ≈ LUNCH_DURATION между резками одного дня) — отдельной
             // строкой перед послеобеденной резкой, чтобы зазор не выглядел «дырой».
             g.lunches = ganttLunchMarkers(ordered, scale, o.lunchDurationMin, o.lunchStartMin);
+            // #3909: «несущее» обед задание растягиваем до старта послеобеденного (заполняем зазор,
+            // куда генерация зашила +40), чтобы обед нарисовался в 12:20 ВНУТРИ его пролёта, а не
+            // дырой после него. Минуты подписи (barMin) — рабочие, обед в сумму не входит.
+            (g.lunches || []).forEach(function(lb) {
+                if (lb.carrierIndex == null || lb.postStartMs == null) return;
+                var carrier = g.tasks[lb.carrierIndex];
+                if (!carrier) return;
+                var fillPx = round3(scale.toPx(lb.postStartMs) - carrier.leftPx);
+                if (fillPx > carrier.widthPx) {
+                    carrier.widthPx = fillPx;
+                    carrier.barText = formatTime(carrier.startMs) + '-' + formatTime(lb.postStartMs) +
+                        ' (' + carrier.barMin + ' мин)';   // пролёт со встроенным обедом; минуты — рабочие
+                }
+            });
             delete g.cuts;
         });
         return { groups: groups, trackPx: trackPx, window: win, scale: scale, pxPerMin: pxPerMin };

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3583,11 +3583,12 @@
         // buildSchedule). Окно сегмента — [windowStartMin, +setup+намотка]; пустой blockedRanges
         // → no-op. Вызываем перед каждым return (gapFill-ветка и базовая).
         function applyDowntime(segs) {
-            // #3907: предел конца сегмента при сдвиге за простой — конец смены с нахлёстом резки
-            // (dayEndHour + maxOverworkCuts), как в упаковке; нет овертайма → cutEndMin (dayEnd).
+            // #3907: предел конца сегмента при сдвиге за простой — тот же потолок, что в упаковке
+            // (availFor 'cuts'): cutEndMin + maxOverworkCuts; нет овертайма → cutEndMin (dayEnd).
+            // #3909/#3910: потолок привязан к cutEndMin (dayEnd), а не к DAY_END_HOUR (см. availFor).
             // Без него сегмент на целый день, сдвинутый простоем/выходным на старт в середине дня,
             // вылезал за смену (#3907: 108 проходов с 10:35 до 17:26) — теперь переносится на завтра.
-            var fitEnd = overworkOn ? (dayEndHour + maxOverworkCuts) : dayEnd;
+            var fitEnd = overworkOn ? (dayEnd + maxOverworkCuts) : dayEnd;
             if (hasWindow) shiftPlacementsPastDowntime(segs, opts.blockedRanges, dayStart, dayEnd, {
                 windowStart: function(s) { return s.windowStartMin; },
                 length: function(s) { return (Number(s.setupMin) || 0) + (Number(s.durationMin) || 0); },
@@ -3610,7 +3611,13 @@
             if (!overworkOn || !hasWindow) return base;
             var lunchRes = (lunch && !lunchDone[d]) ? lunch.durationMin : 0;
             var margin = (kind === 'tune') ? maxOverworkTune : maxOverworkCuts;
-            return (dayEndHour - dayStart) + margin - lunchRes - clock;
+            // #3909/#3910: нахлёст добавляем к cutEndMin (dayEnd = DAY_END_HOUR−TOTAL_INTERVALS),
+            // а НЕ к DAY_END_HOUR. Последнее задание дня обязано кончиться ≤ cutEndMin+margin
+            // (резка → +MAX_OVERWORK_CUTS, настройка → +MAX_OVERWORK_TUNE). Раньше базой был
+            // dayEndHour (16:30), и день паковался до 16:35+, копя 475–494 раб. мин (#3910 «494
+            // мин во 2 июле»). Теперь потолок 16:15 (резка) / 16:20 (настройка) — буфер уборки
+            // (TOTAL_INTERVALS) поглощает нахлёст, а не растёт за конец смены.
+            return (dayEnd - dayStart) + margin - lunchRes - clock;
         }
         // #3658: якорь дня по «Дате план» — резка ложится на СВОЙ рабочий день, а не паком от
         // дня «С». Иначе автозаполнение дней (#3619) при генерации с другой даты переписывало

--- a/download/atex/js/production-planning.js
+++ b/download/atex/js/production-planning.js
@@ -3484,10 +3484,13 @@
         opts = opts || {};
         var lunchDur = Number(opts.lunchDurationMin) || 0;
         if (!(lunchDur > 0)) return [];
+        var lunchStart = Number(opts.lunchStartMin);   // #3909: 12:20 (мин от полуночи); NaN → привязка к зазору
+        var hasFixed = isFinite(lunchStart);
         var segs = (schedule || []).slice().filter(function(s) {
             return s && isFinite(Number(s.startMin));
         }).sort(function(a, b) { return a.startMin - b.startMin; });
         var byDay = {};
+        var prevCutByDay = {};   // #3909: cutId задания, после которого идёт зазор (несущее обед)
         var lunchByDay = {};
         segs.forEach(function(s) {
             var winStart = Number(s.startMin) - (Number(s.setupMin) || 0);   // начало окна (настройки)
@@ -3498,15 +3501,24 @@
             if (prevEnd != null && !lunchByDay[day]) {
                 var gap = winStart - prevEnd;
                 // Зазор сопоставим с обедом (терпимо к округлению; «через обед» режется по
-                // длительности): берём, если он не меньше почти полного обеда. Обед привязываем к
-                // НАЧАЛУ послеобеденной резки (finishMin = winStart) — так блок всегда прилегает к
-                // следующей карточке (надёжный матч при рендере), а любой остаточный простой (если
-                // зазор > обеда) остаётся ДО обеда.
+                // длительности): берём, если он не меньше почти полного обеда. finishMin (= НАЧАЛО
+                // послеобеденной резки) остаётся КЛЮЧОМ привязки строки обеда к карточке.
                 if (gap >= lunchDur - 1) {
-                    lunchByDay[day] = { day: day, startMin: round3(winStart - lunchDur), finishMin: round3(winStart), durationMin: lunchDur };
+                    // #3909: при известном LUNCH_START ПОКАЗЫВАЕМ обед в 12:20 (внутри несущего его
+                    // задания prevCutByDay), а не в зазоре после него; carrierCutId — это задание.
+                    // LUNCH_START неизвестен → показываем в зазоре (dispStart = startMin), как было.
+                    var dispStart = hasFixed ? round3(day * 1440 + lunchStart) : round3(winStart - lunchDur);
+                    lunchByDay[day] = {
+                        day: day,
+                        startMin: round3(winStart - lunchDur), finishMin: round3(winStart),   // ключ привязки (зазор)
+                        dispStartMin: dispStart, dispFinishMin: round3(dispStart + lunchDur),  // #3909: показываемое время
+                        carrierCutId: hasFixed && prevCutByDay[day] != null ? String(prevCutByDay[day]) : null,
+                        durationMin: lunchDur
+                    };
                 }
             }
             if (byDay[day] == null || winEnd > byDay[day]) byDay[day] = winEnd;
+            prevCutByDay[day] = s.cutId;   // #3909: для зазора следующего задания дня
         });
         return Object.keys(lunchByDay).map(function(d) { return lunchByDay[d]; });
     }
@@ -10973,8 +10985,12 @@
             if (sc && cardSchedDay != null) {
                 var lb = lunchByDay[cardSchedDay];
                 if (lb && !lb._rendered && Math.abs((sc.startMin - sc.setupMin) - lb.finishMin) <= 1) {
+                    // #3909: показываем обед в фиксированные 12:20–13:00 (dispStartMin/dispFinishMin),
+                    // а не в зазоре после несущего задания; привязка строки — по finishMin (зазор).
+                    var lbS = lb.dispStartMin != null ? lb.dispStartMin : lb.startMin;
+                    var lbF = lb.dispFinishMin != null ? lb.dispFinishMin : lb.finishMin;
                     groupEl.appendChild(el('div', { class: 'atex-pp-lunch',
-                        text: '🍽 Обед · ' + formatClock(lb.startMin) + ' – ' + formatClock(lb.finishMin) +
+                        text: '🍽 Обед · ' + formatClock(lbS) + ' – ' + formatClock(lbF) +
                               ' · ' + lb.durationMin + ' мин' }));
                     lb._rendered = true;
                 }

--- a/experiments/atex-production-planning-3847.test.js
+++ b/experiments/atex-production-planning-3847.test.js
@@ -1,10 +1,12 @@
 // Unit tests for #3847 — «Максимальное время нахлёста за конец рабочего дня».
 //
-// Настройки MAX_OVERWORK_CUTS / MAX_OVERWORK_TUNE (Настройка/ATEH): резку (проход) нельзя класть
-// с нахлёстом, если она кончится позже DAY_END_HOUR+MAX_OVERWORK_CUTS; настройку (ножи/смена сырья)
-// — позже DAY_END_HOUR+MAX_OVERWORK_TUNE. DAY_END_HOUR = реальный конец смены (endMin), обычно >
-// cutEndMin (= DAY_END_HOUR − TOTAL_INTERVALS, буфер #3599). Задание делится по проходам: короткий
-// «хвостовой» проход с нахлёстом ≤ лимита остаётся в дне, длинный — уходит на следующий день.
+// #3909/#3910: ПОТОЛОК нахлёста привязан к cutEndMin (= DAY_END_HOUR − TOTAL_INTERVALS), а НЕ к
+// DAY_END_HOUR. Резку (проход) нельзя класть с нахлёстом, если она кончится позже
+// cutEndMin+MAX_OVERWORK_CUTS; настройку (ножи/смена сырья) — позже cutEndMin+MAX_OVERWORK_TUNE.
+// Раньше базой был DAY_END_HOUR (день паковался до 16:35, копя 475–494 раб. мин — #3910); теперь
+// 16:15 (резка) / 16:20 (настройка), буфер уборки (TOTAL_INTERVALS) поглощает нахлёст. Задание
+// делится по проходам: короткий «хвостовой» проход/настройка ≤ лимита остаётся в дне, длинный — на
+// следующий день.
 //
 // Фича включается ТОЛЬКО когда лимит задан (resolveWorkingWindow → maxOverworkCutsMin != null);
 // без настроек планировщик пакует как раньше (до cutEndMin, #3821) — это проверяем отдельно.
@@ -35,16 +37,16 @@ function runsById(segs) {
     return segs.map(function(s) { return { day: s.dayOffset, runs: s.runs, setup: s.setupMin, ws: s.windowStartMin }; });
 }
 
-// ── Базовая ветка (генерация, gapFill=false): нахлёст резки ограничен DAY_END_HOUR+5 ──────────
-// perPass 103: 5 проходов = 515 мин, конец 480+515=995=16:35 = DAY_END_HOUR+5 (ровно лимит) → ОК.
-// 6-й кончился бы в 16:35+103 — за лимитом → на следующий день.
+// ── Базовая ветка (генерация, gapFill=false): нахлёст резки ограничен cutEndMin+5 (#3909) ──────
+// perPass 99: 5 проходов = 495 мин, конец 480+495=975=16:15 = cutEndMin+5 (ровно лимит) → ОК.
+// Без нахлёста влезает 4 (floor(490/99)); нахлёст добавляет ровно 1 проход.
 var baseOpts = { dayStartMin: DAY_START, dayEndMin: CUT_END, leader: 0, times: TIMES,
-    perPassByCut: { A: 103 }, runsByCut: { A: 6 } };
+    perPassByCut: { A: 99 }, runsByCut: { A: 6 } };
 var onBase = planning.splitMachineQueue([cut('A')], Object.assign({}, baseOpts, OVER));
 assertEqual(runsById(onBase), [{ day: 0, runs: 5, setup: 0, ws: 480 }, { day: 1, runs: 1, setup: 0, ws: 1920 }],
-    '#3847 база: 5 проходов в день0 (последний кончается 16:35=DAY_END_HOUR+5), 6-й — день1');
-// Сегмент дня0 кончается ровно в DAY_END_HOUR+MAX_OVERWORK_CUTS (995).
-assertEqual(onBase[0].startMin + onBase[0].durationMin, 995, '#3847 база: конец дня0 = DAY_END_HOUR+5 (16:35)');
+    '#3847/#3909 база: 5 проходов в день0 (последний кончается 16:15=cutEndMin+5), 6-й — день1');
+// Сегмент дня0 кончается ровно в cutEndMin+MAX_OVERWORK_CUTS (975).
+assertEqual(onBase[0].startMin + onBase[0].durationMin, 975, '#3847/#3909 база: конец дня0 = cutEndMin+5 (16:15)');
 
 // ── Фича выключена (нет лимита) → пакуем до cutEndMin (#3821): 4 прохода в день0 ───────────────
 var offBase = planning.splitMachineQueue([cut('A')], baseOpts);
@@ -63,26 +65,27 @@ assertEqual(runsById(offGap).map(function(s) { return { day: s.day, runs: s.runs
     [{ day: 0, runs: 4 }, { day: 1, runs: 2 }],
     '#3847 gapFill: без лимита — 4 прохода (как #3821)');
 
-// ── Нахлёст НАСТРОЙКИ ограничен DAY_END_HOUR+10 ────────────────────────────────────────────────
-// A заполняет день0 до 16:20 (clock 500). B — другое сырьё (setup 15). Первый проход B не влезает,
-// но настройка 15 кончается в 16:35 = DAY_END_HOUR+5 ≤ DAY_END_HOUR+10 → сегмент НАСТРОЙКИ в хвост,
+// ── Нахлёст НАСТРОЙКИ ограничен cutEndMin+10 (#3909) ───────────────────────────────────────────
+// A (p97×5=485) заполняет день0 до 16:05. B — другое сырьё (setup 15). Первый проход B не влезает
+// (cutEndMin+5), но настройка 15 кончается в 16:20 = cutEndMin+10 → сегмент НАСТРОЙКИ в хвост,
 // проходы B — на день1.
 var setupOpts = { dayStartMin: DAY_START, dayEndMin: CUT_END, leader: 0, times: TIMES,
-    perPassByCut: { A: 100, B: 100 }, runsByCut: { A: 5, B: 2 } };
+    perPassByCut: { A: 97, B: 100 }, runsByCut: { A: 5, B: 2 } };
 var withSetup = planning.splitMachineQueue([cut('A', 'M1'), cut('B', 'M2')], Object.assign({}, setupOpts, OVER));
 var bSegs = withSetup.filter(function(s) { return s.cutId === 'B'; });
 assertEqual(bSegs.map(function(s) { return { day: s.dayOffset, runs: s.runs, setup: s.setupMin, setupOnly: !!s.setupOnly }; }),
     [{ day: 0, runs: 0, setup: 15, setupOnly: true }, { day: 1, runs: 2, setup: 0, setupOnly: false }],
-    '#3847: настройка B (15 мин) кладётся в хвост дня0 (нахлёст ≤ +10), проходы — день1');
-assertEqual(bSegs[0].startMin + bSegs[0].durationMin, 995, '#3847: конец настройки в хвосте = 16:35 (≤ DAY_END_HOUR+10)');
+    '#3847/#3909: настройка B (15 мин) кладётся в хвост дня0 (нахлёст ≤ +10), проходы — день1');
+assertEqual(bSegs[0].startMin + bSegs[0].durationMin, 980, '#3847/#3909: конец настройки в хвосте = 16:20 (= cutEndMin+10)');
 
-// Та же раскладка, но смена И сырья И ножей (setup 45): настройка кончилась бы в 17:05 (за +10) →
-// ВСЯ резка B (с настройкой) уходит на следующий день, в хвосте дня0 настройки нет.
-var withBigSetup = planning.splitMachineQueue([cut('A', 'M1', [30]), cut('B', 'M2', [40])], Object.assign({}, setupOpts, OVER));
+// Та же раскладка, но A заполняет день0 ровно до cutEndMin (p98×5=490, 16:10): в нахлёст настройки
+// остаётся лишь 10 мин < 15 → настройка B не влезает даже в хвост → ВСЯ резка B на день1.
+var setupOpts2 = Object.assign({}, setupOpts, { perPassByCut: { A: 98, B: 100 } });
+var withBigSetup = planning.splitMachineQueue([cut('A', 'M1'), cut('B', 'M2')], Object.assign({}, setupOpts2, OVER));
 var bBig = withBigSetup.filter(function(s) { return s.cutId === 'B'; });
 assertEqual(bBig.map(function(s) { return { day: s.dayOffset, runs: s.runs, setup: s.setupMin }; }),
-    [{ day: 1, runs: 2, setup: 45 }],
-    '#3847: настройка 45 мин не влезает в нахлёст +10 → вся резка B на день1, хвост дня0 пуст');
+    [{ day: 1, runs: 2, setup: 15 }],
+    '#3847/#3909: настройка не влезает в остаток нахлёста (10<15) → вся резка B на день1');
 
 // ── resolveWorkingWindow парсит лимиты ────────────────────────────────────────────────────────
 function ww(extra) {

--- a/experiments/atex-production-planning-3909.test.js
+++ b/experiments/atex-production-planning-3909.test.js
@@ -1,0 +1,92 @@
+// Unit tests for #3909 — обед ФИКСИРУЕТСЯ в 12:20 и «растягивает» несущее его задание.
+//
+// Заказчик (issue #3909): обед — реальная пауза 12:20–13:00 ВНУТРИ задания, идущего в это время;
+// задание остаётся одной записью, но его полоса растягивается на LUNCH_DURATION (следующие задания
+// реально сдвинуты на +40 ещё генерацией). Раньше обед «плавал» — рисовался в первом зазоре после
+// 12:20 (на Ганте 12:53/14:25/12:46). Генерация уже даёт нужные planStart — это правки отображения:
+//   • lunchBlocksFromSchedule (очередь) и ganttLunchMarkers (Гант) при известном LUNCH_START
+//     показывают обед в 12:20 и помечают «несущее» задание (carrierCutId / carrierIndex);
+//   • Гант растягивает полосу несущего задания до старта послеобеденного (заполняя зазор).
+// LUNCH_START неизвестен → прежняя привязка к зазору (деградация без поломки).
+//
+// Run with: node experiments/atex-production-planning-3909.test.js
+
+process.env.TZ = 'Europe/Moscow';
+var planning = require('../download/atex/js/production-planning.js').planning;
+var gantt = require('../download/atex/js/cut-gantt.js').gantt;
+
+var passed = 0;
+function assertEqual(actual, expected, name) {
+    var ok = JSON.stringify(actual) === JSON.stringify(expected);
+    console.log((ok ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (ok) { passed++; }
+    else { console.log('  expected:', JSON.stringify(expected)); console.log('  actual:  ', JSON.stringify(actual)); process.exitCode = 1; }
+}
+
+var LUNCH_START = 12 * 60 + 20;   // 740 = 12:20
+var LUNCH_DUR = 40;
+
+// ── ОЧЕРЕДЬ: lunchBlocksFromSchedule ──────────────────────────────────────────────────────────
+// A — несущее задание: окно 11:00–12:30 (содержит 12:20). Зазор-обед 12:30–13:10. B — после обеда.
+var schedule = [
+    { cutId: 'A', startMin: 660, setupMin: 0, finishMin: 750, leaderMin: 0 },   // 11:00–12:30
+    { cutId: 'B', startMin: 790, setupMin: 0, finishMin: 850, leaderMin: 0 }    // 13:10–14:10 (+40 обеда)
+];
+var lbsFixed = planning.lunchBlocksFromSchedule(schedule, { lunchStartMin: LUNCH_START, lunchDurationMin: LUNCH_DUR });
+assertEqual(lbsFixed.length, 1, '#3909 очередь: один обед на день');
+assertEqual([lbsFixed[0].dispStartMin, lbsFixed[0].dispFinishMin], [740, 780],
+    '#3909 очередь: обед показывается в 12:20–13:00 (а не в зазоре 12:30–13:10)');
+assertEqual(lbsFixed[0].carrierCutId, 'A', '#3909 очередь: несущее обед задание — A (его окно содержит 12:20)');
+assertEqual(lbsFixed[0].finishMin, 790, '#3909 очередь: ключ привязки строки — старт послеобеденной B (зазор)');
+
+// LUNCH_START неизвестен → обед показывается в зазоре (прежнее поведение), carrierCutId нет.
+var lbsOld = planning.lunchBlocksFromSchedule(schedule, { lunchDurationMin: LUNCH_DUR });
+assertEqual([lbsOld[0].dispStartMin, lbsOld[0].dispFinishMin], [750, 790],
+    '#3909 очередь: без LUNCH_START — обед в зазоре 12:30–13:10 (прежнее поведение)');
+assertEqual(lbsOld[0].carrierCutId, null, '#3909 очередь: без LUNCH_START несущее не помечается');
+
+// ── ГАНТ: ganttLunchMarkers ───────────────────────────────────────────────────────────────────
+function gcut(id, planIso, knife, material, cutTime) {
+    return { id: id, planDate: planIso, setupKnifeMin: knife, setupMaterialMin: material, cutTimeMin: cutTime };
+}
+function scaleFor(cuts) {
+    var range = gantt.ganttRange('2026-06-29', 'day');
+    return gantt.ganttScale(gantt.workingSegments(cuts, range, {}), 2);
+}
+// A: 11:00–12:26 (содержит 12:20). B: 13:06 — зазор-обед 12:26–13:06 (40).
+var day = [gcut('A', '2026-06-29 11:00', 0, 0, 86), gcut('B', '2026-06-29 13:06', 0, 0, 30)];
+var mk = gantt.ganttLunchMarkers(day, scaleFor(day), LUNCH_DUR, LUNCH_START);
+assertEqual(mk.length, 1, '#3909 Гант: один обед на день');
+assertEqual(mk[0].beforeIndex, 1, '#3909 Гант: строка обеда — перед послеобеденным заданием B');
+assertEqual(mk[0].carrierIndex, 0, '#3909 Гант: несущее обед задание — A (index 0)');
+var lunch1220 = new Date('2026-06-29 12:20').getTime();
+var lunch1300 = new Date('2026-06-29 13:00').getTime();
+assertEqual([mk[0].startMs, mk[0].endMs], [lunch1220, lunch1300],
+    '#3909 Гант: маркер обеда в 12:20–13:00 (фиксированно), а не в зазоре после A');
+assertEqual(mk[0].postStartMs, new Date('2026-06-29 13:06').getTime(),
+    '#3909 Гант: postStartMs = старт послеобеденного B (предел растяжки несущего)');
+
+// Без LUNCH_START — маркер в зазоре (прежнее поведение), carrierIndex отсутствует.
+var mkOld = gantt.ganttLunchMarkers(day, scaleFor(day), LUNCH_DUR);
+assertEqual(mkOld[0].carrierIndex, null, '#3909 Гант: без LUNCH_START несущее не помечается (carrierIndex null)');
+assertEqual(mkOld[0].endMs, new Date('2026-06-29 13:06').getTime(),
+    '#3909 Гант: без LUNCH_START маркер кончается на старте послеобеденного (зазор)');
+
+// ── ГАНТ полностью: layoutGroups растягивает полосу несущего задания до старта послеобеденного ──
+var gcuts = [
+    { id: 'A', planDate: '2026-06-29 11:00', cutTimeMin: 86, sequence: 1, slitter: { id: '1', label: 'Станок 1' } },
+    { id: 'B', planDate: '2026-06-29 13:06', cutTimeMin: 30, sequence: 2, slitter: { id: '1', label: 'Станок 1' } }
+];
+var dayRange = gantt.ganttRange('2026-06-29', 'day');
+var laid = gantt.layoutGroups(gcuts, dayRange, new Date('2026-06-29 10:00').getTime(), {},
+    { pxPerMin: 1, lunchDurationMin: LUNCH_DUR, lunchStartMin: LUNCH_START });
+var gA = laid.groups[0].tasks[0], gB = laid.groups[0].tasks[1];
+// A: 11:00 (cut 86 → 12:26). Растянуто до старта B (13:06) = 126 мин при ppm=1.
+assertEqual(gA.widthPx, 126, '#3909 Гант: полоса несущего A растянута до старта B (126 px = 11:00→13:06)');
+assertEqual(gA.barText, '11:00-13:06 (86 мин)',
+    '#3909 Гант: подпись несущего — пролёт 11:00–13:06, минуты рабочие (86, обед не в сумме)');
+assertEqual(laid.groups[0].lunches[0].carrierIndex, 0, '#3909 Гант: layoutGroups помечает несущее A');
+// barMin (для «Σ мин» станка) — рабочие, без обеда.
+assertEqual(gA.barMin, 86, '#3909 Гант: barMin несущего = рабочие минуты (86), обед в сумму не входит');
+
+console.log('\n' + passed + ' проверок прошло.');

--- a/experiments/atex-production-planning-3910.test.js
+++ b/experiments/atex-production-planning-3910.test.js
@@ -1,0 +1,86 @@
+// Unit tests for #3910 / #3909 (потолок дня) — «Почему опять 494 мин во 2 июле?».
+//
+// Корень: splitMachineQueue (генерация «Сгенерировать») паковал день до нахлёста за DAY_END_HOUR
+// (16:30) + MAX_OVERWORK → ~16:35, накапливая 475–494 РАБОЧИХ минут в одном станко-дне. По #3909
+// потолок последнего задания дня = cutEndMin (DAY_END_HOUR − TOTAL_INTERVALS = 16:10) + нахлёст:
+//   • заканчивается резкой   → ≤ cutEndMin + MAX_OVERWORK_CUTS (16:15)
+//   • заканчивается настройкой → ≤ cutEndMin + MAX_OVERWORK_TUNE (16:20)
+// Тогда рабочих минут в дне (без обеда) ≤ (cutEndMin−dayStart) − обед + нахлёст ≈ 455 — «494» больше
+// невозможно. Обед в эту сумму не входит (резерв в бюджете, но не в подписи минут).
+//
+// Run with: node experiments/atex-production-planning-3910.test.js
+
+process.env.TZ = 'UTC';
+var planning = require('../download/atex/js/production-planning.js').planning;
+
+var passed = 0;
+function assert(cond, name) {
+    console.log((cond ? 'PASS' : 'FAIL') + ' — ' + name);
+    if (cond) { passed++; } else { process.exitCode = 1; }
+}
+
+var TIMES = { BETWEEN_CUTS: 2, KNIFE: 30, MATERIAL_WINDING: 15, KNIFE_MOVE: 2, CLEANUP_SHIFT: 30 };
+function cut(id, mat, runs) {
+    return { id: id, slitter: { id: 'm1' }, materialId: mat, winding: 'OUT',
+        knifeWidths: [100], knifeCount: 1, rollerWidth: 0, plannedRuns: runs };
+}
+
+// Реальная «Настройка» ateh: 08:00–16:30, TOTAL_INTERVALS 20 → cutEndMin 16:10 (970); нахлёст резки
+// 5, настройки 10; обед 12:20 / 40 мин. Путь генерации (9016): base-ветка, без gapFill/anchors.
+var DAY_START = 480, CUT_END = 970, DAY_END_HOUR = 990, OVER_CUTS = 5, OVER_TUNE = 10, LUNCH = 40;
+var CAP_CUTS = CUT_END + OVER_CUTS;   // 975 = 16:15
+var CAP_TUNE = CUT_END + OVER_TUNE;   // 980 = 16:20
+var opts = {
+    dayStartMin: DAY_START, dayEndMin: CUT_END, dayEndHourMin: DAY_END_HOUR,
+    maxOverworkCutsMin: OVER_CUTS, maxOverworkTuneMin: OVER_TUNE,
+    times: TIMES, lunchStartMin: 740, lunchDurationMin: LUNCH, firstCutSetup: true
+};
+
+// Заведомо переполняющая очередь: 10 резок по 13 проходов, чередуем сырьё (каждая несёт настройку).
+var cuts = [], pp = {}, rr = {};
+for (var i = 0; i < 10; i++) { var id = 'c' + i; cuts.push(cut(id, 'M' + (i % 2), 13)); pp[id] = 5; rr[id] = 13; }
+var segs = planning.splitMachineQueue(cuts, Object.assign({}, opts, { perPassByCut: pp, runsByCut: rr }));
+
+// Группируем по реальному дню (день выводим из windowStartMin — dayOffset устаревает после сдвигов).
+var byDay = {};
+segs.forEach(function (s) {
+    var ws = s.windowStartMin, day = Math.floor(ws / 1440), tod = ws - day * 1440;
+    var work = (Number(s.setupMin) || 0) + (Number(s.durationMin) || 0);
+    var endTod = tod + work;
+    var endsWithSetupOnly = !!s.setupOnly || !(Number(s.durationMin) > 0);
+    if (!byDay[day]) byDay[day] = { work: 0, worstEnd: 0, worstCutEnd: 0, segs: 0 };
+    byDay[day].work += work;
+    byDay[day].segs++;
+    if (endTod > byDay[day].worstEnd) byDay[day].worstEnd = endTod;
+    if (!endsWithSetupOnly && endTod > byDay[day].worstCutEnd) byDay[day].worstCutEnd = endTod;
+});
+var days = Object.keys(byDay).map(Number).sort(function (a, b) { return a - b; });
+
+// ── 1) Ни один день не заканчивается позже cutEndMin+TUNE (16:20) ──
+var allWithinTune = days.every(function (d) { return byDay[d].worstEnd <= CAP_TUNE + 1e-6; });
+assert(allWithinTune, '#3910: ни один станко-день не заканчивается позже cutEndMin+TUNE = 16:20 (' +
+    days.map(function (d) { return 'd' + d + ':' + byDay[d].worstEnd; }).join(' ') + ')');
+
+// ── 2) Сегмент, заканчивающийся РЕЗКОЙ, не выходит за cutEndMin+CUTS (16:15) ──
+var cutsWithin = days.every(function (d) { return byDay[d].worstCutEnd <= CAP_CUTS + 1e-6; });
+assert(cutsWithin, '#3910: задание, заканчивающееся резкой, не позже cutEndMin+CUTS = 16:15');
+
+// ── 3) Рабочих минут в дне не больше бюджета (cutEndMin−dayStart)−обед+TUNE ≈ 460 → «494» невозможно ──
+var WORK_CAP = (CUT_END - DAY_START) - LUNCH + OVER_TUNE;   // 490 − 40 + 10 = 460
+var noOverbook = days.every(function (d) { return byDay[d].work <= WORK_CAP + 1e-6; });
+assert(noOverbook, '#3910: рабочих минут в дне ≤ ' + WORK_CAP + ' (≈455), «494» больше не набирается (' +
+    days.map(function (d) { return 'd' + d + ':' + Math.round(byDay[d].work); }).join(' ') + ')');
+
+// ── 4) Контроль: со СТАРЫМ потолком (DAY_END_HOUR база) первый день держал бы > 460 раб. мин ──
+// Эмулируем старую базу, подняв cutEndMin до DAY_END_HOUR (dayEndMin = 990): день переполняется.
+var oldSegs = planning.splitMachineQueue(cuts, Object.assign({}, opts, {
+    dayEndMin: DAY_END_HOUR, perPassByCut: pp, runsByCut: rr
+}));
+var oldDay0 = 0;
+oldSegs.forEach(function (s) {
+    if (Math.floor(s.windowStartMin / 1440) === 0) oldDay0 += (Number(s.setupMin) || 0) + (Number(s.durationMin) || 0);
+});
+assert(oldDay0 > WORK_CAP, '#3910 контроль: старый потолок (DAY_END_HOUR) держал бы > ' + WORK_CAP +
+    ' раб. мин в дне0 (было ' + Math.round(oldDay0) + ') — теперь нет');
+
+console.log('\n' + passed + ' assertions passed');


### PR DESCRIPTION
Решает #3910 и #3909 (день «за 17:00» / «494 мин» + обед). Две части, обе готовы.

## Часть 1 — потолок дня (закрывает #3910, п.3 #3909) ✅
**Симптом:** «Сгенерировать» пакует станко-день до ~16:35, копя 475–494 рабочих минуты (#3910 «Почему опять 494 мин во 2 июле?»; задания заканчиваются после конца смены).

**Причина:** нахлёст (MAX_OVERWORK_CUTS/TUNE, #3847) отсчитывался от `DAY_END_HOUR` (16:30) → потолок 16:35.

**Фикс (#3909, п.3):** нахлёст отсчитывается от `cutEndMin = DAY_END_HOUR − TOTAL_INTERVALS` (16:10):
- задание заканчивается **резкой** → не позже `cutEndMin + MAX_OVERWORK_CUTS` = **16:15**;
- заканчивается **настройкой** → не позже `cutEndMin + MAX_OVERWORK_TUNE` = **16:20**.

Буфер уборки (TOTAL_INTERVALS) теперь поглощает нахлёст. Рабочих минут в дне (без обеда) ≤ `(cutEndMin−dayStart) − обед + нахлёст ≈ 455` — «494» больше не набирается. Правки в `availFor()` и `applyDowntime/fitEnd` (#3907): база нахлёста — `dayEnd` (cutEndMin), а не `dayEndHour`.

Тесты: `atex-production-planning-3910.test.js` (4); обновлён `atex-production-planning-3847.test.js` (нахлёст теперь от cutEndMin, 12).

## Часть 2 — обед фиксируется в 12:20 (закрывает п.1–2 #3909) ✅
**Модель (выбрана заказчиком):** обед — реальная пауза 12:20–13:00 **внутри** задания, идущего в это время. Задание остаётся одной записью, его полоса растягивается на 40 мин (обед в середине), следующие задания реально сдвинуты на +40 (уже генерацией). Обед в сумму минут не входит.

**Было:** обед «плавал» — рисовался в первом зазоре после 12:20 (на Ганте 12:53/14:25/12:46).

**Фикс — только отображение** (генерация уже даёт нужные planStart: резерв обеда в бюджете + потолок дня):
- `ganttLunchMarkers` / `lunchBlocksFromSchedule` при известном `LUNCH_START` показывают обед в **12:20** и помечают «несущее» задание (его окно содержит 12:20);
- Гант **растягивает полосу** несущего задания до старта послеобеденного (заполняя зазор, куда генерация зашила +40); подпись — пролёт со встроенным обедом, минуты рабочие (`barMin` без обеда);
- очередь показывает строку «🍽 Обед · 12:20 – 13:00».
- `LUNCH_START` неизвестен → прежняя привязка к зазору (деградация без поломки).

Тест: `atex-production-planning-3909.test.js` (17: позиция обеда, несущее задание, растяжка полосы через `layoutGroups`, обед не в сумме).

## Проверка
Регрессов нет: затронутые тесты зелёные (#3846/#3904/#3847/#3910/#3909); пред-существующие падения (cut-gantt #3708/#3770, #3619, base production-planning) идентичны до и после — не связаны с изменением.

⚠️ Визуальную часть (растяжка полосы несущего задания + позиция обеда на Ганте/в очереди) стоит глянуть в браузере — юнит-тесты покрывают логику (позиция, ширина, подпись), но не пиксельную отрисовку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)